### PR TITLE
fix: ADMIN_EMAILS 자동 승인된 가입에 대한 승인 대기 메시지 미표시 (#143)

### DIFF
--- a/frontend/src/pages/Signup.js
+++ b/frontend/src/pages/Signup.js
@@ -134,18 +134,21 @@ function Signup() {
     {
       onSuccess: (response) => {
         toast.success('회원가입이 완료되었습니다!', { duration: 6000 });
-        // 별도의 상세 안내 메시지
-        setTimeout(() => {
-          toast('관리자의 승인이 완료된 후 로그인을 진행하실 수 있습니다. 승인까지 다소 시간이 소요될 수 있으니 양해 부탁드립니다.', {
-            icon: '📋',
-            duration: 8000,
-            style: {
-              background: '#e3f2fd',
-              color: '#1565c0',
-            },
-          });
-        }, 1000);
-        
+        const isApproved = response?.data?.user?.approvalStatus === 'approved';
+        // ADMIN_EMAILS 자동 승인 등으로 이미 approved 인 경우 승인 대기 안내를 띄우지 않음
+        if (!isApproved) {
+          setTimeout(() => {
+            toast('관리자의 승인이 완료된 후 로그인을 진행하실 수 있습니다. 승인까지 다소 시간이 소요될 수 있으니 양해 부탁드립니다.', {
+              icon: '📋',
+              duration: 8000,
+              style: {
+                background: '#e3f2fd',
+                color: '#1565c0',
+              },
+            });
+          }, 1000);
+        }
+
         setTimeout(() => {
           navigate('/login');
         }, 2000);

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -115,6 +115,7 @@ router.post('/signup', signupRateLimit, validate(signupSchema), async (req, res)
         email: newUser.email,
         nickname: newUser.nickname,
         isAdmin: newUser.isAdmin,
+        approvalStatus: newUser.approvalStatus,
         authProvider: newUser.authProvider,
         preferences: newUser.preferences
       },


### PR DESCRIPTION
## Summary
ADMIN_EMAILS 에 등록된 이메일로 가입하면 백엔드는 자동 승인 (`approvalStatus: 'approved'`, `isAdmin: true`) 처리하지만, 프론트엔드가 응답의 `approvalStatus` 를 확인하지 않고 일괄 "관리자 승인 대기" 토스트를 띄우던 문제 수정.

## 변경
- `src/routes/auth.js`: `POST /signup` 응답의 user 객체에 `approvalStatus` 포함
- `frontend/src/pages/Signup.js`: `signupMutation` `onSuccess` 가 `approvalStatus` 가 `'approved'` 인 경우 승인 대기 토스트를 띄우지 않도록 분기 추가

## 로컬 검증
- [x] ADMIN_EMAILS 일치 이메일로 signup → `approvalStatus: 'approved'` 반환, 승인 대기 토스트 없음
- [x] 일반 이메일로 signup → `approvalStatus: 'pending'` 반환, 기존 승인 대기 토스트 정상 표시
- [x] 로그인 흐름 회귀 없음

## 영향 범위
- 2 파일, +16/-12
- 백엔드 응답 스키마에 필드 추가 (호환성 유지)
- 프론트엔드 로직만 변경

closes #143