### PR TITLE
release: v1.7.3

### DIFF
--- a/docs/updatelogs/v1.md
+++ b/docs/updatelogs/v1.md
@@ -1,5 +1,20 @@
 # v1 업데이트 내역
 
+## v1.7.3
+
+- feat: GPT Image 작업판 템플릿에 `gpt-image-2` 모델 지원 추가 (#172, #173)
+  - OpenAI 가 2026-04-21 출시한 신규 모델 `gpt-image-2` 를 작업판 기본 템플릿에 반영
+  - `imageSizes` 에 `auto` 옵션 추가, `quality` 에 `auto` 옵션 추가 (기본값 `auto`)
+  - 신규 추가 입력 필드:
+    - `background` (`opaque` / `transparent`, gpt-image-2 전용)
+    - `output_compression` (1-100, JPEG/WebP 출력 시 압축률, gpt-image-2 전용)
+  - `gpt-image-2` 는 OpenAI 조직 인증(Verify Organization) 완료 후 약 15분 뒤부터 사용 가능. 다음 3 layer 가이드로 안내:
+    - 모델 옵션 라벨에 "조직 인증 필요" 명시
+    - 작업판 생성 폼에 안내 Alert 추가
+    - 백엔드에서 OpenAI 의 "organization must be verified" 응답을 한국어 + 인증 링크 메시지로 치환
+  - 일반 OpenAI 에러도 `OpenAI: <원문>` 으로 prefix 가공해 잡 에러에서 의미 확인 가능
+  - 기존 GPT Image 1/1.5/1-mini 호환 유지, 비-GPT Image 경로 영향 없음
+
 ## v1.7.2
 
 - fix: ImageGenerationJob 모델의 `workflowData` 필수 제약 제거 (#165, #167)

--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -1540,9 +1540,14 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
                 </Alert>
               )}
               {isGptImage && (
-                <Alert severity="info">
-                  GPT Image 작업판은 워크플로우 JSON 없이 OpenAI Images API로 이미지를 생성합니다.
-                </Alert>
+                <>
+                  <Alert severity="info">
+                    GPT Image 작업판은 워크플로우 JSON 없이 OpenAI Images API로 이미지를 생성합니다.
+                  </Alert>
+                  <Alert severity="warning" sx={{ mt: 1 }}>
+                    <strong>gpt-image-2</strong> 모델은 OpenAI 조직 인증(Verify Organization) 완료 후 약 15분 뒤부터 사용 가능합니다. 인증 페이지: <a href="https://platform.openai.com/settings/organization/general" target="_blank" rel="noopener noreferrer">platform.openai.com/settings/organization/general</a>
+                  </Alert>
+                </>
               )}
             </Box>
           )}
@@ -2146,11 +2151,13 @@ function WorkboardManagement() {
           referenceImageMethods: []
         } : isGptImageApi ? {
           aiModel: [
+            { key: 'GPT Image 2 (조직 인증 필요)', value: 'gpt-image-2' },
             { key: 'GPT Image 1.5', value: 'gpt-image-1.5' },
             { key: 'GPT Image 1', value: 'gpt-image-1' },
             { key: 'GPT Image 1 Mini', value: 'gpt-image-1-mini' }
           ],
           imageSizes: [
+            { key: '자동 (auto)', value: 'auto' },
             { key: '1024x1024', value: '1024x1024' },
             { key: '1024x1536', value: '1024x1536' },
             { key: '1536x1024', value: '1536x1024' }
@@ -2180,13 +2187,34 @@ function WorkboardManagement() {
             label: '품질',
             type: 'select',
             required: true,
-            defaultValue: 'medium',
+            defaultValue: 'auto',
             options: [
+              { key: 'Auto', value: 'auto' },
               { key: 'Low', value: 'low' },
               { key: 'Medium', value: 'medium' },
               { key: 'High', value: 'high' }
             ],
             description: 'GPT Image 생성 품질을 선택합니다.'
+          },
+          {
+            name: 'background',
+            label: '배경',
+            type: 'select',
+            required: false,
+            defaultValue: 'opaque',
+            options: [
+              { key: '불투명 (opaque)', value: 'opaque' },
+              { key: '투명 (transparent)', value: 'transparent' }
+            ],
+            description: 'gpt-image-2 전용. 투명 배경으로 출력하려면 transparent. 다른 모델에서는 무시됨.'
+          },
+          {
+            name: 'output_compression',
+            label: '출력 압축률',
+            type: 'number',
+            required: false,
+            defaultValue: 100,
+            description: 'gpt-image-2 의 JPEG/WebP 출력 시 압축률 (1-100). PNG 에는 영향 없음. 다른 모델에서는 무시됨.'
           }
         ] : isGeminiApi ? [
           {

--- a/src/services/gptImageService.js
+++ b/src/services/gptImageService.js
@@ -16,29 +16,50 @@ const generateImage = async (serverUrl, apiKey, prompt, options = {}) => {
   const quality = extractValue(options.quality) || 'medium';
   const outputFormat = extractValue(options.outputFormat) || 'png';
   const n = options.n || 1;
+  const background = extractValue(options.background);
+  const outputCompression = extractValue(options.outputCompression);
 
   if (!apiKey) {
     throw new Error('GPT Image API key is required');
   }
 
-  const response = await axios.post(
-    `${resolvedServerUrl}/v1/images/generations`,
-    {
-      model,
-      prompt,
-      n,
-      size,
-      quality,
-      output_format: outputFormat
-    },
-    {
-      headers: {
-        'Authorization': `Bearer ${apiKey}`,
-        'Content-Type': 'application/json'
-      },
-      timeout: options.timeout || 300000
+  const requestBody = {
+    model,
+    prompt,
+    n,
+    size,
+    quality,
+    output_format: outputFormat,
+  };
+  if (background) requestBody.background = background;
+  if (outputCompression !== undefined && outputCompression !== null && outputCompression !== '') {
+    const compression = Number(outputCompression);
+    if (Number.isFinite(compression)) requestBody.output_compression = compression;
+  }
+
+  let response;
+  try {
+    response = await axios.post(
+      `${resolvedServerUrl}/v1/images/generations`,
+      requestBody,
+      {
+        headers: {
+          'Authorization': `Bearer ${apiKey}`,
+          'Content-Type': 'application/json'
+        },
+        timeout: options.timeout || 300000
+      }
+    );
+  } catch (err) {
+    const apiMessage = err.response?.data?.error?.message;
+    if (apiMessage && /organization must be verified/i.test(apiMessage)) {
+      throw new Error(
+        `${model} 모델 사용에는 OpenAI 조직 인증(Verify Organization)이 필요합니다. https://platform.openai.com/settings/organization/general 에서 인증 후 약 15분 대기하세요.`
+      );
     }
-  );
+    if (apiMessage) throw new Error(`OpenAI: ${apiMessage}`);
+    throw err;
+  }
 
   const images = (response.data?.data || [])
     .filter((entry) => entry?.b64_json)

--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -163,6 +163,8 @@ const processImageGeneration = async (job) => {
           outputFormat: extractOptionValue(
             inputData.additionalParams?.outputFormat || inputData.outputFormat
           ) || 'png',
+          background: extractOptionValue(inputData.additionalParams?.background),
+          outputCompression: extractOptionValue(inputData.additionalParams?.output_compression),
           timeout: workboardData.timeout
         }
       );


### PR DESCRIPTION
## v1.7.3 릴리스

### 포함 변경사항

**feat**
- **#173** (closes #172): GPT Image 작업판 템플릿에 `gpt-image-2` 모델 지원 추가
  - OpenAI 신규 모델 `gpt-image-2` (2026-04-21 출시) 를 작업판 기본 템플릿에 반영
  - 신규 옵션: `background` (opaque/transparent), `output_compression` (1-100), `auto` 사이즈/품질
  - OpenAI 조직 인증 요건 안내 (모델 라벨 + 폼 Alert + 에러 메시지 한국어 가공)

**docs**
- v1.7.3 업데이트 내역 작성

### 호환성
- 기존 GPT Image 1/1.5/1-mini 동작 유지
- 비-GPT Image 경로 영향 없음
- Workboard / Job 모델 스키마 변경 없음

## Test plan
- [x] gpt-image-1.5 회귀 정상
- [x] gpt-image-2 호출 시 OpenAI 403 → 한국어 안내 메시지 치환 확인
- [ ] main 머지 후 v1.7.3 태그 부착