### PR TITLE
release: v1.8.0

### DIFF
--- a/docs/updatelogs/v1.md
+++ b/docs/updatelogs/v1.md
@@ -1,5 +1,46 @@
 # v1 업데이트 내역
 
+## v1.8.0
+
+### Server·Workboard 구조 리팩토링 (Phase 1-5, #181)
+대규모 구조 정리. Server 는 provider 단위(`OpenAI` / `OpenAI Compatible` / `Gemini` / `ComfyUI`)로 재정의되고, Workboard 는 (server, outputFormat) 조합으로 capability 가 결정됨. OpenAI 같은 멀티 capability provider 를 단일 서버로 등록하고 작업판 레벨에서 capability 를 고르는 단순 모델로 전환.
+
+- **Phase 2 (#182, #183)**: Server 모델 정리
+  - `serverType` enum 에 `OpenAI` 추가, `GPT Image` 는 deprecated 표시 (다음 메이저에서 제거 예정)
+  - `outputType` 필드 제거 (UI 미노출, 사용처 없음)
+  - 기존 `GPT Image` Server 를 `OpenAI` 로 자동 마이그레이션
+  - `OpenAI` 헬스체크 로직 추가 (`/v1/models`)
+- **Phase 3 (#184, #185)**: 라우팅 dispatcher 통합
+  - `queueService` 의 if/else 사슬을 `SERVICE_MAP[(serverType, outputFormat)]` 기반 dispatcher 로 교체. 신규 provider 추가 시 한 곳만 수정
+  - `openAIChatService.js` 신규 — OpenAI 공식 / Local LLM (Ollama, LiteLLM 등) 공통 사용. 조직 인증 에러 메시지 한국어 치환 포함
+  - `geminiService.complete` 신규 — Gemini LLM 모드 (선반영, Phase 5 까지는 호출자 없음)
+  - `routes/jobs.js` prompt-generate 가 인라인 axios 대신 서비스 모듈 사용
+- **Phase 4 (#186, #187)**: 작업판 템플릿 JSON 분리
+  - `frontend/src/templates/<serverType>-<outputFormat>.json` 5개 (+ `index.js` 로더)
+  - `WorkboardManagement.handleSave` 의 ~110라인 인라인 ternary 제거
+  - 신규 템플릿 추가가 JSON 파일 + index 매핑 한 줄로 가능
+- **Phase 5 (#188, #189)**: 작업판 폼 전환
+  - 작업판 생성 폼에서 `apiFormat` 드롭다운 제거
+  - 사용자는 (server, outputFormat) 만 선택, apiFormat 은 derived
+  - `outputFormat` 옵션이 선택된 server.serverType 의 capability 기반으로 동적 필터링
+  - `frontend/src/templates/capabilities.js` 신규 — capability matrix + 라벨 헬퍼
+
+### 폴리싱
+- fix: 작업판 import 시 deprecated `serverType` 자동 폴백 매핑 추가 (#190, #191)
+  - 옛 환경의 export 파일 (`server.serverType: 'GPT Image'`) 을 v1.8.0 환경에 import 시 자동 매칭이 실패해 수동 서버 선택을 강제하던 문제 보강
+  - import 1차 매칭 실패 시 Phase 2 와 동일한 매핑(`'GPT Image' → 'OpenAI'`) 으로 한번 더 시도
+  - 프로덕션 백업 → 신규 환경 복구 흐름이 매끄럽게 동작
+
+### 기타
+- refactor: 작업판 카드 메뉴에서 중복된 "편집" 항목 제거 (#177, #178). 상세 편집과 strict subset 관계라 단일화
+- refactor: `WorkboardDialog` 의 편집 모드 dead code 제거 및 `WorkboardCreateDialog` 로 리네이밍 (#179, #180)
+- fix: nginx `index.html` 캐시 무효화 헤더 추가 (#175, #176). 신규 배포 시 사용자 브라우저가 옛 번들을 잡고 있던 문제 해결
+
+### 호환성 / 후속
+- 기존 작업판 / 서버 동작 영향 없음 (마이그레이션 idempotent, 기존 `apiFormat` 보존)
+- `apiFormat` 필드는 deprecated 이지만 schema 유지 (Phase 6 에서 완전 제거 예정 — 1 버전 후)
+- 프로덕션 마이그레이션 권장 절차: ① 백업 ② v1.8.0 배포 (자동 마이그레이션 실행)
+
 ## v1.7.3
 
 - feat: GPT Image 작업판 템플릿에 `gpt-image-2` 모델 지원 추가 (#172, #173)

--- a/frontend/src/components/admin/ServerManagement.js
+++ b/frontend/src/components/admin/ServerManagement.js
@@ -73,11 +73,11 @@ function ServerCard({ server, onEdit, onDelete, onHealthCheck, onLoraSync, loraS
     switch (serverType) {
       case 'ComfyUI':
         return <Computer />;
+      case 'OpenAI':
       case 'OpenAI Compatible':
+      case 'GPT Image':
         return <TextFields />;
       case 'Gemini':
-        return <Storage />;
-      case 'GPT Image':
         return <Storage />;
       default:
         return <Storage />;
@@ -88,12 +88,14 @@ function ServerCard({ server, onEdit, onDelete, onHealthCheck, onLoraSync, loraS
     switch (serverType) {
       case 'ComfyUI':
         return 'ComfyUI API';
+      case 'OpenAI':
+        return 'OpenAI API';
       case 'OpenAI Compatible':
         return 'OpenAI Compatible API';
       case 'Gemini':
-        return 'Gemini Image API';
+        return 'Gemini API';
       case 'GPT Image':
-        return 'GPT Image API';
+        return 'GPT Image API (deprecated)';
       default:
         return serverType;
     }
@@ -344,9 +346,9 @@ function ServerDialog({ open, onClose, server, onSubmit }) {
                   label="AI API 형식"
                 >
                   <MenuItem value="ComfyUI">ComfyUI API</MenuItem>
+                  <MenuItem value="OpenAI">OpenAI API</MenuItem>
                   <MenuItem value="OpenAI Compatible">OpenAI Compatible API</MenuItem>
-                  <MenuItem value="Gemini">Gemini Image API</MenuItem>
-                  <MenuItem value="GPT Image">GPT Image API</MenuItem>
+                  <MenuItem value="Gemini">Gemini API</MenuItem>
                 </Select>
               </FormControl>
             </Grid>
@@ -373,7 +375,7 @@ function ServerDialog({ open, onClose, server, onSubmit }) {
                 placeholder={
                   formData.serverType === 'Gemini'
                     ? 'https://generativelanguage.googleapis.com'
-                    : formData.serverType === 'GPT Image'
+                    : formData.serverType === 'OpenAI'
                       ? 'https://api.openai.com'
                       : 'http://localhost:8188'
                 }

--- a/frontend/src/components/admin/WorkboardBasicInfoForm.js
+++ b/frontend/src/components/admin/WorkboardBasicInfoForm.js
@@ -34,10 +34,13 @@ function WorkboardBasicInfoForm({ control, errors, showActiveSwitch = false, sho
     }
   };
 
+  // 'GPT Image' apiFormat 은 deprecated — Phase 2 마이그레이션 이후 서버는 'OpenAI' 로 저장됨.
+  // workboard.apiFormat 은 deprecation 기간 동안 그대로 유지되므로 서버 조회 시에만 매핑.
+  const apiFormatToServerType = (af) => (af === 'GPT Image' ? 'OpenAI' : af);
   const { data: serversData } = useQuery(
     ['servers', apiFormat],
     () => serverAPI.getServers({
-      serverType: apiFormat
+      serverType: apiFormatToServerType(apiFormat)
     }),
     { enabled: isDialogOpen }
   );

--- a/frontend/src/components/admin/WorkboardBasicInfoForm.js
+++ b/frontend/src/components/admin/WorkboardBasicInfoForm.js
@@ -9,103 +9,43 @@ import {
   FormControlLabel,
   Switch,
   Typography,
-  Alert
+  Alert,
 } from '@mui/material';
 import { Controller, useWatch } from 'react-hook-form';
 import { useQuery } from 'react-query';
 import { serverAPI } from '../../services/api';
+import {
+  getCapableOutputFormats,
+  getOutputFormatLabel,
+  getServerTypeLabel,
+} from '../../templates/capabilities';
 
-function WorkboardBasicInfoForm({ control, errors, showActiveSwitch = false, showTypeSelector = false, isDialogOpen = true }) {
-  const apiFormat = useWatch({ control, name: 'apiFormat' }) || 'ComfyUI';
+function WorkboardBasicInfoForm({ control, setValue, errors, showActiveSwitch = false, showTypeSelector = false, isDialogOpen = true }) {
+  const selectedServerId = useWatch({ control, name: 'serverId' });
   const outputFormat = useWatch({ control, name: 'outputFormat' }) || 'image';
-  const isFixedImageApiFormat = ['Gemini', 'GPT Image'].includes(apiFormat);
-  const getApiFormatLabel = (format) => {
-    switch (format) {
-      case 'ComfyUI':
-        return 'ComfyUI API';
-      case 'OpenAI Compatible':
-        return 'OpenAI Compatible API';
-      case 'Gemini':
-        return 'Gemini Image API';
-      case 'GPT Image':
-        return 'GPT Image API';
-      default:
-        return format;
-    }
-  };
 
-  // 'GPT Image' apiFormat 은 deprecated — Phase 2 마이그레이션 이후 서버는 'OpenAI' 로 저장됨.
-  // workboard.apiFormat 은 deprecation 기간 동안 그대로 유지되므로 서버 조회 시에만 매핑.
-  const apiFormatToServerType = (af) => (af === 'GPT Image' ? 'OpenAI' : af);
   const { data: serversData } = useQuery(
-    ['servers', apiFormat],
-    () => serverAPI.getServers({
-      serverType: apiFormatToServerType(apiFormat)
-    }),
+    'servers-all-active',
+    () => serverAPI.getServers({}),
     { enabled: isDialogOpen }
   );
 
   const servers = serversData?.data?.data?.servers || [];
+  const selectedServer = servers.find((s) => s._id === selectedServerId);
+  const selectedServerType = selectedServer?.serverType;
+  const capableOutputFormats = selectedServerType ? getCapableOutputFormats(selectedServerType) : [];
+
+  // 서버가 바뀌면 폼의 serverType 을 동기화하고, 현재 outputFormat 이 capability 에 없으면 첫 옵션으로 보정.
+  React.useEffect(() => {
+    if (!setValue) return;
+    setValue('serverType', selectedServerType || '');
+    if (selectedServerType && capableOutputFormats.length > 0 && !capableOutputFormats.includes(outputFormat)) {
+      setValue('outputFormat', capableOutputFormats[0]);
+    }
+  }, [setValue, selectedServerType, capableOutputFormats, outputFormat]);
 
   return (
     <Grid container spacing={2}>
-      {showTypeSelector && (
-        <>
-          <Grid item xs={12} sm={6}>
-            <Controller
-              name="apiFormat"
-              control={control}
-              render={({ field }) => (
-                <FormControl fullWidth>
-                  <InputLabel>AI API 형식</InputLabel>
-                  <Select
-                    {...field}
-                    label="AI API 형식"
-                  >
-                    <MenuItem value="ComfyUI">ComfyUI API</MenuItem>
-                    <MenuItem value="OpenAI Compatible">OpenAI Compatible API</MenuItem>
-                    <MenuItem value="Gemini">Gemini Image API</MenuItem>
-                    <MenuItem value="GPT Image">GPT Image API</MenuItem>
-                  </Select>
-                </FormControl>
-              )}
-            />
-          </Grid>
-          <Grid item xs={12} sm={6}>
-            <Controller
-              name="outputFormat"
-              control={control}
-              render={({ field }) => (
-                <FormControl fullWidth>
-                  <InputLabel>출력 형식</InputLabel>
-                  <Select
-                    {...field}
-                    label="출력 형식"
-                    value={isFixedImageApiFormat ? 'image' : outputFormat}
-                    disabled={isFixedImageApiFormat}
-                  >
-                    <MenuItem value="image">이미지</MenuItem>
-                    {!isFixedImageApiFormat && <MenuItem value="video">비디오</MenuItem>}
-                    {!isFixedImageApiFormat && <MenuItem value="text">텍스트</MenuItem>}
-                  </Select>
-                </FormControl>
-              )}
-            />
-          </Grid>
-          <Grid item xs={12}>
-            <Typography variant="caption" color="textSecondary">
-              {apiFormat === 'OpenAI Compatible'
-                ? 'OpenAI Compatible API를 사용하여 텍스트 기반 콘텐츠를 생성합니다.'
-                : apiFormat === 'Gemini'
-                  ? 'Gemini Image API를 사용하여 이미지 기반 콘텐츠를 생성합니다.'
-                  : apiFormat === 'GPT Image'
-                    ? 'GPT Image API를 사용하여 OpenAI 이미지 모델로 이미지를 생성합니다.'
-                  : 'ComfyUI API를 사용하여 이미지/비디오 콘텐츠를 생성합니다.'}
-            </Typography>
-          </Grid>
-        </>
-      )}
-
       <Grid item xs={12}>
         <Controller
           name="name"
@@ -140,7 +80,7 @@ function WorkboardBasicInfoForm({ control, errors, showActiveSwitch = false, sho
         />
       </Grid>
 
-      <Grid item xs={12}>
+      <Grid item xs={12} sm={showTypeSelector ? 6 : 12}>
         <Controller
           name="serverId"
           control={control}
@@ -154,13 +94,11 @@ function WorkboardBasicInfoForm({ control, errors, showActiveSwitch = false, sho
                 disabled={servers.length === 0}
               >
                 {servers.length === 0 ? (
-                  <MenuItem disabled>
-                    사용 가능한 서버가 없습니다
-                  </MenuItem>
+                  <MenuItem disabled>사용 가능한 서버가 없습니다</MenuItem>
                 ) : (
                   servers.map((server) => (
                     <MenuItem key={server._id} value={server._id}>
-                      {server.name} ({getApiFormatLabel(server.serverType)})
+                      {server.name} ({getServerTypeLabel(server.serverType)})
                     </MenuItem>
                   ))
                 )}
@@ -174,6 +112,42 @@ function WorkboardBasicInfoForm({ control, errors, showActiveSwitch = false, sho
           )}
         />
       </Grid>
+
+      {showTypeSelector && (
+        <Grid item xs={12} sm={6}>
+          <Controller
+            name="outputFormat"
+            control={control}
+            render={({ field }) => (
+              <FormControl fullWidth>
+                <InputLabel>출력 형식</InputLabel>
+                <Select
+                  {...field}
+                  label="출력 형식"
+                  value={capableOutputFormats.includes(outputFormat) ? outputFormat : (capableOutputFormats[0] || '')}
+                  disabled={!selectedServerType || capableOutputFormats.length <= 1}
+                >
+                  {capableOutputFormats.length === 0 ? (
+                    <MenuItem value="" disabled>먼저 서버를 선택하세요</MenuItem>
+                  ) : (
+                    capableOutputFormats.map((fmt) => (
+                      <MenuItem key={fmt} value={fmt}>{getOutputFormatLabel(fmt)}</MenuItem>
+                    ))
+                  )}
+                </Select>
+              </FormControl>
+            )}
+          />
+        </Grid>
+      )}
+
+      {showTypeSelector && selectedServerType && (
+        <Grid item xs={12}>
+          <Typography variant="caption" color="textSecondary">
+            선택된 서버 타입: <strong>{getServerTypeLabel(selectedServerType)}</strong> · 지원 출력 형식: {capableOutputFormats.map(getOutputFormatLabel).join(', ') || '없음'}
+          </Typography>
+        </Grid>
+      )}
 
       {showActiveSwitch && (
         <Grid item xs={12}>
@@ -193,13 +167,7 @@ function WorkboardBasicInfoForm({ control, errors, showActiveSwitch = false, sho
       {servers.length === 0 && (
         <Grid item xs={12}>
           <Alert severity="warning">
-            {apiFormat === 'OpenAI Compatible'
-              ? '작업판을 생성하기 전에 서버 관리에서 OpenAI Compatible 서버를 등록해주세요.'
-              : apiFormat === 'Gemini'
-                ? '작업판을 생성하기 전에 서버 관리에서 Gemini 서버를 등록해주세요.'
-                : apiFormat === 'GPT Image'
-                  ? '작업판을 생성하기 전에 서버 관리에서 GPT Image 서버를 등록해주세요.'
-                : '작업판을 생성하기 전에 서버 관리에서 ComfyUI 서버를 등록해주세요.'}
+            작업판을 생성하기 전에 서버 관리에서 사용할 서버를 등록해주세요.
           </Alert>
         </Grid>
       )}

--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -1560,32 +1560,30 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
   );
 }
 
-function WorkboardDialog({ open, onClose, workboard = null, onSave }) {
-  const isEditing = !!workboard;
-  
-  const { control, handleSubmit, reset, watch, formState: { errors } } = useForm({
+function WorkboardCreateDialog({ open, onClose, onSave }) {
+  const { control, handleSubmit, reset, formState: { errors } } = useForm({
     defaultValues: {
-      name: workboard?.name || '',
-      description: workboard?.description || '',
-      apiFormat: workboard?.apiFormat || 'ComfyUI',
-      outputFormat: workboard?.outputFormat || 'image',
-      serverId: workboard?.serverId?._id || '',
-      isActive: workboard?.isActive ?? true
+      name: '',
+      description: '',
+      apiFormat: 'ComfyUI',
+      outputFormat: 'image',
+      serverId: '',
+      isActive: true
     }
   });
 
   React.useEffect(() => {
     if (open) {
       reset({
-        name: workboard?.name || '',
-        description: workboard?.description || '',
-        apiFormat: workboard?.apiFormat || (workboard?.workboardType === 'prompt' ? 'OpenAI Compatible' : 'ComfyUI'),
-        outputFormat: workboard?.outputFormat || (workboard?.workboardType === 'prompt' ? 'text' : 'image'),
-        serverId: workboard?.serverId?._id || '',
-        isActive: workboard?.isActive ?? true
+        name: '',
+        description: '',
+        apiFormat: 'ComfyUI',
+        outputFormat: 'image',
+        serverId: '',
+        isActive: true
       });
     }
-  }, [open, workboard, reset]);
+  }, [open, reset]);
 
   const onSubmit = (data) => {
     onSave(data);
@@ -1593,34 +1591,25 @@ function WorkboardDialog({ open, onClose, workboard = null, onSave }) {
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
-      <DialogTitle>
-        {isEditing ? '작업판 편집' : '새 작업판 생성'}
-      </DialogTitle>
+      <DialogTitle>새 작업판 생성</DialogTitle>
       <form onSubmit={handleSubmit(onSubmit)}>
         <DialogContent>
           <WorkboardBasicInfoForm
             control={control}
             errors={errors}
             showActiveSwitch={false}
-            showTypeSelector={!isEditing}
+            showTypeSelector={true}
             isDialogOpen={open}
           />
 
-          {!isEditing && (
-            <Alert severity="info" sx={{ mt: 2 }}>
-              기본 작업판 구조가 생성됩니다. 상세 설정(AI 모델, 입력 필드 등)은 
-              생성 후 상세 편집에서 추가할 수 있습니다.
-            </Alert>
-          )}
+          <Alert severity="info" sx={{ mt: 2 }}>
+            기본 작업판 구조가 생성됩니다. 상세 설정(AI 모델, 입력 필드 등)은
+            생성 후 편집에서 추가할 수 있습니다.
+          </Alert>
         </DialogContent>
         <DialogActions>
           <Button onClick={onClose}>취소</Button>
-          <Button 
-            type="submit" 
-            variant="contained"
-          >
-            {isEditing ? '수정' : '생성'}
-          </Button>
+          <Button type="submit" variant="contained">생성</Button>
         </DialogActions>
       </form>
     </Dialog>
@@ -2329,10 +2318,9 @@ function WorkboardManagement() {
         </Grid>
       )}
 
-      <WorkboardDialog
+      <WorkboardCreateDialog
         open={dialogOpen}
         onClose={() => setDialogOpen(false)}
-        workboard={selectedWorkboard}
         onSave={handleSave}
       />
 

--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -54,6 +54,16 @@ import { useForm, Controller } from 'react-hook-form';
 import toast from 'react-hot-toast';
 import { workboardAPI, serverAPI } from '../../services/api';
 import WorkboardBasicInfoForm from './WorkboardBasicInfoForm';
+import { getWorkboardTemplate } from '../../templates';
+
+// Deprecated apiFormat → 신규 serverType 매핑. 'GPT Image' workboard 의 server 는
+// Phase 2 에서 'OpenAI' 로 마이그레이션됐으므로 템플릿 키도 OpenAI 로 매핑.
+const APIFORMAT_TO_SERVERTYPE = {
+  ComfyUI: 'ComfyUI',
+  Gemini: 'Gemini',
+  'GPT Image': 'OpenAI',
+  'OpenAI Compatible': 'OpenAI Compatible',
+};
 
 function WorkboardCard({ workboard, onEdit, onDelete, onDuplicate, onExport, onView, onToggleActive }) {
   const [anchorEl, setAnchorEl] = useState(null);
@@ -2105,123 +2115,14 @@ function WorkboardManagement() {
     if (selectedWorkboard) {
       updateMutation.mutate({ id: selectedWorkboard._id, data: normalizedData });
     } else {
-      const isOpenAI = normalizedApiFormat === 'OpenAI Compatible';
-      const isGeminiApi = normalizedApiFormat === 'Gemini';
-      const isGptImageApi = normalizedApiFormat === 'GPT Image';
+      // Phase 4: 템플릿은 frontend/src/templates/<serverType>-<outputFormat>.json 에서 로드.
+      // 'GPT Image' apiFormat 은 Phase 2 에서 server 가 'OpenAI' 로 마이그레이션됐으므로 매핑.
+      const serverType = APIFORMAT_TO_SERVERTYPE[normalizedApiFormat] || normalizedApiFormat;
+      const template = getWorkboardTemplate(serverType, normalizedData.outputFormat);
 
       const workboardData = {
         ...normalizedData,
-        baseInputFields: isOpenAI ? {
-          aiModel: [
-            { key: 'GPT-4', value: 'gpt-4' },
-            { key: 'GPT-3.5 Turbo', value: 'gpt-3.5-turbo' }
-          ],
-          systemPrompt: '',
-          referenceImages: []
-        } : isGeminiApi ? {
-          aiModel: [
-            { key: 'Nano Banana', value: 'gemini-2.5-flash-image' },
-            { key: 'Nano Banana Pro', value: 'gemini-3-pro-image-preview' },
-            { key: 'Nano Banana 2', value: 'gemini-3.1-flash-image-preview' }
-          ],
-          imageSizes: [
-            { key: '정사각 (1:1)', value: '1:1' },
-            { key: '가로 와이드 (16:9)', value: '16:9' },
-            { key: '세로 와이드 (9:16)', value: '9:16' },
-            { key: '가로 (4:3)', value: '4:3' },
-            { key: '세로 (3:4)', value: '3:4' },
-            { key: '영화 (21:9)', value: '21:9' }
-          ],
-          referenceImageMethods: []
-        } : isGptImageApi ? {
-          aiModel: [
-            { key: 'GPT Image 2 (조직 인증 필요)', value: 'gpt-image-2' },
-            { key: 'GPT Image 1.5', value: 'gpt-image-1.5' },
-            { key: 'GPT Image 1', value: 'gpt-image-1' },
-            { key: 'GPT Image 1 Mini', value: 'gpt-image-1-mini' }
-          ],
-          imageSizes: [
-            { key: '자동 (auto)', value: 'auto' },
-            { key: '1024x1024', value: '1024x1024' },
-            { key: '1024x1536', value: '1024x1536' },
-            { key: '1536x1024', value: '1536x1024' }
-          ],
-          referenceImageMethods: []
-        } : {
-          aiModel: [
-            { key: 'Default Model', value: 'default.safetensors' }
-          ],
-          imageSizes: [
-            { key: '1024x1024', value: '1024x1024' },
-            { key: '896x1152', value: '896x1152' },
-            { key: '1152x896', value: '1152x896' },
-            { key: '832x1216', value: '832x1216' },
-            { key: '1216x832', value: '1216x832' },
-            { key: '768x1344', value: '768x1344' },
-            { key: '1344x768', value: '1344x768' }
-          ],
-          referenceImageMethods: [
-            { key: 'Image to Image', value: 'img2img' },
-            { key: 'ControlNet Canny', value: 'controlnet_canny' }
-          ]
-        },
-        additionalInputFields: isGptImageApi ? [
-          {
-            name: 'quality',
-            label: '품질',
-            type: 'select',
-            required: true,
-            defaultValue: 'auto',
-            options: [
-              { key: 'Auto', value: 'auto' },
-              { key: 'Low', value: 'low' },
-              { key: 'Medium', value: 'medium' },
-              { key: 'High', value: 'high' }
-            ],
-            description: 'GPT Image 생성 품질을 선택합니다.'
-          },
-          {
-            name: 'background',
-            label: '배경',
-            type: 'select',
-            required: false,
-            defaultValue: 'opaque',
-            options: [
-              { key: '불투명 (opaque)', value: 'opaque' },
-              { key: '투명 (transparent)', value: 'transparent' }
-            ],
-            description: 'gpt-image-2 전용. 투명 배경으로 출력하려면 transparent. 다른 모델에서는 무시됨.'
-          },
-          {
-            name: 'output_compression',
-            label: '출력 압축률',
-            type: 'number',
-            required: false,
-            defaultValue: 100,
-            description: 'gpt-image-2 의 JPEG/WebP 출력 시 압축률 (1-100). PNG 에는 영향 없음. 다른 모델에서는 무시됨.'
-          }
-        ] : isGeminiApi ? [
-          {
-            name: 'resolution',
-            label: '해상도',
-            type: 'select',
-            required: true,
-            defaultValue: '2K',
-            options: [
-              { key: '1K (기본)', value: '1K' },
-              { key: '2K', value: '2K' },
-              { key: '4K', value: '4K' }
-            ],
-            description: 'Gemini 이미지 출력 해상도를 선택합니다.'
-          }
-        ] : [],
-        workflowData: (isOpenAI || isGeminiApi || isGptImageApi) ? '' : JSON.stringify({
-          "prompt": "{{##prompt##}}",
-          "negative_prompt": "{{##negative_prompt##}}",
-          "model": "{{##model##}}",
-          "width": "{{##width##}}",
-          "height": "{{##height##}}"
-        }, null, 2)
+        ...template,
       };
       createMutation.mutate(workboardData);
     }

--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -55,15 +55,7 @@ import toast from 'react-hot-toast';
 import { workboardAPI, serverAPI } from '../../services/api';
 import WorkboardBasicInfoForm from './WorkboardBasicInfoForm';
 import { getWorkboardTemplate } from '../../templates';
-
-// Deprecated apiFormat → 신규 serverType 매핑. 'GPT Image' workboard 의 server 는
-// Phase 2 에서 'OpenAI' 로 마이그레이션됐으므로 템플릿 키도 OpenAI 로 매핑.
-const APIFORMAT_TO_SERVERTYPE = {
-  ComfyUI: 'ComfyUI',
-  Gemini: 'Gemini',
-  'GPT Image': 'OpenAI',
-  'OpenAI Compatible': 'OpenAI Compatible',
-};
+import { deriveLegacyApiFormat } from '../../templates/capabilities';
 
 function WorkboardCard({ workboard, onEdit, onDelete, onDuplicate, onExport, onView, onToggleActive }) {
   const [anchorEl, setAnchorEl] = useState(null);
@@ -272,6 +264,7 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
       name: '',
       description: '',
       serverId: '',
+      serverType: '',
       apiFormat: 'ComfyUI',
       outputFormat: 'image',
       workflowData: '',
@@ -356,6 +349,7 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
             name: fullData.name || '',
             description: fullData.description || '',
             serverId: fullData.serverId?._id || fullData.serverId || '',
+            serverType: fullData.serverId?.serverType || '',
             apiFormat: fullData.apiFormat || (fullData.workboardType === 'prompt' ? 'OpenAI Compatible' : 'ComfyUI'),
             outputFormat: fullData.outputFormat || (fullData.workboardType === 'prompt' ? 'text' : 'image'),
             workflowData: fullData.workflowData || '',
@@ -556,6 +550,7 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
           {tabValue === 0 && (
             <WorkboardBasicInfoForm
               control={control}
+              setValue={setValue}
               errors={errors}
               showActiveSwitch={true}
               showTypeSelector={true}
@@ -1571,13 +1566,13 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
 }
 
 function WorkboardCreateDialog({ open, onClose, onSave }) {
-  const { control, handleSubmit, reset, formState: { errors } } = useForm({
+  const { control, handleSubmit, reset, setValue, formState: { errors } } = useForm({
     defaultValues: {
       name: '',
       description: '',
-      apiFormat: 'ComfyUI',
       outputFormat: 'image',
       serverId: '',
+      serverType: '',
       isActive: true
     }
   });
@@ -1587,9 +1582,9 @@ function WorkboardCreateDialog({ open, onClose, onSave }) {
       reset({
         name: '',
         description: '',
-        apiFormat: 'ComfyUI',
         outputFormat: 'image',
         serverId: '',
+        serverType: '',
         isActive: true
       });
     }
@@ -1606,6 +1601,7 @@ function WorkboardCreateDialog({ open, onClose, onSave }) {
         <DialogContent>
           <WorkboardBasicInfoForm
             control={control}
+            setValue={setValue}
             errors={errors}
             showActiveSwitch={false}
             showTypeSelector={true}
@@ -2104,24 +2100,27 @@ function WorkboardManagement() {
   };
 
   const handleSave = (data) => {
-    const normalizedApiFormat = data.apiFormat || 'ComfyUI';
-    const isFixedImageApiFormat = ['Gemini', 'GPT Image'].includes(normalizedApiFormat);
-    const normalizedData = {
-      ...data,
-      apiFormat: normalizedApiFormat,
-      outputFormat: isFixedImageApiFormat ? 'image' : (data.outputFormat || 'image')
-    };
-
     if (selectedWorkboard) {
+      // 편집: 기존 apiFormat 유지. data 는 form 에서 온 새 값으로 덮어씀.
+      const normalizedData = { ...data };
+      // 폼이 더 이상 apiFormat 을 노출하지 않으므로 기존 값 보존
+      if (selectedWorkboard.apiFormat && !normalizedData.apiFormat) {
+        normalizedData.apiFormat = selectedWorkboard.apiFormat;
+      }
+      delete normalizedData.serverType; // 폼 내부 헬퍼 필드
       updateMutation.mutate({ id: selectedWorkboard._id, data: normalizedData });
     } else {
-      // Phase 4: 템플릿은 frontend/src/templates/<serverType>-<outputFormat>.json 에서 로드.
-      // 'GPT Image' apiFormat 은 Phase 2 에서 server 가 'OpenAI' 로 마이그레이션됐으므로 매핑.
-      const serverType = APIFORMAT_TO_SERVERTYPE[normalizedApiFormat] || normalizedApiFormat;
-      const template = getWorkboardTemplate(serverType, normalizedData.outputFormat);
+      // 생성: serverType + outputFormat → 템플릿 + legacy apiFormat 파생
+      const serverType = data.serverType || 'ComfyUI';
+      const outputFormat = data.outputFormat || 'image';
+      const template = getWorkboardTemplate(serverType, outputFormat);
+      const apiFormat = deriveLegacyApiFormat(serverType, outputFormat);
 
+      const { serverType: _omit, ...rest } = data;
       const workboardData = {
-        ...normalizedData,
+        ...rest,
+        apiFormat,
+        outputFormat,
         ...template,
       };
       createMutation.mutate(workboardData);

--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -1805,7 +1805,7 @@ function WorkboardImportDialog({ open, onClose, onSuccess }) {
                   >
                     {availableServers.map((s) => (
                       <MenuItem key={s._id} value={s._id}>
-                        {s.name} ({s.serverType} - {s.outputType})
+                        {s.name} ({s.serverType})
                       </MenuItem>
                     ))}
                   </Select>

--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -38,7 +38,6 @@ import {
   VisibilityOff,
   Computer,
   TrendingUp,
-  Settings,
   ExpandMore,
   ToggleOn,
   ToggleOff,
@@ -211,13 +210,9 @@ function WorkboardCard({ workboard, onEdit, onDelete, onDuplicate, onExport, onV
           <Visibility sx={{ mr: 1 }} fontSize="small" />
           보기
         </MenuItem>
-        <MenuItem onClick={() => { onEdit(workboard); handleMenuClose(); }}>
+        <MenuItem onClick={() => { onEdit(workboard, 'detailed'); handleMenuClose(); }}>
           <Edit sx={{ mr: 1 }} fontSize="small" />
           편집
-        </MenuItem>
-        <MenuItem onClick={() => { onEdit(workboard, 'detailed'); handleMenuClose(); }}>
-          <Settings sx={{ mr: 1 }} fontSize="small" />
-          상세 편집
         </MenuItem>
         <MenuItem onClick={() => { onDuplicate(workboard); handleMenuClose(); }}>
           <ContentCopy sx={{ mr: 1 }} fontSize="small" />

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,7 +1,7 @@
 const config = {
   version: {
     major: 1,
-    minor: 7
+    minor: 8
   },
   monitoring: {
     // 작업 목록 모니터링 주기 (3초)

--- a/frontend/src/templates/ComfyUI-image.json
+++ b/frontend/src/templates/ComfyUI-image.json
@@ -1,0 +1,22 @@
+{
+  "baseInputFields": {
+    "aiModel": [
+      { "key": "Default Model", "value": "default.safetensors" }
+    ],
+    "imageSizes": [
+      { "key": "1024x1024", "value": "1024x1024" },
+      { "key": "896x1152", "value": "896x1152" },
+      { "key": "1152x896", "value": "1152x896" },
+      { "key": "832x1216", "value": "832x1216" },
+      { "key": "1216x832", "value": "1216x832" },
+      { "key": "768x1344", "value": "768x1344" },
+      { "key": "1344x768", "value": "1344x768" }
+    ],
+    "referenceImageMethods": [
+      { "key": "Image to Image", "value": "img2img" },
+      { "key": "ControlNet Canny", "value": "controlnet_canny" }
+    ]
+  },
+  "additionalInputFields": [],
+  "workflowData": "{\n  \"prompt\": \"{{##prompt##}}\",\n  \"negative_prompt\": \"{{##negative_prompt##}}\",\n  \"model\": \"{{##model##}}\",\n  \"width\": \"{{##width##}}\",\n  \"height\": \"{{##height##}}\"\n}"
+}

--- a/frontend/src/templates/ComfyUI-video.json
+++ b/frontend/src/templates/ComfyUI-video.json
@@ -1,0 +1,22 @@
+{
+  "baseInputFields": {
+    "aiModel": [
+      { "key": "Default Model", "value": "default.safetensors" }
+    ],
+    "imageSizes": [
+      { "key": "1024x1024", "value": "1024x1024" },
+      { "key": "896x1152", "value": "896x1152" },
+      { "key": "1152x896", "value": "1152x896" },
+      { "key": "832x1216", "value": "832x1216" },
+      { "key": "1216x832", "value": "1216x832" },
+      { "key": "768x1344", "value": "768x1344" },
+      { "key": "1344x768", "value": "1344x768" }
+    ],
+    "referenceImageMethods": [
+      { "key": "Image to Image", "value": "img2img" },
+      { "key": "ControlNet Canny", "value": "controlnet_canny" }
+    ]
+  },
+  "additionalInputFields": [],
+  "workflowData": "{\n  \"prompt\": \"{{##prompt##}}\",\n  \"negative_prompt\": \"{{##negative_prompt##}}\",\n  \"model\": \"{{##model##}}\",\n  \"width\": \"{{##width##}}\",\n  \"height\": \"{{##height##}}\"\n}"
+}

--- a/frontend/src/templates/Gemini-image.json
+++ b/frontend/src/templates/Gemini-image.json
@@ -1,0 +1,34 @@
+{
+  "baseInputFields": {
+    "aiModel": [
+      { "key": "Nano Banana", "value": "gemini-2.5-flash-image" },
+      { "key": "Nano Banana Pro", "value": "gemini-3-pro-image-preview" },
+      { "key": "Nano Banana 2", "value": "gemini-3.1-flash-image-preview" }
+    ],
+    "imageSizes": [
+      { "key": "정사각 (1:1)", "value": "1:1" },
+      { "key": "가로 와이드 (16:9)", "value": "16:9" },
+      { "key": "세로 와이드 (9:16)", "value": "9:16" },
+      { "key": "가로 (4:3)", "value": "4:3" },
+      { "key": "세로 (3:4)", "value": "3:4" },
+      { "key": "영화 (21:9)", "value": "21:9" }
+    ],
+    "referenceImageMethods": []
+  },
+  "additionalInputFields": [
+    {
+      "name": "resolution",
+      "label": "해상도",
+      "type": "select",
+      "required": true,
+      "defaultValue": "2K",
+      "options": [
+        { "key": "1K (기본)", "value": "1K" },
+        { "key": "2K", "value": "2K" },
+        { "key": "4K", "value": "4K" }
+      ],
+      "description": "Gemini 이미지 출력 해상도를 선택합니다."
+    }
+  ],
+  "workflowData": ""
+}

--- a/frontend/src/templates/OpenAI Compatible-text.json
+++ b/frontend/src/templates/OpenAI Compatible-text.json
@@ -1,0 +1,12 @@
+{
+  "baseInputFields": {
+    "aiModel": [
+      { "key": "GPT-4", "value": "gpt-4" },
+      { "key": "GPT-3.5 Turbo", "value": "gpt-3.5-turbo" }
+    ],
+    "systemPrompt": "",
+    "referenceImages": []
+  },
+  "additionalInputFields": [],
+  "workflowData": ""
+}

--- a/frontend/src/templates/OpenAI-image.json
+++ b/frontend/src/templates/OpenAI-image.json
@@ -1,0 +1,54 @@
+{
+  "baseInputFields": {
+    "aiModel": [
+      { "key": "GPT Image 2 (조직 인증 필요)", "value": "gpt-image-2" },
+      { "key": "GPT Image 1.5", "value": "gpt-image-1.5" },
+      { "key": "GPT Image 1", "value": "gpt-image-1" },
+      { "key": "GPT Image 1 Mini", "value": "gpt-image-1-mini" }
+    ],
+    "imageSizes": [
+      { "key": "자동 (auto)", "value": "auto" },
+      { "key": "1024x1024", "value": "1024x1024" },
+      { "key": "1024x1536", "value": "1024x1536" },
+      { "key": "1536x1024", "value": "1536x1024" }
+    ],
+    "referenceImageMethods": []
+  },
+  "additionalInputFields": [
+    {
+      "name": "quality",
+      "label": "품질",
+      "type": "select",
+      "required": true,
+      "defaultValue": "auto",
+      "options": [
+        { "key": "Auto", "value": "auto" },
+        { "key": "Low", "value": "low" },
+        { "key": "Medium", "value": "medium" },
+        { "key": "High", "value": "high" }
+      ],
+      "description": "GPT Image 생성 품질을 선택합니다."
+    },
+    {
+      "name": "background",
+      "label": "배경",
+      "type": "select",
+      "required": false,
+      "defaultValue": "opaque",
+      "options": [
+        { "key": "불투명 (opaque)", "value": "opaque" },
+        { "key": "투명 (transparent)", "value": "transparent" }
+      ],
+      "description": "gpt-image-2 전용. 투명 배경으로 출력하려면 transparent. 다른 모델에서는 무시됨."
+    },
+    {
+      "name": "output_compression",
+      "label": "출력 압축률",
+      "type": "number",
+      "required": false,
+      "defaultValue": 100,
+      "description": "gpt-image-2 의 JPEG/WebP 출력 시 압축률 (1-100). PNG 에는 영향 없음. 다른 모델에서는 무시됨."
+    }
+  ],
+  "workflowData": ""
+}

--- a/frontend/src/templates/capabilities.js
+++ b/frontend/src/templates/capabilities.js
@@ -1,0 +1,53 @@
+// 각 server type 이 지원하는 outputFormat 목록.
+// frontend/src/templates/index.js 의 TEMPLATES 키와 일치해야 함.
+// 새 (serverType, outputFormat) 조합 지원 시 여기와 templates 양쪽을 함께 갱신.
+
+export const CAPABILITIES = {
+  ComfyUI: ['image', 'video'],
+  OpenAI: ['image'],
+  'OpenAI Compatible': ['text'],
+  Gemini: ['image'],
+};
+
+const OUTPUT_FORMAT_LABELS = {
+  image: '이미지',
+  video: '비디오',
+  text: '텍스트',
+};
+
+const SERVER_TYPE_LABELS = {
+  ComfyUI: 'ComfyUI',
+  OpenAI: 'OpenAI',
+  'OpenAI Compatible': 'OpenAI Compatible',
+  Gemini: 'Gemini',
+  'GPT Image': 'GPT Image (deprecated)',
+};
+
+export function getCapableOutputFormats(serverType) {
+  return CAPABILITIES[serverType] || [];
+}
+
+export function getOutputFormatLabel(outputFormat) {
+  return OUTPUT_FORMAT_LABELS[outputFormat] || outputFormat;
+}
+
+export function getServerTypeLabel(serverType) {
+  return SERVER_TYPE_LABELS[serverType] || serverType;
+}
+
+// (server, outputFormat) → workboard schema 의 apiFormat 으로 매핑.
+// Phase 6 에서 apiFormat 필드가 제거되면 이 매핑도 함께 사라짐.
+const SERVER_OUTPUT_TO_LEGACY_APIFORMAT = {
+  'ComfyUI:image': 'ComfyUI',
+  'ComfyUI:video': 'ComfyUI',
+  'OpenAI:image': 'GPT Image',
+  'OpenAI:text': 'OpenAI Compatible',
+  'OpenAI Compatible:image': 'GPT Image',
+  'OpenAI Compatible:text': 'OpenAI Compatible',
+  'Gemini:image': 'Gemini',
+  'Gemini:text': 'Gemini',
+};
+
+export function deriveLegacyApiFormat(serverType, outputFormat) {
+  return SERVER_OUTPUT_TO_LEGACY_APIFORMAT[`${serverType}:${outputFormat}`] || 'ComfyUI';
+}

--- a/frontend/src/templates/index.js
+++ b/frontend/src/templates/index.js
@@ -1,0 +1,30 @@
+// 신규 작업판 생성 시 사용되는 (serverType, outputFormat) 별 기본 템플릿.
+// 각 JSON 파일은 { baseInputFields, additionalInputFields, workflowData } 구조.
+// 신규 provider/capability 추가 시 새 JSON 파일을 만들고 아래 TEMPLATES 에 등록.
+
+import comfyImage from './ComfyUI-image.json';
+import comfyVideo from './ComfyUI-video.json';
+import openAIImage from './OpenAI-image.json';
+import geminiImage from './Gemini-image.json';
+import openAICompatibleText from './OpenAI Compatible-text.json';
+
+const TEMPLATES = {
+  'ComfyUI:image': comfyImage,
+  'ComfyUI:video': comfyVideo,
+  'OpenAI:image': openAIImage,
+  'Gemini:image': geminiImage,
+  'OpenAI Compatible:text': openAICompatibleText,
+};
+
+// 매핑이 없을 때 사용하는 빈 폴백 (Workboard 가 항상 baseInputFields/additionalInputFields 를 갖도록 보장).
+const EMPTY_TEMPLATE = {
+  baseInputFields: {},
+  additionalInputFields: [],
+  workflowData: '',
+};
+
+export function getWorkboardTemplate(serverType, outputFormat) {
+  return TEMPLATES[`${serverType}:${outputFormat}`] || EMPTY_TEMPLATE;
+}
+
+export { TEMPLATES };

--- a/nginx.conf
+++ b/nginx.conf
@@ -7,8 +7,11 @@ server {
     root /usr/share/nginx/html;
     index index.html index.htm;
 
+    # SPA 라우트 fallback — index.html 은 항상 최신을 받아와 새 JS 해시 참조가 즉시 반영되도록 캐시 무효화
+    # (해시된 정적 자산 /static/*.{js,css,...} 은 아래 location 에서 별도 처리되어 영향 없음)
     location / {
         try_files $uri $uri/ /index.html;
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
     }
 
     location /api {

--- a/src/migrations/migrateServerTypeToOpenAI.js
+++ b/src/migrations/migrateServerTypeToOpenAI.js
@@ -1,0 +1,30 @@
+const Server = require('../models/Server');
+
+// Phase 2 (#181, #182): 'GPT Image' Server 를 'OpenAI' 로 이전 + outputType 필드 제거.
+async function migrateServerTypeToOpenAI() {
+  try {
+    const renameResult = await Server.updateMany(
+      { serverType: 'GPT Image' },
+      { $set: { serverType: 'OpenAI' } }
+    );
+    if (renameResult.modifiedCount > 0) {
+      console.log(`[Migration] Server.serverType: 'GPT Image' → 'OpenAI' (${renameResult.modifiedCount} 건)`);
+    } else {
+      console.log("[Migration] Server.serverType 'GPT Image' 마이그레이션 불필요 (대상 없음)");
+    }
+
+    const dropResult = await Server.updateMany(
+      { outputType: { $exists: true } },
+      { $unset: { outputType: '' } }
+    );
+    if (dropResult.modifiedCount > 0) {
+      console.log(`[Migration] Server.outputType 필드 제거 (${dropResult.modifiedCount} 건)`);
+    } else {
+      console.log("[Migration] Server.outputType 마이그레이션 불필요 (대상 없음)");
+    }
+  } catch (error) {
+    console.error('[Migration] Server type/outputType 마이그레이션 오류:', error);
+  }
+}
+
+module.exports = migrateServerTypeToOpenAI;

--- a/src/models/Server.js
+++ b/src/models/Server.js
@@ -13,7 +13,9 @@ const serverSchema = new mongoose.Schema({
   },
   serverType: {
     type: String,
-    enum: ['ComfyUI', 'OpenAI Compatible', 'Gemini', 'GPT Image'],
+    // 'GPT Image' 는 deprecated — Phase 2 마이그레이션으로 'OpenAI' 로 전환됨.
+    // enum 에는 다음 메이저까지 잔존시켜 stale 문서가 있어도 Mongoose 검증 실패가 안 나도록 함.
+    enum: ['ComfyUI', 'OpenAI', 'OpenAI Compatible', 'Gemini', 'GPT Image'],
     required: true
   },
   serverUrl: {
@@ -32,11 +34,6 @@ const serverSchema = new mongoose.Schema({
       },
       message: '올바른 URL 형식이 아닙니다.'
     }
-  },
-  outputType: {
-    type: String,
-    enum: ['Image', 'Video', 'Text'],
-    required: false
   },
   isActive: {
     type: Boolean,
@@ -87,14 +84,13 @@ serverSchema.methods.checkHealth = async function() {
       case 'ComfyUI':
         healthEndpoint = `${this.serverUrl}/system_stats`;
         break;
+      case 'OpenAI':
       case 'OpenAI Compatible':
+      case 'GPT Image': // deprecated — Phase 2 후 데이터는 'OpenAI' 로 마이그레이션됨
         healthEndpoint = `${this.serverUrl}/v1/models`;
         break;
       case 'Gemini':
         healthEndpoint = `${this.serverUrl}/v1beta/models`;
-        break;
-      case 'GPT Image':
-        healthEndpoint = `${this.serverUrl}/v1/models`;
         break;
       default:
         healthEndpoint = this.serverUrl;

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -1,7 +1,7 @@
 const express = require('express');
-const axios = require('axios');
 const { requireAuth } = require('../middleware/auth');
 const { addImageGenerationJob, getQueueStats } = require('../services/queueService');
+const openAIChatService = require('../services/openAIChatService');
 const { deleteFile } = require('../utils/fileUpload');
 const ImageGenerationJob = require('../models/ImageGenerationJob');
 const UploadedImage = require('../models/UploadedImage');
@@ -408,49 +408,16 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
       messages.push({ role: 'system', content: systemPrompt });
     }
     messages.push({ role: 'user', content: inputData.userPrompt });
-    
-    const apiUrl = `${server.serverUrl}/v1/chat/completions`;
-    const requestBody = {
-      model,
+
+    const { content: result, usage } = await openAIChatService.complete(
+      server.serverUrl,
+      server.configuration?.apiKey,
       messages,
-      temperature,
-      max_tokens: maxTokens
-    };
-    
-    const headers = {
-      'Content-Type': 'application/json'
-    };
-    
-    if (server.configuration?.apiKey) {
-      headers['Authorization'] = `Bearer ${server.configuration.apiKey}`;
-    }
-    
-    const response = await axios.post(apiUrl, requestBody, { headers, timeout: 60000 });
-    
-    console.log('LLM API response:', JSON.stringify(response.data, null, 2));
-    
-    if (!response.data?.choices || !Array.isArray(response.data.choices) || response.data.choices.length === 0) {
-      console.error('Invalid LLM response structure:', response.data);
-      return res.status(502).json({
-        message: response.data?.error?.message || 'LLM 서버에서 유효한 응답을 받지 못했습니다. 서버 URL과 설정을 확인해주세요.'
-      });
-    }
-    
-    const result = response.data.choices[0]?.message?.content || '';
-    if (!result) {
-      return res.status(502).json({
-        message: 'LLM 서버에서 빈 응답을 반환했습니다.'
-      });
-    }
-    
-    const usage = {
-      promptTokens: response.data?.usage?.prompt_tokens || 0,
-      completionTokens: response.data?.usage?.completion_tokens || 0,
-      totalTokens: response.data?.usage?.total_tokens || 0
-    };
-    
+      { model, temperature, maxTokens, timeout: 60000 }
+    );
+
     await workboard.incrementUsage();
-    
+
     res.json({
       success: true,
       result,
@@ -459,14 +426,7 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
     });
   } catch (error) {
     console.error('Prompt generation error:', error);
-    
-    if (error.response) {
-      return res.status(error.response.status).json({
-        message: error.response.data?.error?.message || 'API request failed'
-      });
-    }
-    
-    res.status(500).json({ message: error.message });
+    res.status(502).json({ message: error.message });
   }
 });
 

--- a/src/routes/servers.js
+++ b/src/routes/servers.js
@@ -10,18 +10,14 @@ const comfyUIService = require('../services/comfyUIService');
 // 서버 목록 조회 (일반 사용자도 접근 가능)
 router.get('/', verifyJWT, async (req, res) => {
   try {
-    const { serverType, outputType, includeInactive = false } = req.query;
-    
+    const { serverType, includeInactive = false } = req.query;
+
     let filter = {};
-    
+
     if (serverType) {
       filter.serverType = serverType;
     }
-    
-    if (outputType) {
-      filter.outputType = outputType;
-    }
-    
+
     if (!includeInactive || includeInactive === 'false') {
       filter.isActive = true;
     }
@@ -78,10 +74,9 @@ router.post('/', requireAdmin, async (req, res) => {
       description,
       serverType,
       serverUrl,
-      outputType,
       configuration = {}
     } = req.body;
-    
+
     // 필수 필드 검증
     if (!name || !serverType || !serverUrl) {
       return res.status(400).json({
@@ -90,14 +85,14 @@ router.post('/', requireAdmin, async (req, res) => {
       });
     }
 
-    // 서버 타입 검증
-    if (!['ComfyUI', 'OpenAI Compatible', 'Gemini', 'GPT Image'].includes(serverType)) {
+    // 서버 타입 검증 ('GPT Image' 는 deprecated — 신규 생성 차단)
+    if (!['ComfyUI', 'OpenAI', 'OpenAI Compatible', 'Gemini'].includes(serverType)) {
       return res.status(400).json({
         success: false,
         message: '지원하지 않는 서버 타입입니다.'
       });
     }
-    
+
     // 중복 이름 검증
     const existingServer = await Server.findOne({ name });
     if (existingServer) {
@@ -106,13 +101,12 @@ router.post('/', requireAdmin, async (req, res) => {
         message: '같은 이름의 서버가 이미 존재합니다.'
       });
     }
-    
+
     const server = new Server({
       name,
       description,
       serverType,
       serverUrl,
-      outputType,
       configuration,
       createdBy: req.user.id
     });
@@ -159,7 +153,6 @@ router.put('/:id', requireAdmin, async (req, res) => {
       description,
       serverType,
       serverUrl,
-      outputType,
       configuration,
       isActive
     } = req.body;
@@ -193,7 +186,6 @@ router.put('/:id', requireAdmin, async (req, res) => {
     if (description !== undefined) updateFields.description = description;
     if (serverType !== undefined) updateFields.serverType = serverType;
     if (serverUrl !== undefined) updateFields.serverUrl = serverUrl;
-    if (outputType !== undefined) updateFields.outputType = outputType;
     if (configuration !== undefined) {
       // API 키가 비어있으면 기존 값을 유지
       if (!configuration.apiKey && server.configuration?.apiKey) {

--- a/src/routes/workboards.js
+++ b/src/routes/workboards.js
@@ -48,7 +48,7 @@ router.get('/', requireAuth, async (req, res) => {
     
     const workboards = await Workboard.find(filter)
       .populate('createdBy', 'nickname email')
-      .populate('serverId', 'name serverType serverUrl outputType isActive')
+      .populate('serverId', 'name serverType serverUrl isActive')
       .select('-workflowData')
       .sort({ usageCount: -1, createdAt: -1 })
       .skip(skip)
@@ -115,7 +115,7 @@ router.post('/import', requireAdmin, async (req, res) => {
         serverMatchInfo = { name: server.name, matched: true, manual: false };
       } else {
         // 매칭 실패 - 서버 목록과 함께 반환
-        const servers = await Server.find({ isActive: true }).select('name serverType outputType');
+        const servers = await Server.find({ isActive: true }).select('name serverType');
         return res.json({
           needsServer: true,
           preview: {
@@ -131,7 +131,7 @@ router.post('/import', requireAdmin, async (req, res) => {
       }
     } else {
       // 서버 정보가 없는 경우
-      const servers = await Server.find({ isActive: true }).select('name serverType outputType');
+      const servers = await Server.find({ isActive: true }).select('name serverType');
       return res.json({
         needsServer: true,
         preview: {
@@ -170,7 +170,7 @@ router.post('/import', requireAdmin, async (req, res) => {
 
     await newWorkboard.save();
     await newWorkboard.populate('createdBy', 'nickname email');
-    await newWorkboard.populate('serverId', 'name serverType serverUrl outputType isActive');
+    await newWorkboard.populate('serverId', 'name serverType serverUrl isActive');
 
     res.status(201).json({
       message: '작업판을 가져왔습니다.',
@@ -188,7 +188,7 @@ router.get('/:id', requireAuth, async (req, res) => {
   try {
     const workboard = await Workboard.findById(req.params.id)
       .populate('createdBy', 'nickname email')
-      .populate('serverId', 'name serverType serverUrl outputType isActive');
+      .populate('serverId', 'name serverType serverUrl isActive');
     
     if (!workboard) {
       return res.status(404).json({ message: 'Workboard not found' });
@@ -209,7 +209,7 @@ router.get('/admin/:id', requireAdmin, async (req, res) => {
   try {
     const workboard = await Workboard.findById(req.params.id)
       .populate('createdBy', 'nickname email')
-      .populate('serverId', 'name serverType serverUrl outputType isActive');
+      .populate('serverId', 'name serverType serverUrl isActive');
     
     if (!workboard) {
       return res.status(404).json({ message: 'Workboard not found' });
@@ -299,7 +299,7 @@ router.post('/', requireAdmin, async (req, res) => {
     
     await workboard.save();
     await workboard.populate('createdBy', 'nickname email');
-    await workboard.populate('serverId', 'name serverType serverUrl outputType isActive');
+    await workboard.populate('serverId', 'name serverType serverUrl isActive');
     
     res.status(201).json({
       message: 'Workboard created successfully',
@@ -387,7 +387,7 @@ router.put('/:id', requireAdmin, async (req, res) => {
     console.log('Before save:', workboard.toObject());
     await workboard.save();
     await workboard.populate('createdBy', 'nickname email');
-    await workboard.populate('serverId', 'name serverType serverUrl outputType isActive');
+    await workboard.populate('serverId', 'name serverType serverUrl isActive');
     
     res.json({
       message: 'Workboard updated successfully',
@@ -519,8 +519,7 @@ router.get('/:id/export', requireAdmin, async (req, res) => {
       if (server) {
         serverInfo = {
           name: server.name,
-          serverType: server.serverType,
-          outputType: server.outputType
+          serverType: server.serverType
         };
       }
     }

--- a/src/routes/workboards.js
+++ b/src/routes/workboards.js
@@ -11,6 +11,12 @@ const router = express.Router();
 const EXPORT_VERSION = 1;
 const APP_VERSION = { major: 1, minor: 3 };
 
+// 옛 환경에서 export 한 작업판 백업의 server.serverType 을 신규 enum 으로 폴백 매핑.
+// Phase 2 (#181, #182) 마이그레이션과 동일 매핑. import 자동 매칭 1차 실패 시 시도.
+const SERVER_TYPE_LEGACY_FALLBACK = {
+  'GPT Image': 'OpenAI',
+};
+
 router.get('/', requireAuth, async (req, res) => {
   try {
     const { search = '', workboardType, apiFormat, outputFormat, includeAll, includeInactive } = req.query;
@@ -106,10 +112,17 @@ router.post('/import', requireAdmin, async (req, res) => {
       serverMatchInfo = { name: server.name, matched: true, manual: true };
     } else if (data.server) {
       // 자동 매칭 시도
-      const server = await Server.findOne({
+      let server = await Server.findOne({
         name: data.server.name,
         serverType: data.server.serverType
       });
+      // Phase 2 마이그레이션으로 deprecated 된 serverType 의 자동 폴백 (옛 환경 export 호환)
+      if (!server && SERVER_TYPE_LEGACY_FALLBACK[data.server.serverType]) {
+        server = await Server.findOne({
+          name: data.server.name,
+          serverType: SERVER_TYPE_LEGACY_FALLBACK[data.server.serverType]
+        });
+      }
       if (server) {
         matchedServerId = server._id;
         serverMatchInfo = { name: server.name, matched: true, manual: false };

--- a/src/server.js
+++ b/src/server.js
@@ -28,6 +28,7 @@ const { transformUploadUrls } = require('./utils/signedUrl');
 const { initializeQueues } = require('./services/queueService');
 const migrateWorkboardApiFormat = require('./migrations/migrateWorkboardApiFormat');
 const migrateMediaOrderIndex = require('./migrations/migrateMediaOrderIndex');
+const migrateServerTypeToOpenAI = require('./migrations/migrateServerTypeToOpenAI');
 
 dotenv.config();
 
@@ -171,6 +172,7 @@ const startServer = async () => {
     console.log('Running migrations...');
     await migrateWorkboardApiFormat();
     await migrateMediaOrderIndex();
+    await migrateServerTypeToOpenAI();
 
     // Initialize job queues after database connection
     console.log('Initializing job queues...');

--- a/src/services/geminiService.js
+++ b/src/services/geminiService.js
@@ -110,6 +110,62 @@ const generateImage = async (serverUrl, apiKey, prompt, options = {}) => {
   return { images, videos: [] };
 };
 
+// Gemini LLM (Chat) — generateContent 호출 후 첫 번째 candidate 의 텍스트 본문 반환.
+// Phase 4/5 에서 Gemini Chat 워크보드 도입 시 호출되도록 마련해 둔 인터페이스.
+const complete = async (serverUrl, apiKey, messages, options = {}) => {
+  const resolvedServerUrl = (serverUrl || DEFAULT_SERVER_URL).replace(/\/+$/, '');
+  const model = extractValue(options.model);
+  if (!model) throw new Error('Gemini Chat: model is required');
+  if (!apiKey) throw new Error('Gemini Chat: api key is required');
+
+  const contents = (Array.isArray(messages) ? messages : []).map((m) => ({
+    role: m.role === 'assistant' ? 'model' : 'user',
+    parts: [{ text: m.content || '' }],
+  }));
+  if (contents.length === 0) {
+    throw new Error('Gemini Chat: messages is empty');
+  }
+
+  const generationConfig = {
+    responseModalities: ['TEXT'],
+  };
+  if (options.temperature !== undefined) {
+    generationConfig.temperature = options.temperature;
+  }
+  if (options.maxTokens !== undefined) {
+    generationConfig.maxOutputTokens = options.maxTokens;
+  }
+
+  const response = await axios.post(
+    `${resolvedServerUrl}/v1beta/models/${model}:generateContent`,
+    { contents, generationConfig },
+    {
+      params: { key: apiKey },
+      headers: { 'Content-Type': 'application/json' },
+      timeout: options.timeout || 60000,
+    }
+  );
+
+  const parts = response.data?.candidates?.[0]?.content?.parts || [];
+  const content = parts
+    .map((p) => p.text || '')
+    .filter(Boolean)
+    .join('');
+
+  if (!content) {
+    throw new Error('Gemini Chat: 빈 응답이 반환되었습니다.');
+  }
+
+  const usage = {
+    promptTokens: response.data?.usageMetadata?.promptTokenCount || 0,
+    completionTokens: response.data?.usageMetadata?.candidatesTokenCount || 0,
+    totalTokens: response.data?.usageMetadata?.totalTokenCount || 0,
+  };
+
+  return { content, usage, model };
+};
+
 module.exports = {
-  generateImage
+  generateImage,
+  complete,
 };

--- a/src/services/openAIChatService.js
+++ b/src/services/openAIChatService.js
@@ -1,0 +1,72 @@
+const axios = require('axios');
+
+const extractValue = (input) => {
+  if (input && typeof input === 'object' && input.value !== undefined) {
+    return input.value;
+  }
+  return input;
+};
+
+// OpenAI 호환 `/v1/chat/completions` 호출 — OpenAI 공식 / Local LLM (Ollama, LiteLLM, vLLM 등) 공통.
+// 응답에서 첫 번째 choice 의 메시지 본문 + usage 를 추출해 반환.
+const complete = async (serverUrl, apiKey, messages, options = {}) => {
+  const resolvedServerUrl = (serverUrl || '').replace(/\/+$/, '');
+  if (!resolvedServerUrl) {
+    throw new Error('OpenAI Chat: serverUrl is required');
+  }
+
+  const model = extractValue(options.model);
+  if (!model) {
+    throw new Error('OpenAI Chat: model is required');
+  }
+
+  const requestBody = {
+    model,
+    messages,
+    temperature: options.temperature ?? 0.7,
+    max_tokens: options.maxTokens ?? 2000,
+  };
+
+  const headers = { 'Content-Type': 'application/json' };
+  if (apiKey) {
+    headers['Authorization'] = `Bearer ${apiKey}`;
+  }
+
+  let response;
+  try {
+    response = await axios.post(
+      `${resolvedServerUrl}/v1/chat/completions`,
+      requestBody,
+      { headers, timeout: options.timeout || 60000 }
+    );
+  } catch (err) {
+    const apiMessage = err.response?.data?.error?.message;
+    if (apiMessage && /organization must be verified/i.test(apiMessage)) {
+      throw new Error(
+        `${model} 모델 사용에는 OpenAI 조직 인증(Verify Organization)이 필요합니다. https://platform.openai.com/settings/organization/general 에서 인증 후 약 15분 대기하세요.`
+      );
+    }
+    if (apiMessage) throw new Error(`OpenAI: ${apiMessage}`);
+    throw err;
+  }
+
+  const choices = response.data?.choices;
+  if (!Array.isArray(choices) || choices.length === 0) {
+    throw new Error('LLM 서버에서 유효한 응답을 받지 못했습니다. 서버 URL과 설정을 확인해주세요.');
+  }
+
+  const content = choices[0]?.message?.content || '';
+  if (!content) {
+    throw new Error('LLM 서버에서 빈 응답을 반환했습니다.');
+  }
+
+  const usage = {
+    promptTokens: response.data?.usage?.prompt_tokens || 0,
+    completionTokens: response.data?.usage?.completion_tokens || 0,
+    totalTokens: response.data?.usage?.total_tokens || 0,
+  };
+
+  return { content, usage, model };
+};
+
+module.exports = { complete };

--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -117,124 +117,161 @@ const initializeQueues = async () => {
   }
 };
 
+// (serverType, outputFormat) → 핸들러 매핑.
+// 신규 provider/capability 추가 시 이 테이블에만 추가하면 됨.
+// 핸들러 시그니처: ({ workboardData, inputData, jobId, job }) => Promise<{ images?, videos?, seed? }>
+const SERVICE_MAP = {
+  'Gemini:image': handleGeminiImage,
+  'OpenAI:image': handleOpenAIImage,
+  'OpenAI Compatible:image': handleOpenAIImage,
+  'ComfyUI:image': handleComfyUIWorkflow,
+  'ComfyUI:video': handleComfyUIWorkflow,
+};
+
+// Deprecated apiFormat 만 가진 잡 (Phase 4 이전 데이터) 을 위한 fallback 매핑.
+const APIFORMAT_TO_SERVERTYPE = {
+  'ComfyUI': 'ComfyUI',
+  'OpenAI Compatible': 'OpenAI Compatible',
+  'Gemini': 'Gemini',
+  'GPT Image': 'OpenAI', // Phase 2 마이그레이션 후 server 는 OpenAI 로 저장됨
+};
+
+const resolveServiceKey = (workboardData) => {
+  const serverType = workboardData.serverType
+    || APIFORMAT_TO_SERVERTYPE[workboardData.apiFormat];
+  const outputFormat = workboardData.outputFormat || 'image';
+  return { key: `${serverType}:${outputFormat}`, serverType, outputFormat };
+};
+
+async function handleGeminiImage({ workboardData, inputData, job }) {
+  const geminiImages = await loadImageInputs(
+    workboardData.additionalInputFields || [],
+    inputData
+  );
+  job.progress(20);
+
+  const result = await geminiService.generateImage(
+    workboardData.serverUrl,
+    workboardData.apiKey || process.env.GEMINI_API_KEY,
+    buildGeminiPrompt(inputData),
+    {
+      model: inputData.aiModel,
+      aspectRatio: deriveAspectRatio(extractOptionValue(inputData.imageSize)),
+      resolution: extractOptionValue(inputData.additionalParams?.resolution),
+      images: geminiImages,
+      timeout: workboardData.timeout,
+    }
+  );
+  job.progress(90);
+  return result;
+}
+
+async function handleOpenAIImage({ workboardData, inputData, job }) {
+  const result = await gptImageService.generateImage(
+    workboardData.serverUrl,
+    workboardData.apiKey || process.env.OPENAI_IMAGE_API_KEY,
+    buildGeminiPrompt(inputData),
+    {
+      model: inputData.aiModel,
+      size: extractOptionValue(inputData.imageSize),
+      quality: extractOptionValue(
+        inputData.additionalParams?.quality || inputData.quality
+      ),
+      n: extractOptionValue(
+        inputData.additionalParams?.n || inputData.n
+      ) || 1,
+      outputFormat: extractOptionValue(
+        inputData.additionalParams?.outputFormat || inputData.outputFormat
+      ) || 'png',
+      background: extractOptionValue(inputData.additionalParams?.background),
+      outputCompression: extractOptionValue(inputData.additionalParams?.output_compression),
+      timeout: workboardData.timeout,
+    }
+  );
+  job.progress(90);
+  return result;
+}
+
+async function handleComfyUIWorkflow({ workboardData, inputData, job, jobId }) {
+  const uploadedImageMap = await uploadImageFieldsToComfyUI(
+    workboardData.serverUrl,
+    workboardData.additionalInputFields || [],
+    inputData
+  );
+  job.progress(15);
+
+  let workflowJson;
+  let actualSeed;
+  try {
+    ({ workflowJson, actualSeed } = await injectInputsIntoWorkflow(
+      workboardData.workflowData,
+      inputData,
+      workboardData,
+      uploadedImageMap
+    ));
+  } catch (injectError) {
+    const resolvedString = injectError.resolvedWorkflowString || workboardData.workflowData;
+    try {
+      await ImageGenerationJob.findByIdAndUpdate(jobId, {
+        resolvedWorkflowData: resolvedString,
+      });
+    } catch (saveError) {
+      console.error(`⚠️ Failed to save workflow data for job ${jobId}:`, saveError.message);
+    }
+    throw injectError;
+  }
+  job.progress(20);
+
+  try {
+    await ImageGenerationJob.findByIdAndUpdate(jobId, {
+      resolvedWorkflowData: JSON.stringify(workflowJson),
+    });
+  } catch (saveError) {
+    console.error(`⚠️ Failed to save resolved workflow data for job ${jobId}:`, saveError.message);
+  }
+
+  console.log(`🚀 Submitting workflow to ComfyUI for job ${jobId} with seed: ${actualSeed}`);
+  console.log(`🔗 ComfyUI Server URL: ${workboardData.serverUrl}`);
+  console.log(`📝 Workflow JSON preview:`, JSON.stringify(workflowJson).substring(0, 200) + '...');
+
+  const result = await comfyUIService.submitWorkflow(
+    workboardData.serverUrl,
+    workflowJson,
+    (progress) => job.progress(20 + (progress * 0.7))
+  );
+  job.progress(90);
+
+  console.log(`✅ ComfyUI workflow completed for job ${jobId}`);
+  console.log(`📊 ComfyUI result:`, {
+    hasImages: !!result.images,
+    imageCount: result.images?.length || 0,
+    hasVideos: !!result.videos,
+    videoCount: result.videos?.length || 0,
+    resultKeys: Object.keys(result),
+  });
+
+  return { ...result, seed: actualSeed };
+}
+
 const processImageGeneration = async (job) => {
   const { jobId, workboardData, inputData } = job.data;
-  
+
   try {
     job.progress(5);
-    
-    let generationResult;
-    let enhancedInputData = { ...inputData };
 
-    if (workboardData.apiFormat === 'Gemini') {
-      const geminiImages = await loadImageInputs(
-        workboardData.additionalInputFields || [],
-        inputData
+    const { key, serverType, outputFormat } = resolveServiceKey(workboardData);
+    const handler = SERVICE_MAP[key];
+    if (!handler) {
+      throw new Error(
+        `지원하지 않는 서비스 조합입니다: serverType=${serverType ?? '(unknown)'}, outputFormat=${outputFormat}`
       );
-      job.progress(20);
-
-      generationResult = await geminiService.generateImage(
-        workboardData.serverUrl,
-        workboardData.apiKey || process.env.GEMINI_API_KEY,
-        buildGeminiPrompt(inputData),
-        {
-          model: inputData.aiModel,
-          aspectRatio: deriveAspectRatio(extractOptionValue(inputData.imageSize)),
-          resolution: extractOptionValue(inputData.additionalParams?.resolution),
-          images: geminiImages,
-          timeout: workboardData.timeout
-        }
-      );
-      job.progress(90);
-    } else if (workboardData.apiFormat === 'GPT Image') {
-      generationResult = await gptImageService.generateImage(
-        workboardData.serverUrl,
-        workboardData.apiKey || process.env.OPENAI_IMAGE_API_KEY,
-        buildGeminiPrompt(inputData),
-        {
-          model: inputData.aiModel,
-          size: extractOptionValue(inputData.imageSize),
-          quality: extractOptionValue(
-            inputData.additionalParams?.quality || inputData.quality
-          ),
-          n: extractOptionValue(
-            inputData.additionalParams?.n || inputData.n
-          ) || 1,
-          outputFormat: extractOptionValue(
-            inputData.additionalParams?.outputFormat || inputData.outputFormat
-          ) || 'png',
-          background: extractOptionValue(inputData.additionalParams?.background),
-          outputCompression: extractOptionValue(inputData.additionalParams?.output_compression),
-          timeout: workboardData.timeout
-        }
-      );
-      job.progress(90);
-    } else {
-      // 이미지 타입 필드들을 ComfyUI에 업로드
-      const uploadedImageMap = await uploadImageFieldsToComfyUI(
-        workboardData.serverUrl,
-        workboardData.additionalInputFields || [],
-        inputData
-      );
-      job.progress(15);
-
-      let workflowJson, actualSeed;
-      try {
-        ({ workflowJson, actualSeed } = await injectInputsIntoWorkflow(
-          workboardData.workflowData,
-          inputData,
-          workboardData,
-          uploadedImageMap
-        ));
-      } catch (injectError) {
-        // 워크플로우 주입 실패 시 치환된 워크플로우 문자열을 저장하여 디버깅 가능하게 함
-        const resolvedString = injectError.resolvedWorkflowString || workboardData.workflowData;
-        try {
-          await ImageGenerationJob.findByIdAndUpdate(jobId, {
-            resolvedWorkflowData: resolvedString
-          });
-        } catch (saveError) {
-          console.error(`⚠️ Failed to save workflow data for job ${jobId}:`, saveError.message);
-        }
-        throw injectError;
-      }
-      job.progress(20);
-
-      // resolved 워크플로우 JSON 저장 (전송 전 저장하여 실패한 작업도 확인 가능)
-      try {
-        await ImageGenerationJob.findByIdAndUpdate(jobId, {
-          resolvedWorkflowData: JSON.stringify(workflowJson)
-        });
-      } catch (saveError) {
-        console.error(`⚠️ Failed to save resolved workflow data for job ${jobId}:`, saveError.message);
-      }
-
-      enhancedInputData = {
-        ...inputData,
-        seed: actualSeed
-      };
-
-      console.log(`🚀 Submitting workflow to ComfyUI for job ${jobId} with seed: ${actualSeed}`);
-      console.log(`🔗 ComfyUI Server URL: ${workboardData.serverUrl}`);
-      console.log(`📝 Workflow JSON preview:`, JSON.stringify(workflowJson).substring(0, 200) + '...');
-
-      generationResult = await comfyUIService.submitWorkflow(
-        workboardData.serverUrl,
-        workflowJson,
-        (progress) => job.progress(20 + (progress * 0.7))
-      );
-      job.progress(90);
-
-      console.log(`✅ ComfyUI workflow completed for job ${jobId}`);
-      console.log(`📊 ComfyUI result:`, {
-        hasImages: !!generationResult.images,
-        imageCount: generationResult.images?.length || 0,
-        hasVideos: !!generationResult.videos,
-        videoCount: generationResult.videos?.length || 0,
-        resultKeys: Object.keys(generationResult),
-        fullResult: generationResult
-      });
     }
+    console.log(`[dispatch] job ${jobId} → ${key}`);
+
+    const generationResult = await handler({ workboardData, inputData, job, jobId });
+    const enhancedInputData = generationResult.seed != null
+      ? { ...inputData, seed: generationResult.seed }
+      : inputData;
     
     const hasImages = generationResult.images && generationResult.images.length > 0;
     const hasVideos = generationResult.videos && generationResult.videos.length > 0;
@@ -878,6 +915,9 @@ const addImageGenerationJob = async (userId, workboardId, inputData) => {
     const queueJob = await imageGenerationQueue.add('generateImage', {
       jobId: job._id.toString(),
       workboardData: {
+        // Phase 3: 라우팅은 (serverType, outputFormat) 우선, apiFormat 은 fallback
+        serverType: workboard.serverId?.serverType,
+        outputFormat: workboard.outputFormat,
         apiFormat: workboard.apiFormat,
         serverUrl: workboard.serverUrl,
         apiKey: workboard.serverId?.configuration?.apiKey,


### PR DESCRIPTION
## v1.8.0 릴리스

Server·Workboard 구조의 대규모 리팩토링 (#181 의 Phase 1-5) 와 보강 패치를 포함하는 메이저 마이너 릴리스.

### 핵심 변화
- **Server.serverType** 이 provider 단위로 정리 (`OpenAI` / `OpenAI Compatible` / `Gemini` / `ComfyUI`). 기존 `GPT Image` 서버는 `OpenAI` 로 자동 마이그레이션
- **Workboard 생성** 이 (server, outputFormat) 기반으로 단순화. `apiFormat` 드롭다운 제거
- **라우팅 dispatcher** 가 단일 `SERVICE_MAP` 으로 통합 — 신규 provider 추가가 한 곳만 수정으로 충분
- **작업판 템플릿** 이 `frontend/src/templates/*.json` 으로 분리 — 코드 변경 없이 PR 로 추가/수정
- **OpenAI Compatible chat / Gemini chat** 호출 모듈 분리 — 향후 Local LLM / Gemini LLM 워크보드 도입 기반

### 포함 PR
- #183 — Phase 2: Server 모델 enum/outputType 정리 + 마이그레이션
- #185 — Phase 3: 라우팅 dispatcher 통합 + 서비스 인터페이스 정리
- #187 — Phase 4: 신규 작업판 템플릿을 JSON 모듈로 분리
- #189 — Phase 5: 작업판 폼을 (server, outputFormat) 기반으로 전환
- #191 — fix: 작업판 import deprecated serverType 자동 폴백
- #178, #180 — 작업판 메뉴/다이얼로그 정리
- #176 — nginx index.html 캐시 무효화

### 마이그레이션
- 자동 (서버 부팅 시 `migrateServerTypeToOpenAI` 실행)
- idempotent — 두 번 실행해도 안전
- 기존 작업판의 `apiFormat` / `serverId` 유지

### 권장 배포 절차
1. 프로덕션 백업 실행
2. v1.8.0 배포 (자동 마이그레이션)
3. 헬스체크 + 작업판 생성/생성 검증

### 호환성
- `apiFormat` 필드는 deprecated 이지만 schema 유지 (Phase 6 에서 완전 제거 예정 — 1 버전 후)
- 기존 작업판은 변경 없이 동작 (라우팅 dispatcher 가 fallback 처리)
- 옛 환경 export → 신규 환경 import 자동 매칭 (#191 폴백 매핑)

## Test plan
- [x] Phase 별 로컬 검증 완료 (각 PR 본문에 기록)
- [x] 마이그레이션 1건 정상 적용 + idempotent 확인
- [x] 기존 GPT Image / Gemini / ComfyUI 작업판 회귀 없음
- [x] 신규 작업판 폼 → workboard 생성 + 라우팅 → 이미지 생성 정상
- [x] 옛 형식 export → 신규 환경 import 자동 매칭 검증
- [ ] main 머지 후 v1.8.0 태그 부착