### PR TITLE
fix: 작업판 import 시 deprecated serverType 자동 폴백 매핑 추가 (#190)

### DIFF
--- a/src/routes/workboards.js
+++ b/src/routes/workboards.js
@@ -11,6 +11,12 @@ const router = express.Router();
 const EXPORT_VERSION = 1;
 const APP_VERSION = { major: 1, minor: 3 };
 
+// 옛 환경에서 export 한 작업판 백업의 server.serverType 을 신규 enum 으로 폴백 매핑.
+// Phase 2 (#181, #182) 마이그레이션과 동일 매핑. import 자동 매칭 1차 실패 시 시도.
+const SERVER_TYPE_LEGACY_FALLBACK = {
+  'GPT Image': 'OpenAI',
+};
+
 router.get('/', requireAuth, async (req, res) => {
   try {
     const { search = '', workboardType, apiFormat, outputFormat, includeAll, includeInactive } = req.query;
@@ -106,10 +112,17 @@ router.post('/import', requireAdmin, async (req, res) => {
       serverMatchInfo = { name: server.name, matched: true, manual: true };
     } else if (data.server) {
       // 자동 매칭 시도
-      const server = await Server.findOne({
+      let server = await Server.findOne({
         name: data.server.name,
         serverType: data.server.serverType
       });
+      // Phase 2 마이그레이션으로 deprecated 된 serverType 의 자동 폴백 (옛 환경 export 호환)
+      if (!server && SERVER_TYPE_LEGACY_FALLBACK[data.server.serverType]) {
+        server = await Server.findOne({
+          name: data.server.name,
+          serverType: SERVER_TYPE_LEGACY_FALLBACK[data.server.serverType]
+        });
+      }
       if (server) {
         matchedServerId = server._id;
         serverMatchInfo = { name: server.name, matched: true, manual: false };


### PR DESCRIPTION
## Summary
Phase 2 마이그레이션 이후 deprecated 된 serverType (`'GPT Image'` → `'OpenAI'`) 의 옛 export 파일을 신규 환경에 import 할 때 자동 매칭 실패 → 수동 선택 강제되던 UX 보강. v1.8.0 릴리스 전 폴리싱.

## 변경
- `src/routes/workboards.js`
  - `SERVER_TYPE_LEGACY_FALLBACK` 상수 추가 (Phase 2 마이그레이션과 동일 매핑)
  - import 핸들러: 1차 매칭(`name + serverType`) 실패 시 fallback enum 으로 한 번 더 시도

## 로컬 검증
- [x] **레거시 export → 신규 import**: `server.serverType: 'GPT Image'` 를 가진 export → 자동 매칭 → `OpenAI` 서버로 연결됨, apiFormat 'GPT Image' 보존
- [x] **신규 export → 신규 import** 회귀 없음 (1차 매칭으로 즉시 성공)
- [x] **미지의 serverType** → 기존 동작 (`needsServer: true`) 유지

## 영향 범위
- `routes/workboards.js` 1 파일, +14/-1
- 마이그레이션 / schema / 라우팅 dispatcher 영향 없음

## 비고
프로덕션 백업 → v1.8.0 환경 import 흐름이 매끄럽게 동작하도록 안전망 추가.

closes #190