### PR TITLE
fix: BackupJob 의 TTL 자동 삭제 제거 (#195)

### DIFF
--- a/src/migrations/dropBackupJobTTL.js
+++ b/src/migrations/dropBackupJobTTL.js
@@ -1,0 +1,31 @@
+const BackupJob = require('../models/BackupJob');
+
+// #195: BackupJob 의 expiresAt 기반 TTL 인덱스 + 필드 제거. 자동 삭제로 백업이 사라지던 문제 해결.
+async function dropBackupJobTTL() {
+  try {
+    const indexes = await BackupJob.collection.indexes();
+    const ttlIndex = indexes.find(
+      (idx) => idx.key && idx.key.expiresAt === 1 && typeof idx.expireAfterSeconds === 'number'
+    );
+    if (ttlIndex) {
+      await BackupJob.collection.dropIndex(ttlIndex.name);
+      console.log(`[Migration] BackupJob TTL 인덱스 제거: ${ttlIndex.name}`);
+    } else {
+      console.log('[Migration] BackupJob TTL 인덱스 마이그레이션 불필요 (대상 없음)');
+    }
+
+    const unsetResult = await BackupJob.updateMany(
+      { expiresAt: { $exists: true } },
+      { $unset: { expiresAt: '' } }
+    );
+    if (unsetResult.modifiedCount > 0) {
+      console.log(`[Migration] BackupJob.expiresAt 필드 제거 (${unsetResult.modifiedCount}건)`);
+    } else {
+      console.log('[Migration] BackupJob.expiresAt 필드 제거 불필요 (대상 없음)');
+    }
+  } catch (error) {
+    console.error('[Migration] BackupJob TTL 제거 오류:', error);
+  }
+}
+
+module.exports = dropBackupJobTTL;

--- a/src/models/BackupJob.js
+++ b/src/models/BackupJob.js
@@ -48,10 +48,6 @@ const backupJobSchema = new mongoose.Schema({
   },
   completedAt: {
     type: Date
-  },
-  expiresAt: {
-    type: Date,
-    default: () => new Date(Date.now() + 7 * 24 * 60 * 60 * 1000) // 7일 후
   }
 }, {
   timestamps: true
@@ -61,7 +57,6 @@ const backupJobSchema = new mongoose.Schema({
 backupJobSchema.index({ status: 1 });
 backupJobSchema.index({ createdBy: 1 });
 backupJobSchema.index({ createdAt: -1 });
-backupJobSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
 
 // 진행 상태 업데이트 메서드
 backupJobSchema.methods.updateProgress = function(current, total, stage) {

--- a/src/server.js
+++ b/src/server.js
@@ -29,6 +29,7 @@ const { initializeQueues } = require('./services/queueService');
 const migrateWorkboardApiFormat = require('./migrations/migrateWorkboardApiFormat');
 const migrateMediaOrderIndex = require('./migrations/migrateMediaOrderIndex');
 const migrateServerTypeToOpenAI = require('./migrations/migrateServerTypeToOpenAI');
+const dropBackupJobTTL = require('./migrations/dropBackupJobTTL');
 
 dotenv.config();
 
@@ -173,6 +174,7 @@ const startServer = async () => {
     await migrateWorkboardApiFormat();
     await migrateMediaOrderIndex();
     await migrateServerTypeToOpenAI();
+    await dropBackupJobTTL();
 
     // Initialize job queues after database connection
     console.log('Initializing job queues...');


### PR DESCRIPTION
## Summary
7일 후 자동 삭제되는 `expiresAt` 기반 TTL 인덱스로 인해 사용자가 직접 만든 백업이 목록에서 사라지던 문제 수정. 자동 백업 기능이 없는 현재 시스템에서 사용자 의도와 어긋나는 동작.

## 변경
- `src/models/BackupJob.js`
  - `expiresAt` 필드 제거
  - `expireAfterSeconds: 0` 의 TTL 인덱스 정의 제거
- `src/migrations/dropBackupJobTTL.js` (신규)
  - 기존 TTL 인덱스를 명시적으로 drop (Mongoose schema 변경만으로는 자동 drop 안 됨)
  - 모든 BackupJob 의 `expiresAt` 필드 `$unset`
  - idempotent (이미 제거된 경우 noop)
- `src/server.js` 마이그레이션 체인에 등록

## 로컬 검증
- [x] 부팅 시 `[Migration] BackupJob TTL 인덱스 제거: expiresAt_1` 로그 확인
- [x] `db.backupjobs.getIndexes()` 에 TTL 인덱스 없음 (`status`, `createdBy`, `createdAt`, `_id` 만 남음)
- [x] 마이그레이션 idempotent (두 번째 실행 시 "마이그레이션 불필요")

## 호환성 / 비고
- TTL 로 이미 사라진 백업 레코드는 복구 불가
- 백업 ZIP 파일의 orphan 정리(과거 TTL 로 DB 만 사라지고 디스크에 남은 파일들)는 별도 작업

closes #195