### PR TITLE
fix: OpenAI / Gemini 텍스트 작업판 템플릿 모델 목록 갱신 (#224)

### DIFF
--- a/frontend/src/templates/Gemini-text.json
+++ b/frontend/src/templates/Gemini-text.json
@@ -2,9 +2,9 @@
   "baseInputFields": {
     "aiModel": [
       { "key": "Gemini 3.1 Pro Preview (latest)", "value": "gemini-3.1-pro-preview" },
-      { "key": "Gemini 3 Pro Preview", "value": "gemini-3-pro-preview" },
       { "key": "Gemini 3 Flash Preview", "value": "gemini-3-flash-preview" },
-      { "key": "Gemini 3.1 Flash Lite Preview", "value": "gemini-3.1-flash-lite-preview" }
+      { "key": "Gemini 3.1 Flash Lite Preview", "value": "gemini-3.1-flash-lite-preview" },
+      { "key": "Gemini 3.1 Flash Live Preview", "value": "gemini-3.1-flash-live-preview" }
     ],
     "systemPrompt": "",
     "referenceImages": []

--- a/frontend/src/templates/OpenAI-text.json
+++ b/frontend/src/templates/OpenAI-text.json
@@ -2,12 +2,15 @@
   "baseInputFields": {
     "aiModel": [
       { "key": "GPT-5.5 (latest)", "value": "gpt-5.5" },
-      { "key": "GPT-5.5 Pro", "value": "gpt-5.5-pro" },
       { "key": "GPT-5.4", "value": "gpt-5.4" },
-      { "key": "GPT-5.4 Pro", "value": "gpt-5.4-pro" },
+      { "key": "GPT-5.4 mini", "value": "gpt-5.4-mini" },
+      { "key": "GPT-5.4 nano", "value": "gpt-5.4-nano" },
+      { "key": "GPT-5.2", "value": "gpt-5.2" },
+      { "key": "GPT-5.2 Pro", "value": "gpt-5.2-pro" },
       { "key": "GPT-5.1", "value": "gpt-5.1" },
       { "key": "GPT-5", "value": "gpt-5" },
-      { "key": "GPT-5 Pro", "value": "gpt-5-pro" }
+      { "key": "GPT-5 mini", "value": "gpt-5-mini" },
+      { "key": "GPT-5 nano", "value": "gpt-5-nano" }
     ],
     "systemPrompt": "",
     "referenceImages": []


### PR DESCRIPTION
## Summary
v1.8.2 텍스트 작업판 템플릿의 모델 목록을 OpenAI / Gemini 공식 API 문서 기준으로 정정.

### OpenAI-text
- 호출 시 에러 나는 Pro 변종 제거: `gpt-5.5-pro`, `gpt-5.4-pro`, `gpt-5-pro`
- 5.0+ 누락 모델 추가: `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.2`, `gpt-5.2-pro`, `gpt-5-mini`, `gpt-5-nano`
- `*-chat-latest` 별칭은 제외 (legacy)
- Pro 는 5.2 까지만 (5.3+ Pro 는 의미 없음)

### Gemini-text
- `gemini-3-pro-preview` 제거 — 2026-03-09 deprecated
- `gemini-3.1-flash-live-preview` 추가 (real-time dialogue)
- `gemini-3.1-pro-preview` / `gemini-3-flash-preview` / `gemini-3.1-flash-lite-preview` 유지

## v2.0 후속 (별도)
- v2.0 에서는 `/v1/models` 등 API 기반 동적 조회로 전환 예정
- #198 (작업판 모델 노출 정책) / #200 (모델 선택 UI) 의 후속 작업으로 같이 처리

## Test plan
- [x] Frontend Docker build 성공
- [ ] OpenAI-text 작업판 신규 생성 시 모델 드롭다운에 새 목록 노출
- [ ] Gemini-text 작업판 신규 생성 시 deprecated 모델 미노출 + Flash Live 노출
- [ ] 기존 OpenAI / Gemini text 작업판이 갖고 있는 모델 값은 그대로 유지 (UI 에서 잘못된 값으로 보일 수 있으나 admin 이 새로 선택하면 정정)

closes #224