### PR TITLE
feat: 워크플로우 변수 복사 버튼 + 작업판 ID 표시 (#149, #151)

### DIFF
--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -45,6 +45,7 @@ import {
   DragIndicator,
   FileDownload,
   FileUpload,
+  Check,
   CheckCircle,
   Warning
 } from '@mui/icons-material';
@@ -66,6 +67,15 @@ function WorkboardCard({ workboard, onEdit, onDelete, onDuplicate, onExport, onV
 
   const handleMenuClose = () => {
     setAnchorEl(null);
+  };
+
+  const handleCopyWorkboardId = async () => {
+    try {
+      await navigator.clipboard.writeText(workboard._id);
+      toast.success('작업판 ID를 복사했습니다.');
+    } catch (error) {
+      toast.error('작업판 ID 복사에 실패했습니다.');
+    }
   };
 
   return (
@@ -120,6 +130,15 @@ function WorkboardCard({ workboard, onEdit, onDelete, onDuplicate, onExport, onV
           <Typography variant="caption" color="textSecondary">
             사용횟수: {workboard.usageCount || 0}회
           </Typography>
+        </Box>
+
+        <Box display="flex" alignItems="center" gap={0.5} mb={2}>
+          <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+            ID: {workboard._id}
+          </Typography>
+          <IconButton size="small" onClick={handleCopyWorkboardId} aria-label="작업판 ID 복사">
+            <ContentCopy fontSize="inherit" />
+          </IconButton>
         </Box>
 
         <Box display="flex" flexWrap="wrap" gap={1} mb={2}>
@@ -215,6 +234,8 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
   const [tabValue, setTabValue] = useState(0);
   const [fullWorkboard, setFullWorkboard] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [copiedVariable, setCopiedVariable] = useState('');
+  const copyResetTimerRef = React.useRef(null);
   const { control, handleSubmit, reset, watch, setValue, formState: { errors } } = useForm({
     defaultValues: {
       name: '',
@@ -240,6 +261,48 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
 
   const apiFormat = watch('apiFormat');
   const isComfyUI = apiFormat === 'ComfyUI';
+
+  React.useEffect(() => {
+    return () => {
+      if (copyResetTimerRef.current) {
+        clearTimeout(copyResetTimerRef.current);
+      }
+    };
+  }, []);
+
+  const handleCopyVariable = async (variable) => {
+    try {
+      await navigator.clipboard.writeText(variable);
+      setCopiedVariable(variable);
+
+      if (copyResetTimerRef.current) {
+        clearTimeout(copyResetTimerRef.current);
+      }
+      copyResetTimerRef.current = setTimeout(() => {
+        setCopiedVariable('');
+      }, 1500);
+    } catch (error) {
+      toast.error('변수 복사에 실패했습니다.');
+    }
+  };
+
+  const renderVariableRow = (variable, description, rowKey = variable) => (
+    <tr key={rowKey}>
+      <td>
+        <Box display="flex" alignItems="center" gap={1}>
+          <code>{variable}</code>
+          <IconButton
+            size="small"
+            onClick={() => handleCopyVariable(variable)}
+            aria-label={`${variable} 복사`}
+          >
+            {copiedVariable === variable ? <Check fontSize="small" color="success" /> : <ContentCopy fontSize="small" />}
+          </IconButton>
+        </Box>
+      </td>
+      <td>{description}</td>
+    </tr>
+  );
 
   // 관리자 전용 API로 완전한 데이터 로딩
   React.useEffect(() => {
@@ -430,6 +493,19 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
             </Box>
           ) : (
             <>
+          <Box display="flex" alignItems="center" gap={0.5} mb={2}>
+            <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+              작업판 ID: {workboard?._id}
+            </Typography>
+            <IconButton
+              size="small"
+              onClick={() => handleCopyVariable(workboard?._id)}
+              aria-label="작업판 ID 복사"
+              disabled={!workboard?._id}
+            >
+              {copiedVariable === workboard?._id ? <Check fontSize="small" color="success" /> : <ContentCopy fontSize="small" />}
+            </IconButton>
+          </Box>
           <Tabs value={tabValue} onChange={(e, newValue) => setTabValue(newValue)} sx={{ mb: 3 }}>
             <Tab label="기본 정보" />
             <Tab label="기초 입력값" />
@@ -1333,33 +1409,33 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
                   <Typography variant="subtitle2" fontWeight="bold" gutterBottom>기본 변수</Typography>
                   <Box component="table" sx={{ width: '100%', mb: 2, '& td, & th': { p: 1, borderBottom: '1px solid #eee' } }}>
                     <tbody>
-                      <tr><td><code>{'{{##prompt##}}'}</code></td><td>프롬프트 (문자열)</td></tr>
-                      <tr><td><code>{'{{##negative_prompt##}}'}</code></td><td>네거티브 프롬프트 (문자열)</td></tr>
-                      <tr><td><code>{'{{##model##}}'}</code></td><td>AI 모델 (문자열)</td></tr>
-                      <tr><td><code>{'{{##width##}}'}</code></td><td>이미지 너비 (숫자)</td></tr>
-                      <tr><td><code>{'{{##height##}}'}</code></td><td>이미지 높이 (숫자)</td></tr>
-                      <tr><td><code>{'{{##seed##}}'}</code></td><td>시드값 (숫자, 64비트)</td></tr>
+                      {renderVariableRow('{{##prompt##}}', '프롬프트 (문자열)')}
+                      {renderVariableRow('{{##negative_prompt##}}', '네거티브 프롬프트 (문자열)')}
+                      {renderVariableRow('{{##model##}}', 'AI 모델 (문자열)')}
+                      {renderVariableRow('{{##width##}}', '이미지 너비 (숫자)')}
+                      {renderVariableRow('{{##height##}}', '이미지 높이 (숫자)')}
+                      {renderVariableRow('{{##seed##}}', '시드값 (숫자, 64비트)')}
                     </tbody>
                   </Box>
 
                   <Typography variant="subtitle2" fontWeight="bold" gutterBottom>샘플링 파라미터</Typography>
                   <Box component="table" sx={{ width: '100%', mb: 2, '& td, & th': { p: 1, borderBottom: '1px solid #eee' } }}>
                     <tbody>
-                      <tr><td><code>{'{{##steps##}}'}</code></td><td>스텝 수 (숫자, 기본값: 20)</td></tr>
-                      <tr><td><code>{'{{##cfg##}}'}</code></td><td>CFG 스케일 (숫자, 기본값: 7)</td></tr>
-                      <tr><td><code>{'{{##sampler##}}'}</code></td><td>샘플러 (문자열, 기본값: euler)</td></tr>
-                      <tr><td><code>{'{{##scheduler##}}'}</code></td><td>스케줄러 (문자열, 기본값: normal)</td></tr>
+                      {renderVariableRow('{{##steps##}}', '스텝 수 (숫자, 기본값: 20)')}
+                      {renderVariableRow('{{##cfg##}}', 'CFG 스케일 (숫자, 기본값: 7)')}
+                      {renderVariableRow('{{##sampler##}}', '샘플러 (문자열, 기본값: euler)')}
+                      {renderVariableRow('{{##scheduler##}}', '스케줄러 (문자열, 기본값: normal)')}
                     </tbody>
                   </Box>
 
                   <Typography variant="subtitle2" fontWeight="bold" gutterBottom>추가 기능</Typography>
                   <Box component="table" sx={{ width: '100%', mb: 2, '& td, & th': { p: 1, borderBottom: '1px solid #eee' } }}>
                     <tbody>
-                      <tr><td><code>{'{{##reference_method##}}'}</code></td><td>참조 이미지 방식 (문자열)</td></tr>
-                      <tr><td><code>{'{{##upscale_method##}}'}</code></td><td>업스케일 방식 (문자열)</td></tr>
-                      <tr><td><code>{'{{##upscale##}}'}</code></td><td>업스케일 방식 별칭 (문자열)</td></tr>
-                      <tr><td><code>{'{{##base_style##}}'}</code></td><td>기본 스타일 (문자열)</td></tr>
-                      <tr><td><code>{'{{##user_id##}}'}</code></td><td>사용자 ID 해시 (문자열, 8자리)</td></tr>
+                      {renderVariableRow('{{##reference_method##}}', '참조 이미지 방식 (문자열)')}
+                      {renderVariableRow('{{##upscale_method##}}', '업스케일 방식 (문자열)')}
+                      {renderVariableRow('{{##upscale##}}', '업스케일 방식 별칭 (문자열)')}
+                      {renderVariableRow('{{##base_style##}}', '기본 스타일 (문자열)')}
+                      {renderVariableRow('{{##user_id##}}', '사용자 ID 해시 (문자열, 8자리)')}
                     </tbody>
                   </Box>
 
@@ -1369,10 +1445,11 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
                       <tbody>
                         {watch('additionalCustomFields').map((field, idx) => (
                           field.name && (
-                            <tr key={idx}>
-                              <td><code>{field.formatString || `{{##${field.name}##}}`}</code></td>
-                              <td>{field.label || field.name} ({field.type === 'number' ? '숫자' : field.type === 'select' ? '선택' : field.type === 'image' ? '이미지' : '문자열'})</td>
-                            </tr>
+                            renderVariableRow(
+                              field.formatString || `{{##${field.name}##}}`,
+                              `${field.label || field.name} (${field.type === 'number' ? '숫자' : field.type === 'select' ? '선택' : field.type === 'image' ? '이미지' : '문자열'})`,
+                              `custom-${idx}`
+                            )
                           )
                         ))}
                       </tbody>

--- a/frontend/src/pages/ImageGeneration.js
+++ b/frontend/src/pages/ImageGeneration.js
@@ -37,7 +37,8 @@ import {
   FolderOpen,
   AutoAwesome,
   AutoFixHigh,
-  Storage as StorageIcon
+  Storage as StorageIcon,
+  ContentCopy
 } from '@mui/icons-material';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
@@ -395,6 +396,17 @@ function ImageGeneration() {
     { enabled: !!projectId }
   );
   const projectContext = projectData?.data?.data?.project;
+
+  const handleCopyWorkboardId = async () => {
+    if (!workboardData?._id) return;
+
+    try {
+      await navigator.clipboard.writeText(workboardData._id);
+      toast.success('작업판 ID를 복사했습니다.');
+    } catch (error) {
+      toast.error('작업판 ID 복사에 실패했습니다.');
+    }
+  };
 
   const handleLoraModalOpen = () => {
     setLoraModalOpen(true);
@@ -984,6 +996,14 @@ function ImageGeneration() {
             {workboardData.description}
           </Typography>
         )}
+        <Box display="flex" alignItems="center" gap={0.5} mb={1}>
+          <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+            작업판 ID: {workboardData?._id}
+          </Typography>
+          <IconButton size="small" onClick={handleCopyWorkboardId} aria-label="작업판 ID 복사">
+            <ContentCopy fontSize="inherit" />
+          </IconButton>
+        </Box>
       </Box>
 
       <form key={workboardData?._id} onSubmit={handleSubmit(onSubmit)}>

--- a/frontend/src/pages/PromptGeneration.js
+++ b/frontend/src/pages/PromptGeneration.js
@@ -6,16 +6,19 @@ import {
   Box,
   Alert,
   CircularProgress,
-  Chip
+  Chip,
+  IconButton
 } from '@mui/material';
 import {
   ArrowBack,
-  Chat
+  Chat,
+  ContentCopy
 } from '@mui/icons-material';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery } from 'react-query';
 import { workboardAPI } from '../services/api';
 import PromptGeneratorPanel from '../components/PromptGeneratorPanel';
+import toast from 'react-hot-toast';
 
 function PromptGeneration() {
   const { workboardId } = useParams();
@@ -28,6 +31,17 @@ function PromptGeneration() {
   );
 
   const workboard = workboardData?.data?.workboard;
+
+  const handleCopyWorkboardId = async () => {
+    if (!workboard?._id) return;
+
+    try {
+      await navigator.clipboard.writeText(workboard._id);
+      toast.success('작업판 ID를 복사했습니다.');
+    } catch (error) {
+      toast.error('작업판 ID 복사에 실패했습니다.');
+    }
+  };
 
   if (workboardLoading) {
     return (
@@ -70,6 +84,15 @@ function PromptGeneration() {
           <Typography variant="h5">{workboard.name}</Typography>
         </Box>
         <Chip label="프롬프트 생성" color="secondary" size="small" />
+      </Box>
+
+      <Box display="flex" alignItems="center" gap={0.5} mb={2}>
+        <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+          작업판 ID: {workboard._id}
+        </Typography>
+        <IconButton size="small" onClick={handleCopyWorkboardId} aria-label="작업판 ID 복사">
+          <ContentCopy fontSize="inherit" />
+        </IconButton>
       </Box>
 
       {workboard.description && (

--- a/frontend/src/pages/PromptWorkboards.js
+++ b/frontend/src/pages/PromptWorkboards.js
@@ -17,7 +17,8 @@ import {
   DialogTitle,
   DialogContent,
   DialogContentText,
-  DialogActions
+  DialogActions,
+  IconButton
 } from '@mui/material';
 import {
   Search,
@@ -25,11 +26,13 @@ import {
   Info,
   TrendingUp,
   Computer,
-  Chat
+  Chat,
+  ContentCopy
 } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
 import { useQuery } from 'react-query';
 import { workboardAPI } from '../services/api';
+import toast from 'react-hot-toast';
 
 function PromptWorkboardCard({ workboard }) {
   const navigate = useNavigate();
@@ -45,6 +48,15 @@ function PromptWorkboardCard({ workboard }) {
 
   const handleInfoClose = () => {
     setInfoOpen(false);
+  };
+
+  const handleCopyWorkboardId = async () => {
+    try {
+      await navigator.clipboard.writeText(workboard._id);
+      toast.success('작업판 ID를 복사했습니다.');
+    } catch (error) {
+      toast.error('작업판 ID 복사에 실패했습니다.');
+    }
   };
 
   return (
@@ -76,6 +88,15 @@ function PromptWorkboardCard({ workboard }) {
             <Typography variant="caption" color="textSecondary">
               사용횟수: {workboard.usageCount || 0}회
             </Typography>
+          </Box>
+
+          <Box display="flex" alignItems="center" gap={0.5} mb={2}>
+            <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+              ID: {workboard._id}
+            </Typography>
+            <IconButton size="small" onClick={handleCopyWorkboardId} aria-label="작업판 ID 복사">
+              <ContentCopy fontSize="inherit" />
+            </IconButton>
           </Box>
 
           <Box display="flex" flexWrap="wrap" gap={1}>
@@ -131,6 +152,15 @@ function PromptWorkboardCard({ workboard }) {
           <DialogContentText paragraph>
             {workboard.description || '설명이 없습니다.'}
           </DialogContentText>
+
+          <Box display="flex" alignItems="center" gap={0.5} mb={2}>
+            <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+              작업판 ID: {workboard._id}
+            </Typography>
+            <IconButton size="small" onClick={handleCopyWorkboardId} aria-label="작업판 ID 복사">
+              <ContentCopy fontSize="inherit" />
+            </IconButton>
+          </Box>
 
           <Typography variant="h6" gutterBottom sx={{ mt: 2 }}>
             지원 AI 모델

--- a/frontend/src/pages/Workboards.js
+++ b/frontend/src/pages/Workboards.js
@@ -21,14 +21,16 @@ import {
   FormControl,
   InputLabel,
   Select,
-  MenuItem
+  MenuItem,
+  IconButton
 } from '@mui/material';
 import {
   Search,
   PlayArrow,
   Info,
   TrendingUp,
-  Computer
+  Computer,
+  ContentCopy
 } from '@mui/icons-material';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useQuery } from 'react-query';
@@ -78,6 +80,15 @@ function WorkboardCard({ workboard, projectId }) {
     setInfoOpen(false);
   };
 
+  const handleCopyWorkboardId = async () => {
+    try {
+      await navigator.clipboard.writeText(workboard._id);
+      toast.success('작업판 ID를 복사했습니다.');
+    } catch (error) {
+      toast.error('작업판 ID 복사에 실패했습니다.');
+    }
+  };
+
   const getOutputFormatLabel = (format) => {
     switch (format) {
       case 'image': return '이미지';
@@ -121,6 +132,15 @@ function WorkboardCard({ workboard, projectId }) {
             <Typography variant="caption" color="textSecondary">
               사용횟수: {workboard.usageCount || 0}회
             </Typography>
+          </Box>
+
+          <Box display="flex" alignItems="center" gap={0.5} mb={2}>
+            <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+              ID: {workboard._id}
+            </Typography>
+            <IconButton size="small" onClick={handleCopyWorkboardId} aria-label="작업판 ID 복사">
+              <ContentCopy fontSize="inherit" />
+            </IconButton>
           </Box>
 
           <Box display="flex" flexWrap="wrap" gap={0.5} mb={2}>
@@ -184,6 +204,15 @@ function WorkboardCard({ workboard, projectId }) {
           <DialogContentText paragraph>
             {workboard.description || '설명이 없습니다.'}
           </DialogContentText>
+
+          <Box display="flex" alignItems="center" gap={0.5} mb={2}>
+            <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+              작업판 ID: {workboard._id}
+            </Typography>
+            <IconButton size="small" onClick={handleCopyWorkboardId} aria-label="작업판 ID 복사">
+              <ContentCopy fontSize="inherit" />
+            </IconButton>
+          </Box>
 
           <Box display="flex" flexWrap="wrap" gap={1} mb={2}>
             <Chip


### PR DESCRIPTION
## 변경사항

### #149: 워크플로우 변수 복사 버튼
- 워크플로우 설정 다이얼로그에서 변수 옆 복사 버튼(📋) 추가
- 클릭 시 클립보드 복사 + 체크 아이콘 피드백 (1.5초)

### #151: 작업판 ID 표시
- 작업판 카드에 ID + 복사 버튼 표시
- 작업판 상세 다이얼로그에도 ID 노출
- 모든 작업판 페이지 적용 (이미지/프롬프트/프롬프트워크보드/작업판)

closes #149
closes #151