### PR TITLE
release: v1.8.1

### DIFF
--- a/docs/updatelogs/v1.md
+++ b/docs/updatelogs/v1.md
@@ -1,5 +1,17 @@
 # v1 업데이트 내역
 
+## v1.8.1
+
+- fix: `BackupJob` 의 7일 TTL 자동 삭제 제거 (#195, #196)
+  - 사용자가 직접 만든 백업이 7일 후 자동으로 목록에서 사라지던 문제 수정. 자동 백업 기능이 없는 현재 시스템에서 의도와 어긋나는 동작이었음
+  - `expiresAt` 필드와 `expireAfterSeconds: 0` TTL 인덱스 제거
+  - 신규 마이그레이션이 기존 TTL 인덱스를 명시적으로 drop (Mongoose schema 변경만으로는 자동 drop 안 됨)
+  - 이미 TTL 로 사라진 백업 레코드는 복구 불가. 백업 ZIP 파일의 orphan 정리는 별도 작업
+- feat: 서버 추가 시 알려진 provider 의 URL 자동 채우기 (#193, #194)
+  - 관리자 폼에서 `OpenAI` 또는 `Gemini` 선택 시 base URL 자동 입력 (`https://api.openai.com`, `https://generativelanguage.googleapis.com`)
+  - 사용자가 입력한 URL 이 있으면 보존
+  - `ComfyUI` / `OpenAI Compatible` 은 환경마다 다양하므로 placeholder 만 유지
+
 ## v1.8.0
 
 ### Server·Workboard 구조 리팩토링 (Phase 1-5, #181)

--- a/frontend/src/components/admin/ServerManagement.js
+++ b/frontend/src/components/admin/ServerManagement.js
@@ -42,6 +42,12 @@ import { useQuery, useMutation, useQueryClient } from 'react-query';
 import toast from 'react-hot-toast';
 import { serverAPI } from '../../services/api';
 
+// 공식 base URL 이 알려진 provider — 서버 추가 시 자동 입력 (사용자 입력 우선)
+const KNOWN_SERVER_URLS = {
+  OpenAI: 'https://api.openai.com',
+  Gemini: 'https://generativelanguage.googleapis.com',
+};
+
 function ServerCard({ server, onEdit, onDelete, onHealthCheck, onLoraSync, loraSyncStatus }) {
   const [healthChecking, setHealthChecking] = useState(false);
   const isComfyUI = server.serverType === 'ComfyUI';
@@ -342,7 +348,15 @@ function ServerDialog({ open, onClose, server, onSubmit }) {
                 <InputLabel>AI API 형식</InputLabel>
                 <Select
                   value={formData.serverType}
-                  onChange={(e) => setFormData(prev => ({ ...prev, serverType: e.target.value }))}
+                  onChange={(e) => {
+                    const newType = e.target.value;
+                    setFormData(prev => ({
+                      ...prev,
+                      serverType: newType,
+                      // 알려진 provider 면 URL 비어있을 때만 자동 입력
+                      serverUrl: prev.serverUrl || KNOWN_SERVER_URLS[newType] || '',
+                    }));
+                  }}
                   label="AI API 형식"
                 >
                   <MenuItem value="ComfyUI">ComfyUI API</MenuItem>

--- a/src/migrations/dropBackupJobTTL.js
+++ b/src/migrations/dropBackupJobTTL.js
@@ -1,0 +1,31 @@
+const BackupJob = require('../models/BackupJob');
+
+// #195: BackupJob 의 expiresAt 기반 TTL 인덱스 + 필드 제거. 자동 삭제로 백업이 사라지던 문제 해결.
+async function dropBackupJobTTL() {
+  try {
+    const indexes = await BackupJob.collection.indexes();
+    const ttlIndex = indexes.find(
+      (idx) => idx.key && idx.key.expiresAt === 1 && typeof idx.expireAfterSeconds === 'number'
+    );
+    if (ttlIndex) {
+      await BackupJob.collection.dropIndex(ttlIndex.name);
+      console.log(`[Migration] BackupJob TTL 인덱스 제거: ${ttlIndex.name}`);
+    } else {
+      console.log('[Migration] BackupJob TTL 인덱스 마이그레이션 불필요 (대상 없음)');
+    }
+
+    const unsetResult = await BackupJob.updateMany(
+      { expiresAt: { $exists: true } },
+      { $unset: { expiresAt: '' } }
+    );
+    if (unsetResult.modifiedCount > 0) {
+      console.log(`[Migration] BackupJob.expiresAt 필드 제거 (${unsetResult.modifiedCount}건)`);
+    } else {
+      console.log('[Migration] BackupJob.expiresAt 필드 제거 불필요 (대상 없음)');
+    }
+  } catch (error) {
+    console.error('[Migration] BackupJob TTL 제거 오류:', error);
+  }
+}
+
+module.exports = dropBackupJobTTL;

--- a/src/models/BackupJob.js
+++ b/src/models/BackupJob.js
@@ -48,10 +48,6 @@ const backupJobSchema = new mongoose.Schema({
   },
   completedAt: {
     type: Date
-  },
-  expiresAt: {
-    type: Date,
-    default: () => new Date(Date.now() + 7 * 24 * 60 * 60 * 1000) // 7일 후
   }
 }, {
   timestamps: true
@@ -61,7 +57,6 @@ const backupJobSchema = new mongoose.Schema({
 backupJobSchema.index({ status: 1 });
 backupJobSchema.index({ createdBy: 1 });
 backupJobSchema.index({ createdAt: -1 });
-backupJobSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
 
 // 진행 상태 업데이트 메서드
 backupJobSchema.methods.updateProgress = function(current, total, stage) {

--- a/src/server.js
+++ b/src/server.js
@@ -29,6 +29,7 @@ const { initializeQueues } = require('./services/queueService');
 const migrateWorkboardApiFormat = require('./migrations/migrateWorkboardApiFormat');
 const migrateMediaOrderIndex = require('./migrations/migrateMediaOrderIndex');
 const migrateServerTypeToOpenAI = require('./migrations/migrateServerTypeToOpenAI');
+const dropBackupJobTTL = require('./migrations/dropBackupJobTTL');
 
 dotenv.config();
 
@@ -173,6 +174,7 @@ const startServer = async () => {
     await migrateWorkboardApiFormat();
     await migrateMediaOrderIndex();
     await migrateServerTypeToOpenAI();
+    await dropBackupJobTTL();
 
     // Initialize job queues after database connection
     console.log('Initializing job queues...');


### PR DESCRIPTION
## v1.8.1 패치 릴리스

### 포함 변경사항

**fix**
- **#196** (closes #195): `BackupJob` 의 7일 TTL 자동 삭제 제거. 사용자가 직접 만든 백업이 시간 경과로 사라지던 문제 수정. 마이그레이션이 기존 TTL 인덱스를 명시적으로 drop.

**feat**
- **#194** (closes #193): 서버 추가 시 알려진 provider (OpenAI, Gemini) 의 URL 자동 채우기

### 호환성
- 마이그레이션 idempotent (TTL 인덱스 미존재 시 noop)
- 모델 schema 만 변경, 데이터 영향 없음
- 이미 TTL 로 사라진 백업 레코드는 복구 불가 (DB 에서 이미 삭제됨)

## Test plan
- [x] 부팅 시 BackupJob TTL 인덱스 제거 로그 확인
- [x] db.backupjobs.getIndexes() 에 TTL 인덱스 사라짐 확인
- [x] 서버 폼에서 OpenAI/Gemini 선택 시 URL 자동 입력 동작 확인
- [ ] main 머지 후 v1.8.1 태그 부착