### PR TITLE
docs: DEVELOPMENT.md / API.md v1.7.0+ 반영 (#214)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,57 +1,93 @@
 # VCC Manager API Documentation
 
-이 문서는 VCC Manager의 REST API 엔드포인트를 설명합니다.
-모든 API 요청의 기본 URL은 `/api` 입니다. (예: `http://localhost/api/auth/status`)
+VCC Manager 의 REST API 엔드포인트 목록. 모든 요청의 기본 URL 은 `/api` (예: `http://localhost/api/auth/status`).
 
-## 🔐 인증 (Auth)
+인증은 JWT 쿠키 또는 `X-API-Key` / `Authorization: Bearer <api_key>` 헤더 지원. 자세한 인증 정책은 root [CLAUDE.md](../../CLAUDE.md) 참고.
 
-| Method | Endpoint | Description | Auth Required |
+## 인증 (Auth)
+
+| Method | Endpoint | Description | Auth |
 |:---:|---|---|:---:|
-| `GET` | `/auth/google` | 구글 OAuth 로그인 시작 | No |
-| `GET` | `/auth/google/callback` | 구글 OAuth 콜백 | No |
-| `GET` | `/auth/me` | 현재 로그인한 사용자 정보 조회 | Yes |
-| `POST` | `/auth/logout` | 로그아웃 | Yes |
-| `POST` | `/auth/signup` | 이메일/비밀번호 회원가입 | No |
-| `POST` | `/auth/signin` | 이메일/비밀번호 로그인 | No |
-| `GET` | `/auth/check-email/:email` | 이메일 중복 확인 | No |
-| `GET` | `/auth/check-nickname/:nickname` | 닉네임 중복 확인 | No |
-| `GET` | `/auth/status` | 인증 상태 확인 (Health check) | No |
+| `GET` | `/auth/google` | Google OAuth 시작 | - |
+| `GET` | `/auth/google/callback` | Google OAuth 콜백 (토큰 fragment 반환) | - |
+| `GET` | `/auth/me` | 현재 사용자 정보 | Yes |
+| `POST` | `/auth/logout` | 로그아웃 | - |
+| `POST` | `/auth/signup` | 이메일/비밀번호 회원가입 | - |
+| `POST` | `/auth/signin` | 이메일/비밀번호 로그인 | - |
+| `GET` | `/auth/check-email/:email` | 이메일 중복 확인 | - |
+| `GET` | `/auth/check-nickname/:nickname` | 닉네임 중복 확인 | - |
+| `GET` | `/auth/status` | Health check | - |
+| `POST` | `/auth/forgot-password` | 비밀번호 재설정 이메일 발송 | - |
+| `GET` | `/auth/verify-reset-token/:token` | 재설정 토큰 검증 | - |
+| `POST` | `/auth/reset-password` | 비밀번호 재설정 실행 | - |
 
-## 👤 사용자 (Users)
+## 사용자 (Users)
 
-| Method | Endpoint | Description | Auth Required |
+| Method | Endpoint | Description | Auth |
 |:---:|---|---|:---:|
-| `GET` | `/users/profile` | 내 프로필 상세 정보 조회 | Yes |
-| `PUT` | `/users/profile` | 내 프로필 수정 (닉네임, 설정 등) | Yes |
-| `GET` | `/users/stats` | 내 활동 통계 (작업 수, 이미지 수 등) | Yes |
+| `GET` | `/users/profile` | 내 프로필 상세 | Yes |
+| `PUT` | `/users/profile` | 내 프로필 수정 (닉네임 / `preferences`) | Yes |
+| `GET` | `/users/stats` | 내 활동 통계 | Yes |
 | `DELETE` | `/users/account` | 회원 탈퇴 | Yes |
 
-## 📋 작업판 (Workboards)
+## API Key
 
-| Method | Endpoint | Description | Auth Required |
+| Method | Endpoint | Description | Auth |
 |:---:|---|---|:---:|
-| `GET` | `/workboards` | 활성화된 작업판 목록 조회 (페이징, 검색) | Yes |
-| `GET` | `/workboards/:id` | 작업판 상세 정보 조회 | Yes |
-| `GET` | `/workboards/admin/:id` | (관리자) 작업판 상세 조회 (Workflow 데이터 포함) | **Admin** |
-| `POST` | `/workboards` | (관리자) 새 작업판 생성 | **Admin** |
-| `PUT` | `/workboards/:id` | (관리자) 작업판 수정 | **Admin** |
-| `DELETE` | `/workboards/:id` | (관리자) 작업판 비활성화 (삭제) | **Admin** |
-| `POST` | `/workboards/:id/duplicate` | (관리자) 작업판 복제 | **Admin** |
-| `GET` | `/workboards/:id/stats` | (관리자) 작업판별 사용 통계 조회 | **Admin** |
+| `GET` | `/apikeys` | 내 API Key 목록 | Yes |
+| `POST` | `/apikeys` | API Key 발급 (사용자당 최대 10개) | Yes |
+| `DELETE` | `/apikeys/:id` | API Key 폐기 | Yes |
 
-## 🎨 이미지 생성 작업 (Jobs)
+## 서버 (Servers, v1.2.4+)
 
-| Method | Endpoint | Description | Auth Required |
+| Method | Endpoint | Description | Auth |
 |:---:|---|---|:---:|
-| `POST` | `/jobs/generate` | 이미지 생성 요청 | Yes |
-| `GET` | `/jobs/my` | 내 작업 목록 조회 | Yes |
-| `GET` | `/jobs/:id` | 작업 상세 정보 조회 | Yes |
-| `DELETE` | `/jobs/:id` | 작업 기록 삭제 | Yes |
-| `POST` | `/jobs/:id/retry` | 실패한 작업 재시도 | Yes |
-| `POST` | `/jobs/:id/cancel` | 대기/진행 중인 작업 취소 | Yes |
-| `GET` | `/jobs/queue/stats` | 전체 큐 상태 조회 (대기열 수 등) | Yes |
+| `GET` | `/servers` | 활성 서버 목록 | Yes |
+| `GET` | `/servers/:id` | 서버 상세 | **Admin** |
+| `POST` | `/servers` | 서버 등록 (`serverType`: `OpenAI` / `OpenAI Compatible` / `Gemini` / `ComfyUI`) | **Admin** |
+| `PUT` | `/servers/:id` | 서버 수정 | **Admin** |
+| `DELETE` | `/servers/:id` | 서버 삭제 | **Admin** |
+| `POST` | `/servers/:id/health-check` | 단일 서버 헬스체크 | **Admin** |
+| `POST` | `/servers/health-check/all` | 전체 서버 헬스체크 | **Admin** |
+| `GET` | `/servers/:id/models` | 서버 모델 목록 (ComfyUI: 체크포인트, OpenAI: `/v1/models`) | Yes |
+| `GET` | `/servers/:id/loras` | 서버 LoRA 목록 | Yes |
+| `POST` | `/servers/:id/loras/sync` | LoRA 동기화 시작 | **Admin** |
+| `GET` | `/servers/:id/loras/status` | LoRA 동기화 상태 | Yes |
 
-### Job 생성 Request Body 예시
+## 작업판 (Workboards)
+
+| Method | Endpoint | Description | Auth |
+|:---:|---|---|:---:|
+| `GET` | `/workboards` | 활성 작업판 목록 (페이징·검색) | Yes |
+| `GET` | `/workboards/:id` | 작업판 상세 | Yes |
+| `GET` | `/workboards/admin/:id` | 작업판 상세 (workflowData 포함) | **Admin** |
+| `POST` | `/workboards` | 작업판 생성 (`serverId`, `outputFormat`) | **Admin** |
+| `PUT` | `/workboards/:id` | 작업판 수정 | **Admin** |
+| `PATCH` | `/workboards/:id/activate` | 작업판 활성화 | **Admin** |
+| `PATCH` | `/workboards/:id/deactivate` | 작업판 비활성화 (소프트 삭제) | **Admin** |
+| `DELETE` | `/workboards/:id` | 작업판 삭제 | **Admin** |
+| `POST` | `/workboards/:id/duplicate` | 작업판 복제 | **Admin** |
+| `GET` | `/workboards/:id/export` | 작업판 내보내기 (JSON) | **Admin** |
+| `POST` | `/workboards/import` | 작업판 가져오기 | **Admin** |
+| `GET` | `/workboards/:id/stats` | 작업판 사용 통계 | **Admin** |
+| `GET` | `/workboards/:id/lora-models` | 작업판 LoRA 모델 | Yes |
+| `POST` | `/workboards/:id/lora-models/refresh` | LoRA 캐시 갱신 | Yes |
+
+## 작업 (Jobs)
+
+| Method | Endpoint | Description | Auth |
+|:---:|---|---|:---:|
+| `POST` | `/jobs/generate` | 이미지/비디오 생성 요청 | Yes |
+| `POST` | `/jobs/generate-prompt` | AI 프롬프트 생성 (텍스트 출력) | Yes |
+| `GET` | `/jobs/my` | 내 작업 목록 | Yes |
+| `GET` | `/jobs/:id` | 작업 상세 | Yes |
+| `DELETE` | `/jobs/:id` | 작업 삭제 | Yes |
+| `POST` | `/jobs/:id/retry` | 실패 작업 재시도 | Yes |
+| `POST` | `/jobs/:id/cancel` | 진행 중 작업 취소 | Yes |
+| `GET` | `/jobs/queue/stats` | 큐 상태 조회 | Yes |
+
+### `POST /jobs/generate` 요청 예시
+
 ```json
 {
   "workboardId": "...",
@@ -61,32 +97,116 @@
   "seed": 12345,
   "additionalParams": {
     "steps": 30,
-    "cfg": 7
+    "cfg": 7,
+    "referenceImage": "<imageId>"
   }
 }
 ```
 
-## 🖼️ 이미지 관리 (Images)
+`workboardId` 의 `serverId.serverType` 와 `outputFormat` 으로 백엔드의 `SERVICE_MAP` 이 dispatch 한다 (v1.8.0).
 
-| Method | Endpoint | Description | Auth Required |
+## 이미지 (Images)
+
+| Method | Endpoint | Description | Auth |
 |:---:|---|---|:---:|
-| `POST` | `/images/upload` | 레퍼런스 이미지 업로드 (Multipart/form-data) | Yes |
-| `GET` | `/images/uploaded` | 업로드한 이미지 목록 조회 | Yes |
-| `GET` | `/images/generated` | 생성된 이미지 목록 조회 | Yes |
-| `GET` | `/images/uploaded/:id` | 업로드 이미지 상세 조회 | Yes |
-| `GET` | `/images/generated/:id` | 생성 이미지 상세 조회 | Yes |
-| `PUT` | `/images/uploaded/:id` | 업로드 이미지 정보 수정 (태그 등) | Yes |
-| `PUT` | `/images/generated/:id` | 생성 이미지 정보 수정 (공개 여부 등) | Yes |
+| `POST` | `/images/upload` | 레퍼런스 이미지 업로드 (multipart) | Yes |
+| `GET` | `/images/uploaded` | 업로드 이미지 목록 | Yes |
+| `GET` | `/images/uploaded/:id` | 업로드 이미지 상세 | Yes |
+| `PUT` | `/images/uploaded/:id` | 업로드 이미지 수정 (태그 등) | Yes |
 | `DELETE` | `/images/uploaded/:id` | 업로드 이미지 삭제 | Yes |
+| `GET` | `/images/generated` | 생성 이미지 목록 | Yes |
+| `GET` | `/images/generated/:id` | 생성 이미지 상세 | Yes |
+| `PUT` | `/images/generated/:id` | 생성 이미지 수정 | Yes |
 | `DELETE` | `/images/generated/:id` | 생성 이미지 삭제 | Yes |
-| `GET` | `/images/stats` | 이미지 통계 조회 | Yes |
-| `POST` | `/images/generated/:id/download` | 생성된 이미지 다운로드 | Yes |
+| `POST` | `/images/generated/:id/download` | 생성 이미지 다운로드 | Yes |
+| `POST` | `/images/bulk-delete` | 다중 삭제 (id 목록) | Yes |
+| `POST` | `/images/bulk-delete-by-filter` | 검색 결과 일괄 삭제 | Yes |
+| `GET` | `/images/stats` | 이미지 통계 | Yes |
 
-## 👑 관리자 (Admin)
+## 비디오 (Videos)
 
-| Method | Endpoint | Description | Auth Required |
+| Method | Endpoint | Description | Auth |
 |:---:|---|---|:---:|
-| `GET` | `/admin/users` | 전체 사용자 목록 조회 | **Admin** |
-| `DELETE` | `/admin/users/:id` | 사용자 강제 탈퇴 및 데이터 삭제 | **Admin** |
-| `GET` | `/admin/stats` | 전체 시스템 통합 통계 조회 | **Admin** |
-| `GET` | `/admin/jobs` | 전체 작업 목록 조회 | **Admin** |
+| `GET` | `/images/videos` | 생성 비디오 목록 | Yes |
+| `GET` | `/images/videos/:id` | 비디오 상세 | Yes |
+| `PUT` | `/images/videos/:id` | 비디오 수정 (태그 등) | Yes |
+| `DELETE` | `/images/videos/:id` | 비디오 삭제 | Yes |
+| `POST` | `/images/videos/:id/download` | 비디오 다운로드 | Yes |
+
+## 미디어 파일 (Files, Signed URL)
+
+| Method | Endpoint | Description | Auth |
+|:---:|---|---|:---:|
+| `GET` | `/files/*` | Signed URL 검증 후 미디어 서빙 (`/uploads/*` 직접 접근 차단) | 서명 |
+
+## 프로젝트 (Projects, v1.3.0+)
+
+| Method | Endpoint | Description | Auth |
+|:---:|---|---|:---:|
+| `GET` | `/projects` | 프로젝트 목록 | Yes |
+| `GET` | `/projects/favorites` | 즐겨찾기 프로젝트 | Yes |
+| `GET` | `/projects/by-tag/:tagId` | 태그별 프로젝트 | Yes |
+| `GET` | `/projects/:id` | 프로젝트 상세 | Yes |
+| `POST` | `/projects` | 프로젝트 생성 | Yes |
+| `PUT` | `/projects/:id` | 프로젝트 수정 (커버 이미지 포함) | Yes |
+| `DELETE` | `/projects/:id` | 프로젝트 삭제 | Yes |
+| `POST` | `/projects/:id/favorite` | 즐겨찾기 토글 | Yes |
+| `GET` | `/projects/:id/images` | 프로젝트 이미지 | Yes |
+| `GET` | `/projects/:id/jobs` | 프로젝트 작업 | Yes |
+| `GET` | `/projects/:id/prompt-data` | 프로젝트 프롬프트 데이터 | Yes |
+
+## 프롬프트 데이터 (PromptData, v1.2.4+)
+
+| Method | Endpoint | Description | Auth |
+|:---:|---|---|:---:|
+| `GET` | `/prompt-data` | 프롬프트 데이터 목록 | Yes |
+| `GET` | `/prompt-data/:id` | 상세 | Yes |
+| `POST` | `/prompt-data` | 생성 | Yes |
+| `PUT` | `/prompt-data/:id` | 수정 | Yes |
+| `DELETE` | `/prompt-data/:id` | 삭제 | Yes |
+| `POST` | `/prompt-data/:id/use` | 사용 횟수 증가 | Yes |
+
+## 태그 (Tags, v1.2.4+)
+
+| Method | Endpoint | Description | Auth |
+|:---:|---|---|:---:|
+| `GET` | `/tags` | 태그 목록 | Yes |
+| `GET` | `/tags/my` | 내 태그 | Yes |
+| `GET` | `/tags/search` | 태그 검색 | Yes |
+| `POST` | `/tags` | 태그 생성 | Yes |
+| `PUT` | `/tags/:id` | 태그 수정 | Yes |
+| `DELETE` | `/tags/:id` | 태그 삭제 | Yes |
+
+## 백업 / 복원 (Backup, v1.2.4+)
+
+| Method | Endpoint | Description | Auth |
+|:---:|---|---|:---:|
+| `GET` | `/admin/backup/lock-status` | 백업 진행 잠금 상태 | **Admin** |
+| `POST` | `/admin/backup` | 백업 시작 | **Admin** |
+| `GET` | `/admin/backup/list` | 백업 목록 | **Admin** |
+| `GET` | `/admin/backup/status/:id` | 백업 잡 상태 | **Admin** |
+| `GET` | `/admin/backup/download/:id` | 백업 파일 다운로드 | **Admin** |
+| `DELETE` | `/admin/backup/:id` | 백업 삭제 | **Admin** |
+| `POST` | `/admin/backup/restore/validate` | 복원 파일 검증 (multipart) | **Admin** |
+| `POST` | `/admin/backup/restore` | 복원 실행 | **Admin** |
+| `GET` | `/admin/backup/restore/list` | 복원 히스토리 | **Admin** |
+| `GET` | `/admin/backup/restore/status/:id` | 복원 잡 상태 | **Admin** |
+
+## 업데이트 로그 (UpdateLog, v1.2.5+)
+
+| Method | Endpoint | Description | Auth |
+|:---:|---|---|:---:|
+| `GET` | `/updatelog/:majorVersion` | `docs/updatelogs/v{major}.md` 마크다운 반환 (대시보드 뷰어용) | Yes |
+
+## 관리자 (Admin)
+
+| Method | Endpoint | Description | Auth |
+|:---:|---|---|:---:|
+| `GET` | `/admin/users` | 전체 사용자 목록 | **Admin** |
+| `POST` | `/admin/users/:id/approve` | 사용자 승인 | **Admin** |
+| `POST` | `/admin/users/:id/reject` | 사용자 승인 거절 | **Admin** |
+| `DELETE` | `/admin/users/:id` | 사용자 강제 탈퇴 | **Admin** |
+| `GET` | `/admin/stats` | 시스템 통합 통계 | **Admin** |
+| `GET` | `/admin/jobs` | 전체 작업 목록 | **Admin** |
+| `GET` | `/admin/settings/lora` | LoRA 전역 설정 | **Admin** |
+| `PUT` | `/admin/settings/lora` | LoRA 전역 설정 수정 (Civitai API 키 / NSFW 정책 등) | **Admin** |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,442 +1,90 @@
-# Visual Content Creator (VCC) Manager - 개발 문서
+# Visual Content Creator (VCC) Manager — 개발 문서
+
+VCC Manager 의 백엔드 / 프론트엔드 / MCP 서버 구조와 핵심 모듈을 설명한다. Claude Code 작업 지침은 root [CLAUDE.md](../../CLAUDE.md), 환경변수는 [CONFIGURATION.md](./CONFIGURATION.md), API 명세는 [API.md](./API.md), MCP 도구 명세는 [MCP_SERVER_API.md](./MCP_SERVER_API.md) 를 참고.
 
 ## 프로젝트 개요
 
-VCC Manager는 ComfyUI 워크플로우를 관리하고 이미지 생성 작업을 효율적으로 처리하기 위한 웹 애플리케이션입니다.
+여러 AI 이미지/비디오/텍스트 생성 provider 를 단일 작업판(Workboard) 모델로 추상화하여 관리하는 웹 애플리케이션.
 
-### 주요 기능
-- **사용자 관리**: JWT 기반 인증, 역할별 권한 관리 (admin/user)
-- **작업판 관리**: ComfyUI 워크플로우 템플릿 관리 (관리자 전용)
-- **이미지/비디오 생성**: 작업 큐를 통한 비동기 이미지 및 비디오 생성
-- **파일 관리**: 레퍼런스 이미지 업로드, 생성 이미지/비디오 관리
-- **ComfyUI 통합**: Load Image 노드용 이미지 자동 업로드
-- **모니터링**: 실시간 작업 상태 및 시스템 통계
-- **태그 시스템**: 이미지/비디오/프롬프트 데이터에 태그 관리
+- **지원 provider** (`serverType`): `OpenAI`, `OpenAI Compatible` (Ollama / LiteLLM 등), `Gemini`, `ComfyUI`
+- **출력 형식** (`outputFormat`): `image`, `video`, `text` — provider 별 capability matrix 에서 결정
+- **인증**: JWT (웹) + API Key (MCP / 외부) — 세부 정책은 root `CLAUDE.md` "알려진 패턴 및 주의사항" 참고
 
 ## 아키텍처
 
 ```
-┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
-│   Frontend      │    │    Backend      │    │   External      │
-│   (React)       │    │  (Node.js)      │    │   Services      │
-│                 │    │                 │    │                 │
-│ - React 18      │◄──►│ - Express.js    │◄──►│ - ComfyUI       │
-│ - Material-UI   │    │ - MongoDB       │    │ - Redis         │
-│ - React Query   │    │ - Bull Queue    │    │                 │
-│ - React Router  │    │ - Multer        │    │                 │
-└─────────────────┘    └─────────────────┘    └─────────────────┘
-        │                       │                       │
-        │                       │                       │
-        v                       v                       v
-┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
-│     Nginx       │    │    Database     │    │   File System   │
-│  (Reverse Proxy)│    │   (MongoDB)     │    │   (Uploads)     │
-└─────────────────┘    └─────────────────┘    └─────────────────┘
+┌──────────────┐    ┌─────────────────┐    ┌──────────────────────┐
+│  Frontend    │    │    Backend      │    │  External Providers  │
+│  (React 18)  │◄──►│  (Express)      │◄──►│  ComfyUI / OpenAI /  │
+│  CRA + MUI   │    │  Bull Queue     │    │  Gemini / Compatible │
+│  React Query │    │  Mongoose       │    └──────────────────────┘
+└──────────────┘    └─────────────────┘             ▲
+       ▲                    │                       │
+       │                    ▼                       │
+┌──────────────┐    ┌─────────────────┐    ┌──────────────────┐
+│   Nginx      │    │  MongoDB +      │    │  MCP Server      │
+│ (reverse     │    │  Redis (Bull)   │    │  (stdio + HTTP)  │
+│  proxy)      │    └─────────────────┘    └──────────────────┘
+└──────────────┘
 ```
 
-## 프로젝트 구조
+## 디렉토리 구조
 
-```
-vcc-manager-claude/
-├── frontend/                 # React 프론트엔드
-│   ├── src/
-│   │   ├── components/      # 공통 컴포넌트
-│   │   │   ├── common/      # 공통 UI 컴포넌트
-│   │   │   │   ├── ImageSelectDialog.js    # 이미지 선택 다이얼로그
-│   │   │   │   ├── ImageViewerDialog.js    # 이미지 뷰어 다이얼로그
-│   │   │   │   ├── VideoViewerDialog.js    # 비디오 뷰어 다이얼로그
-│   │   │   │   ├── Pagination.js           # 페이지네이션
-│   │   │   │   └── TagInput.js             # 태그 입력
-│   │   │   └── admin/       # 관리자 전용 컴포넌트
-│   │   ├── pages/           # 페이지 컴포넌트
-│   │   ├── services/        # API 서비스
-│   │   ├── contexts/        # React Context
-│   │   └── config/          # 설정 파일
-│   └── package.json
-├── src/                     # Node.js 백엔드
-│   ├── routes/              # API 라우트
-│   ├── models/              # MongoDB 모델
-│   ├── services/            # 비즈니스 로직
-│   ├── middleware/          # Express 미들웨어
-│   ├── config/              # 설정 파일
-│   └── utils/               # 유틸리티 함수
-├── docker-compose.yml       # Docker 구성
-├── Dockerfile.frontend      # 프론트엔드 Docker 이미지
-├── Dockerfile.backend       # 백엔드 Docker 이미지
-├── nginx.conf               # Nginx 설정
-└── uploads/                 # 업로드된 파일
-```
+전체 구조는 root [CLAUDE.md](../../CLAUDE.md#주요-디렉토리-구조) 참고. 본 문서는 모듈별 진입점만 다룬다.
 
-## 환경 설정
+## 백엔드 핵심 모듈
 
-### 필수 환경변수
+| 모듈 | 위치 | 역할 |
+| --- | --- | --- |
+| 인증 | `src/routes/auth.js` | 이메일/비밀번호 + Google OAuth, 비밀번호 재설정 (v1.2.4) |
+| API Key | `src/routes/apikeys.js` | 사용자별 API Key 발급/관리 (v1.3.6) |
+| 작업판 | `src/routes/workboards.js` | Server·outputFormat 기반 작업판 CRUD |
+| 작업 큐 | `src/services/queueService.js` | `SERVICE_MAP[(serverType, outputFormat)]` dispatcher (v1.8.0) |
+| ComfyUI | `src/services/comfyUIService.js` | 워크플로우 실행 / WebSocket 모니터링 / 이미지 업로드 |
+| OpenAI Chat | `src/services/openAIChatService.js` | OpenAI 공식 + Local LLM (Ollama / LiteLLM) 공통 (v1.8.0) |
+| Gemini | `src/services/geminiService.js` | 이미지 + 텍스트 생성 (v1.7.0 / v1.8.2) |
+| GPT Image | `src/services/gptImageService.js` | OpenAI 이미지 생성 (`gpt-image-2` 포함, v1.7.3) |
+| Signed URL | `src/utils/signedUrl.js` + `src/routes/files.js` | HMAC 기반 미디어 접근 제어 (v1.4.0) |
+| 백업/복원 | `src/services/backupService.js` / `src/services/restoreService.js` | 시스템 백업 (v1.2.4) |
+| 마이그레이션 | `src/migrations/` | Mongoose 일회성 스크립트 |
+| 단위 테스트 | `src/tests/` | Jest (signedUrl, escapeRegex, queueService 등) |
 
-#### 백엔드 (.env)
-```bash
-# 데이터베이스
-MONGODB_URI=mongodb://admin:password@mongodb:27017/vcc-manager?authSource=admin
+## 프론트엔드 핵심 모듈
 
-# Redis (작업 큐)
-REDIS_URL=redis://:redispassword@redis:6379
-REDIS_PASSWORD=redispassword
+| 모듈 | 위치 | 역할 |
+| --- | --- | --- |
+| 인증 컨텍스트 | `frontend/src/contexts/AuthContext.js` | 전역 사용자 상태, 토큰 관리 |
+| 작업판 템플릿 | `frontend/src/templates/` | `<serverType>-<outputFormat>.json` + `index.js` 로더 + `capabilities.js` (capability matrix) (v1.8.0) |
+| 관리자 작업판 편집 | `frontend/src/components/admin/WorkboardManagement.js` | 작업판 생성·편집, 템플릿 기반 폼 |
+| 공통 컴포넌트 | `frontend/src/components/common/` | 13개 공통 다이얼로그/패널 (root `CLAUDE.md` "공통 컴포넌트 활용" 참고) |
 
-# JWT 인증
-JWT_SECRET=your-super-secret-jwt-key
-JWT_EXPIRES_IN=7d
+## MCP 서버
 
-# 파일 업로드
-UPLOAD_PATH=./uploads
-MAX_FILE_SIZE=10485760
-
-# 기타
-NODE_ENV=production
-PORT=3000
-FRONTEND_URL=http://localhost:3001
-```
-
-#### 프론트엔드 (frontend/.env)
-```bash
-# API 설정
-REACT_APP_API_URL=/api
-
-# 모니터링 업데이트 주기 (밀리초)
-REACT_APP_QUEUE_STATUS_INTERVAL=5000    # 작업 큐 상태: 5초
-REACT_APP_RECENT_JOBS_INTERVAL=15000    # 최근 작업: 15초
-REACT_APP_USER_STATS_INTERVAL=30000     # 사용자 통계: 30초
-```
-
-## 개발 환경 시작
-
-### 1. 의존성 설치
-```bash
-# 백엔드
-npm install
-
-# 프론트엔드
-cd frontend && npm install
-```
-
-### 2. Docker Compose로 실행
-```bash
-# 전체 서비스 시작
-docker-compose up -d
-
-# 개발 환경으로 시작
-docker-compose -f docker-compose.dev.yml up -d
-```
-
-### 3. 개별 서비스 실행
-```bash
-# 백엔드 (포트 3136)
-npm start
-
-# 프론트엔드 (포트 3001)
-cd frontend && npm start
-```
-
-## 주요 컴포넌트 설명
-
-### 백엔드 서비스
-
-#### 1. 인증 시스템 (`src/routes/auth.js`)
-- JWT 기반 토큰 인증
-- 사용자 등록/로그인/로그아웃
-- 역할별 접근 권한 관리
-
-#### 2. 작업판 관리 (`src/routes/workboards.js`)
-- ComfyUI 워크플로우 템플릿 CRUD
-- 관리자 전용 편집 권한
-- 동적 입력 필드 설정
-
-#### 3. 이미지 생성 작업 (`src/services/queueService.js`)
-- Bull Queue를 통한 비동기 작업 처리
-- ComfyUI WebSocket 통신
-- 진행률 추적 및 상태 관리
-- 이미지 타입 필드 자동 업로드 (ComfyUI Load Image 노드 지원)
-- 비디오 출력 지원 (mp4, webm, gif 등)
-
-#### 4. 파일 관리 (`src/routes/images.js`)
-- Multer를 통한 파일 업로드
-- 이미지/비디오 메타데이터 관리
-- 레퍼런스 이미지 연결
-- 태그 기반 검색 및 필터링
-
-#### 5. ComfyUI 통합 (`src/services/comfyUIService.js`)
-- 워크플로우 실행 및 WebSocket 모니터링
-- 이미지 업로드 API (`/upload/image`)
-- 미디어 타입 자동 감지 (이미지/비디오/애니메이션)
-- prompt_id 기반 메시지 필터링으로 다중 작업 지원
-
-### 프론트엔드 컴포넌트
-
-#### 1. 인증 컨텍스트 (`frontend/src/contexts/AuthContext.js`)
-- 전역 사용자 상태 관리
-- 토큰 자동 갱신
-- 권한별 라우팅
-
-#### 2. 관리자 대시보드 (`frontend/src/components/admin/AdminDashboard.js`)
-- 시스템 통계 모니터링
-- 실시간 작업 큐 상태
-- 사용자 및 작업 관리
-
-#### 3. 작업판 관리 (`frontend/src/components/admin/WorkboardManagement.js`)
-- 워크플로우 템플릿 편집
-- 동적 입력 필드 구성
-- JSON 워크플로우 데이터 관리
-
-## API 엔드포인트
-
-### 인증 관련
-```
-POST /api/auth/signin          # 로그인
-POST /api/auth/signup          # 회원가입
-POST /api/auth/logout          # 로그아웃
-GET  /api/auth/me              # 현재 사용자 정보
-```
-
-### 작업판 관리
-```
-GET    /api/workboards         # 작업판 목록 (일반 사용자)
-GET    /api/workboards/:id     # 작업판 상세 (일반 사용자)
-GET    /api/workboards/admin/:id # 작업판 상세 (관리자, workflowData 포함)
-POST   /api/workboards         # 작업판 생성 (관리자)
-PUT    /api/workboards/:id     # 작업판 수정 (관리자)
-DELETE /api/workboards/:id     # 작업판 삭제 (관리자)
-```
-
-### 이미지 생성
-```
-POST /api/jobs/generate        # 이미지 생성 작업 요청
-GET  /api/jobs/my             # 내 작업 목록
-GET  /api/jobs/:id            # 작업 상세 정보
-POST /api/jobs/:id/retry      # 작업 재시도
-POST /api/jobs/:id/cancel     # 작업 취소
-```
-
-### 파일 관리
-```
-GET  /api/images/uploaded      # 업로드된 이미지 목록
-GET  /api/images/generated     # 생성된 이미지 목록
-GET  /api/images/videos        # 생성된 비디오 목록
-POST /api/images/upload        # 이미지 업로드
-GET  /api/images/videos/:id/download  # 비디오 다운로드
-GET  /uploads/generated/:filename     # 생성된 이미지 다운로드
-GET  /uploads/videos/:filename        # 생성된 비디오 다운로드
-```
+`mcp-server/src/server.js` 가 McpServer 인스턴스를 생성하고, `tools/{workboards,jobs,media}.js` 에서 도구를 등록한다. stdio + Streamable HTTP 양 모드 지원. 멀티유저 인증 / `VCC_BASE_URL_FOR_MCP` 등 운영 정책은 root `CLAUDE.md` 와 [MCP_SERVER.md](./MCP_SERVER.md) 참고.
 
 ## 데이터베이스 스키마
 
-### User 모델
-```javascript
-{
-  email: String,
-  password: String (hashed),
-  nickname: String,
-  isAdmin: Boolean,
-  createdAt: Date,
-  updatedAt: Date
-}
-```
+핵심 모델 (`src/models/`):
 
-### Workboard 모델
-```javascript
-{
-  name: String,
-  description: String,
-  serverUrl: String,
-  isActive: Boolean,
-  baseInputFields: {
-    aiModel: [SelectOption],
-    imageSizes: [SelectOption],
-    // ...
-  },
-  additionalInputFields: [InputField],
-  workflowData: String, // JSON
-  createdBy: ObjectId,
-  version: Number,
-  usageCount: Number
-}
-```
+- **User** — 이메일 / 비밀번호 / 닉네임 / `isAdmin` / `apiKeys[]` (최대 10개) / `passwordResetToken` / 사용자 설정 (`preferences.deleteContentWithHistory` 등)
+- **Server** — `serverType` (`OpenAI` / `OpenAI Compatible` / `Gemini` / `ComfyUI`), `baseUrl`, `apiKey`, healthcheck 결과
+- **Workboard** — `serverId`, `outputFormat` (`image` / `video` / `text`), `apiFormat` (deprecated), `baseInputFields`, `additionalInputFields`, `workflowData` (ComfyUI 만 사용, `default: ''`)
+- **ImageGenerationJob** — `userId`, `workboardId`, `serverId`, `inputData` (prompt / aiModel / additionalParams), `resultImages[]` / `resultVideos[]`, `progress`, `error`, `resolvedWorkflow` (ComfyUI 디버깅용)
+- **GeneratedImage** / **GeneratedVideo** — `jobId` (선택), `userId`, `path`, `metadata`, `tags[]`
+- **ApiKey** — 해시된 키 + 라벨 + `lastUsedAt`
+- **BackupJob** / **RestoreJob** — 백업·복원 잡 (v1.8.1 에서 TTL 자동 삭제 제거)
+- **Project** — 프로젝트 분류 + 커버 이미지 (v1.3.0)
+- **PromptData** — 프롬프트 라이브러리 (v1.2.4)
+- **Tag** — 사용자 기반 태그 (v1.2.4)
+- **LoraCache** / **ServerLoraCache** / **ModelCache** — 외부 모델 카탈로그 캐시
 
-### ImageGenerationJob 모델
-```javascript
-{
-  userId: ObjectId,
-  workboardId: ObjectId,
-  status: String, // 'pending'|'processing'|'completed'|'failed'
-  inputData: {
-    prompt: String,
-    negativePrompt: String,
-    aiModel: String,
-    additionalParams: Object, // 이미지 필드 포함
-    // ...
-  },
-  resultImages: [ObjectId],  // GeneratedImage 참조
-  resultVideos: [ObjectId],  // GeneratedVideo 참조
-  progress: Number,
-  error: Object,
-  createdAt: Date,
-  completedAt: Date
-}
-```
+## 트러블슈팅 / 운영
 
-### GeneratedVideo 모델
-```javascript
-{
-  jobId: ObjectId,
-  userId: ObjectId,
-  filename: String,
-  originalName: String,
-  mimeType: String,
-  size: Number,
-  path: String,
-  url: String,
-  metadata: {
-    width: Number,
-    height: Number,
-    duration: Number
-  },
-  tags: [String],
-  createdAt: Date
-}
-```
-
-## 트러블슈팅
-
-### 일반적인 문제들
-
-#### 1. 이미지가 표시되지 않는 경우
-**원인**: nginx 정적 파일 라우팅 설정 문제
-**해결**: `nginx.conf`에서 `/uploads` 경로가 백엔드로 프록시되도록 설정 확인
-
-```nginx
-location /uploads {
-    proxy_pass http://backend:3000;
-    # ... proxy headers
-}
-```
-
-#### 2. 작업이 즉시 완료되는 경우
-**원인**: ComfyUI가 동일한 시드/파라미터에 대해 이전 결과 재사용
-**해결**: 시드값 변경 또는 워크플로우 파라미터 수정
-
-#### 3. 작업 큐가 작동하지 않는 경우
-**원인**: Redis 연결 문제 또는 Bull Queue 초기화 실패
-**해결**: Redis 연결 확인 및 환경변수 검증
-
-```bash
-# Redis 연결 확인
-docker-compose logs redis
-
-# 백엔드 로그 확인
-docker-compose logs backend
-```
-
-#### 4. 워크플로우 JSON이 저장되지 않는 경우
-**원인**: `ImageGenerationJob.updateStatus()` 메서드에서 resultImages 처리 누락
-**해결**: updateStatus 메서드에 resultImages 필드 처리 추가
-
-### 개발 도구
-
-#### 로그 확인
-```bash
-# 전체 서비스 로그
-docker-compose logs -f
-
-# 특정 서비스 로그
-docker-compose logs -f backend
-docker-compose logs -f frontend
-```
-
-#### 데이터베이스 접근
-```bash
-# MongoDB 접속
-docker-compose exec mongodb mongosh "mongodb://admin:password@localhost:27017/vcc-manager?authSource=admin"
-```
-
-#### Redis 상태 확인
-```bash
-# Redis CLI 접속
-docker-compose exec redis redis-cli -a redispassword
-```
-
-## 배포
-
-### 프로덕션 배포
-```bash
-# 프로덕션 이미지 빌드
-docker-compose build
-
-# 프로덕션 환경 시작
-docker-compose up -d
-```
-
-### 환경별 설정
-- **개발**: `docker-compose.dev.yml` 사용
-- **프로덕션**: `docker-compose.yml` 사용
-
-## 향후 개발 계획
-
-### 단기 목표
-1. 작업 우선순위 설정 기능
-2. 이미지 메타데이터 편집 기능
-3. 배치 작업 처리 기능
-
-### 중기 목표
-1. 사용자별 할당량 관리
-2. 워크플로우 버전 관리
-3. API 율한계 설정
-
-### 장기 목표
-1. 다중 ComfyUI 서버 지원
-2. 플러그인 시스템
-3. 고급 모니터링 및 알림
-
-## 기여 가이드라인
-
-1. **코드 스타일**: ESLint 및 Prettier 설정 준수
-2. **커밋 메시지**: Conventional Commits 형식 사용
-3. **테스트**: 새로운 기능에 대한 테스트 코드 작성
-4. **문서**: 변경사항에 대한 문서 업데이트
+운영 트러블슈팅은 [TROUBLESHOOTING.md](./TROUBLESHOOTING.md), 백업/복원은 [BACKUP_RESTORE.md](./BACKUP_RESTORE.md), 보안은 [SECURITY.md](./SECURITY.md) 참고.
 
 ## 라이선스
 
-[라이선스 정보 추가 필요]
-
-## 공통 컴포넌트
-
-### ImageSelectDialog
-이미지 선택을 위한 공통 다이얼로그 컴포넌트입니다.
-
-```jsx
-<ImageSelectDialog
-  open={open}
-  onClose={handleClose}
-  onSelect={handleSelect}
-  title="이미지 선택"
-  multiple={true}        // 다중 선택 활성화
-  maxImages={3}          // 최대 선택 개수
-  initialSelected={[]}   // 초기 선택 이미지
-/>
-```
-
-### VideoViewerDialog
-비디오 뷰어를 위한 공통 다이얼로그 컴포넌트입니다.
-
-```jsx
-<VideoViewerDialog
-  videos={videoList}        // 비디오 배열
-  selectedIndex={0}         // 시작 인덱스
-  open={open}
-  onClose={handleClose}
-  title="동영상 보기"
-/>
-```
-
-- 다운로드 기능 내장
-- 이전/다음 네비게이션 (다중 비디오 시)
-- iOS Safari 호환 다운로드 처리
+MIT — [LICENSE](../LICENSE) 참고.
 
 ---
-**마지막 업데이트**: 2026-01-31
-**작성자**: Claude Code Assistant
+**마지막 업데이트**: 2026-05-02


### PR DESCRIPTION
## Summary
#209 Phase 1 — `DEVELOPMENT.md` / `API.md` 를 v1.7.0+ 코드 기준으로 갱신·정리.

### `docs/DEVELOPMENT.md`
- ComfyUI-only 시스템 묘사 → 멀티 provider (`OpenAI` / `OpenAI Compatible` / `Gemini` / `ComfyUI`) + (server, outputFormat) capability 모델 반영
- root `CLAUDE.md` / `API.md` / `CONFIGURATION.md` 와 중복되는 섹션 제거. 링크 또는 요약으로 대체
- 빈 placeholder (라이선스 / 향후 개발 계획) 정리, LICENSE 파일로 대체
- 백엔드 핵심 모듈 / 프론트엔드 핵심 모듈 / DB 스키마 표를 v1.8.x 기준으로 재작성
- **441줄 → 약 80줄**

### `docs/API.md`
- 누락된 라우트 그룹 8개 추가: `apikeys`, `servers`, `projects`, `prompt-data`, `tags`, `backup/restore`, `updatelog`, `files`(signed URL), 비디오, 비밀번호 재설정
- `workboards` 의 v1.3.3+ activate / deactivate / export / import 반영
- `jobs/generate-prompt` (v1.2.4+) 반영
- `admin` 의 사용자 승인 / 거절, LoRA 전역 설정 반영

## Test plan
- [ ] `API.md` 의 모든 엔드포인트가 `src/routes/*.js` 의 정의와 일치하는지 확인
- [ ] `DEVELOPMENT.md` 의 모듈 표가 실제 파일 경로와 일치하는지 확인
- [ ] 링크 유효성 (`../../CLAUDE.md`, `./CONFIGURATION.md` 등)

closes #214
Refs #209