### PR TITLE
refactor: WorkboardDialog 의 편집 모드 dead code 제거 및 의도 명확화 (#179)

### DIFF
--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -1560,32 +1560,30 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
   );
 }
 
-function WorkboardDialog({ open, onClose, workboard = null, onSave }) {
-  const isEditing = !!workboard;
-  
-  const { control, handleSubmit, reset, watch, formState: { errors } } = useForm({
+function WorkboardCreateDialog({ open, onClose, onSave }) {
+  const { control, handleSubmit, reset, formState: { errors } } = useForm({
     defaultValues: {
-      name: workboard?.name || '',
-      description: workboard?.description || '',
-      apiFormat: workboard?.apiFormat || 'ComfyUI',
-      outputFormat: workboard?.outputFormat || 'image',
-      serverId: workboard?.serverId?._id || '',
-      isActive: workboard?.isActive ?? true
+      name: '',
+      description: '',
+      apiFormat: 'ComfyUI',
+      outputFormat: 'image',
+      serverId: '',
+      isActive: true
     }
   });
 
   React.useEffect(() => {
     if (open) {
       reset({
-        name: workboard?.name || '',
-        description: workboard?.description || '',
-        apiFormat: workboard?.apiFormat || (workboard?.workboardType === 'prompt' ? 'OpenAI Compatible' : 'ComfyUI'),
-        outputFormat: workboard?.outputFormat || (workboard?.workboardType === 'prompt' ? 'text' : 'image'),
-        serverId: workboard?.serverId?._id || '',
-        isActive: workboard?.isActive ?? true
+        name: '',
+        description: '',
+        apiFormat: 'ComfyUI',
+        outputFormat: 'image',
+        serverId: '',
+        isActive: true
       });
     }
-  }, [open, workboard, reset]);
+  }, [open, reset]);
 
   const onSubmit = (data) => {
     onSave(data);
@@ -1593,34 +1591,25 @@ function WorkboardDialog({ open, onClose, workboard = null, onSave }) {
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
-      <DialogTitle>
-        {isEditing ? '작업판 편집' : '새 작업판 생성'}
-      </DialogTitle>
+      <DialogTitle>새 작업판 생성</DialogTitle>
       <form onSubmit={handleSubmit(onSubmit)}>
         <DialogContent>
           <WorkboardBasicInfoForm
             control={control}
             errors={errors}
             showActiveSwitch={false}
-            showTypeSelector={!isEditing}
+            showTypeSelector={true}
             isDialogOpen={open}
           />
 
-          {!isEditing && (
-            <Alert severity="info" sx={{ mt: 2 }}>
-              기본 작업판 구조가 생성됩니다. 상세 설정(AI 모델, 입력 필드 등)은 
-              생성 후 상세 편집에서 추가할 수 있습니다.
-            </Alert>
-          )}
+          <Alert severity="info" sx={{ mt: 2 }}>
+            기본 작업판 구조가 생성됩니다. 상세 설정(AI 모델, 입력 필드 등)은
+            생성 후 편집에서 추가할 수 있습니다.
+          </Alert>
         </DialogContent>
         <DialogActions>
           <Button onClick={onClose}>취소</Button>
-          <Button 
-            type="submit" 
-            variant="contained"
-          >
-            {isEditing ? '수정' : '생성'}
-          </Button>
+          <Button type="submit" variant="contained">생성</Button>
         </DialogActions>
       </form>
     </Dialog>
@@ -2329,10 +2318,9 @@ function WorkboardManagement() {
         </Grid>
       )}
 
-      <WorkboardDialog
+      <WorkboardCreateDialog
         open={dialogOpen}
         onClose={() => setDialogOpen(false)}
-        workboard={selectedWorkboard}
         onSave={handleSave}
       />
 


### PR DESCRIPTION
## Summary
#178 머지 후 `WorkboardDialog` 호출 경로가 신규 작업판 생성 한 곳뿐이 됨에 따라, `isEditing` 분기를 정리하고 컴포넌트명을 의도가 드러나도록 변경.

## 변경
- `WorkboardDialog` → `WorkboardCreateDialog` 로 리네이밍
- `workboard` prop 제거 (호출자에서 더 이상 전달 안 함)
- `isEditing` 플래그와 4곳 분기 제거:
  - 다이얼로그 제목: `새 작업판 생성` 고정
  - `showTypeSelector`: 항상 `true`
  - 안내 Alert: 항상 표시 (문구 `상세 편집` → `편집` 으로 정리)
  - 제출 버튼: `생성` 고정
- `useForm` `defaultValues` / `reset` 의 `workboard?.…` 폴백 제거
- 미사용 `watch` 제거
- `WorkboardManagement` 의 `<WorkboardCreateDialog>` 사용처에서 `workboard={selectedWorkboard}` 제거

## 영향 범위
- `frontend/src/components/admin/WorkboardManagement.js` 1 파일, +23/-35
- 기능 변화 없음 (이전에도 항상 `isEditing=false` 경로만 실행됨)

## 후속 검토 (스코프 밖)
`handleSave` 함수에 남아있는 `if (selectedWorkboard) { update } else { create }` 분기 중 `update` 경로도 호출자가 사라져 dead code 입니다. 별도 PR 로 검토.

closes #179