### PR TITLE
fix: 글로벌 axios 에러 메시지를 상황별로 명확하게 (#144)

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -24,6 +24,30 @@ api.interceptors.request.use(
   }
 );
 
+function deriveErrorMessage(error) {
+  // 1. 백엔드가 보낸 message 우선
+  const apiMessage = error.response?.data?.message || error.response?.data?.error?.message;
+  if (apiMessage) return apiMessage;
+
+  // 2. axios timeout
+  if (error.code === 'ECONNABORTED' || /timeout/i.test(error.message || '')) {
+    return '서버 응답이 시간 초과되었습니다. 잠시 후 다시 시도해주세요.';
+  }
+
+  // 3. 응답 자체가 없는 경우 (네트워크 / CORS / DNS 등)
+  if (!error.response) {
+    return '서버에 연결할 수 없습니다. 네트워크 상태를 확인해주세요.';
+  }
+
+  // 4. status 별 일반 메시지
+  const status = error.response.status;
+  if (status >= 500) return `서버 오류가 발생했습니다 (HTTP ${status}). 잠시 후 다시 시도해주세요.`;
+  if (status === 429) return '요청 횟수가 너무 많습니다. 잠시 후 다시 시도해주세요.';
+  if (status === 403) return '권한이 없습니다.';
+  if (status === 404) return '요청한 리소스를 찾을 수 없습니다.';
+  return `요청 실패 (HTTP ${status})`;
+}
+
 api.interceptors.response.use(
   (response) => response,
   (error) => {
@@ -31,10 +55,9 @@ api.interceptors.response.use(
       Cookies.remove('token');
       window.location.href = '/login';
     }
-    
-    const message = error.response?.data?.message || 'An error occurred';
-    toast.error(message);
-    
+
+    toast.error(deriveErrorMessage(error));
+
     return Promise.reject(error);
   }
 );


### PR DESCRIPTION
## Summary
가입/로그인 등에서 네트워크 오류 / 타임아웃 / 백엔드 message 부재 시 일률적으로 'An error occurred' 만 표시되던 문제 수정. 상황별 한국어 메시지로 분기.

## 변경
- `frontend/src/services/api.js`
  - `deriveErrorMessage(error)` 헬퍼 추가
  - 백엔드 `message` 우선
  - axios timeout (`ECONNABORTED`) → "서버 응답이 시간 초과되었습니다..."
  - 응답 자체 없음 (네트워크/CORS/DNS) → "서버에 연결할 수 없습니다..."
  - status 별 일반 메시지: 5xx / 429 / 403 / 404 / 기타
  - response interceptor 가 헬퍼 사용

## 영향 범위
- 1 파일, +27/-4
- 백엔드 / 라우팅 영향 없음
- 백엔드가 `message` 를 보내는 모든 정상 흐름은 동작 그대로

## 로컬 검증
- [x] 빌드된 번들에 신규 메시지 문자열 모두 포함 (`서버에 연결할 수 없습니다`, `서버 응답이 시간 초과`, `요청 횟수가 너무 많습니다`)
- [x] 'An error occurred' 문자열 제거됨

## 후속 (별도 이슈로 검토)
- 호출자 onError 와 글로벌 토스트의 중복 토스트 문제는 본 PR 스코프 밖 (option B 로 추후 정리)

closes #144