### PR TITLE
feat: GPT Image 작업판 템플릿에 gpt-image-2 모델 지원 추가 (#172)

### DIFF
--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -1540,9 +1540,14 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
                 </Alert>
               )}
               {isGptImage && (
-                <Alert severity="info">
-                  GPT Image 작업판은 워크플로우 JSON 없이 OpenAI Images API로 이미지를 생성합니다.
-                </Alert>
+                <>
+                  <Alert severity="info">
+                    GPT Image 작업판은 워크플로우 JSON 없이 OpenAI Images API로 이미지를 생성합니다.
+                  </Alert>
+                  <Alert severity="warning" sx={{ mt: 1 }}>
+                    <strong>gpt-image-2</strong> 모델은 OpenAI 조직 인증(Verify Organization) 완료 후 약 15분 뒤부터 사용 가능합니다. 인증 페이지: <a href="https://platform.openai.com/settings/organization/general" target="_blank" rel="noopener noreferrer">platform.openai.com/settings/organization/general</a>
+                  </Alert>
+                </>
               )}
             </Box>
           )}
@@ -2146,11 +2151,13 @@ function WorkboardManagement() {
           referenceImageMethods: []
         } : isGptImageApi ? {
           aiModel: [
+            { key: 'GPT Image 2 (조직 인증 필요)', value: 'gpt-image-2' },
             { key: 'GPT Image 1.5', value: 'gpt-image-1.5' },
             { key: 'GPT Image 1', value: 'gpt-image-1' },
             { key: 'GPT Image 1 Mini', value: 'gpt-image-1-mini' }
           ],
           imageSizes: [
+            { key: '자동 (auto)', value: 'auto' },
             { key: '1024x1024', value: '1024x1024' },
             { key: '1024x1536', value: '1024x1536' },
             { key: '1536x1024', value: '1536x1024' }
@@ -2180,13 +2187,34 @@ function WorkboardManagement() {
             label: '품질',
             type: 'select',
             required: true,
-            defaultValue: 'medium',
+            defaultValue: 'auto',
             options: [
+              { key: 'Auto', value: 'auto' },
               { key: 'Low', value: 'low' },
               { key: 'Medium', value: 'medium' },
               { key: 'High', value: 'high' }
             ],
             description: 'GPT Image 생성 품질을 선택합니다.'
+          },
+          {
+            name: 'background',
+            label: '배경',
+            type: 'select',
+            required: false,
+            defaultValue: 'opaque',
+            options: [
+              { key: '불투명 (opaque)', value: 'opaque' },
+              { key: '투명 (transparent)', value: 'transparent' }
+            ],
+            description: 'gpt-image-2 전용. 투명 배경으로 출력하려면 transparent. 다른 모델에서는 무시됨.'
+          },
+          {
+            name: 'output_compression',
+            label: '출력 압축률',
+            type: 'number',
+            required: false,
+            defaultValue: 100,
+            description: 'gpt-image-2 의 JPEG/WebP 출력 시 압축률 (1-100). PNG 에는 영향 없음. 다른 모델에서는 무시됨.'
           }
         ] : isGeminiApi ? [
           {

--- a/src/services/gptImageService.js
+++ b/src/services/gptImageService.js
@@ -16,29 +16,50 @@ const generateImage = async (serverUrl, apiKey, prompt, options = {}) => {
   const quality = extractValue(options.quality) || 'medium';
   const outputFormat = extractValue(options.outputFormat) || 'png';
   const n = options.n || 1;
+  const background = extractValue(options.background);
+  const outputCompression = extractValue(options.outputCompression);
 
   if (!apiKey) {
     throw new Error('GPT Image API key is required');
   }
 
-  const response = await axios.post(
-    `${resolvedServerUrl}/v1/images/generations`,
-    {
-      model,
-      prompt,
-      n,
-      size,
-      quality,
-      output_format: outputFormat
-    },
-    {
-      headers: {
-        'Authorization': `Bearer ${apiKey}`,
-        'Content-Type': 'application/json'
-      },
-      timeout: options.timeout || 300000
+  const requestBody = {
+    model,
+    prompt,
+    n,
+    size,
+    quality,
+    output_format: outputFormat,
+  };
+  if (background) requestBody.background = background;
+  if (outputCompression !== undefined && outputCompression !== null && outputCompression !== '') {
+    const compression = Number(outputCompression);
+    if (Number.isFinite(compression)) requestBody.output_compression = compression;
+  }
+
+  let response;
+  try {
+    response = await axios.post(
+      `${resolvedServerUrl}/v1/images/generations`,
+      requestBody,
+      {
+        headers: {
+          'Authorization': `Bearer ${apiKey}`,
+          'Content-Type': 'application/json'
+        },
+        timeout: options.timeout || 300000
+      }
+    );
+  } catch (err) {
+    const apiMessage = err.response?.data?.error?.message;
+    if (apiMessage && /organization must be verified/i.test(apiMessage)) {
+      throw new Error(
+        `${model} 모델 사용에는 OpenAI 조직 인증(Verify Organization)이 필요합니다. https://platform.openai.com/settings/organization/general 에서 인증 후 약 15분 대기하세요.`
+      );
     }
-  );
+    if (apiMessage) throw new Error(`OpenAI: ${apiMessage}`);
+    throw err;
+  }
 
   const images = (response.data?.data || [])
     .filter((entry) => entry?.b64_json)

--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -163,6 +163,8 @@ const processImageGeneration = async (job) => {
           outputFormat: extractOptionValue(
             inputData.additionalParams?.outputFormat || inputData.outputFormat
           ) || 'png',
+          background: extractOptionValue(inputData.additionalParams?.background),
+          outputCompression: extractOptionValue(inputData.additionalParams?.output_compression),
           timeout: workboardData.timeout
         }
       );


### PR DESCRIPTION
## Summary
OpenAI 가 2026-04-21 출시한 `gpt-image-2` 모델과 신규 파라미터(`background`, `output_compression`) 를 작업판 기본 템플릿/서비스 코드에 반영. 기존 모델 호환 유지.

## 변경 파일
- `src/services/gptImageService.js` — `background` / `output_compression` 수신, OpenAI 에러 메시지 가공 (조직 인증 안내 + 일반 OpenAI 에러 prefix)
- `src/services/queueService.js` — GPT Image 호출부에 `additionalParams.background`, `output_compression` 패스스루
- `frontend/src/components/admin/WorkboardManagement.js`
  - 신규 GPT Image 작업판 기본 템플릿: `gpt-image-2` 추가 (라벨에 "조직 인증 필요" 명시), `imageSizes` 에 `auto`, `quality` 에 `auto` (기본), `background` / `output_compression` 신규 select·number 추가
  - 작업판 폼에 OpenAI 조직 인증 요건 안내 warning Alert 추가 (apiFormat=GPT Image 일 때 표시)

## 사용자 가이드 노출 (3 layer)
| Layer | 위치 |
|---|---|
| B. 모델 옵션 라벨 | "GPT Image 2 (조직 인증 필요)" |
| D. 에러 메시지 가공 | 잡 실패 시 한국어 + 인증 링크 메시지 |
| A. 폼 인라인 Alert | 관리자 작업판 다이얼로그 |

## 로컬 검증
- [x] gpt-image-1.5 회귀 정상 동작
- [x] gpt-image-2 호출 시 OpenAI 403 → 사용자 친화적 한국어 에러로 치환됨 확인 (curl 직접 호출로 OpenAI 응답 메시지 cross-check)
- [x] 신규 작업판 생성 API 로 새 템플릿 옵션 4개 (`gpt-image-2` / `auto` 사이즈 / `auto` 품질 / `background` / `output_compression`) 모두 저장됨 확인

## 비고
- gpt-image-2 실 생성은 OpenAI 조직 인증 후에만 가능. 인증 안 된 환경에서는 안내 메시지로 fail-fast.
- 기존 GPT Image 작업판 (이전 템플릿) 은 영향 없음. 신규 작업판부터 새 옵션 적용.

## Test plan
- [ ] 관리자 페이지 → 신규 GPT Image 작업판 생성 시 새 옵션이 모두 보이는지 확인
- [ ] 조직 인증 완료된 환경에서 gpt-image-2 + transparent/output_compression=90 실 생성 검증
- [ ] 기존 GPT Image 1.5 워크보드 회귀 없음 확인

closes #172