### PR TITLE
fix: 동영상 썸네일 깜박임 수정 (#91)

### DIFF
--- a/frontend/src/components/common/JobHistoryPanel.js
+++ b/frontend/src/components/common/JobHistoryPanel.js
@@ -439,7 +439,7 @@ function JobCard({ job, onView, onRetry, onCancel, onDelete, onImageView, onCont
             <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', maxWidth: '100%', overflow: 'hidden' }}>
               {job.resultVideos.slice(0, 6).map((video, index) => (
                 <Box
-                  key={index}
+                  key={video._id || index}
                   onClick={() => onImageView(job.resultVideos, index, true)}
                   sx={{
                     width: { xs: 40, sm: 56, md: 64 },
@@ -755,7 +755,7 @@ function JobDetailDialog({ job, open, onClose, onImageView }) {
             <Typography variant="h6" gutterBottom>생성된 동영상</Typography>
             <Grid container spacing={2}>
               {job.resultVideos.map((video, index) => (
-                <Grid item xs={6} sm={4} md={3} key={index}>
+                <Grid item xs={6} sm={4} md={3} key={video._id || index}>
                   <Box
                     onClick={() => onImageView(job.resultVideos, index, true)}
                     sx={{

--- a/frontend/src/components/common/VideoViewerDialog.js
+++ b/frontend/src/components/common/VideoViewerDialog.js
@@ -99,7 +99,7 @@ function VideoViewerDialog({
       </DialogTitle>
       <DialogContent sx={{ textAlign: 'center', p: 2, bgcolor: 'black' }}>
         <video
-          key={currentVideo?.url}
+          key={currentVideo?._id || currentIndex}
           src={currentVideo?.url}
           controls
           autoPlay

--- a/src/utils/signedUrl.js
+++ b/src/utils/signedUrl.js
@@ -23,7 +23,11 @@ function createSignature(filePath, expires) {
 function generateSignedUrl(uploadPath, expirySeconds = DEFAULT_EXPIRY) {
   // Strip '/uploads' prefix to get relative file path
   const filePath = uploadPath.replace(/^\/uploads/, '');
-  const expires = Math.floor(Date.now() / 1000) + expirySeconds;
+  // 만료 시간을 5분 단위로 라운딩하여 동일 구간 내에서는 같은 URL 생성
+  // → 빈번한 API refetch 시에도 URL이 바뀌지 않아 <video>/<img> 재로드 방지
+  const ROUND_SECONDS = 300; // 5분
+  const now = Math.floor(Date.now() / 1000);
+  const expires = Math.ceil((now + expirySeconds) / ROUND_SECONDS) * ROUND_SECONDS;
   const sig = createSignature(filePath, expires);
   return `/api/files${filePath}?expires=${expires}&sig=${sig}`;
 }


### PR DESCRIPTION
## Summary
- Signed URL 만료 타임스탬프를 5분 단위로 라운딩하여 동일 구간 내 동일 URL 보장
- `<video>` 요소 및 `VideoViewerDialog`의 key를 URL 기반 → `_id` 기반으로 변경
- React Query refetch(3초 간격)가 발생해도 URL이 동일하므로 비디오 재로드 없음

## 변경 내용

| 파일 | 변경 |
|------|------|
| `src/utils/signedUrl.js` | `expires` 타임스탬프 5분 단위 ceil 라운딩 |
| `frontend/.../JobHistoryPanel.js` | 비디오 리스트 `key={index}` → `key={video._id \|\| index}` |
| `frontend/.../VideoViewerDialog.js` | `key={currentVideo?.url}` → `key={currentVideo?._id \|\| currentIndex}` |

## Test plan
- [ ] 작업 히스토리 페이지에서 동영상 썸네일이 깜박이지 않는지 확인
- [ ] 동영상 뷰어에서 영상 전환 시 정상 재생되는지 확인
- [ ] 미디어 그리드 페이지에서 동영상이 안정적으로 표시되는지 확인
- [ ] Signed URL이 정상적으로 유효한지 확인 (만료 전 접근 가능)

closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)