### PR TITLE
refactor (Phase 5): 작업판 폼을 (server, outputFormat) 기반으로 전환 (#188)

### DIFF
--- a/frontend/src/components/admin/WorkboardBasicInfoForm.js
+++ b/frontend/src/components/admin/WorkboardBasicInfoForm.js
@@ -9,103 +9,43 @@ import {
   FormControlLabel,
   Switch,
   Typography,
-  Alert
+  Alert,
 } from '@mui/material';
 import { Controller, useWatch } from 'react-hook-form';
 import { useQuery } from 'react-query';
 import { serverAPI } from '../../services/api';
+import {
+  getCapableOutputFormats,
+  getOutputFormatLabel,
+  getServerTypeLabel,
+} from '../../templates/capabilities';
 
-function WorkboardBasicInfoForm({ control, errors, showActiveSwitch = false, showTypeSelector = false, isDialogOpen = true }) {
-  const apiFormat = useWatch({ control, name: 'apiFormat' }) || 'ComfyUI';
+function WorkboardBasicInfoForm({ control, setValue, errors, showActiveSwitch = false, showTypeSelector = false, isDialogOpen = true }) {
+  const selectedServerId = useWatch({ control, name: 'serverId' });
   const outputFormat = useWatch({ control, name: 'outputFormat' }) || 'image';
-  const isFixedImageApiFormat = ['Gemini', 'GPT Image'].includes(apiFormat);
-  const getApiFormatLabel = (format) => {
-    switch (format) {
-      case 'ComfyUI':
-        return 'ComfyUI API';
-      case 'OpenAI Compatible':
-        return 'OpenAI Compatible API';
-      case 'Gemini':
-        return 'Gemini Image API';
-      case 'GPT Image':
-        return 'GPT Image API';
-      default:
-        return format;
-    }
-  };
 
-  // 'GPT Image' apiFormat 은 deprecated — Phase 2 마이그레이션 이후 서버는 'OpenAI' 로 저장됨.
-  // workboard.apiFormat 은 deprecation 기간 동안 그대로 유지되므로 서버 조회 시에만 매핑.
-  const apiFormatToServerType = (af) => (af === 'GPT Image' ? 'OpenAI' : af);
   const { data: serversData } = useQuery(
-    ['servers', apiFormat],
-    () => serverAPI.getServers({
-      serverType: apiFormatToServerType(apiFormat)
-    }),
+    'servers-all-active',
+    () => serverAPI.getServers({}),
     { enabled: isDialogOpen }
   );
 
   const servers = serversData?.data?.data?.servers || [];
+  const selectedServer = servers.find((s) => s._id === selectedServerId);
+  const selectedServerType = selectedServer?.serverType;
+  const capableOutputFormats = selectedServerType ? getCapableOutputFormats(selectedServerType) : [];
+
+  // 서버가 바뀌면 폼의 serverType 을 동기화하고, 현재 outputFormat 이 capability 에 없으면 첫 옵션으로 보정.
+  React.useEffect(() => {
+    if (!setValue) return;
+    setValue('serverType', selectedServerType || '');
+    if (selectedServerType && capableOutputFormats.length > 0 && !capableOutputFormats.includes(outputFormat)) {
+      setValue('outputFormat', capableOutputFormats[0]);
+    }
+  }, [setValue, selectedServerType, capableOutputFormats, outputFormat]);
 
   return (
     <Grid container spacing={2}>
-      {showTypeSelector && (
-        <>
-          <Grid item xs={12} sm={6}>
-            <Controller
-              name="apiFormat"
-              control={control}
-              render={({ field }) => (
-                <FormControl fullWidth>
-                  <InputLabel>AI API 형식</InputLabel>
-                  <Select
-                    {...field}
-                    label="AI API 형식"
-                  >
-                    <MenuItem value="ComfyUI">ComfyUI API</MenuItem>
-                    <MenuItem value="OpenAI Compatible">OpenAI Compatible API</MenuItem>
-                    <MenuItem value="Gemini">Gemini Image API</MenuItem>
-                    <MenuItem value="GPT Image">GPT Image API</MenuItem>
-                  </Select>
-                </FormControl>
-              )}
-            />
-          </Grid>
-          <Grid item xs={12} sm={6}>
-            <Controller
-              name="outputFormat"
-              control={control}
-              render={({ field }) => (
-                <FormControl fullWidth>
-                  <InputLabel>출력 형식</InputLabel>
-                  <Select
-                    {...field}
-                    label="출력 형식"
-                    value={isFixedImageApiFormat ? 'image' : outputFormat}
-                    disabled={isFixedImageApiFormat}
-                  >
-                    <MenuItem value="image">이미지</MenuItem>
-                    {!isFixedImageApiFormat && <MenuItem value="video">비디오</MenuItem>}
-                    {!isFixedImageApiFormat && <MenuItem value="text">텍스트</MenuItem>}
-                  </Select>
-                </FormControl>
-              )}
-            />
-          </Grid>
-          <Grid item xs={12}>
-            <Typography variant="caption" color="textSecondary">
-              {apiFormat === 'OpenAI Compatible'
-                ? 'OpenAI Compatible API를 사용하여 텍스트 기반 콘텐츠를 생성합니다.'
-                : apiFormat === 'Gemini'
-                  ? 'Gemini Image API를 사용하여 이미지 기반 콘텐츠를 생성합니다.'
-                  : apiFormat === 'GPT Image'
-                    ? 'GPT Image API를 사용하여 OpenAI 이미지 모델로 이미지를 생성합니다.'
-                  : 'ComfyUI API를 사용하여 이미지/비디오 콘텐츠를 생성합니다.'}
-            </Typography>
-          </Grid>
-        </>
-      )}
-
       <Grid item xs={12}>
         <Controller
           name="name"
@@ -140,7 +80,7 @@ function WorkboardBasicInfoForm({ control, errors, showActiveSwitch = false, sho
         />
       </Grid>
 
-      <Grid item xs={12}>
+      <Grid item xs={12} sm={showTypeSelector ? 6 : 12}>
         <Controller
           name="serverId"
           control={control}
@@ -154,13 +94,11 @@ function WorkboardBasicInfoForm({ control, errors, showActiveSwitch = false, sho
                 disabled={servers.length === 0}
               >
                 {servers.length === 0 ? (
-                  <MenuItem disabled>
-                    사용 가능한 서버가 없습니다
-                  </MenuItem>
+                  <MenuItem disabled>사용 가능한 서버가 없습니다</MenuItem>
                 ) : (
                   servers.map((server) => (
                     <MenuItem key={server._id} value={server._id}>
-                      {server.name} ({getApiFormatLabel(server.serverType)})
+                      {server.name} ({getServerTypeLabel(server.serverType)})
                     </MenuItem>
                   ))
                 )}
@@ -174,6 +112,42 @@ function WorkboardBasicInfoForm({ control, errors, showActiveSwitch = false, sho
           )}
         />
       </Grid>
+
+      {showTypeSelector && (
+        <Grid item xs={12} sm={6}>
+          <Controller
+            name="outputFormat"
+            control={control}
+            render={({ field }) => (
+              <FormControl fullWidth>
+                <InputLabel>출력 형식</InputLabel>
+                <Select
+                  {...field}
+                  label="출력 형식"
+                  value={capableOutputFormats.includes(outputFormat) ? outputFormat : (capableOutputFormats[0] || '')}
+                  disabled={!selectedServerType || capableOutputFormats.length <= 1}
+                >
+                  {capableOutputFormats.length === 0 ? (
+                    <MenuItem value="" disabled>먼저 서버를 선택하세요</MenuItem>
+                  ) : (
+                    capableOutputFormats.map((fmt) => (
+                      <MenuItem key={fmt} value={fmt}>{getOutputFormatLabel(fmt)}</MenuItem>
+                    ))
+                  )}
+                </Select>
+              </FormControl>
+            )}
+          />
+        </Grid>
+      )}
+
+      {showTypeSelector && selectedServerType && (
+        <Grid item xs={12}>
+          <Typography variant="caption" color="textSecondary">
+            선택된 서버 타입: <strong>{getServerTypeLabel(selectedServerType)}</strong> · 지원 출력 형식: {capableOutputFormats.map(getOutputFormatLabel).join(', ') || '없음'}
+          </Typography>
+        </Grid>
+      )}
 
       {showActiveSwitch && (
         <Grid item xs={12}>
@@ -193,13 +167,7 @@ function WorkboardBasicInfoForm({ control, errors, showActiveSwitch = false, sho
       {servers.length === 0 && (
         <Grid item xs={12}>
           <Alert severity="warning">
-            {apiFormat === 'OpenAI Compatible'
-              ? '작업판을 생성하기 전에 서버 관리에서 OpenAI Compatible 서버를 등록해주세요.'
-              : apiFormat === 'Gemini'
-                ? '작업판을 생성하기 전에 서버 관리에서 Gemini 서버를 등록해주세요.'
-                : apiFormat === 'GPT Image'
-                  ? '작업판을 생성하기 전에 서버 관리에서 GPT Image 서버를 등록해주세요.'
-                : '작업판을 생성하기 전에 서버 관리에서 ComfyUI 서버를 등록해주세요.'}
+            작업판을 생성하기 전에 서버 관리에서 사용할 서버를 등록해주세요.
           </Alert>
         </Grid>
       )}

--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -55,15 +55,7 @@ import toast from 'react-hot-toast';
 import { workboardAPI, serverAPI } from '../../services/api';
 import WorkboardBasicInfoForm from './WorkboardBasicInfoForm';
 import { getWorkboardTemplate } from '../../templates';
-
-// Deprecated apiFormat → 신규 serverType 매핑. 'GPT Image' workboard 의 server 는
-// Phase 2 에서 'OpenAI' 로 마이그레이션됐으므로 템플릿 키도 OpenAI 로 매핑.
-const APIFORMAT_TO_SERVERTYPE = {
-  ComfyUI: 'ComfyUI',
-  Gemini: 'Gemini',
-  'GPT Image': 'OpenAI',
-  'OpenAI Compatible': 'OpenAI Compatible',
-};
+import { deriveLegacyApiFormat } from '../../templates/capabilities';
 
 function WorkboardCard({ workboard, onEdit, onDelete, onDuplicate, onExport, onView, onToggleActive }) {
   const [anchorEl, setAnchorEl] = useState(null);
@@ -272,6 +264,7 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
       name: '',
       description: '',
       serverId: '',
+      serverType: '',
       apiFormat: 'ComfyUI',
       outputFormat: 'image',
       workflowData: '',
@@ -356,6 +349,7 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
             name: fullData.name || '',
             description: fullData.description || '',
             serverId: fullData.serverId?._id || fullData.serverId || '',
+            serverType: fullData.serverId?.serverType || '',
             apiFormat: fullData.apiFormat || (fullData.workboardType === 'prompt' ? 'OpenAI Compatible' : 'ComfyUI'),
             outputFormat: fullData.outputFormat || (fullData.workboardType === 'prompt' ? 'text' : 'image'),
             workflowData: fullData.workflowData || '',
@@ -556,6 +550,7 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
           {tabValue === 0 && (
             <WorkboardBasicInfoForm
               control={control}
+              setValue={setValue}
               errors={errors}
               showActiveSwitch={true}
               showTypeSelector={true}
@@ -1571,13 +1566,13 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
 }
 
 function WorkboardCreateDialog({ open, onClose, onSave }) {
-  const { control, handleSubmit, reset, formState: { errors } } = useForm({
+  const { control, handleSubmit, reset, setValue, formState: { errors } } = useForm({
     defaultValues: {
       name: '',
       description: '',
-      apiFormat: 'ComfyUI',
       outputFormat: 'image',
       serverId: '',
+      serverType: '',
       isActive: true
     }
   });
@@ -1587,9 +1582,9 @@ function WorkboardCreateDialog({ open, onClose, onSave }) {
       reset({
         name: '',
         description: '',
-        apiFormat: 'ComfyUI',
         outputFormat: 'image',
         serverId: '',
+        serverType: '',
         isActive: true
       });
     }
@@ -1606,6 +1601,7 @@ function WorkboardCreateDialog({ open, onClose, onSave }) {
         <DialogContent>
           <WorkboardBasicInfoForm
             control={control}
+            setValue={setValue}
             errors={errors}
             showActiveSwitch={false}
             showTypeSelector={true}
@@ -2104,24 +2100,27 @@ function WorkboardManagement() {
   };
 
   const handleSave = (data) => {
-    const normalizedApiFormat = data.apiFormat || 'ComfyUI';
-    const isFixedImageApiFormat = ['Gemini', 'GPT Image'].includes(normalizedApiFormat);
-    const normalizedData = {
-      ...data,
-      apiFormat: normalizedApiFormat,
-      outputFormat: isFixedImageApiFormat ? 'image' : (data.outputFormat || 'image')
-    };
-
     if (selectedWorkboard) {
+      // 편집: 기존 apiFormat 유지. data 는 form 에서 온 새 값으로 덮어씀.
+      const normalizedData = { ...data };
+      // 폼이 더 이상 apiFormat 을 노출하지 않으므로 기존 값 보존
+      if (selectedWorkboard.apiFormat && !normalizedData.apiFormat) {
+        normalizedData.apiFormat = selectedWorkboard.apiFormat;
+      }
+      delete normalizedData.serverType; // 폼 내부 헬퍼 필드
       updateMutation.mutate({ id: selectedWorkboard._id, data: normalizedData });
     } else {
-      // Phase 4: 템플릿은 frontend/src/templates/<serverType>-<outputFormat>.json 에서 로드.
-      // 'GPT Image' apiFormat 은 Phase 2 에서 server 가 'OpenAI' 로 마이그레이션됐으므로 매핑.
-      const serverType = APIFORMAT_TO_SERVERTYPE[normalizedApiFormat] || normalizedApiFormat;
-      const template = getWorkboardTemplate(serverType, normalizedData.outputFormat);
+      // 생성: serverType + outputFormat → 템플릿 + legacy apiFormat 파생
+      const serverType = data.serverType || 'ComfyUI';
+      const outputFormat = data.outputFormat || 'image';
+      const template = getWorkboardTemplate(serverType, outputFormat);
+      const apiFormat = deriveLegacyApiFormat(serverType, outputFormat);
 
+      const { serverType: _omit, ...rest } = data;
       const workboardData = {
-        ...normalizedData,
+        ...rest,
+        apiFormat,
+        outputFormat,
         ...template,
       };
       createMutation.mutate(workboardData);

--- a/frontend/src/templates/capabilities.js
+++ b/frontend/src/templates/capabilities.js
@@ -1,0 +1,53 @@
+// 각 server type 이 지원하는 outputFormat 목록.
+// frontend/src/templates/index.js 의 TEMPLATES 키와 일치해야 함.
+// 새 (serverType, outputFormat) 조합 지원 시 여기와 templates 양쪽을 함께 갱신.
+
+export const CAPABILITIES = {
+  ComfyUI: ['image', 'video'],
+  OpenAI: ['image'],
+  'OpenAI Compatible': ['text'],
+  Gemini: ['image'],
+};
+
+const OUTPUT_FORMAT_LABELS = {
+  image: '이미지',
+  video: '비디오',
+  text: '텍스트',
+};
+
+const SERVER_TYPE_LABELS = {
+  ComfyUI: 'ComfyUI',
+  OpenAI: 'OpenAI',
+  'OpenAI Compatible': 'OpenAI Compatible',
+  Gemini: 'Gemini',
+  'GPT Image': 'GPT Image (deprecated)',
+};
+
+export function getCapableOutputFormats(serverType) {
+  return CAPABILITIES[serverType] || [];
+}
+
+export function getOutputFormatLabel(outputFormat) {
+  return OUTPUT_FORMAT_LABELS[outputFormat] || outputFormat;
+}
+
+export function getServerTypeLabel(serverType) {
+  return SERVER_TYPE_LABELS[serverType] || serverType;
+}
+
+// (server, outputFormat) → workboard schema 의 apiFormat 으로 매핑.
+// Phase 6 에서 apiFormat 필드가 제거되면 이 매핑도 함께 사라짐.
+const SERVER_OUTPUT_TO_LEGACY_APIFORMAT = {
+  'ComfyUI:image': 'ComfyUI',
+  'ComfyUI:video': 'ComfyUI',
+  'OpenAI:image': 'GPT Image',
+  'OpenAI:text': 'OpenAI Compatible',
+  'OpenAI Compatible:image': 'GPT Image',
+  'OpenAI Compatible:text': 'OpenAI Compatible',
+  'Gemini:image': 'Gemini',
+  'Gemini:text': 'Gemini',
+};
+
+export function deriveLegacyApiFormat(serverType, outputFormat) {
+  return SERVER_OUTPUT_TO_LEGACY_APIFORMAT[`${serverType}:${outputFormat}`] || 'ComfyUI';
+}


### PR DESCRIPTION
## Summary
[#181](https://github.com/iceemperor-gcempire/vcc-manager/issues/181) 의 **Phase 5**. 작업판 생성 폼에서 `apiFormat` 드롭다운 제거. 사용자는 (server, outputFormat) 만 선택하고 apiFormat 은 frontend 에서 derived 값으로 채워 schema 호환을 유지.

## 변경
- `frontend/src/templates/capabilities.js` (신규)
  - `CAPABILITIES` 매핑 (serverType → 지원 outputFormat 배열)
  - `getCapableOutputFormats` / `getOutputFormatLabel` / `getServerTypeLabel` 헬퍼
  - `SERVER_OUTPUT_TO_LEGACY_APIFORMAT` + `deriveLegacyApiFormat` — schema enum 통과용 apiFormat 계산
- `WorkboardBasicInfoForm.js`
  - apiFormat 드롭다운 **제거**
  - 서버 dropdown: 모든 활성 서버 표시 (apiFormat 필터 제거)
  - outputFormat dropdown: 선택된 `server.serverType` 의 capabilities 로 옵션 동적 필터링 (capability 1개면 disabled)
  - 서버 변경 시 form 의 `serverType` 동기화 + outputFormat 자동 보정
  - 서버 라벨에 `GPT Image API (deprecated)` 등 명시
- `WorkboardManagement.js`
  - `WorkboardCreateDialog`: apiFormat 제거, serverType 추가, setValue 를 BasicInfoForm 으로 전달
  - `WorkboardDetailDialog`: defaultValues 에 serverType 추가, 기존 workboard 로드 시 동기화
  - `handleSave`: 생성 흐름에서 (serverType, outputFormat) 으로 템플릿 로드 + apiFormat 파생. 편집 흐름은 기존 apiFormat 보존
  - 미사용 `APIFORMAT_TO_SERVERTYPE` 상수 제거 (capabilities.js 로 통일)

## 로컬 검증
- [x] 신규 폼 시뮬레이션 (Gemini 서버 + image) → 새 워크보드 생성 → `apiFormat: 'Gemini'` 저장 → dispatcher 가 `Gemini:image` 로 라우팅 → 이미지 1장 정상 생성
- [x] 기존 워크보드 (ComfyUI / GPT Image / Gemini) 회귀 없음
- [x] 프론트 빌드된 번들에 신규 capabilities + form 텍스트 포함 확인 (Korean unicode escape 형태)

## 호환성
- 기존 워크보드 편집 시 `apiFormat` 변경 안 됨 (편집 폼은 apiFormat 미노출)
- 백엔드 라우팅은 Phase 3 의 (serverType, outputFormat) 우선 + apiFormat fallback 유지

## 후속 (Phase 6)
- `apiFormat` 필드 Workboard 모델에서 완전 제거
- 라우팅 dispatcher 의 `APIFORMAT_TO_SERVERTYPE` fallback 제거
- `templates/capabilities.js` 의 `deriveLegacyApiFormat` 제거

closes #188
부모: #181