### PR TITLE
refactor (Phase 2): Server 모델 enum/outputType 정리 및 마이그레이션 (#182)

### DIFF
--- a/frontend/src/components/admin/ServerManagement.js
+++ b/frontend/src/components/admin/ServerManagement.js
@@ -73,11 +73,11 @@ function ServerCard({ server, onEdit, onDelete, onHealthCheck, onLoraSync, loraS
     switch (serverType) {
       case 'ComfyUI':
         return <Computer />;
+      case 'OpenAI':
       case 'OpenAI Compatible':
+      case 'GPT Image':
         return <TextFields />;
       case 'Gemini':
-        return <Storage />;
-      case 'GPT Image':
         return <Storage />;
       default:
         return <Storage />;
@@ -88,12 +88,14 @@ function ServerCard({ server, onEdit, onDelete, onHealthCheck, onLoraSync, loraS
     switch (serverType) {
       case 'ComfyUI':
         return 'ComfyUI API';
+      case 'OpenAI':
+        return 'OpenAI API';
       case 'OpenAI Compatible':
         return 'OpenAI Compatible API';
       case 'Gemini':
-        return 'Gemini Image API';
+        return 'Gemini API';
       case 'GPT Image':
-        return 'GPT Image API';
+        return 'GPT Image API (deprecated)';
       default:
         return serverType;
     }
@@ -344,9 +346,9 @@ function ServerDialog({ open, onClose, server, onSubmit }) {
                   label="AI API 형식"
                 >
                   <MenuItem value="ComfyUI">ComfyUI API</MenuItem>
+                  <MenuItem value="OpenAI">OpenAI API</MenuItem>
                   <MenuItem value="OpenAI Compatible">OpenAI Compatible API</MenuItem>
-                  <MenuItem value="Gemini">Gemini Image API</MenuItem>
-                  <MenuItem value="GPT Image">GPT Image API</MenuItem>
+                  <MenuItem value="Gemini">Gemini API</MenuItem>
                 </Select>
               </FormControl>
             </Grid>
@@ -373,7 +375,7 @@ function ServerDialog({ open, onClose, server, onSubmit }) {
                 placeholder={
                   formData.serverType === 'Gemini'
                     ? 'https://generativelanguage.googleapis.com'
-                    : formData.serverType === 'GPT Image'
+                    : formData.serverType === 'OpenAI'
                       ? 'https://api.openai.com'
                       : 'http://localhost:8188'
                 }

--- a/frontend/src/components/admin/WorkboardBasicInfoForm.js
+++ b/frontend/src/components/admin/WorkboardBasicInfoForm.js
@@ -34,10 +34,13 @@ function WorkboardBasicInfoForm({ control, errors, showActiveSwitch = false, sho
     }
   };
 
+  // 'GPT Image' apiFormat 은 deprecated — Phase 2 마이그레이션 이후 서버는 'OpenAI' 로 저장됨.
+  // workboard.apiFormat 은 deprecation 기간 동안 그대로 유지되므로 서버 조회 시에만 매핑.
+  const apiFormatToServerType = (af) => (af === 'GPT Image' ? 'OpenAI' : af);
   const { data: serversData } = useQuery(
     ['servers', apiFormat],
     () => serverAPI.getServers({
-      serverType: apiFormat
+      serverType: apiFormatToServerType(apiFormat)
     }),
     { enabled: isDialogOpen }
   );

--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -1805,7 +1805,7 @@ function WorkboardImportDialog({ open, onClose, onSuccess }) {
                   >
                     {availableServers.map((s) => (
                       <MenuItem key={s._id} value={s._id}>
-                        {s.name} ({s.serverType} - {s.outputType})
+                        {s.name} ({s.serverType})
                       </MenuItem>
                     ))}
                   </Select>

--- a/src/migrations/migrateServerTypeToOpenAI.js
+++ b/src/migrations/migrateServerTypeToOpenAI.js
@@ -1,0 +1,30 @@
+const Server = require('../models/Server');
+
+// Phase 2 (#181, #182): 'GPT Image' Server 를 'OpenAI' 로 이전 + outputType 필드 제거.
+async function migrateServerTypeToOpenAI() {
+  try {
+    const renameResult = await Server.updateMany(
+      { serverType: 'GPT Image' },
+      { $set: { serverType: 'OpenAI' } }
+    );
+    if (renameResult.modifiedCount > 0) {
+      console.log(`[Migration] Server.serverType: 'GPT Image' → 'OpenAI' (${renameResult.modifiedCount} 건)`);
+    } else {
+      console.log("[Migration] Server.serverType 'GPT Image' 마이그레이션 불필요 (대상 없음)");
+    }
+
+    const dropResult = await Server.updateMany(
+      { outputType: { $exists: true } },
+      { $unset: { outputType: '' } }
+    );
+    if (dropResult.modifiedCount > 0) {
+      console.log(`[Migration] Server.outputType 필드 제거 (${dropResult.modifiedCount} 건)`);
+    } else {
+      console.log("[Migration] Server.outputType 마이그레이션 불필요 (대상 없음)");
+    }
+  } catch (error) {
+    console.error('[Migration] Server type/outputType 마이그레이션 오류:', error);
+  }
+}
+
+module.exports = migrateServerTypeToOpenAI;

--- a/src/models/Server.js
+++ b/src/models/Server.js
@@ -13,7 +13,9 @@ const serverSchema = new mongoose.Schema({
   },
   serverType: {
     type: String,
-    enum: ['ComfyUI', 'OpenAI Compatible', 'Gemini', 'GPT Image'],
+    // 'GPT Image' 는 deprecated — Phase 2 마이그레이션으로 'OpenAI' 로 전환됨.
+    // enum 에는 다음 메이저까지 잔존시켜 stale 문서가 있어도 Mongoose 검증 실패가 안 나도록 함.
+    enum: ['ComfyUI', 'OpenAI', 'OpenAI Compatible', 'Gemini', 'GPT Image'],
     required: true
   },
   serverUrl: {
@@ -32,11 +34,6 @@ const serverSchema = new mongoose.Schema({
       },
       message: '올바른 URL 형식이 아닙니다.'
     }
-  },
-  outputType: {
-    type: String,
-    enum: ['Image', 'Video', 'Text'],
-    required: false
   },
   isActive: {
     type: Boolean,
@@ -87,14 +84,13 @@ serverSchema.methods.checkHealth = async function() {
       case 'ComfyUI':
         healthEndpoint = `${this.serverUrl}/system_stats`;
         break;
+      case 'OpenAI':
       case 'OpenAI Compatible':
+      case 'GPT Image': // deprecated — Phase 2 후 데이터는 'OpenAI' 로 마이그레이션됨
         healthEndpoint = `${this.serverUrl}/v1/models`;
         break;
       case 'Gemini':
         healthEndpoint = `${this.serverUrl}/v1beta/models`;
-        break;
-      case 'GPT Image':
-        healthEndpoint = `${this.serverUrl}/v1/models`;
         break;
       default:
         healthEndpoint = this.serverUrl;

--- a/src/routes/servers.js
+++ b/src/routes/servers.js
@@ -10,18 +10,14 @@ const comfyUIService = require('../services/comfyUIService');
 // 서버 목록 조회 (일반 사용자도 접근 가능)
 router.get('/', verifyJWT, async (req, res) => {
   try {
-    const { serverType, outputType, includeInactive = false } = req.query;
-    
+    const { serverType, includeInactive = false } = req.query;
+
     let filter = {};
-    
+
     if (serverType) {
       filter.serverType = serverType;
     }
-    
-    if (outputType) {
-      filter.outputType = outputType;
-    }
-    
+
     if (!includeInactive || includeInactive === 'false') {
       filter.isActive = true;
     }
@@ -78,10 +74,9 @@ router.post('/', requireAdmin, async (req, res) => {
       description,
       serverType,
       serverUrl,
-      outputType,
       configuration = {}
     } = req.body;
-    
+
     // 필수 필드 검증
     if (!name || !serverType || !serverUrl) {
       return res.status(400).json({
@@ -90,14 +85,14 @@ router.post('/', requireAdmin, async (req, res) => {
       });
     }
 
-    // 서버 타입 검증
-    if (!['ComfyUI', 'OpenAI Compatible', 'Gemini', 'GPT Image'].includes(serverType)) {
+    // 서버 타입 검증 ('GPT Image' 는 deprecated — 신규 생성 차단)
+    if (!['ComfyUI', 'OpenAI', 'OpenAI Compatible', 'Gemini'].includes(serverType)) {
       return res.status(400).json({
         success: false,
         message: '지원하지 않는 서버 타입입니다.'
       });
     }
-    
+
     // 중복 이름 검증
     const existingServer = await Server.findOne({ name });
     if (existingServer) {
@@ -106,13 +101,12 @@ router.post('/', requireAdmin, async (req, res) => {
         message: '같은 이름의 서버가 이미 존재합니다.'
       });
     }
-    
+
     const server = new Server({
       name,
       description,
       serverType,
       serverUrl,
-      outputType,
       configuration,
       createdBy: req.user.id
     });
@@ -159,7 +153,6 @@ router.put('/:id', requireAdmin, async (req, res) => {
       description,
       serverType,
       serverUrl,
-      outputType,
       configuration,
       isActive
     } = req.body;
@@ -193,7 +186,6 @@ router.put('/:id', requireAdmin, async (req, res) => {
     if (description !== undefined) updateFields.description = description;
     if (serverType !== undefined) updateFields.serverType = serverType;
     if (serverUrl !== undefined) updateFields.serverUrl = serverUrl;
-    if (outputType !== undefined) updateFields.outputType = outputType;
     if (configuration !== undefined) {
       // API 키가 비어있으면 기존 값을 유지
       if (!configuration.apiKey && server.configuration?.apiKey) {

--- a/src/routes/workboards.js
+++ b/src/routes/workboards.js
@@ -48,7 +48,7 @@ router.get('/', requireAuth, async (req, res) => {
     
     const workboards = await Workboard.find(filter)
       .populate('createdBy', 'nickname email')
-      .populate('serverId', 'name serverType serverUrl outputType isActive')
+      .populate('serverId', 'name serverType serverUrl isActive')
       .select('-workflowData')
       .sort({ usageCount: -1, createdAt: -1 })
       .skip(skip)
@@ -115,7 +115,7 @@ router.post('/import', requireAdmin, async (req, res) => {
         serverMatchInfo = { name: server.name, matched: true, manual: false };
       } else {
         // 매칭 실패 - 서버 목록과 함께 반환
-        const servers = await Server.find({ isActive: true }).select('name serverType outputType');
+        const servers = await Server.find({ isActive: true }).select('name serverType');
         return res.json({
           needsServer: true,
           preview: {
@@ -131,7 +131,7 @@ router.post('/import', requireAdmin, async (req, res) => {
       }
     } else {
       // 서버 정보가 없는 경우
-      const servers = await Server.find({ isActive: true }).select('name serverType outputType');
+      const servers = await Server.find({ isActive: true }).select('name serverType');
       return res.json({
         needsServer: true,
         preview: {
@@ -170,7 +170,7 @@ router.post('/import', requireAdmin, async (req, res) => {
 
     await newWorkboard.save();
     await newWorkboard.populate('createdBy', 'nickname email');
-    await newWorkboard.populate('serverId', 'name serverType serverUrl outputType isActive');
+    await newWorkboard.populate('serverId', 'name serverType serverUrl isActive');
 
     res.status(201).json({
       message: '작업판을 가져왔습니다.',
@@ -188,7 +188,7 @@ router.get('/:id', requireAuth, async (req, res) => {
   try {
     const workboard = await Workboard.findById(req.params.id)
       .populate('createdBy', 'nickname email')
-      .populate('serverId', 'name serverType serverUrl outputType isActive');
+      .populate('serverId', 'name serverType serverUrl isActive');
     
     if (!workboard) {
       return res.status(404).json({ message: 'Workboard not found' });
@@ -209,7 +209,7 @@ router.get('/admin/:id', requireAdmin, async (req, res) => {
   try {
     const workboard = await Workboard.findById(req.params.id)
       .populate('createdBy', 'nickname email')
-      .populate('serverId', 'name serverType serverUrl outputType isActive');
+      .populate('serverId', 'name serverType serverUrl isActive');
     
     if (!workboard) {
       return res.status(404).json({ message: 'Workboard not found' });
@@ -299,7 +299,7 @@ router.post('/', requireAdmin, async (req, res) => {
     
     await workboard.save();
     await workboard.populate('createdBy', 'nickname email');
-    await workboard.populate('serverId', 'name serverType serverUrl outputType isActive');
+    await workboard.populate('serverId', 'name serverType serverUrl isActive');
     
     res.status(201).json({
       message: 'Workboard created successfully',
@@ -387,7 +387,7 @@ router.put('/:id', requireAdmin, async (req, res) => {
     console.log('Before save:', workboard.toObject());
     await workboard.save();
     await workboard.populate('createdBy', 'nickname email');
-    await workboard.populate('serverId', 'name serverType serverUrl outputType isActive');
+    await workboard.populate('serverId', 'name serverType serverUrl isActive');
     
     res.json({
       message: 'Workboard updated successfully',
@@ -519,8 +519,7 @@ router.get('/:id/export', requireAdmin, async (req, res) => {
       if (server) {
         serverInfo = {
           name: server.name,
-          serverType: server.serverType,
-          outputType: server.outputType
+          serverType: server.serverType
         };
       }
     }

--- a/src/server.js
+++ b/src/server.js
@@ -28,6 +28,7 @@ const { transformUploadUrls } = require('./utils/signedUrl');
 const { initializeQueues } = require('./services/queueService');
 const migrateWorkboardApiFormat = require('./migrations/migrateWorkboardApiFormat');
 const migrateMediaOrderIndex = require('./migrations/migrateMediaOrderIndex');
+const migrateServerTypeToOpenAI = require('./migrations/migrateServerTypeToOpenAI');
 
 dotenv.config();
 
@@ -171,6 +172,7 @@ const startServer = async () => {
     console.log('Running migrations...');
     await migrateWorkboardApiFormat();
     await migrateMediaOrderIndex();
+    await migrateServerTypeToOpenAI();
 
     // Initialize job queues after database connection
     console.log('Initializing job queues...');


### PR DESCRIPTION
## Summary
[#181](https://github.com/iceemperor-gcempire/vcc-manager/issues/181) 의 **Phase 2**. Server 의 `serverType` 을 provider 단위로 정리하고 사용되지 않던 `outputType` 필드 제거. 기존 `GPT Image` 서버는 `OpenAI` 로 자동 마이그레이션.

## 변경
- `src/models/Server.js`
  - `serverType` enum 에 `'OpenAI'` 추가
  - `'GPT Image'` 는 deprecated 마커로 enum 에 잔존 (다음 메이저에서 제거)
  - `outputType` 필드 제거
  - `checkHealth` switch 에 `'OpenAI'` 케이스 추가 (`/v1/models`)
- `src/routes/servers.js` — 신규 생성 검증에서 `'GPT Image'` 차단, 요청 본문에서 `outputType` 제거
- `src/routes/workboards.js` — `populate` select 및 export 에서 `outputType` 참조 제거
- `src/migrations/migrateServerTypeToOpenAI.js` — 신규 마이그레이션
  - `serverType: 'GPT Image'` → `'OpenAI'` 일괄 변경
  - `outputType` 필드 일괄 `$unset`
  - `server.js` 마이그레이션 체인에 등록 (idempotent)
- `frontend/src/components/admin/ServerManagement.js`
  - 폼 dropdown 에 `OpenAI` 추가, `GPT Image` 신규 선택 차단
  - legacy 라벨 매핑은 `'GPT Image API (deprecated)'` 로 유지
  - placeholder URL 갱신
- `frontend/src/components/admin/WorkboardBasicInfoForm.js` — apiFormat 이 `'GPT Image'` (deprecated) 인 신규 작업판에서도 서버 조회가 동작하도록 `serverType: 'OpenAI'` 매핑
- `frontend/src/components/admin/WorkboardManagement.js` — import 다이얼로그 서버 선택 라벨에서 `outputType` 참조 제거

## 로컬 검증
- [x] 마이그레이션 1건 정상 적용 (`GPT Image` Server → `OpenAI`)
- [x] 마이그레이션 후 기존 GPT Image 작업판 생성 회귀 없음 — `apiFormat: GPT Image` 워크보드로 이미지 1장 정상 생성 (status: completed)
- [x] `OpenAI` 서버 헬스체크 정상 (`/v1/models` → 200, healthy)
- [x] 마이그레이션 idempotent (두 번 실행 시 modifiedCount=0)

## 호환성 / 후속
- 라우팅 dispatcher 는 여전히 `apiFormat` 기반 — Phase 3 에서 `(serverType, outputFormat)` 로 통합
- 기존 워크보드의 `apiFormat: 'GPT Image'` 는 변경 없음 (deprecation 기간)
- 신규 GPT Image 작업판 생성 시의 deprecated 안내는 Phase 5 의 UI 정리에서 처리

closes #182
부모: #181