### PR TITLE
docs: 작업 절차에 GitHub Release 작성 단계 추가 (#207)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,11 +31,13 @@ VCC Manager는 ComfyUI 워크플로우 기반 이미지/비디오 생성 관리 
 1. 업데이트 로그 작성 (`docs/updatelogs/v{major}.md`) 및 commit.
 2. `dev` → `main` PR 생성 및 머지
 3. `main` 브랜치에서 버전 태그 생성
+4. GitHub Release 작성 (태그 기준, 본문은 해당 버전의 업데이트 로그 발췌)
 
 **기타 개발과 관련 없는 작업 시:**
 1. 작업 진행
 2. `dev` → `main` PR 생성 및 머지
 3. `main` 브랜치에서 버전 태그 생성
+4. GitHub Release 작성 (태그 기준, 본문은 해당 버전의 업데이트 로그 발췌)
 
 ### 주의사항
 1. feature 및 fix 브랜치는 절대 직접 main 으로 PR 하지 말 것. 반드시 dev 에 PR 진행.


### PR DESCRIPTION
## Summary
CLAUDE.md 의 두 워크플로우(버전 릴리스 시 / 기타 개발과 관련 없는 작업 시) 마지막 단계에 GitHub Release 작성을 절차화.

## 변경
- `CLAUDE.md`: 두 워크플로우 각각에 `4. GitHub Release 작성 (태그 기준, 본문은 해당 버전의 업데이트 로그 발췌)` 추가 (총 2 줄)

## 후속 (별도 이슈로 분리)
- 기존 v1.7.x ~ v1.8.x 의 GitHub Release 보정 (이 PR 머지 후 진행)
- CLAUDE.md / docs 디렉토리 전반 정리 — 작업 큼, 별도 기획

closes #207