### PR TITLE
fix: Gemini 텍스트 작업판 admin 폼에서 시스템 프롬프트 입력란 노출 (#220)

### DIFF
--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -275,11 +275,13 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
   });
 
   const apiFormat = watch('apiFormat');
+  const outputFormat = watch('outputFormat');
   const isComfyUI = apiFormat === 'ComfyUI';
   const isGemini = apiFormat === 'Gemini';
   const isGptImage = apiFormat === 'GPT Image';
-  const isPromptFormat = apiFormat === 'OpenAI Compatible';
-  const isImageFormat = ['ComfyUI', 'Gemini', 'GPT Image'].includes(apiFormat);
+  // v1.8.0+ : 분기 기준은 outputFormat. apiFormat 은 legacy.
+  const isPromptFormat = outputFormat === 'text';
+  const isImageFormat = outputFormat === 'image';
 
   React.useEffect(() => {
     return () => {
@@ -472,25 +474,28 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
 
     const normalizedApiFormat = data.apiFormat || 'ComfyUI';
     const isComfyUIFormat = normalizedApiFormat === 'ComfyUI';
-    const isPromptApiFormat = normalizedApiFormat === 'OpenAI Compatible';
-    const isImageApiFormat = ['ComfyUI', 'Gemini', 'GPT Image'].includes(normalizedApiFormat);
-    const isFixedImageApiFormat = ['Gemini', 'GPT Image'].includes(normalizedApiFormat);
+    // v1.8.0+ : baseInputFields 분기는 outputFormat 기준. apiFormat 은 legacy.
+    const normalizedOutputFormat = data.outputFormat || 'image';
+    const isPromptOutputFormat = normalizedOutputFormat === 'text';
+    const isImageOutputFormat = normalizedOutputFormat === 'image';
+    // GPT Image 는 deprecated 이미지 전용 — 강제 image 유지. 그 외 capability 는 사용자 선택 존중.
+    const isFixedImageApiFormat = normalizedApiFormat === 'GPT Image';
     const updateData = {
       name: data.name?.trim(),
       description: data.description?.trim(),
       serverId: data.serverId,
       apiFormat: normalizedApiFormat,
-      outputFormat: isFixedImageApiFormat ? 'image' : (data.outputFormat || 'image'),
+      outputFormat: isFixedImageApiFormat ? 'image' : normalizedOutputFormat,
       workflowData: !isComfyUIFormat ? '' : data.workflowData,
       isActive: Boolean(data.isActive),
       baseInputFields: {
         aiModel: (data.aiModels || []).filter(m => m.key && m.value),
-        imageSizes: isImageApiFormat ? (data.imageSizes || []).filter(s => s.key && s.value) : [],
+        imageSizes: isImageOutputFormat ? (data.imageSizes || []).filter(s => s.key && s.value) : [],
         referenceImageMethods: isComfyUIFormat ? (data.referenceImageMethods || []).filter(r => r.key && r.value) : [],
-        systemPrompt: isPromptApiFormat ? (data.systemPrompt || '') : '',
-        referenceImages: isPromptApiFormat ? (data.referenceImages || []).filter(r => r.key && r.value) : [],
-        temperature: isPromptApiFormat ? (parseFloat(data.temperature) || 0.7) : undefined,
-        maxTokens: isPromptApiFormat ? (parseInt(data.maxTokens) || 2000) : undefined
+        systemPrompt: isPromptOutputFormat ? (data.systemPrompt || '') : '',
+        referenceImages: isPromptOutputFormat ? (data.referenceImages || []).filter(r => r.key && r.value) : [],
+        temperature: isPromptOutputFormat ? (parseFloat(data.temperature) || 0.7) : undefined,
+        maxTokens: isPromptOutputFormat ? (parseInt(data.maxTokens) || 2000) : undefined
       },
       additionalInputFields
     };


### PR DESCRIPTION
## Summary
관리자가 Gemini + 텍스트 작업판을 편집할 때 "시스템 프롬프트" / "생성 설정" / "참조 이미지" 섹션이 노출되지 않던 문제 수정.

## 원인
`WorkboardManagement.js` 의 폼 렌더링·저장 분기가 v1.8.0 이전의 legacy `apiFormat` 단일 차원으로만 동작 — `apiFormat === 'OpenAI Compatible'` 일 때만 prompt 섹션을 노출. v1.8.2 에서 Gemini 가 text capability 를 추가했지만 `deriveLegacyApiFormat('Gemini', 'text')` 결과는 여전히 `'Gemini'` 라 분기가 false 가 됨.

또한 저장 시 `isFixedImageApiFormat` 이 Gemini 를 image-only 로 처리하여 outputFormat='text' 를 'image' 로 silently 덮어쓰던 부수 문제도 동반.

## 수정
- 폼 렌더링·저장 모두 `outputFormat` (v1.8.0+ 진실 소스) 기준으로 분기 변경
  - `isPromptFormat = (outputFormat === 'text')`
  - `isImageFormat = (outputFormat === 'image')`
- `isFixedImageApiFormat` 은 deprecated `GPT Image` 만 — Gemini 는 multi-capability 이므로 사용자 선택 존중

## Test plan
- [ ] Gemini-text 작업판 신규 생성 → 편집 시 시스템 프롬프트 / 생성 설정 / 참조 이미지 섹션 노출
- [ ] OpenAI-text / OpenAI Compatible-text 회귀 없음
- [ ] Gemini-image / OpenAI-image / GPT Image 작업판 이미지 섹션 정상 노출
- [ ] ComfyUI image / video 작업판 영향 없음
- [ ] 편집 → 저장 시 outputFormat 보존 (Gemini-text 가 image 로 silent overwrite 되지 않음)

## 영향 / 후속
- 기존에 영향받은 Gemini-text 작업판 (편집 시 outputFormat='image' 로 덮어쓰여진 경우) 데이터는 자동 마이그레이션 대상이 아님. 사용자가 다시 outputFormat='text' 로 저장 시 정상화

closes #220