### PR TITLE
feat: 서버 추가 시 알려진 provider 의 URL 자동 채우기 (#193)

### DIFF
--- a/frontend/src/components/admin/ServerManagement.js
+++ b/frontend/src/components/admin/ServerManagement.js
@@ -42,6 +42,12 @@ import { useQuery, useMutation, useQueryClient } from 'react-query';
 import toast from 'react-hot-toast';
 import { serverAPI } from '../../services/api';
 
+// 공식 base URL 이 알려진 provider — 서버 추가 시 자동 입력 (사용자 입력 우선)
+const KNOWN_SERVER_URLS = {
+  OpenAI: 'https://api.openai.com',
+  Gemini: 'https://generativelanguage.googleapis.com',
+};
+
 function ServerCard({ server, onEdit, onDelete, onHealthCheck, onLoraSync, loraSyncStatus }) {
   const [healthChecking, setHealthChecking] = useState(false);
   const isComfyUI = server.serverType === 'ComfyUI';
@@ -342,7 +348,15 @@ function ServerDialog({ open, onClose, server, onSubmit }) {
                 <InputLabel>AI API 형식</InputLabel>
                 <Select
                   value={formData.serverType}
-                  onChange={(e) => setFormData(prev => ({ ...prev, serverType: e.target.value }))}
+                  onChange={(e) => {
+                    const newType = e.target.value;
+                    setFormData(prev => ({
+                      ...prev,
+                      serverType: newType,
+                      // 알려진 provider 면 URL 비어있을 때만 자동 입력
+                      serverUrl: prev.serverUrl || KNOWN_SERVER_URLS[newType] || '',
+                    }));
+                  }}
                   label="AI API 형식"
                 >
                   <MenuItem value="ComfyUI">ComfyUI API</MenuItem>


### PR DESCRIPTION
## Summary
서버 추가 폼에서 OpenAI / Gemini 같이 공식 base URL 이 알려진 provider 를 선택하면 URL 필드에 자동 입력. 사용자가 입력한 URL 이 있으면 보존.

## 변경
- `ServerManagement.js`
  - `KNOWN_SERVER_URLS` 매핑 (OpenAI: `https://api.openai.com`, Gemini: `https://generativelanguage.googleapis.com`) 추가
  - `serverType` Select 의 `onChange` 핸들러: `serverUrl` 이 비어있을 때만 알려진 URL 로 자동 채우기
- ComfyUI / OpenAI Compatible 은 환경마다 다르므로 자동 채우기 제외 (placeholder 만 유지)

## 영향 범위
- 1 파일, +15/-1
- 모델 / 백엔드 / 마이그레이션 영향 없음

## 동작
| 상황 | URL 자동 입력 여부 |
|---|---|
| URL 비어있음 + Gemini 선택 | ✅ `https://generativelanguage.googleapis.com` |
| URL 비어있음 + OpenAI 선택 | ✅ `https://api.openai.com` |
| URL 비어있음 + ComfyUI / OpenAI Compatible 선택 | ❌ (placeholder 만) |
| 사용자가 URL 입력 후 type 변경 | ❌ (입력값 보존) |

closes #193