### PR TITLE
fix: validate required additionalFields before generate (#136)

### DIFF
--- a/mcp-server/src/tools/jobs.js
+++ b/mcp-server/src/tools/jobs.js
@@ -90,6 +90,24 @@ export function registerJobTools(server, apiRequest) {
           additionalParams = mapped;
         }
 
+        // Validate required additionalFields (#136)
+        if (wb.additionalInputFields) {
+          const missing = wb.additionalInputFields
+            .filter((field) => field.required && (additionalParams[field.name] === undefined || additionalParams[field.name] === ''))
+            .map((field) => `${field.name} ("${field.label}")`);
+          if (missing.length > 0) {
+            return {
+              content: [{
+                type: 'text',
+                text: JSON.stringify({
+                  error: `Missing required additional parameters: ${missing.join(', ')}. Use additionalParams to provide them. Check get_workboard for available options.`,
+                }, null, 2),
+              }],
+              isError: true,
+            };
+          }
+        }
+
         const payload = {
           workboardId: params.workboardId,
           prompt: params.prompt,
@@ -248,6 +266,24 @@ export function registerJobTools(server, apiRequest) {
             } else {
               additionalParams[field.name] = inputVal;
             }
+          }
+        }
+
+        // Validate required additionalFields (#136)
+        if (wb.additionalInputFields) {
+          const missing = wb.additionalInputFields
+            .filter((field) => field.required && (additionalParams[field.name] === undefined || additionalParams[field.name] === ''))
+            .map((field) => `${field.name} ("${field.label}")`);
+          if (missing.length > 0) {
+            return {
+              content: [{
+                type: 'text',
+                text: JSON.stringify({
+                  error: `Missing required additional parameters: ${missing.join(', ')}. Use additionalParams to provide them. Check get_workboard for available options.`,
+                }, null, 2),
+              }],
+              isError: true,
+            };
           }
         }
 


### PR DESCRIPTION
## 변경사항

`generate` 및 `continue_job` 호출 시 workboard의 `additionalInputFields` 중 `required: true`인 필드가 `additionalParams`에 누락되면, ComfyUI에 전달하지 않고 MCP 에러를 반환하도록 사전 검증 추가.

### 문제
- required 필드 누락 시 워크플로우 JSON에 빈 값이 들어가 `Unexpected token , in JSON` 파싱 에러 발생
- 에러 메시지가 `PROCESSING_ERROR`로만 표시되어 원인 파악 어려움

### 해결
- `generate`: payload 생성 전 required additionalFields 검증
- `continue_job`: payload 생성 전 동일 검증
- 누락 시 구체적인 필드명과 라벨을 포함한 에러 메시지 반환

Closes #136