### PR TITLE
refactor: 작업판 카드 메뉴에서 중복된 편집 항목 제거 (#177)

### DIFF
--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -38,7 +38,6 @@ import {
   VisibilityOff,
   Computer,
   TrendingUp,
-  Settings,
   ExpandMore,
   ToggleOn,
   ToggleOff,
@@ -211,13 +210,9 @@ function WorkboardCard({ workboard, onEdit, onDelete, onDuplicate, onExport, onV
           <Visibility sx={{ mr: 1 }} fontSize="small" />
           보기
         </MenuItem>
-        <MenuItem onClick={() => { onEdit(workboard); handleMenuClose(); }}>
+        <MenuItem onClick={() => { onEdit(workboard, 'detailed'); handleMenuClose(); }}>
           <Edit sx={{ mr: 1 }} fontSize="small" />
           편집
-        </MenuItem>
-        <MenuItem onClick={() => { onEdit(workboard, 'detailed'); handleMenuClose(); }}>
-          <Settings sx={{ mr: 1 }} fontSize="small" />
-          상세 편집
         </MenuItem>
         <MenuItem onClick={() => { onDuplicate(workboard); handleMenuClose(); }}>
           <ContentCopy sx={{ mr: 1 }} fontSize="small" />


### PR DESCRIPTION
## Summary
편집 / 상세 편집 두 메뉴를 단일 **편집** 으로 통합. 기존 상세 편집 다이얼로그(`WorkboardDetailDialog`) 가 그대로 호출되어 모든 필드(기본 정보 + 기초 입력값 + 커스텀 필드 + 워크플로우) 편집 가능.

## 결정 배경
- 분석 결과 편집(`WorkboardDialog`) 은 상세 편집의 strict subset
- 두 다이얼로그 모두 동일 `WorkboardBasicInfoForm` + 동일 `updateMutation`
- 편집의 3 필드(`name` / `description` / `serverId`) 는 상세 편집 기본 정보 탭에서 동일 편집 가능

## 변경
- `WorkboardCard` 메뉴에서 '상세 편집' MenuItem 제거
- 남은 '편집' MenuItem 클릭 핸들러를 detailed 경로로 변경: `onEdit(workboard, 'detailed')`
- 사용하지 않게 된 `Settings` 아이콘 import 정리

## 영향 범위
- `frontend/src/components/admin/WorkboardManagement.js` 1 파일, +1/-6
- `WorkboardDialog` 컴포넌트는 신규 작업판 생성(`handleCreate`)에서 계속 사용 — 유지
- `WorkboardDialog` 의 `isEditing=true` 분기는 호출 경로가 사라지므로 dead code → 후속 클린업 검토 (이번 스코프 밖)

closes #177