### PR TITLE
refactor (Phase 4): 신규 작업판 템플릿을 JSON 모듈로 분리 (#186)

### DIFF
--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -54,6 +54,16 @@ import { useForm, Controller } from 'react-hook-form';
 import toast from 'react-hot-toast';
 import { workboardAPI, serverAPI } from '../../services/api';
 import WorkboardBasicInfoForm from './WorkboardBasicInfoForm';
+import { getWorkboardTemplate } from '../../templates';
+
+// Deprecated apiFormat → 신규 serverType 매핑. 'GPT Image' workboard 의 server 는
+// Phase 2 에서 'OpenAI' 로 마이그레이션됐으므로 템플릿 키도 OpenAI 로 매핑.
+const APIFORMAT_TO_SERVERTYPE = {
+  ComfyUI: 'ComfyUI',
+  Gemini: 'Gemini',
+  'GPT Image': 'OpenAI',
+  'OpenAI Compatible': 'OpenAI Compatible',
+};
 
 function WorkboardCard({ workboard, onEdit, onDelete, onDuplicate, onExport, onView, onToggleActive }) {
   const [anchorEl, setAnchorEl] = useState(null);
@@ -2105,123 +2115,14 @@ function WorkboardManagement() {
     if (selectedWorkboard) {
       updateMutation.mutate({ id: selectedWorkboard._id, data: normalizedData });
     } else {
-      const isOpenAI = normalizedApiFormat === 'OpenAI Compatible';
-      const isGeminiApi = normalizedApiFormat === 'Gemini';
-      const isGptImageApi = normalizedApiFormat === 'GPT Image';
+      // Phase 4: 템플릿은 frontend/src/templates/<serverType>-<outputFormat>.json 에서 로드.
+      // 'GPT Image' apiFormat 은 Phase 2 에서 server 가 'OpenAI' 로 마이그레이션됐으므로 매핑.
+      const serverType = APIFORMAT_TO_SERVERTYPE[normalizedApiFormat] || normalizedApiFormat;
+      const template = getWorkboardTemplate(serverType, normalizedData.outputFormat);
 
       const workboardData = {
         ...normalizedData,
-        baseInputFields: isOpenAI ? {
-          aiModel: [
-            { key: 'GPT-4', value: 'gpt-4' },
-            { key: 'GPT-3.5 Turbo', value: 'gpt-3.5-turbo' }
-          ],
-          systemPrompt: '',
-          referenceImages: []
-        } : isGeminiApi ? {
-          aiModel: [
-            { key: 'Nano Banana', value: 'gemini-2.5-flash-image' },
-            { key: 'Nano Banana Pro', value: 'gemini-3-pro-image-preview' },
-            { key: 'Nano Banana 2', value: 'gemini-3.1-flash-image-preview' }
-          ],
-          imageSizes: [
-            { key: '정사각 (1:1)', value: '1:1' },
-            { key: '가로 와이드 (16:9)', value: '16:9' },
-            { key: '세로 와이드 (9:16)', value: '9:16' },
-            { key: '가로 (4:3)', value: '4:3' },
-            { key: '세로 (3:4)', value: '3:4' },
-            { key: '영화 (21:9)', value: '21:9' }
-          ],
-          referenceImageMethods: []
-        } : isGptImageApi ? {
-          aiModel: [
-            { key: 'GPT Image 2 (조직 인증 필요)', value: 'gpt-image-2' },
-            { key: 'GPT Image 1.5', value: 'gpt-image-1.5' },
-            { key: 'GPT Image 1', value: 'gpt-image-1' },
-            { key: 'GPT Image 1 Mini', value: 'gpt-image-1-mini' }
-          ],
-          imageSizes: [
-            { key: '자동 (auto)', value: 'auto' },
-            { key: '1024x1024', value: '1024x1024' },
-            { key: '1024x1536', value: '1024x1536' },
-            { key: '1536x1024', value: '1536x1024' }
-          ],
-          referenceImageMethods: []
-        } : {
-          aiModel: [
-            { key: 'Default Model', value: 'default.safetensors' }
-          ],
-          imageSizes: [
-            { key: '1024x1024', value: '1024x1024' },
-            { key: '896x1152', value: '896x1152' },
-            { key: '1152x896', value: '1152x896' },
-            { key: '832x1216', value: '832x1216' },
-            { key: '1216x832', value: '1216x832' },
-            { key: '768x1344', value: '768x1344' },
-            { key: '1344x768', value: '1344x768' }
-          ],
-          referenceImageMethods: [
-            { key: 'Image to Image', value: 'img2img' },
-            { key: 'ControlNet Canny', value: 'controlnet_canny' }
-          ]
-        },
-        additionalInputFields: isGptImageApi ? [
-          {
-            name: 'quality',
-            label: '품질',
-            type: 'select',
-            required: true,
-            defaultValue: 'auto',
-            options: [
-              { key: 'Auto', value: 'auto' },
-              { key: 'Low', value: 'low' },
-              { key: 'Medium', value: 'medium' },
-              { key: 'High', value: 'high' }
-            ],
-            description: 'GPT Image 생성 품질을 선택합니다.'
-          },
-          {
-            name: 'background',
-            label: '배경',
-            type: 'select',
-            required: false,
-            defaultValue: 'opaque',
-            options: [
-              { key: '불투명 (opaque)', value: 'opaque' },
-              { key: '투명 (transparent)', value: 'transparent' }
-            ],
-            description: 'gpt-image-2 전용. 투명 배경으로 출력하려면 transparent. 다른 모델에서는 무시됨.'
-          },
-          {
-            name: 'output_compression',
-            label: '출력 압축률',
-            type: 'number',
-            required: false,
-            defaultValue: 100,
-            description: 'gpt-image-2 의 JPEG/WebP 출력 시 압축률 (1-100). PNG 에는 영향 없음. 다른 모델에서는 무시됨.'
-          }
-        ] : isGeminiApi ? [
-          {
-            name: 'resolution',
-            label: '해상도',
-            type: 'select',
-            required: true,
-            defaultValue: '2K',
-            options: [
-              { key: '1K (기본)', value: '1K' },
-              { key: '2K', value: '2K' },
-              { key: '4K', value: '4K' }
-            ],
-            description: 'Gemini 이미지 출력 해상도를 선택합니다.'
-          }
-        ] : [],
-        workflowData: (isOpenAI || isGeminiApi || isGptImageApi) ? '' : JSON.stringify({
-          "prompt": "{{##prompt##}}",
-          "negative_prompt": "{{##negative_prompt##}}",
-          "model": "{{##model##}}",
-          "width": "{{##width##}}",
-          "height": "{{##height##}}"
-        }, null, 2)
+        ...template,
       };
       createMutation.mutate(workboardData);
     }

--- a/frontend/src/templates/ComfyUI-image.json
+++ b/frontend/src/templates/ComfyUI-image.json
@@ -1,0 +1,22 @@
+{
+  "baseInputFields": {
+    "aiModel": [
+      { "key": "Default Model", "value": "default.safetensors" }
+    ],
+    "imageSizes": [
+      { "key": "1024x1024", "value": "1024x1024" },
+      { "key": "896x1152", "value": "896x1152" },
+      { "key": "1152x896", "value": "1152x896" },
+      { "key": "832x1216", "value": "832x1216" },
+      { "key": "1216x832", "value": "1216x832" },
+      { "key": "768x1344", "value": "768x1344" },
+      { "key": "1344x768", "value": "1344x768" }
+    ],
+    "referenceImageMethods": [
+      { "key": "Image to Image", "value": "img2img" },
+      { "key": "ControlNet Canny", "value": "controlnet_canny" }
+    ]
+  },
+  "additionalInputFields": [],
+  "workflowData": "{\n  \"prompt\": \"{{##prompt##}}\",\n  \"negative_prompt\": \"{{##negative_prompt##}}\",\n  \"model\": \"{{##model##}}\",\n  \"width\": \"{{##width##}}\",\n  \"height\": \"{{##height##}}\"\n}"
+}

--- a/frontend/src/templates/ComfyUI-video.json
+++ b/frontend/src/templates/ComfyUI-video.json
@@ -1,0 +1,22 @@
+{
+  "baseInputFields": {
+    "aiModel": [
+      { "key": "Default Model", "value": "default.safetensors" }
+    ],
+    "imageSizes": [
+      { "key": "1024x1024", "value": "1024x1024" },
+      { "key": "896x1152", "value": "896x1152" },
+      { "key": "1152x896", "value": "1152x896" },
+      { "key": "832x1216", "value": "832x1216" },
+      { "key": "1216x832", "value": "1216x832" },
+      { "key": "768x1344", "value": "768x1344" },
+      { "key": "1344x768", "value": "1344x768" }
+    ],
+    "referenceImageMethods": [
+      { "key": "Image to Image", "value": "img2img" },
+      { "key": "ControlNet Canny", "value": "controlnet_canny" }
+    ]
+  },
+  "additionalInputFields": [],
+  "workflowData": "{\n  \"prompt\": \"{{##prompt##}}\",\n  \"negative_prompt\": \"{{##negative_prompt##}}\",\n  \"model\": \"{{##model##}}\",\n  \"width\": \"{{##width##}}\",\n  \"height\": \"{{##height##}}\"\n}"
+}

--- a/frontend/src/templates/Gemini-image.json
+++ b/frontend/src/templates/Gemini-image.json
@@ -1,0 +1,34 @@
+{
+  "baseInputFields": {
+    "aiModel": [
+      { "key": "Nano Banana", "value": "gemini-2.5-flash-image" },
+      { "key": "Nano Banana Pro", "value": "gemini-3-pro-image-preview" },
+      { "key": "Nano Banana 2", "value": "gemini-3.1-flash-image-preview" }
+    ],
+    "imageSizes": [
+      { "key": "정사각 (1:1)", "value": "1:1" },
+      { "key": "가로 와이드 (16:9)", "value": "16:9" },
+      { "key": "세로 와이드 (9:16)", "value": "9:16" },
+      { "key": "가로 (4:3)", "value": "4:3" },
+      { "key": "세로 (3:4)", "value": "3:4" },
+      { "key": "영화 (21:9)", "value": "21:9" }
+    ],
+    "referenceImageMethods": []
+  },
+  "additionalInputFields": [
+    {
+      "name": "resolution",
+      "label": "해상도",
+      "type": "select",
+      "required": true,
+      "defaultValue": "2K",
+      "options": [
+        { "key": "1K (기본)", "value": "1K" },
+        { "key": "2K", "value": "2K" },
+        { "key": "4K", "value": "4K" }
+      ],
+      "description": "Gemini 이미지 출력 해상도를 선택합니다."
+    }
+  ],
+  "workflowData": ""
+}

--- a/frontend/src/templates/OpenAI Compatible-text.json
+++ b/frontend/src/templates/OpenAI Compatible-text.json
@@ -1,0 +1,12 @@
+{
+  "baseInputFields": {
+    "aiModel": [
+      { "key": "GPT-4", "value": "gpt-4" },
+      { "key": "GPT-3.5 Turbo", "value": "gpt-3.5-turbo" }
+    ],
+    "systemPrompt": "",
+    "referenceImages": []
+  },
+  "additionalInputFields": [],
+  "workflowData": ""
+}

--- a/frontend/src/templates/OpenAI-image.json
+++ b/frontend/src/templates/OpenAI-image.json
@@ -1,0 +1,54 @@
+{
+  "baseInputFields": {
+    "aiModel": [
+      { "key": "GPT Image 2 (조직 인증 필요)", "value": "gpt-image-2" },
+      { "key": "GPT Image 1.5", "value": "gpt-image-1.5" },
+      { "key": "GPT Image 1", "value": "gpt-image-1" },
+      { "key": "GPT Image 1 Mini", "value": "gpt-image-1-mini" }
+    ],
+    "imageSizes": [
+      { "key": "자동 (auto)", "value": "auto" },
+      { "key": "1024x1024", "value": "1024x1024" },
+      { "key": "1024x1536", "value": "1024x1536" },
+      { "key": "1536x1024", "value": "1536x1024" }
+    ],
+    "referenceImageMethods": []
+  },
+  "additionalInputFields": [
+    {
+      "name": "quality",
+      "label": "품질",
+      "type": "select",
+      "required": true,
+      "defaultValue": "auto",
+      "options": [
+        { "key": "Auto", "value": "auto" },
+        { "key": "Low", "value": "low" },
+        { "key": "Medium", "value": "medium" },
+        { "key": "High", "value": "high" }
+      ],
+      "description": "GPT Image 생성 품질을 선택합니다."
+    },
+    {
+      "name": "background",
+      "label": "배경",
+      "type": "select",
+      "required": false,
+      "defaultValue": "opaque",
+      "options": [
+        { "key": "불투명 (opaque)", "value": "opaque" },
+        { "key": "투명 (transparent)", "value": "transparent" }
+      ],
+      "description": "gpt-image-2 전용. 투명 배경으로 출력하려면 transparent. 다른 모델에서는 무시됨."
+    },
+    {
+      "name": "output_compression",
+      "label": "출력 압축률",
+      "type": "number",
+      "required": false,
+      "defaultValue": 100,
+      "description": "gpt-image-2 의 JPEG/WebP 출력 시 압축률 (1-100). PNG 에는 영향 없음. 다른 모델에서는 무시됨."
+    }
+  ],
+  "workflowData": ""
+}

--- a/frontend/src/templates/index.js
+++ b/frontend/src/templates/index.js
@@ -1,0 +1,30 @@
+// 신규 작업판 생성 시 사용되는 (serverType, outputFormat) 별 기본 템플릿.
+// 각 JSON 파일은 { baseInputFields, additionalInputFields, workflowData } 구조.
+// 신규 provider/capability 추가 시 새 JSON 파일을 만들고 아래 TEMPLATES 에 등록.
+
+import comfyImage from './ComfyUI-image.json';
+import comfyVideo from './ComfyUI-video.json';
+import openAIImage from './OpenAI-image.json';
+import geminiImage from './Gemini-image.json';
+import openAICompatibleText from './OpenAI Compatible-text.json';
+
+const TEMPLATES = {
+  'ComfyUI:image': comfyImage,
+  'ComfyUI:video': comfyVideo,
+  'OpenAI:image': openAIImage,
+  'Gemini:image': geminiImage,
+  'OpenAI Compatible:text': openAICompatibleText,
+};
+
+// 매핑이 없을 때 사용하는 빈 폴백 (Workboard 가 항상 baseInputFields/additionalInputFields 를 갖도록 보장).
+const EMPTY_TEMPLATE = {
+  baseInputFields: {},
+  additionalInputFields: [],
+  workflowData: '',
+};
+
+export function getWorkboardTemplate(serverType, outputFormat) {
+  return TEMPLATES[`${serverType}:${outputFormat}`] || EMPTY_TEMPLATE;
+}
+
+export { TEMPLATES };


### PR DESCRIPTION
## Summary
[#181](https://github.com/iceemperor-gcempire/vcc-manager/issues/181) 의 **Phase 4**. 작업판 생성 시 사용되는 `baseInputFields` / `additionalInputFields` / `workflowData` 기본값을 `WorkboardManagement.js` 의 인라인 ternary 에서 JSON 모듈로 분리.

## 변경
- `frontend/src/templates/` 디렉토리 신설 (`<serverType>-<outputFormat>.json`)
  - `ComfyUI-image.json`
  - `ComfyUI-video.json` (image 와 동일 콘텐츠로 시작)
  - `Gemini-image.json`
  - `OpenAI-image.json` (구 `apiFormat='GPT Image'` 대응)
  - `OpenAI Compatible-text.json`
  - `index.js` — `getWorkboardTemplate(serverType, outputFormat)` 헬퍼 + `TEMPLATES` 매핑
- `WorkboardManagement.handleSave`
  - 인라인 ternary ~110라인 → 헬퍼 호출 ~3라인으로 교체
  - apiFormat → serverType 매핑을 컴포넌트 상단 `APIFORMAT_TO_SERVERTYPE` 상수로 단일화

## 영향 범위
- `frontend/src/components/admin/WorkboardManagement.js` 1 파일, +15/-114
- `frontend/src/templates/` 6개 신규 파일

## 로컬 검증
- [x] 기존 GPT Image 작업판 생성 회귀 없음 — 이미지 1장 정상 생성 (`status: completed`)
- [x] 프론트 빌드된 번들에 5개 템플릿 콘텐츠 모두 포함 확인 (`Nano Banana 2`, `GPT Image 2`, `gpt-image-2`, `GPT-3.5 Turbo`, `Default Model` 등 grep 으로 검출)

## 호환성
- 모델 / 백엔드 / 라우팅 영향 없음
- 기존 작업판 동작 영향 없음 (생성 흐름만 영향)

## 후속
- 신규 템플릿 추가는 JSON 파일 + `templates/index.js` 의 `TEMPLATES` 매핑만 수정하면 됨 (예: 향후 `OpenAI-text`, `Gemini-text`, `OpenAI Compatible-image`)
- Phase 5 에서 UI 가 (server, outputFormat) 만 표시하도록 정리되면 `apiFormat` deprecation 마무리

closes #186
부모: #181