### PR TITLE
refactor (Phase 3): 라우팅 dispatcher 통합 + 서비스 인터페이스 정리 (#184)

### DIFF
--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -1,7 +1,7 @@
 const express = require('express');
-const axios = require('axios');
 const { requireAuth } = require('../middleware/auth');
 const { addImageGenerationJob, getQueueStats } = require('../services/queueService');
+const openAIChatService = require('../services/openAIChatService');
 const { deleteFile } = require('../utils/fileUpload');
 const ImageGenerationJob = require('../models/ImageGenerationJob');
 const UploadedImage = require('../models/UploadedImage');
@@ -408,49 +408,16 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
       messages.push({ role: 'system', content: systemPrompt });
     }
     messages.push({ role: 'user', content: inputData.userPrompt });
-    
-    const apiUrl = `${server.serverUrl}/v1/chat/completions`;
-    const requestBody = {
-      model,
+
+    const { content: result, usage } = await openAIChatService.complete(
+      server.serverUrl,
+      server.configuration?.apiKey,
       messages,
-      temperature,
-      max_tokens: maxTokens
-    };
-    
-    const headers = {
-      'Content-Type': 'application/json'
-    };
-    
-    if (server.configuration?.apiKey) {
-      headers['Authorization'] = `Bearer ${server.configuration.apiKey}`;
-    }
-    
-    const response = await axios.post(apiUrl, requestBody, { headers, timeout: 60000 });
-    
-    console.log('LLM API response:', JSON.stringify(response.data, null, 2));
-    
-    if (!response.data?.choices || !Array.isArray(response.data.choices) || response.data.choices.length === 0) {
-      console.error('Invalid LLM response structure:', response.data);
-      return res.status(502).json({
-        message: response.data?.error?.message || 'LLM 서버에서 유효한 응답을 받지 못했습니다. 서버 URL과 설정을 확인해주세요.'
-      });
-    }
-    
-    const result = response.data.choices[0]?.message?.content || '';
-    if (!result) {
-      return res.status(502).json({
-        message: 'LLM 서버에서 빈 응답을 반환했습니다.'
-      });
-    }
-    
-    const usage = {
-      promptTokens: response.data?.usage?.prompt_tokens || 0,
-      completionTokens: response.data?.usage?.completion_tokens || 0,
-      totalTokens: response.data?.usage?.total_tokens || 0
-    };
-    
+      { model, temperature, maxTokens, timeout: 60000 }
+    );
+
     await workboard.incrementUsage();
-    
+
     res.json({
       success: true,
       result,
@@ -459,14 +426,7 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
     });
   } catch (error) {
     console.error('Prompt generation error:', error);
-    
-    if (error.response) {
-      return res.status(error.response.status).json({
-        message: error.response.data?.error?.message || 'API request failed'
-      });
-    }
-    
-    res.status(500).json({ message: error.message });
+    res.status(502).json({ message: error.message });
   }
 });
 

--- a/src/services/geminiService.js
+++ b/src/services/geminiService.js
@@ -110,6 +110,62 @@ const generateImage = async (serverUrl, apiKey, prompt, options = {}) => {
   return { images, videos: [] };
 };
 
+// Gemini LLM (Chat) — generateContent 호출 후 첫 번째 candidate 의 텍스트 본문 반환.
+// Phase 4/5 에서 Gemini Chat 워크보드 도입 시 호출되도록 마련해 둔 인터페이스.
+const complete = async (serverUrl, apiKey, messages, options = {}) => {
+  const resolvedServerUrl = (serverUrl || DEFAULT_SERVER_URL).replace(/\/+$/, '');
+  const model = extractValue(options.model);
+  if (!model) throw new Error('Gemini Chat: model is required');
+  if (!apiKey) throw new Error('Gemini Chat: api key is required');
+
+  const contents = (Array.isArray(messages) ? messages : []).map((m) => ({
+    role: m.role === 'assistant' ? 'model' : 'user',
+    parts: [{ text: m.content || '' }],
+  }));
+  if (contents.length === 0) {
+    throw new Error('Gemini Chat: messages is empty');
+  }
+
+  const generationConfig = {
+    responseModalities: ['TEXT'],
+  };
+  if (options.temperature !== undefined) {
+    generationConfig.temperature = options.temperature;
+  }
+  if (options.maxTokens !== undefined) {
+    generationConfig.maxOutputTokens = options.maxTokens;
+  }
+
+  const response = await axios.post(
+    `${resolvedServerUrl}/v1beta/models/${model}:generateContent`,
+    { contents, generationConfig },
+    {
+      params: { key: apiKey },
+      headers: { 'Content-Type': 'application/json' },
+      timeout: options.timeout || 60000,
+    }
+  );
+
+  const parts = response.data?.candidates?.[0]?.content?.parts || [];
+  const content = parts
+    .map((p) => p.text || '')
+    .filter(Boolean)
+    .join('');
+
+  if (!content) {
+    throw new Error('Gemini Chat: 빈 응답이 반환되었습니다.');
+  }
+
+  const usage = {
+    promptTokens: response.data?.usageMetadata?.promptTokenCount || 0,
+    completionTokens: response.data?.usageMetadata?.candidatesTokenCount || 0,
+    totalTokens: response.data?.usageMetadata?.totalTokenCount || 0,
+  };
+
+  return { content, usage, model };
+};
+
 module.exports = {
-  generateImage
+  generateImage,
+  complete,
 };

--- a/src/services/openAIChatService.js
+++ b/src/services/openAIChatService.js
@@ -1,0 +1,72 @@
+const axios = require('axios');
+
+const extractValue = (input) => {
+  if (input && typeof input === 'object' && input.value !== undefined) {
+    return input.value;
+  }
+  return input;
+};
+
+// OpenAI 호환 `/v1/chat/completions` 호출 — OpenAI 공식 / Local LLM (Ollama, LiteLLM, vLLM 등) 공통.
+// 응답에서 첫 번째 choice 의 메시지 본문 + usage 를 추출해 반환.
+const complete = async (serverUrl, apiKey, messages, options = {}) => {
+  const resolvedServerUrl = (serverUrl || '').replace(/\/+$/, '');
+  if (!resolvedServerUrl) {
+    throw new Error('OpenAI Chat: serverUrl is required');
+  }
+
+  const model = extractValue(options.model);
+  if (!model) {
+    throw new Error('OpenAI Chat: model is required');
+  }
+
+  const requestBody = {
+    model,
+    messages,
+    temperature: options.temperature ?? 0.7,
+    max_tokens: options.maxTokens ?? 2000,
+  };
+
+  const headers = { 'Content-Type': 'application/json' };
+  if (apiKey) {
+    headers['Authorization'] = `Bearer ${apiKey}`;
+  }
+
+  let response;
+  try {
+    response = await axios.post(
+      `${resolvedServerUrl}/v1/chat/completions`,
+      requestBody,
+      { headers, timeout: options.timeout || 60000 }
+    );
+  } catch (err) {
+    const apiMessage = err.response?.data?.error?.message;
+    if (apiMessage && /organization must be verified/i.test(apiMessage)) {
+      throw new Error(
+        `${model} 모델 사용에는 OpenAI 조직 인증(Verify Organization)이 필요합니다. https://platform.openai.com/settings/organization/general 에서 인증 후 약 15분 대기하세요.`
+      );
+    }
+    if (apiMessage) throw new Error(`OpenAI: ${apiMessage}`);
+    throw err;
+  }
+
+  const choices = response.data?.choices;
+  if (!Array.isArray(choices) || choices.length === 0) {
+    throw new Error('LLM 서버에서 유효한 응답을 받지 못했습니다. 서버 URL과 설정을 확인해주세요.');
+  }
+
+  const content = choices[0]?.message?.content || '';
+  if (!content) {
+    throw new Error('LLM 서버에서 빈 응답을 반환했습니다.');
+  }
+
+  const usage = {
+    promptTokens: response.data?.usage?.prompt_tokens || 0,
+    completionTokens: response.data?.usage?.completion_tokens || 0,
+    totalTokens: response.data?.usage?.total_tokens || 0,
+  };
+
+  return { content, usage, model };
+};
+
+module.exports = { complete };

--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -117,124 +117,161 @@ const initializeQueues = async () => {
   }
 };
 
+// (serverType, outputFormat) → 핸들러 매핑.
+// 신규 provider/capability 추가 시 이 테이블에만 추가하면 됨.
+// 핸들러 시그니처: ({ workboardData, inputData, jobId, job }) => Promise<{ images?, videos?, seed? }>
+const SERVICE_MAP = {
+  'Gemini:image': handleGeminiImage,
+  'OpenAI:image': handleOpenAIImage,
+  'OpenAI Compatible:image': handleOpenAIImage,
+  'ComfyUI:image': handleComfyUIWorkflow,
+  'ComfyUI:video': handleComfyUIWorkflow,
+};
+
+// Deprecated apiFormat 만 가진 잡 (Phase 4 이전 데이터) 을 위한 fallback 매핑.
+const APIFORMAT_TO_SERVERTYPE = {
+  'ComfyUI': 'ComfyUI',
+  'OpenAI Compatible': 'OpenAI Compatible',
+  'Gemini': 'Gemini',
+  'GPT Image': 'OpenAI', // Phase 2 마이그레이션 후 server 는 OpenAI 로 저장됨
+};
+
+const resolveServiceKey = (workboardData) => {
+  const serverType = workboardData.serverType
+    || APIFORMAT_TO_SERVERTYPE[workboardData.apiFormat];
+  const outputFormat = workboardData.outputFormat || 'image';
+  return { key: `${serverType}:${outputFormat}`, serverType, outputFormat };
+};
+
+async function handleGeminiImage({ workboardData, inputData, job }) {
+  const geminiImages = await loadImageInputs(
+    workboardData.additionalInputFields || [],
+    inputData
+  );
+  job.progress(20);
+
+  const result = await geminiService.generateImage(
+    workboardData.serverUrl,
+    workboardData.apiKey || process.env.GEMINI_API_KEY,
+    buildGeminiPrompt(inputData),
+    {
+      model: inputData.aiModel,
+      aspectRatio: deriveAspectRatio(extractOptionValue(inputData.imageSize)),
+      resolution: extractOptionValue(inputData.additionalParams?.resolution),
+      images: geminiImages,
+      timeout: workboardData.timeout,
+    }
+  );
+  job.progress(90);
+  return result;
+}
+
+async function handleOpenAIImage({ workboardData, inputData, job }) {
+  const result = await gptImageService.generateImage(
+    workboardData.serverUrl,
+    workboardData.apiKey || process.env.OPENAI_IMAGE_API_KEY,
+    buildGeminiPrompt(inputData),
+    {
+      model: inputData.aiModel,
+      size: extractOptionValue(inputData.imageSize),
+      quality: extractOptionValue(
+        inputData.additionalParams?.quality || inputData.quality
+      ),
+      n: extractOptionValue(
+        inputData.additionalParams?.n || inputData.n
+      ) || 1,
+      outputFormat: extractOptionValue(
+        inputData.additionalParams?.outputFormat || inputData.outputFormat
+      ) || 'png',
+      background: extractOptionValue(inputData.additionalParams?.background),
+      outputCompression: extractOptionValue(inputData.additionalParams?.output_compression),
+      timeout: workboardData.timeout,
+    }
+  );
+  job.progress(90);
+  return result;
+}
+
+async function handleComfyUIWorkflow({ workboardData, inputData, job, jobId }) {
+  const uploadedImageMap = await uploadImageFieldsToComfyUI(
+    workboardData.serverUrl,
+    workboardData.additionalInputFields || [],
+    inputData
+  );
+  job.progress(15);
+
+  let workflowJson;
+  let actualSeed;
+  try {
+    ({ workflowJson, actualSeed } = await injectInputsIntoWorkflow(
+      workboardData.workflowData,
+      inputData,
+      workboardData,
+      uploadedImageMap
+    ));
+  } catch (injectError) {
+    const resolvedString = injectError.resolvedWorkflowString || workboardData.workflowData;
+    try {
+      await ImageGenerationJob.findByIdAndUpdate(jobId, {
+        resolvedWorkflowData: resolvedString,
+      });
+    } catch (saveError) {
+      console.error(`⚠️ Failed to save workflow data for job ${jobId}:`, saveError.message);
+    }
+    throw injectError;
+  }
+  job.progress(20);
+
+  try {
+    await ImageGenerationJob.findByIdAndUpdate(jobId, {
+      resolvedWorkflowData: JSON.stringify(workflowJson),
+    });
+  } catch (saveError) {
+    console.error(`⚠️ Failed to save resolved workflow data for job ${jobId}:`, saveError.message);
+  }
+
+  console.log(`🚀 Submitting workflow to ComfyUI for job ${jobId} with seed: ${actualSeed}`);
+  console.log(`🔗 ComfyUI Server URL: ${workboardData.serverUrl}`);
+  console.log(`📝 Workflow JSON preview:`, JSON.stringify(workflowJson).substring(0, 200) + '...');
+
+  const result = await comfyUIService.submitWorkflow(
+    workboardData.serverUrl,
+    workflowJson,
+    (progress) => job.progress(20 + (progress * 0.7))
+  );
+  job.progress(90);
+
+  console.log(`✅ ComfyUI workflow completed for job ${jobId}`);
+  console.log(`📊 ComfyUI result:`, {
+    hasImages: !!result.images,
+    imageCount: result.images?.length || 0,
+    hasVideos: !!result.videos,
+    videoCount: result.videos?.length || 0,
+    resultKeys: Object.keys(result),
+  });
+
+  return { ...result, seed: actualSeed };
+}
+
 const processImageGeneration = async (job) => {
   const { jobId, workboardData, inputData } = job.data;
-  
+
   try {
     job.progress(5);
-    
-    let generationResult;
-    let enhancedInputData = { ...inputData };
 
-    if (workboardData.apiFormat === 'Gemini') {
-      const geminiImages = await loadImageInputs(
-        workboardData.additionalInputFields || [],
-        inputData
+    const { key, serverType, outputFormat } = resolveServiceKey(workboardData);
+    const handler = SERVICE_MAP[key];
+    if (!handler) {
+      throw new Error(
+        `지원하지 않는 서비스 조합입니다: serverType=${serverType ?? '(unknown)'}, outputFormat=${outputFormat}`
       );
-      job.progress(20);
-
-      generationResult = await geminiService.generateImage(
-        workboardData.serverUrl,
-        workboardData.apiKey || process.env.GEMINI_API_KEY,
-        buildGeminiPrompt(inputData),
-        {
-          model: inputData.aiModel,
-          aspectRatio: deriveAspectRatio(extractOptionValue(inputData.imageSize)),
-          resolution: extractOptionValue(inputData.additionalParams?.resolution),
-          images: geminiImages,
-          timeout: workboardData.timeout
-        }
-      );
-      job.progress(90);
-    } else if (workboardData.apiFormat === 'GPT Image') {
-      generationResult = await gptImageService.generateImage(
-        workboardData.serverUrl,
-        workboardData.apiKey || process.env.OPENAI_IMAGE_API_KEY,
-        buildGeminiPrompt(inputData),
-        {
-          model: inputData.aiModel,
-          size: extractOptionValue(inputData.imageSize),
-          quality: extractOptionValue(
-            inputData.additionalParams?.quality || inputData.quality
-          ),
-          n: extractOptionValue(
-            inputData.additionalParams?.n || inputData.n
-          ) || 1,
-          outputFormat: extractOptionValue(
-            inputData.additionalParams?.outputFormat || inputData.outputFormat
-          ) || 'png',
-          background: extractOptionValue(inputData.additionalParams?.background),
-          outputCompression: extractOptionValue(inputData.additionalParams?.output_compression),
-          timeout: workboardData.timeout
-        }
-      );
-      job.progress(90);
-    } else {
-      // 이미지 타입 필드들을 ComfyUI에 업로드
-      const uploadedImageMap = await uploadImageFieldsToComfyUI(
-        workboardData.serverUrl,
-        workboardData.additionalInputFields || [],
-        inputData
-      );
-      job.progress(15);
-
-      let workflowJson, actualSeed;
-      try {
-        ({ workflowJson, actualSeed } = await injectInputsIntoWorkflow(
-          workboardData.workflowData,
-          inputData,
-          workboardData,
-          uploadedImageMap
-        ));
-      } catch (injectError) {
-        // 워크플로우 주입 실패 시 치환된 워크플로우 문자열을 저장하여 디버깅 가능하게 함
-        const resolvedString = injectError.resolvedWorkflowString || workboardData.workflowData;
-        try {
-          await ImageGenerationJob.findByIdAndUpdate(jobId, {
-            resolvedWorkflowData: resolvedString
-          });
-        } catch (saveError) {
-          console.error(`⚠️ Failed to save workflow data for job ${jobId}:`, saveError.message);
-        }
-        throw injectError;
-      }
-      job.progress(20);
-
-      // resolved 워크플로우 JSON 저장 (전송 전 저장하여 실패한 작업도 확인 가능)
-      try {
-        await ImageGenerationJob.findByIdAndUpdate(jobId, {
-          resolvedWorkflowData: JSON.stringify(workflowJson)
-        });
-      } catch (saveError) {
-        console.error(`⚠️ Failed to save resolved workflow data for job ${jobId}:`, saveError.message);
-      }
-
-      enhancedInputData = {
-        ...inputData,
-        seed: actualSeed
-      };
-
-      console.log(`🚀 Submitting workflow to ComfyUI for job ${jobId} with seed: ${actualSeed}`);
-      console.log(`🔗 ComfyUI Server URL: ${workboardData.serverUrl}`);
-      console.log(`📝 Workflow JSON preview:`, JSON.stringify(workflowJson).substring(0, 200) + '...');
-
-      generationResult = await comfyUIService.submitWorkflow(
-        workboardData.serverUrl,
-        workflowJson,
-        (progress) => job.progress(20 + (progress * 0.7))
-      );
-      job.progress(90);
-
-      console.log(`✅ ComfyUI workflow completed for job ${jobId}`);
-      console.log(`📊 ComfyUI result:`, {
-        hasImages: !!generationResult.images,
-        imageCount: generationResult.images?.length || 0,
-        hasVideos: !!generationResult.videos,
-        videoCount: generationResult.videos?.length || 0,
-        resultKeys: Object.keys(generationResult),
-        fullResult: generationResult
-      });
     }
+    console.log(`[dispatch] job ${jobId} → ${key}`);
+
+    const generationResult = await handler({ workboardData, inputData, job, jobId });
+    const enhancedInputData = generationResult.seed != null
+      ? { ...inputData, seed: generationResult.seed }
+      : inputData;
     
     const hasImages = generationResult.images && generationResult.images.length > 0;
     const hasVideos = generationResult.videos && generationResult.videos.length > 0;
@@ -878,6 +915,9 @@ const addImageGenerationJob = async (userId, workboardId, inputData) => {
     const queueJob = await imageGenerationQueue.add('generateImage', {
       jobId: job._id.toString(),
       workboardData: {
+        // Phase 3: 라우팅은 (serverType, outputFormat) 우선, apiFormat 은 fallback
+        serverType: workboard.serverId?.serverType,
+        outputFormat: workboard.outputFormat,
         apiFormat: workboard.apiFormat,
         serverUrl: workboard.serverUrl,
         apiKey: workboard.serverId?.configuration?.apiKey,


### PR DESCRIPTION
## Summary
[#181](https://github.com/iceemperor-gcempire/vcc-manager/issues/181) 의 **Phase 3**. `queueService` 의 if/else if 사슬을 `(serverType, outputFormat)` 키 기반 `SERVICE_MAP` 으로 교체. OpenAI Compatible chat 호출을 별도 서비스 모듈로 추출하고 Gemini 의 LLM 호출 인터페이스도 선반영.

## 변경
- `src/services/queueService.js`
  - `SERVICE_MAP`, `APIFORMAT_TO_SERVERTYPE`, `resolveServiceKey` 도입
  - 핸들러 3개 추출: `handleGeminiImage`, `handleOpenAIImage`, `handleComfyUIWorkflow`
  - `processImageGeneration` 이 단순 dispatcher 로 정리됨
  - ComfyUI 핸들러는 `actualSeed` 를 반환해 `enhancedInputData` 가 dispatcher 단에서 합성됨
  - 신규 잡은 `serverType + outputFormat` 로 라우팅, 구 잡은 `apiFormat` fallback (`APIFORMAT_TO_SERVERTYPE`) 으로 매핑
- `addImageGenerationJob`: 큐에 push 하는 `workboardData` 에 `serverType`, `outputFormat` 추가
- `src/services/openAIChatService.js` (신규)
  - `/v1/chat/completions` 호출 모듈
  - OpenAI 공식 / Local LLM (Ollama, LiteLLM, vLLM 등) 공통 사용
  - 조직 인증 에러 메시지 한국어 치환 (gptImageService 와 동일 패턴)
- `src/services/geminiService.js`
  - `complete` 메서드 신규 — `generateContent` 텍스트 전용 호출 래핑
  - Phase 4/5 의 Gemini Chat 워크보드 도입 시 호출 예정
- `src/routes/jobs.js` `/api/jobs/generate-prompt`
  - 인라인 axios 호출 제거, `openAIChatService.complete` 사용

## 로컬 검증
- [x] GPT Image 작업판 → `OpenAI:image` 라우팅 확인 (dispatch 로그) → 이미지 1장 정상 생성
- [x] Gemini 이미지 작업판 → `Gemini:image` 라우팅 → 이미지 1장 정상 생성
- [x] 백엔드 부팅 정상, 마이그레이션 idempotent 통과 (Phase 2 마이그레이션 0건 처리)

## 호환성
- 기존 워크보드의 `apiFormat` 값 변경 없음
- ComfyUI image / video 워크보드 모두 동일 핸들러 (`handleComfyUIWorkflow`) 로 라우팅
- routes/jobs.js prompt-generate 의 응답 스키마 동일 (성공 / 에러 모두)

## 후속
- `gptImageService.js` 의 `openAIImageService.js` 리네이밍은 Phase 5 와 함께 검토
- Phase 4 (템플릿 JSON 분리) 로 진행

closes #184
부모: #181