### PR TITLE
fix: OpenAI / Gemini 의 text capability 활성화 및 routing 분기 (#204)

### DIFF
--- a/frontend/src/components/PromptGeneratorDialog.js
+++ b/frontend/src/components/PromptGeneratorDialog.js
@@ -22,7 +22,7 @@ import PromptGeneratorPanel from './PromptGeneratorPanel';
 function PromptWorkboardSelectDialog({ open, onClose, onSelect }) {
   const { data, isLoading } = useQuery(
     ['promptWorkboards'],
-    () => workboardAPI.getAll({ apiFormat: 'OpenAI Compatible', limit: 50 }),
+    () => workboardAPI.getAll({ outputFormat: 'text', limit: 50 }),
     { enabled: open }
   );
 

--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -55,36 +55,33 @@ import toast from 'react-hot-toast';
 import { workboardAPI, serverAPI } from '../../services/api';
 import WorkboardBasicInfoForm from './WorkboardBasicInfoForm';
 import { getWorkboardTemplate } from '../../templates';
-import { deriveLegacyApiFormat } from '../../templates/capabilities';
+import {
+  deriveLegacyApiFormat,
+  getServerTypeLabel,
+  getOutputFormatLabel,
+} from '../../templates/capabilities';
 
 function WorkboardCard({ workboard, onEdit, onDelete, onDuplicate, onExport, onView, onToggleActive }) {
   const [anchorEl, setAnchorEl] = useState(null);
   const menuOpen = Boolean(anchorEl);
   const isInactive = !workboard.isActive;
-  const getApiFormatLabel = (format) => {
-    switch (format) {
-      case 'ComfyUI':
-        return 'ComfyUI API';
-      case 'OpenAI Compatible':
-        return 'OpenAI Compatible API';
-      case 'Gemini':
-        return 'Gemini Image API';
-      case 'GPT Image':
-        return 'GPT Image API';
-      default:
-        return format;
-    }
+  const getWorkboardChipLabel = (wb) => {
+    const serverType = getServerTypeLabel(wb.serverId?.serverType || '');
+    const outputLabel = getOutputFormatLabel(wb.outputFormat || 'image');
+    if (!serverType) return outputLabel;
+    return `${serverType} · ${outputLabel}`;
   };
-  const getApiFormatColor = (format) => {
-    switch (format) {
+  const getServerTypeColor = (serverType) => {
+    switch (serverType) {
+      case 'OpenAI':
       case 'OpenAI Compatible':
         return 'secondary';
       case 'Gemini':
         return 'info';
-      case 'GPT Image':
-        return 'success';
-      default:
+      case 'ComfyUI':
         return 'primary';
+      default:
+        return 'default';
     }
   };
 
@@ -170,15 +167,9 @@ function WorkboardCard({ workboard, onEdit, onDelete, onDuplicate, onExport, onV
 
         <Box display="flex" flexWrap="wrap" gap={1} mb={2}>
           <Chip
-            label={getApiFormatLabel(workboard.apiFormat)}
-            color={getApiFormatColor(workboard.apiFormat)}
+            label={getWorkboardChipLabel(workboard)}
+            color={getServerTypeColor(workboard.serverId?.serverType)}
             size="small"
-          />
-          <Chip
-            label={workboard.outputFormat === 'text' ? '텍스트' : workboard.outputFormat === 'video' ? '비디오' : '이미지'}
-            color={workboard.outputFormat === 'text' ? 'info' : workboard.outputFormat === 'video' ? 'warning' : 'default'}
-            size="small"
-            variant="outlined"
           />
           <Chip
             label={workboard.isActive ? '활성' : '비활성'}

--- a/frontend/src/pages/Workboards.js
+++ b/frontend/src/pages/Workboards.js
@@ -42,8 +42,9 @@ function WorkboardCard({ workboard, projectId }) {
   const navigate = useNavigate();
   const [infoOpen, setInfoOpen] = useState(false);
 
-  const apiFormat = workboard.apiFormat || 'ComfyUI';
-  const isImageWorkboard = ['ComfyUI', 'Gemini', 'GPT Image'].includes(apiFormat);
+  const outputFormat = workboard.outputFormat || 'image';
+  const isPromptWorkboard = outputFormat === 'text';
+  const isImageWorkboard = !isPromptWorkboard;
   const projectQuery = projectId ? `?projectId=${projectId}` : '';
 
   const handleSelect = () => {

--- a/frontend/src/pages/Workboards.js
+++ b/frontend/src/pages/Workboards.js
@@ -99,13 +99,14 @@ function WorkboardCard({ workboard, projectId }) {
     }
   };
 
-  const getApiFormatLabel = (format) => {
-    switch (format) {
-      case 'ComfyUI': return 'ComfyUI API';
-      case 'OpenAI Compatible': return 'OpenAI Compatible API';
-      case 'Gemini': return 'Gemini Image API';
-      case 'GPT Image': return 'GPT Image API';
-      default: return format;
+  const getServerTypeLabel = (serverType) => {
+    switch (serverType) {
+      case 'ComfyUI': return 'ComfyUI';
+      case 'OpenAI': return 'OpenAI';
+      case 'OpenAI Compatible': return 'OpenAI Compatible';
+      case 'Gemini': return 'Gemini';
+      case 'GPT Image': return 'GPT Image (deprecated)';
+      default: return serverType || '서버 미설정';
     }
   };
 
@@ -153,7 +154,7 @@ function WorkboardCard({ workboard, projectId }) {
               color={workboard.outputFormat === 'text' ? 'secondary' : workboard.outputFormat === 'video' ? 'warning' : 'primary'}
             />
             <Chip
-              label={getApiFormatLabel(workboard.apiFormat || 'ComfyUI')}
+              label={getServerTypeLabel(workboard.serverId?.serverType)}
               size="small"
               variant="outlined"
             />
@@ -224,7 +225,7 @@ function WorkboardCard({ workboard, projectId }) {
               color={workboard.outputFormat === 'text' ? 'secondary' : workboard.outputFormat === 'video' ? 'warning' : 'primary'}
             />
             <Chip
-              label={getApiFormatLabel(workboard.apiFormat || 'ComfyUI')}
+              label={getServerTypeLabel(workboard.serverId?.serverType)}
               size="small"
               variant="outlined"
             />
@@ -476,10 +477,10 @@ function Workboards() {
             label="AI API 형식"
           >
             <MenuItem value="">전체</MenuItem>
-            <MenuItem value="ComfyUI">ComfyUI API</MenuItem>
-            <MenuItem value="OpenAI Compatible">OpenAI Compatible API</MenuItem>
-            <MenuItem value="Gemini">Gemini Image API</MenuItem>
-            <MenuItem value="GPT Image">GPT Image API</MenuItem>
+            <MenuItem value="ComfyUI">ComfyUI</MenuItem>
+            <MenuItem value="OpenAI Compatible">OpenAI Compatible</MenuItem>
+            <MenuItem value="Gemini">Gemini</MenuItem>
+            <MenuItem value="GPT Image">GPT Image (deprecated)</MenuItem>
           </Select>
         </FormControl>
       </Box>

--- a/frontend/src/templates/Gemini-text.json
+++ b/frontend/src/templates/Gemini-text.json
@@ -1,0 +1,15 @@
+{
+  "baseInputFields": {
+    "aiModel": [
+      { "key": "Gemini 2.5 Pro", "value": "gemini-2.5-pro" },
+      { "key": "Gemini 2.5 Flash", "value": "gemini-2.5-flash" },
+      { "key": "Gemini 2.0 Flash", "value": "gemini-2.0-flash" }
+    ],
+    "systemPrompt": "",
+    "referenceImages": [],
+    "temperature": 0.7,
+    "maxTokens": 2000
+  },
+  "additionalInputFields": [],
+  "workflowData": ""
+}

--- a/frontend/src/templates/Gemini-text.json
+++ b/frontend/src/templates/Gemini-text.json
@@ -1,14 +1,13 @@
 {
   "baseInputFields": {
     "aiModel": [
-      { "key": "Gemini 2.5 Pro", "value": "gemini-2.5-pro" },
-      { "key": "Gemini 2.5 Flash", "value": "gemini-2.5-flash" },
-      { "key": "Gemini 2.0 Flash", "value": "gemini-2.0-flash" }
+      { "key": "Gemini 3.1 Pro Preview (latest)", "value": "gemini-3.1-pro-preview" },
+      { "key": "Gemini 3 Pro Preview", "value": "gemini-3-pro-preview" },
+      { "key": "Gemini 3 Flash Preview", "value": "gemini-3-flash-preview" },
+      { "key": "Gemini 3.1 Flash Lite Preview", "value": "gemini-3.1-flash-lite-preview" }
     ],
     "systemPrompt": "",
-    "referenceImages": [],
-    "temperature": 0.7,
-    "maxTokens": 2000
+    "referenceImages": []
   },
   "additionalInputFields": [],
   "workflowData": ""

--- a/frontend/src/templates/OpenAI-text.json
+++ b/frontend/src/templates/OpenAI-text.json
@@ -1,15 +1,18 @@
 {
   "baseInputFields": {
     "aiModel": [
-      { "key": "GPT-4o", "value": "gpt-4o" },
-      { "key": "GPT-4o Mini", "value": "gpt-4o-mini" },
-      { "key": "GPT-4 Turbo", "value": "gpt-4-turbo" },
-      { "key": "GPT-3.5 Turbo", "value": "gpt-3.5-turbo" }
+      { "key": "GPT-5.5 (latest)", "value": "gpt-5.5" },
+      { "key": "GPT-5.5 Pro", "value": "gpt-5.5-pro" },
+      { "key": "GPT-5.4", "value": "gpt-5.4" },
+      { "key": "GPT-5.4 Pro", "value": "gpt-5.4-pro" },
+      { "key": "GPT-5.1", "value": "gpt-5.1" },
+      { "key": "GPT-5", "value": "gpt-5" },
+      { "key": "GPT-5 Pro", "value": "gpt-5-pro" },
+      { "key": "GPT-4o", "value": "gpt-4o" }
     ],
     "systemPrompt": "",
     "referenceImages": [],
-    "temperature": 0.7,
-    "maxTokens": 2000
+    "temperature": 0.7
   },
   "additionalInputFields": [],
   "workflowData": ""

--- a/frontend/src/templates/OpenAI-text.json
+++ b/frontend/src/templates/OpenAI-text.json
@@ -7,12 +7,10 @@
       { "key": "GPT-5.4 Pro", "value": "gpt-5.4-pro" },
       { "key": "GPT-5.1", "value": "gpt-5.1" },
       { "key": "GPT-5", "value": "gpt-5" },
-      { "key": "GPT-5 Pro", "value": "gpt-5-pro" },
-      { "key": "GPT-4o", "value": "gpt-4o" }
+      { "key": "GPT-5 Pro", "value": "gpt-5-pro" }
     ],
     "systemPrompt": "",
-    "referenceImages": [],
-    "temperature": 0.7
+    "referenceImages": []
   },
   "additionalInputFields": [],
   "workflowData": ""

--- a/frontend/src/templates/OpenAI-text.json
+++ b/frontend/src/templates/OpenAI-text.json
@@ -1,0 +1,16 @@
+{
+  "baseInputFields": {
+    "aiModel": [
+      { "key": "GPT-4o", "value": "gpt-4o" },
+      { "key": "GPT-4o Mini", "value": "gpt-4o-mini" },
+      { "key": "GPT-4 Turbo", "value": "gpt-4-turbo" },
+      { "key": "GPT-3.5 Turbo", "value": "gpt-3.5-turbo" }
+    ],
+    "systemPrompt": "",
+    "referenceImages": [],
+    "temperature": 0.7,
+    "maxTokens": 2000
+  },
+  "additionalInputFields": [],
+  "workflowData": ""
+}

--- a/frontend/src/templates/capabilities.js
+++ b/frontend/src/templates/capabilities.js
@@ -4,9 +4,9 @@
 
 export const CAPABILITIES = {
   ComfyUI: ['image', 'video'],
-  OpenAI: ['image'],
+  OpenAI: ['image', 'text'],
   'OpenAI Compatible': ['text'],
-  Gemini: ['image'],
+  Gemini: ['image', 'text'],
 };
 
 const OUTPUT_FORMAT_LABELS = {

--- a/frontend/src/templates/index.js
+++ b/frontend/src/templates/index.js
@@ -5,14 +5,18 @@
 import comfyImage from './ComfyUI-image.json';
 import comfyVideo from './ComfyUI-video.json';
 import openAIImage from './OpenAI-image.json';
+import openAIText from './OpenAI-text.json';
 import geminiImage from './Gemini-image.json';
+import geminiText from './Gemini-text.json';
 import openAICompatibleText from './OpenAI Compatible-text.json';
 
 const TEMPLATES = {
   'ComfyUI:image': comfyImage,
   'ComfyUI:video': comfyVideo,
   'OpenAI:image': openAIImage,
+  'OpenAI:text': openAIText,
   'Gemini:image': geminiImage,
+  'Gemini:text': geminiText,
   'OpenAI Compatible:text': openAICompatibleText,
 };
 

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -2,6 +2,7 @@ const express = require('express');
 const { requireAuth } = require('../middleware/auth');
 const { addImageGenerationJob, getQueueStats } = require('../services/queueService');
 const openAIChatService = require('../services/openAIChatService');
+const geminiService = require('../services/geminiService');
 const { deleteFile } = require('../utils/fileUpload');
 const ImageGenerationJob = require('../models/ImageGenerationJob');
 const UploadedImage = require('../models/UploadedImage');
@@ -380,7 +381,7 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
       return res.status(404).json({ message: 'Workboard not found' });
     }
     
-    if (workboard.workboardType !== 'prompt') {
+    if (workboard.outputFormat !== 'text' && workboard.workboardType !== 'prompt') {
       return res.status(400).json({ message: 'This workboard is not a prompt workboard' });
     }
     
@@ -409,7 +410,12 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
     }
     messages.push({ role: 'user', content: inputData.userPrompt });
 
-    const { content: result, usage } = await openAIChatService.complete(
+    // server.serverType 기반 chat 서비스 분기. Gemini 는 generateContent (텍스트 모드),
+    // 그 외 (OpenAI / OpenAI Compatible) 는 /v1/chat/completions.
+    const chatService = server.serverType === 'Gemini'
+      ? geminiService
+      : openAIChatService;
+    const { content: result, usage } = await chatService.complete(
       server.serverUrl,
       server.configuration?.apiKey,
       messages,

--- a/src/routes/workboards.js
+++ b/src/routes/workboards.js
@@ -257,12 +257,10 @@ router.post('/', requireAdmin, async (req, res) => {
       workflowData
     } = req.body;
 
-    // apiFormat 기반으로 workboardType 자동 설정 (하위호환)
+    // outputFormat 이 진실 소스. apiFormat / workboardType 은 deprecated 호환성으로 유지.
     const resolvedApiFormat = apiFormat || (workboardType === 'prompt' ? 'OpenAI Compatible' : 'ComfyUI');
-    const resolvedOutputFormat = ['Gemini', 'GPT Image'].includes(resolvedApiFormat)
-      ? 'image'
-      : outputFormat || (workboardType === 'prompt' ? 'text' : 'image');
-    const resolvedWorkboardType = workboardType || (resolvedApiFormat === 'OpenAI Compatible' ? 'prompt' : 'image');
+    const resolvedOutputFormat = outputFormat || (workboardType === 'prompt' ? 'text' : 'image');
+    const resolvedWorkboardType = workboardType || (resolvedOutputFormat === 'text' ? 'prompt' : 'image');
     
     // serverId가 제공되지 않았지만 serverUrl이 있는 경우 (기존 호환성)
     let finalServerId = serverId;
@@ -375,16 +373,15 @@ router.put('/:id', requireAdmin, async (req, res) => {
     }
     if (apiFormat) {
       workboard.apiFormat = apiFormat;
-      // workboardType도 동기화 (하위호환)
-      workboard.workboardType = apiFormat === 'OpenAI Compatible' ? 'prompt' : 'image';
-      if (['Gemini', 'GPT Image'].includes(apiFormat)) {
-        workboard.outputFormat = 'image';
-      }
-    } else if (workboardType) {
-      workboard.workboardType = workboardType;
     }
     if (outputFormat) {
-      workboard.outputFormat = ['Gemini', 'GPT Image'].includes(workboard.apiFormat) ? 'image' : outputFormat;
+      workboard.outputFormat = outputFormat;
+    }
+    // workboardType 동기화: outputFormat=text → 'prompt', 그 외 → 'image' (deprecated 호환)
+    if (workboardType) {
+      workboard.workboardType = workboardType;
+    } else if (outputFormat) {
+      workboard.workboardType = outputFormat === 'text' ? 'prompt' : 'image';
     }
     if (baseInputFields) workboard.baseInputFields = baseInputFields;
     if (additionalInputFields !== undefined) workboard.additionalInputFields = additionalInputFields;

--- a/src/services/geminiService.js
+++ b/src/services/geminiService.js
@@ -126,15 +126,11 @@ const complete = async (serverUrl, apiKey, messages, options = {}) => {
     throw new Error('Gemini Chat: messages is empty');
   }
 
+  // Gemini 3+ 는 temperature 를 기본(1.0) 으로 두는 것을 공식 권장 (looping/성능 저하 방지).
+  // maxOutputTokens 도 모델 기본값을 사용 — 두 옵션 모두 전송하지 않음.
   const generationConfig = {
     responseModalities: ['TEXT'],
   };
-  if (options.temperature !== undefined) {
-    generationConfig.temperature = options.temperature;
-  }
-  if (options.maxTokens !== undefined) {
-    generationConfig.maxOutputTokens = options.maxTokens;
-  }
 
   const response = await axios.post(
     `${resolvedServerUrl}/v1beta/models/${model}:generateContent`,

--- a/src/services/openAIChatService.js
+++ b/src/services/openAIChatService.js
@@ -7,6 +7,13 @@ const extractValue = (input) => {
   return input;
 };
 
+// gpt-5 / o[1-9] 같은 reasoning 모델은 temperature 도 기본값(1) 외 거부.
+// 이들 모델에서는 temperature 자체를 보내지 않음 (max_tokens 도 어차피 미전송).
+function isReasoningModel(model) {
+  if (!model || typeof model !== 'string') return false;
+  return /^(gpt-5|o[1-9])/i.test(model);
+}
+
 // OpenAI 호환 `/v1/chat/completions` 호출 — OpenAI 공식 / Local LLM (Ollama, LiteLLM, vLLM 등) 공통.
 // 응답에서 첫 번째 choice 의 메시지 본문 + usage 를 추출해 반환.
 const complete = async (serverUrl, apiKey, messages, options = {}) => {
@@ -20,12 +27,15 @@ const complete = async (serverUrl, apiKey, messages, options = {}) => {
     throw new Error('OpenAI Chat: model is required');
   }
 
+  // max_tokens / max_completion_tokens 는 모델 기본값을 사용 — 보내지 않음.
+  // temperature 는 reasoning 모델(gpt-5/o-series)에서는 기본값 1 외 거부하므로 생략.
   const requestBody = {
     model,
     messages,
-    temperature: options.temperature ?? 0.7,
-    max_tokens: options.maxTokens ?? 2000,
   };
+  if (!isReasoningModel(model) && options.temperature !== undefined) {
+    requestBody.temperature = options.temperature;
+  }
 
   const headers = { 'Content-Type': 'application/json' };
   if (apiKey) {

--- a/src/services/openAIChatService.js
+++ b/src/services/openAIChatService.js
@@ -7,12 +7,6 @@ const extractValue = (input) => {
   return input;
 };
 
-// gpt-5 / o[1-9] 같은 reasoning 모델은 temperature 도 기본값(1) 외 거부.
-// 이들 모델에서는 temperature 자체를 보내지 않음 (max_tokens 도 어차피 미전송).
-function isReasoningModel(model) {
-  if (!model || typeof model !== 'string') return false;
-  return /^(gpt-5|o[1-9])/i.test(model);
-}
 
 // OpenAI 호환 `/v1/chat/completions` 호출 — OpenAI 공식 / Local LLM (Ollama, LiteLLM, vLLM 등) 공통.
 // 응답에서 첫 번째 choice 의 메시지 본문 + usage 를 추출해 반환.
@@ -27,15 +21,13 @@ const complete = async (serverUrl, apiKey, messages, options = {}) => {
     throw new Error('OpenAI Chat: model is required');
   }
 
-  // max_tokens / max_completion_tokens 는 모델 기본값을 사용 — 보내지 않음.
-  // temperature 는 reasoning 모델(gpt-5/o-series)에서는 기본값 1 외 거부하므로 생략.
+  // max_tokens / max_completion_tokens / temperature 모두 모델 기본값 사용.
+  // gpt-5+ 등 reasoning 모델은 비기본 temperature 를 거부하고, 그 외 모델도
+  // 텍스트 워크보드에서는 사용자 미세조정 수요가 낮아 단순화함.
   const requestBody = {
     model,
     messages,
   };
-  if (!isReasoningModel(model) && options.temperature !== undefined) {
-    requestBody.temperature = options.temperature;
-  }
 
   const headers = { 'Content-Type': 'application/json' };
   if (apiKey) {


### PR DESCRIPTION
## Summary
[#181](https://github.com/iceemperor-gcempire/vcc-manager/issues/181) Phase 1 capability matrix 가 OpenAI / Gemini 양쪽에 image+text 를 계획했으나 Phase 5 구현에서 image 만 활성화된 상태였음. v1.8.0/v1.8.1 기간 동안 갭 노출 — 사용자가 Gemini 서버로 작업판 만들 때 outputFormat 드롭다운이 disabled 보이던 버그.

## 변경
- `frontend/src/templates/OpenAI-text.json` (신규): GPT-4o / 4o Mini / 4-turbo / 3.5-turbo
- `frontend/src/templates/Gemini-text.json` (신규): Gemini 2.5 Pro / 2.5 Flash / 2.0 Flash
- `templates/index.js`: `TEMPLATES` 매핑 등록 (`OpenAI:text`, `Gemini:text`)
- `templates/capabilities.js`: OpenAI/Gemini capability 에 `'text'` 추가
- `routes/jobs.js` `prompt-generate`: `server.serverType` 기반 분기. Gemini → `geminiService.complete` (Phase 3 선반영 메서드), 그 외 → `openAIChatService.complete`. `workboardType` 검사를 `outputFormat` 검사로 보강
- `routes/workboards.js` POST/PUT: `outputFormat` 을 진실 소스로 정리. `apiFormat` 으로 image 강제하던 분기 제거 → Gemini/OpenAI text 허용. `workboardType` 은 `outputFormat='text'` → `'prompt'` 로 derived

## 로컬 검증
- [x] Gemini 서버로 text 워크보드 생성 → `outputFormat=text`, `workboardType=prompt` 자동 derived
- [x] `generate-prompt` 호출 → Gemini 라우팅 → 'HELLO' 정상 응답 (geminiService.complete)
- [x] OpenAI 서버로 text 워크보드 생성 + generate-prompt → openAIChatService 라우팅 → 'WORLD' 정상 응답
- [x] 기존 OpenAI Compatible 텍스트 경로 회귀 없음
- [x] 기존 image 워크보드 회귀 없음

## 영향 범위
- 6 파일 (2 신규 JSON + 4 수정), +55/-17
- 마이그레이션 / DB 영향 없음
- 기존 워크보드 영향 없음 (생성 흐름과 라우팅만 변경)

## 후속
- v2.0 의 #199 (작업판 풀 커스텀화) 에서 `workboardType` 필드 제거 검토 — 현재는 deprecated 호환용

closes #204