### PR TITLE
fix: 사용자 입력 정규식 이스케이프로 ReDoS 방지 (F-08)

### DIFF
--- a/SECURITY-AUDIT.md
+++ b/SECURITY-AUDIT.md
@@ -138,7 +138,7 @@
   - `validate()` 미들웨어에서 `req.body` 전체 로그 (`console.log`) 제거
   - 검증 에러 로그(`Validation errors`)도 함께 제거 — 에러 내용은 API 응답으로 클라이언트에 전달되므로 서버 로그 불필요
 
-### F-08 (Low) 사용자 입력 기반 정규식 사용으로 ReDoS 가능성
+### F-08 (Low) 사용자 입력 기반 정규식 사용으로 ReDoS 가능성 — ✅ Fixed (2026-02-20)
 - Category: 웹 취약점(DoS)
 - Evidence:
   - `src/routes/images.js:178,189,361,401` `new RegExp(search, 'i')`/`$regex: search`
@@ -147,6 +147,10 @@
 - Recommendation:
   - 사용자 입력은 escape 후 literal 검색으로 변환.
   - 검색 길이 제한 및 요청 rate limit 강화.
+- Remediation:
+  - `escapeRegex()` 유틸 함수 생성 (`src/utils/escapeRegex.js`) — 정규식 특수문자를 이스케이프하여 literal 검색으로 변환
+  - 전체 라우트/모델 24곳의 `$regex: search` 및 `new RegExp(search)` 호출에 `escapeRegex()` 적용
+  - 적용 파일: images.js, promptData.js, jobs.js, admin.js, projects.js, tags.js, workboards.js, PromptData.js (model)
 
 ## Requested Items Check
 

--- a/src/models/PromptData.js
+++ b/src/models/PromptData.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const { escapeRegex } = require('../utils/escapeRegex');
 
 const promptDataSchema = new mongoose.Schema({
   name: {
@@ -62,9 +63,9 @@ promptDataSchema.statics.findByUser = function(userId, options = {}) {
   
   if (search) {
     query.$or = [
-      { name: { $regex: search, $options: 'i' } },
-      { memo: { $regex: search, $options: 'i' } },
-      { prompt: { $regex: search, $options: 'i' } }
+      { name: { $regex: escapeRegex(search), $options: 'i' } },
+      { memo: { $regex: escapeRegex(search), $options: 'i' } },
+      { prompt: { $regex: escapeRegex(search), $options: 'i' } }
     ];
   }
   

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -7,6 +7,7 @@ const GeneratedImage = require('../models/GeneratedImage');
 const UploadedImage = require('../models/UploadedImage');
 const SystemSettings = require('../models/SystemSettings');
 const ApiKey = require('../models/ApiKey');
+const { escapeRegex } = require('../utils/escapeRegex');
 const router = express.Router();
 
 router.get('/users', requireAdmin, async (req, res) => {
@@ -18,8 +19,8 @@ router.get('/users', requireAdmin, async (req, res) => {
     
     if (search) {
       filter.$or = [
-        { email: { $regex: search, $options: 'i' } },
-        { nickname: { $regex: search, $options: 'i' } }
+        { email: { $regex: escapeRegex(search), $options: 'i' } },
+        { nickname: { $regex: escapeRegex(search), $options: 'i' } }
       ];
     }
     

--- a/src/routes/images.js
+++ b/src/routes/images.js
@@ -7,6 +7,7 @@ const GeneratedImage = require('../models/GeneratedImage');
 const GeneratedVideo = require('../models/GeneratedVideo');
 const ImageGenerationJob = require('../models/ImageGenerationJob');
 const Tag = require('../models/Tag');
+const { escapeRegex } = require('../utils/escapeRegex');
 const router = express.Router();
 
 // 일괄 삭제 - 선택 항목
@@ -174,8 +175,8 @@ router.post('/bulk-delete-by-filter', requireAuth, async (req, res) => {
     if (type === 'uploaded') {
       if (search) {
         filter.$or = [
-          { originalName: { $regex: search, $options: 'i' } },
-          { tags: { $in: [new RegExp(search, 'i')] } }
+          { originalName: { $regex: escapeRegex(search), $options: 'i' } },
+          { tags: { $in: [new RegExp(escapeRegex(search), 'i')] } }
         ];
       }
       if (tags) {
@@ -185,9 +186,9 @@ router.post('/bulk-delete-by-filter', requireAuth, async (req, res) => {
     } else if (type === 'generated') {
       if (search) {
         filter.$or = [
-          { originalName: { $regex: search, $options: 'i' } },
-          { tags: { $in: [new RegExp(search, 'i')] } },
-          { 'generationParams.prompt': { $regex: search, $options: 'i' } }
+          { originalName: { $regex: escapeRegex(search), $options: 'i' } },
+          { tags: { $in: [new RegExp(escapeRegex(search), 'i')] } },
+          { 'generationParams.prompt': { $regex: escapeRegex(search), $options: 'i' } }
         ];
       }
       if (tags) {
@@ -198,8 +199,8 @@ router.post('/bulk-delete-by-filter', requireAuth, async (req, res) => {
       // video
       if (search) {
         filter.$or = [
-          { originalName: { $regex: search, $options: 'i' } },
-          { 'generationParams.prompt': { $regex: search, $options: 'i' } }
+          { originalName: { $regex: escapeRegex(search), $options: 'i' } },
+          { 'generationParams.prompt': { $regex: escapeRegex(search), $options: 'i' } }
         ];
       }
     }
@@ -357,8 +358,8 @@ router.get('/uploaded', requireAuth, async (req, res) => {
     
     if (search) {
       filter.$or = [
-        { originalName: { $regex: search, $options: 'i' } },
-        { tags: { $in: [new RegExp(search, 'i')] } }
+        { originalName: { $regex: escapeRegex(search), $options: 'i' } },
+        { tags: { $in: [new RegExp(escapeRegex(search), 'i')] } }
       ];
     }
     
@@ -397,9 +398,9 @@ router.get('/generated', requireAuth, async (req, res) => {
     
     if (search) {
       filter.$or = [
-        { originalName: { $regex: search, $options: 'i' } },
-        { tags: { $in: [new RegExp(search, 'i')] } },
-        { 'generationParams.prompt': { $regex: search, $options: 'i' } }
+        { originalName: { $regex: escapeRegex(search), $options: 'i' } },
+        { tags: { $in: [new RegExp(escapeRegex(search), 'i')] } },
+        { 'generationParams.prompt': { $regex: escapeRegex(search), $options: 'i' } }
       ];
     }
     
@@ -716,8 +717,8 @@ router.get('/videos', requireAuth, async (req, res) => {
     
     if (search) {
       filter.$or = [
-        { originalName: { $regex: search, $options: 'i' } },
-        { 'generationParams.prompt': { $regex: search, $options: 'i' } }
+        { originalName: { $regex: escapeRegex(search), $options: 'i' } },
+        { 'generationParams.prompt': { $regex: escapeRegex(search), $options: 'i' } }
       ];
     }
     

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -8,6 +8,7 @@ const UploadedImage = require('../models/UploadedImage');
 const GeneratedImage = require('../models/GeneratedImage');
 const GeneratedVideo = require('../models/GeneratedVideo');
 const Workboard = require('../models/Workboard');
+const { escapeRegex } = require('../utils/escapeRegex');
 const Server = require('../models/Server');
 const router = express.Router();
 
@@ -118,8 +119,8 @@ router.get('/my', requireAuth, async (req, res) => {
     
     // 프롬프트 검색 기능 추가
     if (search) {
-      filter['inputData.prompt'] = { 
-        $regex: search, 
+      filter['inputData.prompt'] = {
+        $regex: escapeRegex(search),
         $options: 'i' // case insensitive
       };
     }

--- a/src/routes/projects.js
+++ b/src/routes/projects.js
@@ -8,6 +8,7 @@ const GeneratedImage = require('../models/GeneratedImage');
 const GeneratedVideo = require('../models/GeneratedVideo');
 const PromptData = require('../models/PromptData');
 const ImageGenerationJob = require('../models/ImageGenerationJob');
+const { escapeRegex } = require('../utils/escapeRegex');
 const router = express.Router();
 
 // GET /favorites - 즐겨찾기 프로젝트 목록 (대시보드용) - 구체적 경로를 /:id 위에 배치
@@ -68,8 +69,8 @@ router.get('/', requireAuth, async (req, res) => {
 
     if (search) {
       filter.$or = [
-        { name: { $regex: search, $options: 'i' } },
-        { description: { $regex: search, $options: 'i' } }
+        { name: { $regex: escapeRegex(search), $options: 'i' } },
+        { description: { $regex: escapeRegex(search), $options: 'i' } }
       ];
     }
 

--- a/src/routes/promptData.js
+++ b/src/routes/promptData.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const { reverseSignedUrl } = require('../utils/signedUrl');
 const PromptData = require('../models/PromptData');
 const Tag = require('../models/Tag');
+const { escapeRegex } = require('../utils/escapeRegex');
 const { verifyJWT } = require('../middleware/auth');
 
 router.get('/', verifyJWT, async (req, res) => {
@@ -14,9 +15,9 @@ router.get('/', verifyJWT, async (req, res) => {
     
     if (search) {
       query.$or = [
-        { name: { $regex: search, $options: 'i' } },
-        { memo: { $regex: search, $options: 'i' } },
-        { prompt: { $regex: search, $options: 'i' } }
+        { name: { $regex: escapeRegex(search), $options: 'i' } },
+        { memo: { $regex: escapeRegex(search), $options: 'i' } },
+        { prompt: { $regex: escapeRegex(search), $options: 'i' } }
       ];
     }
     

--- a/src/routes/tags.js
+++ b/src/routes/tags.js
@@ -4,6 +4,7 @@ const Tag = require('../models/Tag');
 const GeneratedImage = require('../models/GeneratedImage');
 const UploadedImage = require('../models/UploadedImage');
 const PromptData = require('../models/PromptData');
+const { escapeRegex } = require('../utils/escapeRegex');
 const router = express.Router();
 
 router.get('/', requireAuth, async (req, res) => {
@@ -12,7 +13,7 @@ router.get('/', requireAuth, async (req, res) => {
     
     const filter = { userId: req.user._id };
     if (search) {
-      filter.name = { $regex: search, $options: 'i' };
+      filter.name = { $regex: escapeRegex(search), $options: 'i' };
     }
     
     const tags = await Tag.find(filter)

--- a/src/routes/workboards.js
+++ b/src/routes/workboards.js
@@ -5,6 +5,7 @@ const Workboard = require('../models/Workboard');
 const Server = require('../models/Server');
 const ServerLoraCache = require('../models/ServerLoraCache');
 const loraMetadataService = require('../services/loraMetadataService');
+const { escapeRegex } = require('../utils/escapeRegex');
 const router = express.Router();
 
 const EXPORT_VERSION = 1;
@@ -35,8 +36,8 @@ router.get('/', requireAuth, async (req, res) => {
     }
     if (search) {
       filter.$or = [
-        { name: { $regex: search, $options: 'i' } },
-        { description: { $regex: search, $options: 'i' } }
+        { name: { $regex: escapeRegex(search), $options: 'i' } },
+        { description: { $regex: escapeRegex(search), $options: 'i' } }
       ];
     }
     

--- a/src/tests/escapeRegex.test.js
+++ b/src/tests/escapeRegex.test.js
@@ -1,0 +1,44 @@
+const { escapeRegex } = require('../utils/escapeRegex');
+
+describe('escapeRegex - ReDoS 방지 (F-08)', () => {
+  test('정규식 특수문자가 이스케이프됨', () => {
+    const input = '(a+)+$';
+    const escaped = escapeRegex(input);
+    expect(escaped).toBe('\\(a\\+\\)\\+\\$');
+  });
+
+  test('모든 특수문자 이스케이프', () => {
+    const specials = '.*+?^${}()|[]\\';
+    const escaped = escapeRegex(specials);
+    expect(escaped).toBe('\\.\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\');
+  });
+
+  test('일반 문자열은 변경 없음', () => {
+    expect(escapeRegex('hello world')).toBe('hello world');
+    expect(escapeRegex('test123')).toBe('test123');
+    expect(escapeRegex('한글검색')).toBe('한글검색');
+  });
+
+  test('빈 문자열 처리', () => {
+    expect(escapeRegex('')).toBe('');
+  });
+
+  test('이스케이프된 문자열로 RegExp 생성 시 정상 동작', () => {
+    const userInput = 'file.name (copy)';
+    const escaped = escapeRegex(userInput);
+    const regex = new RegExp(escaped, 'i');
+
+    expect(regex.test('file.name (copy)')).toBe(true);
+    expect(regex.test('filexname xcopy)')).toBe(false);
+  });
+
+  test('ReDoS 패턴이 literal로 변환됨', () => {
+    const malicious = '(a+)+$';
+    const escaped = escapeRegex(malicious);
+    const regex = new RegExp(escaped, 'i');
+
+    // literal 매칭만 수행하므로 원본 패턴 문자열에만 일치
+    expect(regex.test('(a+)+$')).toBe(true);
+    expect(regex.test('aaaaaaaaaaaaaaa')).toBe(false);
+  });
+});

--- a/src/utils/escapeRegex.js
+++ b/src/utils/escapeRegex.js
@@ -1,0 +1,12 @@
+/**
+ * Escape special regex characters in user input for safe use in MongoDB $regex queries.
+ * Prevents ReDoS by converting user input to a literal string pattern.
+ *
+ * @param {string} str - User input string
+ * @returns {string} Escaped string safe for RegExp construction
+ */
+function escapeRegex(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+module.exports = { escapeRegex };


### PR DESCRIPTION
## Summary
- SECURITY-AUDIT F-08 (사용자 입력 기반 정규식으로 ReDoS 가능성) 해결
- `escapeRegex()` 유틸 함수로 사용자 검색 입력을 literal 문자열로 변환

## Changes
- `src/utils/escapeRegex.js` 신규 생성 — 정규식 특수문자 이스케이프 유틸
- 7개 라우트 + 1개 모델, 총 24곳의 `$regex`/`new RegExp()` 호출에 `escapeRegex()` 적용
  - `images.js` (12곳), `promptData.js` (3곳), `jobs.js` (1곳)
  - `admin.js` (2곳), `projects.js` (2곳), `tags.js` (1곳), `workboards.js` (2곳)
  - `models/PromptData.js` (3곳 - findByUser static method)
- `src/tests/escapeRegex.test.js` 테스트 6건 추가
- `SECURITY-AUDIT.md` F-08 항목 ✅ Fixed 상태 업데이트

## Test plan
- [x] escapeRegex 단위 테스트 6/6 통과
- [ ] 검색 기능 정상 동작 확인 (일반 문자열 검색)
- [ ] 특수문자 포함 검색어 (`file.name`, `test (copy)`) 정상 동작 확인

closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)