### PR TITLE
fix: 작업판 관리의 AI API 필터를 serverType 기반으로 갱신 (#228)

### DIFF
--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -1793,7 +1793,7 @@ function WorkboardImportDialog({ open, onClose, onSuccess }) {
 
 function WorkboardManagement() {
   const [search, setSearch] = useState('');
-  const [apiFormatFilter, setApiFormatFilter] = useState('');
+  const [serverTypeFilter, setServerTypeFilter] = useState('');
   const [outputFormatFilter, setOutputFormatFilter] = useState('');
   const [dialogOpen, setDialogOpen] = useState(false);
   const [detailDialogOpen, setDetailDialogOpen] = useState(false);
@@ -1803,8 +1803,8 @@ function WorkboardManagement() {
   const queryClient = useQueryClient();
 
   const { data, isLoading } = useQuery(
-    ['adminWorkboards', { search, apiFormatFilter, outputFormatFilter }],
-    () => workboardAPI.getAll({ search, limit: 50, includeAll: true, includeInactive: true, apiFormat: apiFormatFilter || undefined, outputFormat: outputFormatFilter || undefined }),
+    ['adminWorkboards', { search, serverTypeFilter, outputFormatFilter }],
+    () => workboardAPI.getAll({ search, limit: 50, includeAll: true, includeInactive: true, serverType: serverTypeFilter || undefined, outputFormat: outputFormatFilter || undefined }),
     { keepPreviousData: true }
   );
 
@@ -2109,17 +2109,17 @@ function WorkboardManagement() {
           sx={{ minWidth: 300, flex: 1 }}
         />
         <FormControl sx={{ minWidth: 180 }}>
-          <InputLabel>AI API 타입</InputLabel>
+          <InputLabel>서버 타입</InputLabel>
           <Select
-            value={apiFormatFilter}
-            label="AI API 타입"
-            onChange={(e) => setApiFormatFilter(e.target.value)}
+            value={serverTypeFilter}
+            label="서버 타입"
+            onChange={(e) => setServerTypeFilter(e.target.value)}
           >
             <MenuItem value="">전체</MenuItem>
             <MenuItem value="ComfyUI">ComfyUI</MenuItem>
+            <MenuItem value="OpenAI">OpenAI</MenuItem>
             <MenuItem value="OpenAI Compatible">OpenAI Compatible</MenuItem>
             <MenuItem value="Gemini">Gemini</MenuItem>
-            <MenuItem value="GPT Image">GPT Image</MenuItem>
           </Select>
         </FormControl>
         <FormControl sx={{ minWidth: 150 }}>
@@ -2143,7 +2143,7 @@ function WorkboardManagement() {
         </Box>
       ) : workboards.length === 0 ? (
         <Alert severity="info">
-          {(search || apiFormatFilter || outputFormatFilter) ? '검색 결과가 없습니다.' : '등록된 작업판이 없습니다.'}
+          {(search || serverTypeFilter || outputFormatFilter) ? '검색 결과가 없습니다.' : '등록된 작업판이 없습니다.'}
         </Alert>
       ) : (
         <Grid container spacing={3}>

--- a/src/routes/workboards.js
+++ b/src/routes/workboards.js
@@ -19,7 +19,7 @@ const SERVER_TYPE_LEGACY_FALLBACK = {
 
 router.get('/', requireAuth, async (req, res) => {
   try {
-    const { search = '', workboardType, apiFormat, outputFormat, includeAll, includeInactive } = req.query;
+    const { search = '', workboardType, apiFormat, serverType, outputFormat, includeAll, includeInactive } = req.query;
 
     const parsedPage = Number.parseInt(req.query.page, 10);
     const parsedLimit = Number.parseInt(req.query.limit, 10);
@@ -37,7 +37,13 @@ router.get('/', requireAuth, async (req, res) => {
     if (apiFormat) filter.apiFormat = apiFormat;
     if (outputFormat) filter.outputFormat = outputFormat;
 
-    if (!apiFormat && !outputFormat) {
+    // serverType 필터: 매칭 서버 ID 들 사전 조회 후 serverId $in 으로 필터링
+    if (serverType) {
+      const matchingServers = await Server.find({ serverType }).select('_id');
+      filter.serverId = { $in: matchingServers.map((s) => s._id) };
+    }
+
+    if (!apiFormat && !serverType && !outputFormat) {
       if (includeAll === 'true') {
         // 관리자용: 모든 타입 조회
       } else if (workboardType) {


### PR DESCRIPTION
## Summary
관리자 작업판 관리 페이지의 "AI API 타입" 필터가 v1.8.0 이전의 legacy `apiFormat` enum 으로 남아 있던 문제. 신규 `serverType` 기반으로 전환.

## 원인
v1.8.0 Server·Workboard 구조 리팩토링에서 폼 / 라우팅 / 필드는 (server, outputFormat) 으로 전환됐으나 검색 필터 UI 만 legacy 그대로 남아 있었음. 신규 `OpenAI` 가 빠져있고 deprecated `GPT Image` 가 노출되며, capability 가 다른 항목 (Gemini-image vs Gemini-text 등) 을 한꺼번에 묶어 볼 수 없었음.

## 변경
- **백엔드** \`GET /workboards\`: `serverType` query 파라미터 추가. 매칭 서버 ID 들 사전 조회 → `serverId: { \$in: [...] }` 로 필터링
- **프론트엔드** 필터: "AI API 타입" → "서버 타입" 라벨 변경, 옵션은 신규 enum (`ComfyUI` / `OpenAI` / `OpenAI Compatible` / `Gemini`). deprecated `GPT Image` 제거

## Test plan
- [x] frontend / backend Docker build 성공
- [x] backend `/health` 200
- [ ] 서버 타입 필터로 작업판 목록 정상 필터링
- [ ] "전체" 선택 시 모든 작업판 노출
- [ ] 서버 타입 + 출력 타입 조합 필터 정상 동작

closes #228