### PR TITLE
release: v1.8.2

### DIFF
--- a/docs/updatelogs/v1.md
+++ b/docs/updatelogs/v1.md
@@ -1,5 +1,24 @@
 # v1 업데이트 내역
 
+## v1.8.2
+
+### Phase 5 마무리 — OpenAI / Gemini 의 text capability 활성화 (#204, #205)
+v1.8.0 의 Phase 5 capability matrix 가 OpenAI / Gemini 양쪽에 image+text 를 계획했으나 구현에서 image 만 활성화된 상태였음. 본 릴리스에서 갭을 메움.
+- `templates/OpenAI-text.json` / `templates/Gemini-text.json` 신규
+- `templates/index.js` 의 `TEMPLATES` 매핑 등록 (`OpenAI:text`, `Gemini:text`)
+- `templates/capabilities.js` 의 `OpenAI` / `Gemini` capability 에 `'text'` 추가
+- `routes/jobs.js` prompt-generate 라우트가 server.serverType 기반으로 분기 — Gemini → `geminiService.complete`, 그 외 → `openAIChatService.complete`
+- `routes/workboards.js` POST/PUT 의 outputFormat 처리를 진실 소스로 정리. `apiFormat` 이 image 강제하던 분기 제거. workboardType 은 outputFormat 에서 derived
+- 신규 모델 정책: OpenAI 는 `gpt-5` 이상만, Gemini 는 `3.x` 이상만 템플릿에 노출. reasoning 모델 호환을 위해 `temperature` / `max_tokens` 모두 미전송으로 단순화
+- 작업판 카드 chip 라벨이 `<serverType> · <출력형식>` 통합 표시 ("Gemini · 텍스트", "OpenAI · 이미지" 등). 옛 'Gemini Image API' / 'GPT Image API' 라벨 제거
+- 텍스트 워크보드 라우팅 / AI 프롬프트 생성 다이얼로그가 outputFormat 기반으로 동작 (이전엔 apiFormat 으로 image 페이지로 잘못 라우팅됨)
+
+### 기타 수정
+- fix: ADMIN_EMAILS 자동 승인된 가입에 대한 승인 대기 메시지 미표시 (#143, #202)
+  - 백엔드는 admin 자동 승인 처리하지만 프론트엔드 응답에 `approvalStatus` 가 없어 일괄 "승인 대기" 토스트가 뜨던 문제 수정
+- fix: 글로벌 axios 에러 메시지를 상황별로 명확하게 (#144, #203)
+  - 'An error occurred' 단일 메시지 → 네트워크 / 타임아웃 / 5xx / 429 / 403 / 404 별도 한국어 안내. 호출자 onError 와의 중복 토스트 정리는 후속
+
 ## v1.8.1
 
 - fix: `BackupJob` 의 7일 TTL 자동 삭제 제거 (#195, #196)

--- a/frontend/src/components/PromptGeneratorDialog.js
+++ b/frontend/src/components/PromptGeneratorDialog.js
@@ -22,7 +22,7 @@ import PromptGeneratorPanel from './PromptGeneratorPanel';
 function PromptWorkboardSelectDialog({ open, onClose, onSelect }) {
   const { data, isLoading } = useQuery(
     ['promptWorkboards'],
-    () => workboardAPI.getAll({ apiFormat: 'OpenAI Compatible', limit: 50 }),
+    () => workboardAPI.getAll({ outputFormat: 'text', limit: 50 }),
     { enabled: open }
   );
 

--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -55,36 +55,33 @@ import toast from 'react-hot-toast';
 import { workboardAPI, serverAPI } from '../../services/api';
 import WorkboardBasicInfoForm from './WorkboardBasicInfoForm';
 import { getWorkboardTemplate } from '../../templates';
-import { deriveLegacyApiFormat } from '../../templates/capabilities';
+import {
+  deriveLegacyApiFormat,
+  getServerTypeLabel,
+  getOutputFormatLabel,
+} from '../../templates/capabilities';
 
 function WorkboardCard({ workboard, onEdit, onDelete, onDuplicate, onExport, onView, onToggleActive }) {
   const [anchorEl, setAnchorEl] = useState(null);
   const menuOpen = Boolean(anchorEl);
   const isInactive = !workboard.isActive;
-  const getApiFormatLabel = (format) => {
-    switch (format) {
-      case 'ComfyUI':
-        return 'ComfyUI API';
-      case 'OpenAI Compatible':
-        return 'OpenAI Compatible API';
-      case 'Gemini':
-        return 'Gemini Image API';
-      case 'GPT Image':
-        return 'GPT Image API';
-      default:
-        return format;
-    }
+  const getWorkboardChipLabel = (wb) => {
+    const serverType = getServerTypeLabel(wb.serverId?.serverType || '');
+    const outputLabel = getOutputFormatLabel(wb.outputFormat || 'image');
+    if (!serverType) return outputLabel;
+    return `${serverType} · ${outputLabel}`;
   };
-  const getApiFormatColor = (format) => {
-    switch (format) {
+  const getServerTypeColor = (serverType) => {
+    switch (serverType) {
+      case 'OpenAI':
       case 'OpenAI Compatible':
         return 'secondary';
       case 'Gemini':
         return 'info';
-      case 'GPT Image':
-        return 'success';
-      default:
+      case 'ComfyUI':
         return 'primary';
+      default:
+        return 'default';
     }
   };
 
@@ -170,15 +167,9 @@ function WorkboardCard({ workboard, onEdit, onDelete, onDuplicate, onExport, onV
 
         <Box display="flex" flexWrap="wrap" gap={1} mb={2}>
           <Chip
-            label={getApiFormatLabel(workboard.apiFormat)}
-            color={getApiFormatColor(workboard.apiFormat)}
+            label={getWorkboardChipLabel(workboard)}
+            color={getServerTypeColor(workboard.serverId?.serverType)}
             size="small"
-          />
-          <Chip
-            label={workboard.outputFormat === 'text' ? '텍스트' : workboard.outputFormat === 'video' ? '비디오' : '이미지'}
-            color={workboard.outputFormat === 'text' ? 'info' : workboard.outputFormat === 'video' ? 'warning' : 'default'}
-            size="small"
-            variant="outlined"
           />
           <Chip
             label={workboard.isActive ? '활성' : '비활성'}

--- a/frontend/src/pages/Signup.js
+++ b/frontend/src/pages/Signup.js
@@ -134,18 +134,21 @@ function Signup() {
     {
       onSuccess: (response) => {
         toast.success('회원가입이 완료되었습니다!', { duration: 6000 });
-        // 별도의 상세 안내 메시지
-        setTimeout(() => {
-          toast('관리자의 승인이 완료된 후 로그인을 진행하실 수 있습니다. 승인까지 다소 시간이 소요될 수 있으니 양해 부탁드립니다.', {
-            icon: '📋',
-            duration: 8000,
-            style: {
-              background: '#e3f2fd',
-              color: '#1565c0',
-            },
-          });
-        }, 1000);
-        
+        const isApproved = response?.data?.user?.approvalStatus === 'approved';
+        // ADMIN_EMAILS 자동 승인 등으로 이미 approved 인 경우 승인 대기 안내를 띄우지 않음
+        if (!isApproved) {
+          setTimeout(() => {
+            toast('관리자의 승인이 완료된 후 로그인을 진행하실 수 있습니다. 승인까지 다소 시간이 소요될 수 있으니 양해 부탁드립니다.', {
+              icon: '📋',
+              duration: 8000,
+              style: {
+                background: '#e3f2fd',
+                color: '#1565c0',
+              },
+            });
+          }, 1000);
+        }
+
         setTimeout(() => {
           navigate('/login');
         }, 2000);

--- a/frontend/src/pages/Workboards.js
+++ b/frontend/src/pages/Workboards.js
@@ -42,8 +42,9 @@ function WorkboardCard({ workboard, projectId }) {
   const navigate = useNavigate();
   const [infoOpen, setInfoOpen] = useState(false);
 
-  const apiFormat = workboard.apiFormat || 'ComfyUI';
-  const isImageWorkboard = ['ComfyUI', 'Gemini', 'GPT Image'].includes(apiFormat);
+  const outputFormat = workboard.outputFormat || 'image';
+  const isPromptWorkboard = outputFormat === 'text';
+  const isImageWorkboard = !isPromptWorkboard;
   const projectQuery = projectId ? `?projectId=${projectId}` : '';
 
   const handleSelect = () => {
@@ -99,13 +100,14 @@ function WorkboardCard({ workboard, projectId }) {
     }
   };
 
-  const getApiFormatLabel = (format) => {
-    switch (format) {
-      case 'ComfyUI': return 'ComfyUI API';
-      case 'OpenAI Compatible': return 'OpenAI Compatible API';
-      case 'Gemini': return 'Gemini Image API';
-      case 'GPT Image': return 'GPT Image API';
-      default: return format;
+  const getServerTypeLabel = (serverType) => {
+    switch (serverType) {
+      case 'ComfyUI': return 'ComfyUI';
+      case 'OpenAI': return 'OpenAI';
+      case 'OpenAI Compatible': return 'OpenAI Compatible';
+      case 'Gemini': return 'Gemini';
+      case 'GPT Image': return 'GPT Image (deprecated)';
+      default: return serverType || '서버 미설정';
     }
   };
 
@@ -153,7 +155,7 @@ function WorkboardCard({ workboard, projectId }) {
               color={workboard.outputFormat === 'text' ? 'secondary' : workboard.outputFormat === 'video' ? 'warning' : 'primary'}
             />
             <Chip
-              label={getApiFormatLabel(workboard.apiFormat || 'ComfyUI')}
+              label={getServerTypeLabel(workboard.serverId?.serverType)}
               size="small"
               variant="outlined"
             />
@@ -224,7 +226,7 @@ function WorkboardCard({ workboard, projectId }) {
               color={workboard.outputFormat === 'text' ? 'secondary' : workboard.outputFormat === 'video' ? 'warning' : 'primary'}
             />
             <Chip
-              label={getApiFormatLabel(workboard.apiFormat || 'ComfyUI')}
+              label={getServerTypeLabel(workboard.serverId?.serverType)}
               size="small"
               variant="outlined"
             />
@@ -476,10 +478,10 @@ function Workboards() {
             label="AI API 형식"
           >
             <MenuItem value="">전체</MenuItem>
-            <MenuItem value="ComfyUI">ComfyUI API</MenuItem>
-            <MenuItem value="OpenAI Compatible">OpenAI Compatible API</MenuItem>
-            <MenuItem value="Gemini">Gemini Image API</MenuItem>
-            <MenuItem value="GPT Image">GPT Image API</MenuItem>
+            <MenuItem value="ComfyUI">ComfyUI</MenuItem>
+            <MenuItem value="OpenAI Compatible">OpenAI Compatible</MenuItem>
+            <MenuItem value="Gemini">Gemini</MenuItem>
+            <MenuItem value="GPT Image">GPT Image (deprecated)</MenuItem>
           </Select>
         </FormControl>
       </Box>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -24,6 +24,30 @@ api.interceptors.request.use(
   }
 );
 
+function deriveErrorMessage(error) {
+  // 1. 백엔드가 보낸 message 우선
+  const apiMessage = error.response?.data?.message || error.response?.data?.error?.message;
+  if (apiMessage) return apiMessage;
+
+  // 2. axios timeout
+  if (error.code === 'ECONNABORTED' || /timeout/i.test(error.message || '')) {
+    return '서버 응답이 시간 초과되었습니다. 잠시 후 다시 시도해주세요.';
+  }
+
+  // 3. 응답 자체가 없는 경우 (네트워크 / CORS / DNS 등)
+  if (!error.response) {
+    return '서버에 연결할 수 없습니다. 네트워크 상태를 확인해주세요.';
+  }
+
+  // 4. status 별 일반 메시지
+  const status = error.response.status;
+  if (status >= 500) return `서버 오류가 발생했습니다 (HTTP ${status}). 잠시 후 다시 시도해주세요.`;
+  if (status === 429) return '요청 횟수가 너무 많습니다. 잠시 후 다시 시도해주세요.';
+  if (status === 403) return '권한이 없습니다.';
+  if (status === 404) return '요청한 리소스를 찾을 수 없습니다.';
+  return `요청 실패 (HTTP ${status})`;
+}
+
 api.interceptors.response.use(
   (response) => response,
   (error) => {
@@ -31,10 +55,9 @@ api.interceptors.response.use(
       Cookies.remove('token');
       window.location.href = '/login';
     }
-    
-    const message = error.response?.data?.message || 'An error occurred';
-    toast.error(message);
-    
+
+    toast.error(deriveErrorMessage(error));
+
     return Promise.reject(error);
   }
 );

--- a/frontend/src/templates/Gemini-text.json
+++ b/frontend/src/templates/Gemini-text.json
@@ -1,0 +1,14 @@
+{
+  "baseInputFields": {
+    "aiModel": [
+      { "key": "Gemini 3.1 Pro Preview (latest)", "value": "gemini-3.1-pro-preview" },
+      { "key": "Gemini 3 Pro Preview", "value": "gemini-3-pro-preview" },
+      { "key": "Gemini 3 Flash Preview", "value": "gemini-3-flash-preview" },
+      { "key": "Gemini 3.1 Flash Lite Preview", "value": "gemini-3.1-flash-lite-preview" }
+    ],
+    "systemPrompt": "",
+    "referenceImages": []
+  },
+  "additionalInputFields": [],
+  "workflowData": ""
+}

--- a/frontend/src/templates/OpenAI-text.json
+++ b/frontend/src/templates/OpenAI-text.json
@@ -1,0 +1,17 @@
+{
+  "baseInputFields": {
+    "aiModel": [
+      { "key": "GPT-5.5 (latest)", "value": "gpt-5.5" },
+      { "key": "GPT-5.5 Pro", "value": "gpt-5.5-pro" },
+      { "key": "GPT-5.4", "value": "gpt-5.4" },
+      { "key": "GPT-5.4 Pro", "value": "gpt-5.4-pro" },
+      { "key": "GPT-5.1", "value": "gpt-5.1" },
+      { "key": "GPT-5", "value": "gpt-5" },
+      { "key": "GPT-5 Pro", "value": "gpt-5-pro" }
+    ],
+    "systemPrompt": "",
+    "referenceImages": []
+  },
+  "additionalInputFields": [],
+  "workflowData": ""
+}

--- a/frontend/src/templates/capabilities.js
+++ b/frontend/src/templates/capabilities.js
@@ -4,9 +4,9 @@
 
 export const CAPABILITIES = {
   ComfyUI: ['image', 'video'],
-  OpenAI: ['image'],
+  OpenAI: ['image', 'text'],
   'OpenAI Compatible': ['text'],
-  Gemini: ['image'],
+  Gemini: ['image', 'text'],
 };
 
 const OUTPUT_FORMAT_LABELS = {

--- a/frontend/src/templates/index.js
+++ b/frontend/src/templates/index.js
@@ -5,14 +5,18 @@
 import comfyImage from './ComfyUI-image.json';
 import comfyVideo from './ComfyUI-video.json';
 import openAIImage from './OpenAI-image.json';
+import openAIText from './OpenAI-text.json';
 import geminiImage from './Gemini-image.json';
+import geminiText from './Gemini-text.json';
 import openAICompatibleText from './OpenAI Compatible-text.json';
 
 const TEMPLATES = {
   'ComfyUI:image': comfyImage,
   'ComfyUI:video': comfyVideo,
   'OpenAI:image': openAIImage,
+  'OpenAI:text': openAIText,
   'Gemini:image': geminiImage,
+  'Gemini:text': geminiText,
   'OpenAI Compatible:text': openAICompatibleText,
 };
 

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -115,6 +115,7 @@ router.post('/signup', signupRateLimit, validate(signupSchema), async (req, res)
         email: newUser.email,
         nickname: newUser.nickname,
         isAdmin: newUser.isAdmin,
+        approvalStatus: newUser.approvalStatus,
         authProvider: newUser.authProvider,
         preferences: newUser.preferences
       },

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -2,6 +2,7 @@ const express = require('express');
 const { requireAuth } = require('../middleware/auth');
 const { addImageGenerationJob, getQueueStats } = require('../services/queueService');
 const openAIChatService = require('../services/openAIChatService');
+const geminiService = require('../services/geminiService');
 const { deleteFile } = require('../utils/fileUpload');
 const ImageGenerationJob = require('../models/ImageGenerationJob');
 const UploadedImage = require('../models/UploadedImage');
@@ -380,7 +381,7 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
       return res.status(404).json({ message: 'Workboard not found' });
     }
     
-    if (workboard.workboardType !== 'prompt') {
+    if (workboard.outputFormat !== 'text' && workboard.workboardType !== 'prompt') {
       return res.status(400).json({ message: 'This workboard is not a prompt workboard' });
     }
     
@@ -409,7 +410,12 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
     }
     messages.push({ role: 'user', content: inputData.userPrompt });
 
-    const { content: result, usage } = await openAIChatService.complete(
+    // server.serverType 기반 chat 서비스 분기. Gemini 는 generateContent (텍스트 모드),
+    // 그 외 (OpenAI / OpenAI Compatible) 는 /v1/chat/completions.
+    const chatService = server.serverType === 'Gemini'
+      ? geminiService
+      : openAIChatService;
+    const { content: result, usage } = await chatService.complete(
       server.serverUrl,
       server.configuration?.apiKey,
       messages,

--- a/src/routes/workboards.js
+++ b/src/routes/workboards.js
@@ -257,12 +257,10 @@ router.post('/', requireAdmin, async (req, res) => {
       workflowData
     } = req.body;
 
-    // apiFormat 기반으로 workboardType 자동 설정 (하위호환)
+    // outputFormat 이 진실 소스. apiFormat / workboardType 은 deprecated 호환성으로 유지.
     const resolvedApiFormat = apiFormat || (workboardType === 'prompt' ? 'OpenAI Compatible' : 'ComfyUI');
-    const resolvedOutputFormat = ['Gemini', 'GPT Image'].includes(resolvedApiFormat)
-      ? 'image'
-      : outputFormat || (workboardType === 'prompt' ? 'text' : 'image');
-    const resolvedWorkboardType = workboardType || (resolvedApiFormat === 'OpenAI Compatible' ? 'prompt' : 'image');
+    const resolvedOutputFormat = outputFormat || (workboardType === 'prompt' ? 'text' : 'image');
+    const resolvedWorkboardType = workboardType || (resolvedOutputFormat === 'text' ? 'prompt' : 'image');
     
     // serverId가 제공되지 않았지만 serverUrl이 있는 경우 (기존 호환성)
     let finalServerId = serverId;
@@ -375,16 +373,15 @@ router.put('/:id', requireAdmin, async (req, res) => {
     }
     if (apiFormat) {
       workboard.apiFormat = apiFormat;
-      // workboardType도 동기화 (하위호환)
-      workboard.workboardType = apiFormat === 'OpenAI Compatible' ? 'prompt' : 'image';
-      if (['Gemini', 'GPT Image'].includes(apiFormat)) {
-        workboard.outputFormat = 'image';
-      }
-    } else if (workboardType) {
-      workboard.workboardType = workboardType;
     }
     if (outputFormat) {
-      workboard.outputFormat = ['Gemini', 'GPT Image'].includes(workboard.apiFormat) ? 'image' : outputFormat;
+      workboard.outputFormat = outputFormat;
+    }
+    // workboardType 동기화: outputFormat=text → 'prompt', 그 외 → 'image' (deprecated 호환)
+    if (workboardType) {
+      workboard.workboardType = workboardType;
+    } else if (outputFormat) {
+      workboard.workboardType = outputFormat === 'text' ? 'prompt' : 'image';
     }
     if (baseInputFields) workboard.baseInputFields = baseInputFields;
     if (additionalInputFields !== undefined) workboard.additionalInputFields = additionalInputFields;

--- a/src/services/geminiService.js
+++ b/src/services/geminiService.js
@@ -126,15 +126,11 @@ const complete = async (serverUrl, apiKey, messages, options = {}) => {
     throw new Error('Gemini Chat: messages is empty');
   }
 
+  // Gemini 3+ 는 temperature 를 기본(1.0) 으로 두는 것을 공식 권장 (looping/성능 저하 방지).
+  // maxOutputTokens 도 모델 기본값을 사용 — 두 옵션 모두 전송하지 않음.
   const generationConfig = {
     responseModalities: ['TEXT'],
   };
-  if (options.temperature !== undefined) {
-    generationConfig.temperature = options.temperature;
-  }
-  if (options.maxTokens !== undefined) {
-    generationConfig.maxOutputTokens = options.maxTokens;
-  }
 
   const response = await axios.post(
     `${resolvedServerUrl}/v1beta/models/${model}:generateContent`,

--- a/src/services/openAIChatService.js
+++ b/src/services/openAIChatService.js
@@ -7,6 +7,7 @@ const extractValue = (input) => {
   return input;
 };
 
+
 // OpenAI 호환 `/v1/chat/completions` 호출 — OpenAI 공식 / Local LLM (Ollama, LiteLLM, vLLM 등) 공통.
 // 응답에서 첫 번째 choice 의 메시지 본문 + usage 를 추출해 반환.
 const complete = async (serverUrl, apiKey, messages, options = {}) => {
@@ -20,11 +21,12 @@ const complete = async (serverUrl, apiKey, messages, options = {}) => {
     throw new Error('OpenAI Chat: model is required');
   }
 
+  // max_tokens / max_completion_tokens / temperature 모두 모델 기본값 사용.
+  // gpt-5+ 등 reasoning 모델은 비기본 temperature 를 거부하고, 그 외 모델도
+  // 텍스트 워크보드에서는 사용자 미세조정 수요가 낮아 단순화함.
   const requestBody = {
     model,
     messages,
-    temperature: options.temperature ?? 0.7,
-    max_tokens: options.maxTokens ?? 2000,
   };
 
   const headers = { 'Content-Type': 'application/json' };


### PR DESCRIPTION
## v1.8.2 패치 릴리스

### 핵심
**Phase 5 마무리** — OpenAI / Gemini 의 text capability 가 v1.8.0 에서 누락된 갭을 메움. 두 provider 모두 텍스트 워크보드 정상 동작.

### 포함 PR
- **#205** (closes #204): OpenAI / Gemini text capability 활성화. 라우팅 dispatcher / 템플릿 / 폼 / chip 라벨 일관 정리. reasoning 모델(gpt-5+, gemini-3+) 호환 위해 temperature/max_tokens 전송 단순화. pre-5 OpenAI / pre-3 Gemini 모델 템플릿 제외.
- **#202** (closes #143): ADMIN_EMAILS 자동 승인 가입 시 잘못된 "승인 대기" 토스트 미표시
- **#203** (closes #144): 글로벌 에러 메시지 상황별 한국어로 분기

### 호환성
- 기존 작업판 / 서버 영향 없음
- 마이그레이션 없음 (frontend / 라우팅만 변경)
- chip 라벨 변경은 표시만, 데이터 무관

## Test plan
- [x] Gemini / OpenAI 서버로 text 워크보드 생성 + generate-prompt → 정상 응답
- [x] 기존 image 워크보드 회귀 없음
- [x] 작업판 카드 chip 라벨이 (server · output) 통합 표시
- [x] AI 프롬프트 생성 다이얼로그에 모든 provider text 워크보드 노출
- [x] ADMIN_EMAILS 가입 흐름 / 일반 에러 메시지 검증
- [ ] main 머지 후 v1.8.2 태그 부착