### PR TITLE
fix: nginx index.html 캐시 무효화 헤더 추가 (#175)

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -7,8 +7,11 @@ server {
     root /usr/share/nginx/html;
     index index.html index.htm;
 
+    # SPA 라우트 fallback — index.html 은 항상 최신을 받아와 새 JS 해시 참조가 즉시 반영되도록 캐시 무효화
+    # (해시된 정적 자산 /static/*.{js,css,...} 은 아래 location 에서 별도 처리되어 영향 없음)
     location / {
         try_files $uri $uri/ /index.html;
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
     }
 
     location /api {


### PR DESCRIPTION
## Summary
프로덕션 배포 후 새 빌드의 변경사항이 사용자 브라우저에 즉시 반영되지 않고 옛 화면이 잠시 노출되던 문제 수정.

## 변경
- `nginx.conf` 의 `location /` 에 `Cache-Control: no-cache, no-store, must-revalidate` add_header 추가
- 해시된 정적 자산(`/static/*.{js,css,png,...}`) 의 1년 immutable 캐시는 별도 location 에서 그대로 유지

## 로컬 검증
```
GET /                                  → Cache-Control: no-cache, no-store, must-revalidate ✅
GET /static/js/main.<hash>.js          → Cache-Control: max-age=31536000, public, immutable ✅
```

## 영향 범위
- index.html (또는 SPA fallback 으로 index.html 을 반환하는 모든 경로)
- 정적 자산 / API 응답 / 업로드 차단 정책 영향 없음

closes #175