### PR TITLE
fix: MCP 도구 숫자 파라미터 z.coerce.number() 적용

### DIFF
--- a/mcp-server/src/tools/jobs.js
+++ b/mcp-server/src/tools/jobs.js
@@ -20,7 +20,7 @@ export function registerJobTools(server, apiRequest) {
       imageSize: z.string().optional().describe('Image size name (from get_workboard imageSizes options)'),
       stylePreset: z.string().optional().describe('Style preset name'),
       upscaleMethod: z.string().optional().describe('Upscale method name'),
-      seed: z.number().int().optional().describe('Specific seed number'),
+      seed: z.coerce.number().int().optional().describe('Specific seed number'),
       randomSeed: z.boolean().optional().default(true).describe('Use random seed (default true)'),
       additionalParams: z.record(z.union([z.string(), z.number(), z.boolean()])).optional()
         .describe('Additional parameters as key-value pairs (field name → value)'),
@@ -154,7 +154,7 @@ export function registerJobTools(server, apiRequest) {
       negativePrompt: z.string().optional().describe('Override negative prompt'),
       aiModel: z.string().optional().describe('Override AI model name'),
       imageSize: z.string().optional().describe('Override image size name'),
-      seed: z.number().int().optional().describe('Override seed value'),
+      seed: z.coerce.number().int().optional().describe('Override seed value'),
       randomSeed: z.boolean().optional().describe('Use random seed (default true)'),
       additionalParams: z.record(z.union([z.string(), z.number(), z.boolean()])).optional()
         .describe('Override additional parameters (only specified keys are overridden, rest are matched from original)'),
@@ -405,8 +405,8 @@ export function registerJobTools(server, apiRequest) {
       status: z.enum(['pending', 'processing', 'completed', 'failed', 'cancelled']).optional()
         .describe('Filter by job status'),
       search: z.string().optional().describe('Search in prompts'),
-      page: z.number().int().positive().optional().describe('Page number (default 1)'),
-      limit: z.number().int().positive().max(50).optional().describe('Items per page (default 10)'),
+      page: z.coerce.number().int().positive().optional().describe('Page number (default 1)'),
+      limit: z.coerce.number().int().positive().max(50).optional().describe('Items per page (default 10)'),
     },
     async ({ status, search, page, limit }) => {
       const data = await apiRequest('/jobs/my', {

--- a/mcp-server/src/tools/workboards.js
+++ b/mcp-server/src/tools/workboards.js
@@ -16,8 +16,8 @@ export function registerWorkboardTools(server, apiRequest) {
       search: z.string().optional().describe('Search by name or description'),
       apiFormat: z.enum(['ComfyUI', 'OpenAI Compatible']).optional().describe('Filter by API format'),
       outputFormat: z.enum(['image', 'video', 'text']).optional().describe('Filter by output format'),
-      page: z.number().int().positive().optional().describe('Page number (default 1)'),
-      limit: z.number().int().positive().max(50).optional().describe('Items per page (default 10)'),
+      page: z.coerce.number().int().positive().optional().describe('Page number (default 1)'),
+      limit: z.coerce.number().int().positive().max(50).optional().describe('Items per page (default 10)'),
     },
     async ({ search, apiFormat, outputFormat, page, limit }) => {
       const data = await apiRequest('/workboards', {


### PR DESCRIPTION
## Summary
- MCP 클라이언트가 `page`, `limit`, `seed` 등 숫자 파라미터를 문자열(`"3"`)로 전송하면 Zod `z.number()` 검증 실패로 파라미터가 무시되던 문제 수정
- `z.number()`를 `z.coerce.number()`로 변경하여 문자열을 자동으로 숫자로 변환
- 영향 범위: `list_workboards`, `list_jobs`, `generate`, `continue_job`

## Test plan
- [x] MCP HTTP 프로토콜을 통해 `limit: "3"` (문자열)으로 `list_workboards` 호출 → 3개 반환 확인
- [x] `page: "2"`, `limit: "3"` (문자열)으로 호출 → 2페이지 결과 확인
- [x] 기존 숫자 입력(`limit: 3`)도 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)