### PR TITLE
feat: Gemini 이미지 생성 종횡비/해상도 구조화 전송 (#169)

### DIFF
--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -2136,9 +2136,12 @@ function WorkboardManagement() {
             { key: 'Nano Banana 2', value: 'gemini-3.1-flash-image-preview' }
           ],
           imageSizes: [
-            { key: '1024x1024', value: '1024x1024' },
-            { key: '1024x1536', value: '1024x1536' },
-            { key: '1536x1024', value: '1536x1024' }
+            { key: '정사각 (1:1)', value: '1:1' },
+            { key: '가로 와이드 (16:9)', value: '16:9' },
+            { key: '세로 와이드 (9:16)', value: '9:16' },
+            { key: '가로 (4:3)', value: '4:3' },
+            { key: '세로 (3:4)', value: '3:4' },
+            { key: '영화 (21:9)', value: '21:9' }
           ],
           referenceImageMethods: []
         } : isGptImageApi ? {
@@ -2184,6 +2187,20 @@ function WorkboardManagement() {
               { key: 'High', value: 'high' }
             ],
             description: 'GPT Image 생성 품질을 선택합니다.'
+          }
+        ] : isGeminiApi ? [
+          {
+            name: 'resolution',
+            label: '해상도',
+            type: 'select',
+            required: true,
+            defaultValue: '2K',
+            options: [
+              { key: '1K (기본)', value: '1K' },
+              { key: '2K', value: '2K' },
+              { key: '4K', value: '4K' }
+            ],
+            description: 'Gemini 이미지 출력 해상도를 선택합니다.'
           }
         ] : [],
         workflowData: (isOpenAI || isGeminiApi || isGptImageApi) ? '' : JSON.stringify({

--- a/src/services/geminiService.js
+++ b/src/services/geminiService.js
@@ -2,6 +2,11 @@ const axios = require('axios');
 
 const DEFAULT_SERVER_URL = 'https://generativelanguage.googleapis.com';
 
+const SUPPORTED_ASPECT_RATIOS = new Set([
+  '1:1', '2:3', '3:2', '3:4', '4:3', '4:5', '5:4', '9:16', '16:9', '21:9'
+]);
+const SUPPORTED_RESOLUTIONS = new Set(['1K', '2K', '4K']);
+
 const extractValue = (input) => {
   if (input && typeof input === 'object' && input.value !== undefined) {
     return input.value;
@@ -9,18 +14,19 @@ const extractValue = (input) => {
   return input;
 };
 
-const buildPromptText = (prompt, options = {}) => {
-  const lines = [prompt];
+const buildImageConfig = (options) => {
+  const config = {};
+  const aspectRatio = extractValue(options.aspectRatio);
+  const resolution = extractValue(options.resolution);
 
-  if (options.aspectRatio) {
-    lines.push(`Aspect ratio: ${options.aspectRatio}`);
+  if (typeof aspectRatio === 'string' && SUPPORTED_ASPECT_RATIOS.has(aspectRatio)) {
+    config.aspectRatio = aspectRatio;
+  }
+  if (typeof resolution === 'string' && SUPPORTED_RESOLUTIONS.has(resolution)) {
+    config.imageSize = resolution;
   }
 
-  if (options.imageSize) {
-    lines.push(`Target image size: ${options.imageSize}`);
-  }
-
-  return lines.filter(Boolean).join('\n');
+  return config;
 };
 
 const getExtensionFromMimeType = (mimeType = '') => {
@@ -55,20 +61,21 @@ const generateImage = async (serverUrl, apiKey, prompt, options = {}) => {
     });
   }
 
-  parts.push({
-    text: buildPromptText(prompt, {
-      aspectRatio: options.aspectRatio,
-      imageSize: options.imageSize
-    })
-  });
+  parts.push({ text: prompt });
+
+  const generationConfig = {
+    responseModalities: ['TEXT', 'IMAGE']
+  };
+  const imageConfig = buildImageConfig(options);
+  if (Object.keys(imageConfig).length > 0) {
+    generationConfig.imageConfig = imageConfig;
+  }
 
   const response = await axios.post(
     `${resolvedServerUrl}/v1beta/models/${model}:generateContent`,
     {
       contents: [{ parts }],
-      generationConfig: {
-        responseModalities: ['TEXT', 'IMAGE']
-      }
+      generationConfig
     },
     {
       params: { key: apiKey },

--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -139,8 +139,8 @@ const processImageGeneration = async (job) => {
         buildGeminiPrompt(inputData),
         {
           model: inputData.aiModel,
-          imageSize: extractOptionValue(inputData.imageSize),
           aspectRatio: deriveAspectRatio(extractOptionValue(inputData.imageSize)),
+          resolution: extractOptionValue(inputData.additionalParams?.resolution),
           images: geminiImages,
           timeout: workboardData.timeout
         }
@@ -276,6 +276,8 @@ const extractOptionValue = (value) => {
 
 const deriveAspectRatio = (imageSize) => {
   if (!imageSize || typeof imageSize !== 'string') return undefined;
+
+  if (/^\d+:\d+$/.test(imageSize)) return imageSize;
 
   const match = imageSize.match(/^(\d+)x(\d+)$/i);
   if (!match) return undefined;


### PR DESCRIPTION
## Summary
- Gemini 작업판의 이미지 크기 설정을 프롬프트 텍스트 삽입 방식에서 공식 `generationConfig.imageConfig` 필드로 전환
- aspect ratio 와 resolution(1K/2K/4K) 을 독립적으로 구조화 전송
- Workboard / Job 스키마 변경 없이 기존 구조 재활용 (`baseInputFields.imageSizes` = aspect ratio, `additionalInputFields.resolution` = 해상도)

## 변경 파일
- `src/services/geminiService.js` — `buildImageConfig` 헬퍼, 유효값 화이트리스트, `generationConfig.imageConfig` 구조화 전송, 프롬프트 텍스트 오염 제거
- `src/services/queueService.js` — Gemini 호출 파라미터 정리 (`aspectRatio` + `resolution`), `deriveAspectRatio` 가 비율 문자열 입력도 통과하도록 보강
- `frontend/src/components/admin/WorkboardManagement.js` — Gemini 작업판 신규 생성 기본값: aspect ratio 프리셋 + `resolution` select (GPT Image `quality` 와 동일 패턴)

## 로컬 검증
- [x] 신규 Gemini 작업판(`gemini-3.1-flash-image-preview`, `16:9`, `4K`)으로 생성 요청 → 이미지 정상 반환 (약 3분 소요 — Gemini 서비스 측 지연, 코드 문제 아님)
- [x] `imageConfig` 가 실제로 적용됨을 curl 직접 호출로 교차 검증 (aspect ratio / resolution 반영 확인)
- [x] `deriveAspectRatio` 경로: `1024x1024` → `1:1` 변환 정상, `1:1` 입력은 그대로 통과

## 기존 데이터 처리
- 프로덕션에 남아있을 수 있는 구버전 Gemini 작업판(`imageSizes` 에 픽셀 문자열)은 서비스 단 fallback 덕에 크래시 없이 동작. 관리자 페이지에서 수동으로 aspect ratio 프리셋으로 갱신 권장.

## Test plan
- [ ] 관리자 페이지에서 신규 Gemini 작업판 생성 → 기본값이 aspect ratio + resolution 으로 보이는지
- [ ] 일반 사용자 페이지에서 각 aspect ratio/resolution 조합으로 생성 → 결과 이미지 크기 반영 확인
- [ ] 기존 픽셀 기반 작업판으로도 에러 없이 동작 (회귀 테스트)
- [ ] ComfyUI / GPT Image / OpenAI Compatible 경로 회귀 없음 확인

## 후속 과제 (별도 이슈)
- 장기적으로 `imageSizes` 필드명이 API 포맷별로 의미가 달라지는 혼란이 있음 → 필드명 분리 또는 스키마 리팩토링 고려 필요 (이슈 #169 본문에 후속 과제로 명시)

closes #169