### PR TITLE
fix: MCP 컨테이너 파일 퍼미션 정규화 (#161)

### DIFF
--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -2,16 +2,17 @@ FROM node:18-alpine
 
 WORKDIR /app
 
+# Non-root user for security
+RUN addgroup -g 1001 -S nodejs && adduser -S nodeuser -u 1001 -G nodejs
+
 # Install dependencies first for layer caching
-COPY mcp-server/package*.json ./
+COPY --chown=nodeuser:nodejs mcp-server/package*.json ./
 RUN npm install --omit=dev
 
 # Copy application source
-COPY mcp-server/src/ ./src/
-COPY mcp-server/index.js ./
-
-# Non-root user for security
-RUN addgroup -g 1001 -S nodejs && adduser -S nodeuser -u 1001
+COPY --chown=nodeuser:nodejs mcp-server/src/ ./src/
+COPY --chown=nodeuser:nodejs mcp-server/index.js ./
+RUN chmod -R u=rwX,go=rX /app
 USER nodeuser
 
 EXPOSE 3100


### PR DESCRIPTION
## 변경 사항
- `Dockerfile.mcp`에서 `nodeuser`/`nodejs` 그룹 생성을 `COPY` 앞으로 이동
- `COPY --chown=nodeuser:nodejs` 적용으로 파일 소유권 보장
- `chmod -R u=rwX,go=rX /app` 추가로 호스트 퍼미션에 의존하지 않도록 정규화
- 호스트 소스 파일(`workboards.js`, `jobs.js`) 퍼미션 644로 복원

## 원인
호스트 워킹트리에서 에디터/도구가 `workboards.js`, `jobs.js`를 `0600`으로 작성 → Git은 644/600 차이를 추적하지 않아 감지 불가 → non-root `nodeuser`가 읽지 못해 19만번 크래시 루프

Closes #161