### PR TITLE
fix: text 작업판 admin 폼에서 dead input (temperature / maxTokens) 제거 (#222)

### DIFF
--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -265,8 +265,6 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
       referenceImageMethods: [],
       systemPrompt: '',
       referenceImages: [],
-      temperature: 0.7,
-      maxTokens: 2000,
       negativePromptField: { enabled: false, required: false },
       upscaleMethodField: { enabled: false, required: false, options: [] },
       baseStyleField: { enabled: false, required: false, options: [], formatString: '{{##base_style##}}' },
@@ -352,8 +350,6 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
             referenceImageMethods: fullData.baseInputFields?.referenceImageMethods?.map(r => ({ key: r.key || '', value: r.value || '' })) || [],
             systemPrompt: fullData.baseInputFields?.systemPrompt || '',
             referenceImages: fullData.baseInputFields?.referenceImages?.map(r => ({ key: r.key || '', value: r.value || '' })) || [],
-            temperature: fullData.baseInputFields?.temperature ?? 0.7,
-            maxTokens: fullData.baseInputFields?.maxTokens ?? 2000,
             // 커스텀 필드
             negativePromptField: {
               enabled: fullData.additionalInputFields?.some(f => f.name === 'negativePrompt') || false,
@@ -493,9 +489,7 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
         imageSizes: isImageOutputFormat ? (data.imageSizes || []).filter(s => s.key && s.value) : [],
         referenceImageMethods: isComfyUIFormat ? (data.referenceImageMethods || []).filter(r => r.key && r.value) : [],
         systemPrompt: isPromptOutputFormat ? (data.systemPrompt || '') : '',
-        referenceImages: isPromptOutputFormat ? (data.referenceImages || []).filter(r => r.key && r.value) : [],
-        temperature: isPromptOutputFormat ? (parseFloat(data.temperature) || 0.7) : undefined,
-        maxTokens: isPromptOutputFormat ? (parseInt(data.maxTokens) || 2000) : undefined
+        referenceImages: isPromptOutputFormat ? (data.referenceImages || []).filter(r => r.key && r.value) : []
       },
       additionalInputFields
     };
@@ -673,51 +667,6 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
                           />
                         )}
                       />
-                    </AccordionDetails>
-                  </Accordion>
-
-                  <Accordion>
-                    <AccordionSummary expandIcon={<ExpandMore />}>
-                      <Typography variant="h6">생성 설정</Typography>
-                    </AccordionSummary>
-                    <AccordionDetails>
-                      <Typography variant="body2" color="textSecondary" mb={2}>
-                        프롬프트 생성 시 사용할 파라미터를 설정합니다.
-                      </Typography>
-                      <Grid container spacing={2}>
-                        <Grid item xs={12} sm={6}>
-                          <Controller
-                            name="temperature"
-                            control={control}
-                            render={({ field }) => (
-                              <TextField
-                                {...field}
-                                fullWidth
-                                type="number"
-                                label="Temperature"
-                                inputProps={{ step: 0.1, min: 0, max: 2 }}
-                                helperText="창의성 수준 (0~2, 높을수록 다양한 결과)"
-                              />
-                            )}
-                          />
-                        </Grid>
-                        <Grid item xs={12} sm={6}>
-                          <Controller
-                            name="maxTokens"
-                            control={control}
-                            render={({ field }) => (
-                              <TextField
-                                {...field}
-                                fullWidth
-                                type="number"
-                                label="Max Tokens"
-                                inputProps={{ min: 100, max: 16000 }}
-                                helperText="최대 출력 토큰 수"
-                              />
-                            )}
-                          />
-                        </Grid>
-                      </Grid>
                     </AccordionDetails>
                   </Accordion>
 


### PR DESCRIPTION
## Summary
v1.8.2 에서 OpenAI / Gemini text 호출 시 \`temperature\` / \`max_tokens\` 모두 미전송으로 단순화됐으나 admin 작업판 폼의 "생성 설정" Accordion 이 dead input 으로 남아 있던 문제 정리.

## 백엔드 측 비송신 근거
- \`src/services/openAIChatService.js:24\` — "max_tokens / max_completion_tokens / temperature 모두 모델 기본값 사용"
- \`src/services/geminiService.js:129\` — "Gemini 3+ 는 temperature 를 기본(1.0) 으로 두는 것을 공식 권장 ... 두 옵션 모두 전송하지 않음"

## 변경
- \`WorkboardManagement.js\` 의 prompt 작업판 전용 "생성 설정" Accordion 제거
- form defaultValues / reset / save 분기에서 \`temperature\` / \`maxTokens\` 정리
- Workboard schema 필드는 backward compat 용으로 유지 (기존 데이터에 값이 남아 있어도 무시)

## Test plan
- [x] Frontend Docker build 성공
- [ ] OpenAI-text / OpenAI Compatible-text / Gemini-text 작업판 편집 다이얼로그에 "생성 설정" 섹션이 더 이상 보이지 않음
- [ ] 시스템 프롬프트 / 참조 이미지 섹션은 여전히 노출 (회귀 없음)
- [ ] 기존에 temperature/maxTokens 값이 저장된 작업판 편집 시 에러 없음

## 영향
- 기존 데이터에 저장돼있던 \`baseInputFields.temperature\` / \`maxTokens\` 값은 삭제하지 않음 (그대로 무시됨). 신규 저장 시 폼은 두 필드를 보내지 않음

closes #222