### PR TITLE
docs: CONFIGURATION / COMFYUI_WORKFLOW / MAINTENANCE / TROUBLESHOOTING 갱신 (#218)

### DIFF
--- a/docs/COMFYUI_WORKFLOW.md
+++ b/docs/COMFYUI_WORKFLOW.md
@@ -1,5 +1,7 @@
 # ComfyUI Workflow 처리 로직 문서
 
+> **⚠️ 적용 범위**: 본 문서는 `serverType: ComfyUI` 작업판에 한정된다. v1.7.0 부터 도입된 `OpenAI` / `OpenAI Compatible` / `Gemini` 서버는 워크플로우 JSON 대신 각 provider 의 REST API 를 직접 호출하므로 본 문서의 플레이스홀더 / WebSocket 처리 로직과 무관하다. 백엔드 dispatch 구조는 root [CLAUDE.md](../CLAUDE.md) 의 "Server / Workboard capability 모델" 과 [DEVELOPMENT.md](./DEVELOPMENT.md) 참고.
+
 ## 📋 개요
 
 VCC Manager에서 ComfyUI 워크플로우를 처리하는 전체적인 로직과 데이터 흐름을 설명합니다.
@@ -394,6 +396,6 @@ replacements["{{##customParam##}}"] = { value: 10, type: "number" };
 
 ---
 
-**작성일**: 2026년 1월 24일  
+**작성일**: 2026-01-24 / **마지막 검토**: 2026-05-02 (v1.8.x 기준 적용 범위 명시)  
 **버전**: 1.0  
 **작성자**: Claude Code Assistant

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,78 +1,120 @@
 # VCC Manager 환경 설정 가이드
 
-VCC Manager는 `.env` 파일을 통해 다양한 설정을 관리합니다.
-이 문서는 각 환경 변수의 역할과 설정 방법을 상세히 설명합니다.
+VCC Manager 는 `.env` (개발) / `.env.production` (프로덕션) 파일로 환경 변수를 관리한다. ComfyUI / Civitai API Key 등은 더 이상 환경변수가 아니라 **관리자 화면의 서버 모델로 관리** (v1.2.5 이후, 서버별 다중 등록 지원).
 
-## 📁 파일 위치
-
-프로젝트 루트 디렉토리의 `.env` 파일을 수정하여 설정합니다.
-없는 경우 `.env.example` 파일을 복사하여 생성하세요.
+## 파일 위치
 
 ```bash
+# 개발용
 cp .env.example .env
+
+# 프로덕션
+cp .env.production.example .env.production
 ```
 
-## ⚙️ 서버 설정 (Server)
+> 환경변수가 추가/변경/삭제되면 `docker-compose.yml`, `docker-compose.prod.yml`, `scripts/deploy-prod.sh`, `scripts/stop-prod.sh` 도 함께 점검할 것 (root [CLAUDE.md](../CLAUDE.md) "작업 시 유의사항" 참고).
 
-| 변수명 | 설명 | 기본값 |
+## 서버
+
+| 변수 | 설명 | 기본값 |
 |---|---|---|
-| `NODE_ENV` | 실행 환경 (`development`, `production`) | `development` |
-| `PORT` | 백엔드 API 서버의 내부 포트 | `3000` |
+| `NODE_ENV` | `development` / `production` | `development` |
+| `PORT` | 백엔드 컨테이너 내부 포트 (Dockerfile 변경 시에만 수정) | `3000` |
 
-## 🐳 Docker 포트 설정
+## Docker 호스트 포트
 
-호스트 머신에 노출되는 포트 설정입니다. `docker-compose.yml`에서 사용됩니다.
+`docker-compose.yml` 가 호스트로 노출하는 포트.
 
-| 변수명 | 설명 | 기본값 |
+| 변수 | 설명 | 기본값 |
 |---|---|---|
-| `FRONTEND_PORT` | 프론트엔드 웹 서버 접속 포트 | `80` |
-| `BACKEND_PORT` | 백엔드 API 서버 접속 포트 | `3000` |
-| `MONGODB_PORT` | (개발용) MongoDB 접속 포트 | `27017` |
-| `REDIS_PORT` | (개발용) Redis 접속 포트 | `6379` |
+| `FRONTEND_PORT` | 프론트엔드 (nginx) | `8136` |
+| `BACKEND_PORT` | 백엔드 API | `3136` |
+| `MCP_PORT` | MCP HTTP 서버 (v1.3.3+) | `4136` |
+| `MONGODB_PORT` | (개발용) MongoDB. 프로덕션은 미노출 | `27017` |
+| `REDIS_PORT` | (개발용) Redis. 프로덕션은 미노출 | `6379` |
 
-## 🗄️ 데이터베이스 (Database)
+## 데이터베이스 / Redis
 
-| 변수명 | 설명 | 예시 |
-|---|---|---|
-| `MONGODB_URI` | MongoDB 연결 주소 | `mongodb://localhost:27017/vcc-manager` |
-
-## 🔐 보안 설정 (Security)
-
-| 변수명 | 설명 |
+| 변수 | 설명 |
 |---|---|
-| `JWT_SECRET` | JWT 토큰 서명 키 |
-| `JWT_EXPIRES_IN` | JWT 토큰 만료 시간 |
-| `ADMIN_EMAILS` | 관리자 권한을 부여할 이메일 목록 (쉼표 구분) |
+| `MONGO_ROOT_USER` | MongoDB 루트 계정 |
+| `MONGO_ROOT_PASSWORD` | MongoDB 루트 비밀번호 (프로덕션 필수 변경) |
+| `MONGO_DB` | 기본 DB 명 (`vcc-manager`) |
+| `MONGODB_URI` | 연결 문자열 |
+| `REDIS_PASSWORD` | Redis 비밀번호 (프로덕션 필수 변경) |
+| `REDIS_URL` | Redis 연결 URL (`redis://:<pw>@<host>:<port>`) |
 
-## ☁️ 외부 서비스 (External Services)
+## 인증 / 보안
 
-### Google OAuth
-| 변수명 | 설명 |
+| 변수 | 설명 |
 |---|---|
-| `GOOGLE_CLIENT_ID` | GCP Client ID |
-| `GOOGLE_CLIENT_SECRET` | GCP Client Secret |
-| `GOOGLE_CALLBACK_URL` | 리다이렉트 URL |
+| `JWT_SECRET` | JWT 서명 키 (프로덕션은 32자 이상). 미설정 시 부팅 실패 (v1.4.10 fail-fast) |
+| `JWT_EXPIRES_IN` | 토큰 만료 (예: `7d`) |
+| `ADMIN_EMAILS` | 관리자 자동 승격 이메일 (쉼표 구분) |
+| `BACKUP_ENCRYPTION_KEY` | 백업 ZIP 의 API 키 등 민감정보 암호화 키. **64자리 hex** (`openssl rand -hex 32`). 분실 시 백업의 암호화 항목 복구 불가 |
 
-### ComfyUI
-| 변수명 | 설명 | 기본값 |
+> Signed URL HMAC 키는 `JWT_SECRET` 을 재사용하므로 별도 설정 불필요.
+
+## Google OAuth
+
+| 변수 | 설명 |
+|---|---|
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | GCP OAuth Credentials |
+| `GOOGLE_CALLBACK_URL` | 콜백 URL (개발: `http://localhost:3136/auth/google/callback`, 프로덕션: `https://<domain>/auth/google/callback`) |
+
+## 파일 / 백업
+
+| 변수 | 설명 | 기본값 |
 |---|---|---|
-| `COMFY_UI_BASE_URL` | ComfyUI 서버 주소 | `http://localhost:8188` |
+| `UPLOAD_PATH` | 미디어 저장 경로 | `./uploads` (개발) / `/app/uploads` (프로덕션) |
+| `MAX_FILE_SIZE` | 업로드 최대 byte | `10485760` (10MB) |
+| `BACKUP_PATH` | 백업 ZIP 저장 경로 | `./backups` (개발) / `/app/backups` (프로덕션) |
 
-### Redis
-| 변수명 | 설명 | 기본값 |
+## CORS / 프론트엔드
+
+| 변수 | 설명 |
+|---|---|
+| `FRONTEND_URL` | CORS 허용 origin (예: `http://localhost:8136`, `https://<domain>`) |
+| `REACT_APP_API_URL` | 프론트엔드 빌드 시 API 경로. 컨테이너 배포에서는 `/api` (nginx 프록시) |
+
+## SMTP (비밀번호 재설정 이메일, v1.2.4+)
+
+| 변수 | 설명 |
+|---|---|
+| `SMTP_HOST` / `SMTP_PORT` / `SMTP_SECURE` | SMTP 서버 |
+| `SMTP_USER` / `SMTP_PASSWORD` | 인증 계정 (Gmail 의 경우 앱 비밀번호) |
+| `SMTP_FROM_EMAIL` / `SMTP_FROM_NAME` | 발신자 표기 |
+
+## Signed URL (v1.4.0+)
+
+| 변수 | 설명 | 기본값 |
 |---|---|---|
-| `REDIS_URL` | Redis 연결 URL | `redis://localhost:6379` |
+| `SIGNED_URL_EXPIRY` | 만료 시간 (초) | `3600` (1시간) |
+| `SIGNED_URL_ROUND_SECONDS` | 만료 라운딩 간격 (초). 동일 구간 내 동일 URL 보장 → 비디오 깜박임 방지 (v1.4.3) | `1440` (24분) |
 
-## 📂 파일 업로드
+## MCP Server (v1.3.3+)
 
-| 변수명 | 설명 | 기본값 |
-|---|---|---|
-| `UPLOAD_PATH` | 파일 저장 경로 | `./uploads` |
-| `MAX_FILE_SIZE` | 최대 파일 크기 (Byte) | `10485760` (10MB) |
+| 변수 | 설명 |
+|---|---|
+| `MCP_PORT` | HTTP 모드 포트 (`4136` 기본) |
+| `VCC_API_KEY` | **stdio 모드 전용** 로컬 MCP 서버용. HTTP 모드는 클라이언트 Bearer 토큰 사용 |
+| `VCC_BASE_URL_FOR_MCP` | MCP 의 `download_result` 가 signed URL 을 반환할 때 사용할 VCC 서버 기본 URL. 미설정 시 base64 fallback (`mcp-remote` 1MB 응답 제한 회피용) |
 
-## 🌐 프론트엔드 설정
+상세 운영 정책은 [MCP_SERVER.md](./MCP_SERVER.md) 참고.
 
-| 변수명 | 설명 | 용도 |
-|---|---|---|
-| `FRONTEND_URL` | 프론트엔드 URL | 백엔드 CORS 허용 설정 |
-| `REACT_APP_API_URL` | API 서버 주소 | 프론트엔드 빌드 시 API 요청 주소 지정 |
+## 더 이상 환경변수가 아닌 항목
+
+다음은 v1.2.5 이후 **관리자 화면 > 서버 관리** 에서 설정한다 (서버별 등록):
+
+- ComfyUI 서버 URL (이전 `COMFY_UI_BASE_URL`)
+- OpenAI / Gemini / OpenAI Compatible API Key 및 base URL
+- Civitai API Key (전역 설정 → 관리자 > LoRA 설정)
+
+```
+docs/updatelogs/v1.md (v1.2.5):
+  chore: 서버별 관리로 전환된 환경변수
+  (COMFY_UI_BASE_URL, CIVITAI_API_KEY) 예시 파일에서 제거 (#53)
+```
+
+---
+**마지막 업데이트**: 2026-05-02

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -32,10 +32,10 @@ docker-compose logs --since="2026-01-22T10:00:00" --until="2026-01-22T12:00:00"
 #### 3. 데이터베이스 상태
 ```bash
 # MongoDB 연결 확인
-docker-compose exec mongodb mongosh "mongodb://admin:password@localhost:27017/vcc-manager?authSource=admin" --eval "db.runCommand('ping')"
+docker-compose exec mongodb mongosh "mongodb://${MONGO_ROOT_USER}:${MONGO_ROOT_PASSWORD}@localhost:27017/${MONGO_DB}?authSource=admin" --eval "db.runCommand('ping')"
 
 # 컬렉션 상태 확인
-docker-compose exec mongodb mongosh "mongodb://admin:password@localhost:27017/vcc-manager?authSource=admin" --eval "
+docker-compose exec mongodb mongosh "mongodb://${MONGO_ROOT_USER}:${MONGO_ROOT_PASSWORD}@localhost:27017/${MONGO_DB}?authSource=admin" --eval "
   db.users.countDocuments();
   db.workboards.countDocuments();
   db.imagegenerationjobs.countDocuments();
@@ -45,11 +45,11 @@ docker-compose exec mongodb mongosh "mongodb://admin:password@localhost:27017/vc
 #### 4. Redis 큐 상태
 ```bash
 # Redis 연결 확인
-docker-compose exec redis redis-cli -a redispassword ping
+docker-compose exec redis redis-cli -a "$REDIS_PASSWORD" ping
 
 # 큐 상태 확인
-docker-compose exec redis redis-cli -a redispassword info memory
-docker-compose exec redis redis-cli -a redispassword keys "*"
+docker-compose exec redis redis-cli -a "$REDIS_PASSWORD" info memory
+docker-compose exec redis redis-cli -a "$REDIS_PASSWORD" keys "*"
 ```
 
 ### 정기 정리 작업
@@ -89,10 +89,12 @@ db.generatedimages.reIndex();
 
 ### 백업 절차
 
+> **권장 경로**: 관리자 UI 의 백업 기능 (`/api/admin/backup`, v1.2.4+) 또는 `docs/BACKUP_RESTORE.md` 절차를 사용한다. 이 기능은 MongoDB / 업로드 파일 / API Key 암호화 항목을 한번에 ZIP 으로 묶고 `BACKUP_ENCRYPTION_KEY` 로 민감정보를 암호화한다. 아래 수동 절차는 긴급 / 호환성 목적의 보조 수단이다.
+
 #### 1. 데이터베이스 백업
 ```bash
 # MongoDB 전체 백업
-docker-compose exec mongodb mongodump --uri="mongodb://admin:password@localhost:27017/vcc-manager?authSource=admin" --out="/backup/$(date +%Y%m%d)"
+docker-compose exec mongodb mongodump --uri="mongodb://${MONGO_ROOT_USER}:${MONGO_ROOT_PASSWORD}@localhost:27017/${MONGO_DB}?authSource=admin" --out="/backup/$(date +%Y%m%d)"
 
 # 백업 파일 압축
 tar -czf "backup_$(date +%Y%m%d_%H%M%S).tar.gz" /backup/$(date +%Y%m%d)
@@ -115,7 +117,7 @@ cp .env /backup/config/
 #### 3. 백업 복원
 ```bash
 # 데이터베이스 복원
-docker-compose exec mongodb mongorestore --uri="mongodb://admin:password@localhost:27017/vcc-manager?authSource=admin" /backup/20260122/vcc-manager/
+docker-compose exec mongodb mongorestore --uri="mongodb://${MONGO_ROOT_USER}:${MONGO_ROOT_PASSWORD}@localhost:27017/${MONGO_DB}?authSource=admin" /backup/20260122/vcc-manager/
 
 # 파일 복원
 rsync -av /backup/uploads_20260122/ uploads/
@@ -139,10 +141,10 @@ db.imagegenerationjobs.createIndex({ "createdAt": -1, "status": 1 });
 #### 2. Redis 최적화
 ```bash
 # 메모리 사용량 확인
-docker-compose exec redis redis-cli -a redispassword info memory
+docker-compose exec redis redis-cli -a "$REDIS_PASSWORD" info memory
 
 # 만료된 키 정리
-docker-compose exec redis redis-cli -a redispassword eval "return redis.call('del', unpack(redis.call('keys', ARGV[1])))" 0 "bull:*:completed*"
+docker-compose exec redis redis-cli -a "$REDIS_PASSWORD" eval "return redis.call('del', unpack(redis.call('keys', ARGV[1])))" 0 "bull:*:completed*"
 
 # Redis 설정 최적화 (필요시 redis.conf 수정)
 # maxmemory 2gb
@@ -235,10 +237,10 @@ client.connect().then(() => console.log('Connected')).catch(console.error);
 #### 4. 큐 작업 문제
 ```bash
 # 대기 중인 작업 확인
-docker-compose exec redis redis-cli -a redispassword keys "*waiting*"
+docker-compose exec redis redis-cli -a "$REDIS_PASSWORD" keys "*waiting*"
 
 # 실패한 작업 정리
-docker-compose exec redis redis-cli -a redispassword keys "*failed*" | xargs docker-compose exec redis redis-cli -a redispassword del
+docker-compose exec redis redis-cli -a "$REDIS_PASSWORD" keys "*failed*" | xargs docker-compose exec redis redis-cli -a "$REDIS_PASSWORD" del
 
 # 큐 재시작
 docker-compose restart backend
@@ -340,6 +342,4 @@ fetch('/api/health')
 - [ ] 용량 계획 검토
 
 ---
-**마지막 업데이트**: 2026-01-22  
-**담당자**: 시스템 관리자  
-**비상 연락처**: [연락처 정보 추가 필요]
+**마지막 업데이트**: 2026-05-02

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -176,10 +176,11 @@ const replacements = {
 - 컨테이너 간 통신 실패
 
 #### 해결 방법
-1. `.env` 파일에서 포트 설정 확인:
+1. `.env` 파일에서 포트 설정 확인 (기본값):
    ```bash
-   BACKEND_PORT=3131
-   FRONTEND_PORT=80
+   BACKEND_PORT=3136
+   FRONTEND_PORT=8136
+   MCP_PORT=4136
    ```
 
 2. docker-compose.prod.yml에서 포트 매핑 확인:
@@ -264,11 +265,11 @@ docker-compose -f docker-compose.prod.yml up -d
 
 #### 헬스체크 확인
 ```bash
-# 백엔드 헬스체크
-curl -f http://localhost:3131/health
+# 백엔드 헬스체크 (BACKEND_PORT 기본 3136)
+curl -f http://localhost:3136/health
 
-# 프론트엔드 접근 테스트
-curl -f http://localhost/
+# 프론트엔드 접근 테스트 (FRONTEND_PORT 기본 8136)
+curl -f http://localhost:8136/
 ```
 
 ---
@@ -335,3 +336,6 @@ docker system df
 ---
 
 *이 문서는 실제 문제 해결 경험을 바탕으로 작성되었으며, 새로운 이슈 발견 시 지속적으로 업데이트됩니다.*
+
+---
+**마지막 업데이트**: 2026-05-02


### PR DESCRIPTION
## Summary
#209 후속 — audit 결과 부분 갱신 필요로 확인된 4개 문서 정비.

### `docs/CONFIGURATION.md`
- v1.4.0+ 도입 항목 추가: `SIGNED_URL_*`, `MCP_PORT`, `VCC_BASE_URL_FOR_MCP`, `BACKUP_PATH`, `BACKUP_ENCRYPTION_KEY`, `SMTP_*`
- 포트 기본값 정정 (`FRONTEND_PORT` 80→8136, `BACKEND_PORT` 3000→3136)
- v1.2.5 에서 환경변수에서 제거된 `COMFY_UI_BASE_URL` / `CIVITAI_API_KEY` 는 "관리자 화면 > 서버 관리" 로 이전됐다는 안내 추가

### `docs/COMFYUI_WORKFLOW.md`
- 문서 시작에 "본 문서는 `serverType: ComfyUI` 작업판 한정" 명시 박스 추가 (v1.7.0+ 멀티 provider 맥락 분리)

### `docs/MAINTENANCE.md`
- 예제 명령어의 `admin:password` / `redispassword` 하드코딩 → 환경변수 참조로 치환
- 백업 절차 상단에 v1.2.4+ 관리자 UI 백업 기능 우선 사용 안내 추가
- placeholder 정리 (비상 연락처 등)

### `docs/TROUBLESHOOTING.md`
- 잘못된 포트 예시 정정 (3131 → 3136)
- 헬스체크 curl 포트 정정

## Test plan
- [ ] `CONFIGURATION.md` 표가 `.env.example` / `.env.production.example` 와 일치하는지 확인
- [ ] `COMFYUI_WORKFLOW.md` 의 추가 안내 박스 가독성
- [ ] `MAINTENANCE.md` / `TROUBLESHOOTING.md` 의 환경변수 치환 표현이 zsh / bash 모두에서 유효한지

closes #218
Refs #209