### PR TITLE
fix: preserve UserSelected model name on job continue/re-run

### DIFF
--- a/frontend/src/components/common/JobHistoryPanel.js
+++ b/frontend/src/components/common/JobHistoryPanel.js
@@ -528,9 +528,11 @@ function JobCard({ job, onView, onRetry, onCancel, onDelete, onImageView, onCont
             </Box>
             <Box>
               <Typography variant="caption" color="textSecondary" display="block">AI 모델</Typography>
-              <Typography variant="body2" sx={{ fontSize: '0.75rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              <Typography variant="body2" title={typeof job.inputData?.aiModel === 'object' ? job.inputData.aiModel.value : ''} sx={{ fontSize: '0.75rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                 {typeof job.inputData?.aiModel === 'object' && job.inputData.aiModel?.key
-                  ? job.inputData.aiModel.key
+                  ? (job.inputData.aiModel.key === 'UserSelected'
+                    ? job.inputData.aiModel.value?.split(/[/\\]/).pop() || 'UserSelected'
+                    : job.inputData.aiModel.key)
                   : job.inputData?.aiModel || '-'}
               </Typography>
             </Box>
@@ -701,9 +703,11 @@ function JobDetailDialog({ job, open, onClose, onImageView }) {
           </Grid>
           <Grid item xs={6}>
             <Typography variant="body2" color="textSecondary">AI 모델</Typography>
-            <Typography variant="body1">
+            <Typography variant="body1" title={typeof job.inputData?.aiModel === 'object' ? job.inputData.aiModel.value : ''}>
               {typeof job.inputData?.aiModel === 'object' && job.inputData.aiModel?.key
-                ? job.inputData.aiModel.key
+                ? (job.inputData.aiModel.key === 'UserSelected'
+                  ? job.inputData.aiModel.value?.split(/[/\\]/).pop() || 'UserSelected'
+                  : job.inputData.aiModel.key)
                 : job.inputData?.aiModel || '-'}
             </Typography>
           </Grid>

--- a/frontend/src/pages/ImageGeneration.js
+++ b/frontend/src/pages/ImageGeneration.js
@@ -571,44 +571,48 @@ function ImageGeneration() {
           if (!inputValue) return;
 
           if (key === 'aiModel' && workboardData.baseInputFields?.aiModel) {
-            // AI 모델 매칭: 우선 값으로, 없으면 키로 매칭
-            let matchedValue = null;
-
-            if (typeof inputValue === 'object' && inputValue.value) {
-              // 키-값 객체인 경우, 먼저 값으로 매칭
-              matchedValue = workboardData.baseInputFields.aiModel.find(
-                model => model.value === inputValue.value
-              )?.value;
-
-              // 값 매칭 실패 시 키로 매칭
-              if (!matchedValue) {
-                matchedValue = workboardData.baseInputFields.aiModel.find(
-                  model => model.key === inputValue.key
-                )?.value;
-              }
-            } else if (typeof inputValue === 'string') {
-              // 문자열인 경우, 먼저 값으로 매칭
-              matchedValue = workboardData.baseInputFields.aiModel.find(
-                model => model.value === inputValue
-              )?.value;
-
-              // 값 매칭 실패 시 키로 매칭
-              if (!matchedValue) {
-                matchedValue = workboardData.baseInputFields.aiModel.find(
-                  model => model.key === inputValue
-                )?.value;
-              }
-            }
-
-            if (matchedValue) {
-              safeSetValue(key, matchedValue);
-
-              if (typeof inputValue === 'object' && inputValue.key === 'UserSelected' && inputValue.value) {
-                setSelectedCheckpointModel(inputValue.value);
-              }
-            } else {
-              console.warn(`AI model ${JSON.stringify(inputValue)} not found in workboard, using default`);
+            // UserSelected 모델 (모델 브라우저에서 선택한 체크포인트) 복원
+            if (typeof inputValue === 'object' && inputValue.key === 'UserSelected' && inputValue.value) {
+              setSelectedCheckpointModel(inputValue.value);
+              // 드롭다운은 첫 번째 기본값으로 설정 (표시는 selectedCheckpointModel이 담당)
               safeSetValue(key, workboardData.baseInputFields.aiModel[0]?.value);
+              console.log('🤖 AI Model restored (UserSelected):', inputValue.value);
+            } else {
+              // AI 모델 매칭: 우선 값으로, 없으면 키로 매칭
+              let matchedValue = null;
+
+              if (typeof inputValue === 'object' && inputValue.value) {
+                // 키-값 객체인 경우, 먼저 값으로 매칭
+                matchedValue = workboardData.baseInputFields.aiModel.find(
+                  model => model.value === inputValue.value
+                )?.value;
+
+                // 값 매칭 실패 시 키로 매칭
+                if (!matchedValue) {
+                  matchedValue = workboardData.baseInputFields.aiModel.find(
+                    model => model.key === inputValue.key
+                  )?.value;
+                }
+              } else if (typeof inputValue === 'string') {
+                // 문자열인 경우, 먼저 값으로 매칭
+                matchedValue = workboardData.baseInputFields.aiModel.find(
+                  model => model.value === inputValue
+                )?.value;
+
+                // 값 매칭 실패 시 키로 매칭
+                if (!matchedValue) {
+                  matchedValue = workboardData.baseInputFields.aiModel.find(
+                    model => model.key === inputValue
+                  )?.value;
+                }
+              }
+
+              if (matchedValue) {
+                safeSetValue(key, matchedValue);
+              } else {
+                console.warn(`AI model ${JSON.stringify(inputValue)} not found in workboard, using default`);
+                safeSetValue(key, workboardData.baseInputFields.aiModel[0]?.value);
+              }
             }
 
           } else if (key === 'imageSize' && workboardData.baseInputFields?.imageSizes) {


### PR DESCRIPTION
## Summary
- 히스토리에서 계속하기/재실행 시 모델 브라우저에서 선택한 체크포인트 모델(UserSelected)이 기본 모델로 리셋되던 버그 수정
- ImageGeneration.js: UserSelected 모델을 predefined 매칭 전에 먼저 감지하여 `setSelectedCheckpointModel`로 직접 복원
- JobHistoryPanel.js: UserSelected 모델명을 파일명으로 표시 (전체 경로는 tooltip)

## Test plan
- [ ] 모델 브라우저에서 커스텀 모델 선택 후 이미지 생성
- [ ] 히스토리에서 해당 작업 "계속하기" 시 선택한 모델이 유지되는지 확인
- [ ] 히스토리에서 "재실행" 시 선택한 모델이 유지되는지 확인
- [ ] predefined 모델 선택 시 기존 동작 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)