### PR TITLE
fix: Gemini 응답 파싱 camelCase 키로 수정 (#166)

### DIFF
--- a/src/services/geminiService.js
+++ b/src/services/geminiService.js
@@ -81,10 +81,10 @@ const generateImage = async (serverUrl, apiKey, prompt, options = {}) => {
 
   const partsList = response.data?.candidates?.[0]?.content?.parts || [];
   const images = partsList
-    .filter((part) => part.inline_data?.data)
+    .filter((part) => part.inlineData?.data)
     .map((part, index) => {
-      const mimeType = part.inline_data.mime_type || 'image/png';
-      const buffer = Buffer.from(part.inline_data.data, 'base64');
+      const mimeType = part.inlineData.mimeType || 'image/png';
+      const buffer = Buffer.from(part.inlineData.data, 'base64');
       const extension = getExtensionFromMimeType(mimeType);
       const filename = `gemini_${Date.now()}_${index}.${extension}`;
 


### PR DESCRIPTION
## Summary
- Gemini REST API 응답의 `parts[].inlineData` / `mimeType` 키가 camelCase 인데 `geminiService.js` 는 snake_case (`inline_data`, `mime_type`) 로 접근 → 항상 빈 배열이 반환되어 "No image returned from Gemini" 발생
- 응답 파싱을 camelCase 로 교체

## Context
- Gemini API 직접 curl 호출로 실제 응답 스키마 확인 (#166 이슈 본문에 로그 포함)
- 요청 바디의 snake_case 는 Gemini가 양쪽 포맷을 허용하므로 그대로 유지 (응답 측만 수정해도 충분)
- 도입 시점(#155)부터 존재한 버그로 추정 — Gemini 작업판이 그동안 한 번도 정상 동작하지 않았음

## Dependency
- #165 (Job validation fix) 가 먼저 병합되어야 Gemini 생성 경로 끝까지 도달 가능. 본 PR만 단독 머지해도 충돌은 없음.

## Test plan
- [x] 로컬에서 #165 + 본 수정 반영 후 `gemini-3.1-flash-image-preview` 모델로 이미지 생성 정상 동작 확인
- [ ] 다른 Gemini 이미지 모델(`gemini-2.5-flash-image`, `gemini-3-pro-image-preview`)에서도 동일 응답 구조인지 리뷰 시 교차 확인

closes #166