### PR TITLE
feat: ComfyUI 이미지 필드 미첨부 시 1024x1024 흰색 PNG 자동 주입 (#230)

### DIFF
--- a/frontend/src/pages/ImageGeneration.js
+++ b/frontend/src/pages/ImageGeneration.js
@@ -175,7 +175,7 @@ function PromptDataSelectDialog({ open, onClose, onSelect }) {
 }
 
 // 사용자 정의 이미지 입력 필드 컴포넌트
-function CustomImageField({ field, value, onChange, maxImages = 1 }) {
+function CustomImageField({ field, value, onChange, maxImages = 1, isComfyUI = false }) {
   const [selectedImages, setSelectedImages] = useState(value || []);
   const [dialogOpen, setDialogOpen] = useState(false);
 
@@ -290,6 +290,11 @@ function CustomImageField({ field, value, onChange, maxImages = 1 }) {
           <Typography variant="caption" color="textSecondary">
             최대 {maxImages}장
           </Typography>
+          {isComfyUI && (
+            <Typography variant="caption" color="textSecondary" sx={{ display: 'block', mt: 1 }}>
+              미첨부 시 1024×1024 흰색 이미지가 자동으로 사용됩니다
+            </Typography>
+          )}
         </Box>
       ) : (
         <Grid container spacing={1}>
@@ -1267,6 +1272,7 @@ function ImageGeneration() {
                               value={formField.value || []}
                               onChange={formField.onChange}
                               maxImages={field.imageConfig?.maxImages || 1}
+                              isComfyUI={workboardData?.serverId?.serverType === 'ComfyUI'}
                             />
                           ) : (
                             <TextField

--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -393,75 +393,93 @@ const loadImageInputs = async (additionalInputFields, inputData) => {
   return loadedImages;
 };
 
+// 미첨부 이미지 필드용 1024x1024 흰색 PNG 를 메모리 상에서 생성하여 ComfyUI 에 업로드.
+// ComfyUI 의 LoadImage 노드는 입력이 없으면 워크플로우 실행 자체가 실패하므로 placeholder 주입 필요 (#230).
+// 동일 잡 내 여러 빈 이미지 필드가 있을 경우 1회 업로드 후 재사용 (cache 인자로 전달).
+const uploadBlankWhitePngToComfyUI = async (serverUrl, cache) => {
+  if (cache.blankFilename) return cache.blankFilename;
+  const buffer = await sharp({
+    create: {
+      width: 1024,
+      height: 1024,
+      channels: 3,
+      background: { r: 255, g: 255, b: 255 },
+    },
+  }).png().toBuffer();
+  const filename = `vcc_blank_white_${Date.now()}.png`;
+  const uploadResult = await comfyUIService.uploadImage(serverUrl, buffer, filename);
+  cache.blankFilename = uploadResult.name;
+  return uploadResult.name;
+};
+
 // 이미지 타입 필드들을 ComfyUI에 업로드하고 파일명 맵 반환
 const uploadImageFieldsToComfyUI = async (serverUrl, additionalInputFields, inputData) => {
   const uploadedImageMap = {};
-  
+  const blankCache = {};
+
   if (!additionalInputFields || additionalInputFields.length === 0) {
     return uploadedImageMap;
   }
-  
+
   // 이미지 타입 필드 찾기
   const imageFields = additionalInputFields.filter(field => field.type === 'image');
-  
+
   for (const field of imageFields) {
     const fieldName = field.name;
     let fieldValue = inputData.additionalParams?.[fieldName] || inputData[fieldName];
-    
-    if (!fieldValue) {
-      console.log(`⏭️ Image field "${fieldName}" is empty, skipping`);
-      continue;
-    }
-    
+
     // 배열인 경우 첫 번째 이미지만 사용 (단일 이미지 필드)
     if (Array.isArray(fieldValue)) {
-      if (fieldValue.length === 0) {
-        console.log(`⏭️ Image field "${fieldName}" is empty array, skipping`);
-        continue;
-      }
-      fieldValue = fieldValue[0];
+      fieldValue = fieldValue.length > 0 ? fieldValue[0] : null;
     }
 
-    const imageId = fieldValue.imageId || fieldValue;
-    
+    const imageId = fieldValue ? (fieldValue.imageId || fieldValue) : null;
+
+    // 미첨부 / imageId 부재 시 흰색 1024x1024 PNG 자동 주입 (#230)
     if (!imageId) {
-      console.log(`⏭️ Image field "${fieldName}" has no imageId, skipping`);
+      try {
+        const blankName = await uploadBlankWhitePngToComfyUI(serverUrl, blankCache);
+        uploadedImageMap[fieldName] = blankName;
+        console.log(`🔳 Image field "${fieldName}" empty, injected blank white PNG: ${blankName}`);
+      } catch (error) {
+        console.error(`❌ Failed to inject blank PNG for field "${fieldName}":`, error.message);
+      }
       continue;
     }
-    
+
     try {
       console.log(`🔍 Looking up image for field "${fieldName}": ${imageId}`);
-      
+
       // 이미지 정보 조회 (GeneratedImage 또는 UploadedImage)
       const imageDoc = await findImageDocumentById(imageId);
-      
+
       if (!imageDoc) {
         console.warn(`⚠️ Image not found for field "${fieldName}": ${imageId}`);
         continue;
       }
-      
+
       // 이미지 파일 읽기
       const imagePath = imageDoc.path;
       if (!fs.existsSync(imagePath)) {
         console.warn(`⚠️ Image file not found: ${imagePath}`);
         continue;
       }
-      
+
       const imageBuffer = await fs.promises.readFile(imagePath);
       const filename = `vcc_${fieldName}_${Date.now()}_${path.basename(imagePath)}`;
-      
+
       // ComfyUI에 업로드
       const uploadResult = await comfyUIService.uploadImage(serverUrl, imageBuffer, filename);
-      
+
       // 업로드된 파일명 저장
       uploadedImageMap[fieldName] = uploadResult.name;
       console.log(`✅ Uploaded image for field "${fieldName}": ${uploadResult.name}`);
-      
+
     } catch (error) {
       console.error(`❌ Failed to upload image for field "${fieldName}":`, error.message);
     }
   }
-  
+
   return uploadedImageMap;
 };
 

--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -393,19 +393,30 @@ const loadImageInputs = async (additionalInputFields, inputData) => {
   return loadedImages;
 };
 
-// 미첨부 이미지 필드용 1024x1024 흰색 PNG 를 메모리 상에서 생성하여 ComfyUI 에 업로드.
-// ComfyUI 의 LoadImage 노드는 입력이 없으면 워크플로우 실행 자체가 실패하므로 placeholder 주입 필요 (#230).
-// 동일 잡 내 여러 빈 이미지 필드가 있을 경우 1회 업로드 후 재사용 (cache 인자로 전달).
+// 1024x1024 흰색 PNG 의 메모리 캐시. 첫 호출에서만 sharp 가 raw 픽셀 buffer (~3MB) 를 일시
+// 할당하고, 이후엔 캐시된 PNG 버퍼 (5.3KB) 만 재사용. 동시성 N 잡일 때 raw buffer peak 가
+// N 배로 증폭되는 위험을 차단.
+let blankWhitePngBuffer = null;
+const getBlankWhitePngBuffer = async () => {
+  if (!blankWhitePngBuffer) {
+    blankWhitePngBuffer = await sharp({
+      create: {
+        width: 1024,
+        height: 1024,
+        channels: 3,
+        background: { r: 255, g: 255, b: 255 },
+      },
+    }).png().toBuffer();
+  }
+  return blankWhitePngBuffer;
+};
+
+// 미첨부 이미지 필드용 1024x1024 흰색 PNG 를 ComfyUI 에 업로드 (#230).
+// ComfyUI 의 LoadImage 노드는 입력이 없으면 워크플로우 실행 자체가 실패하므로 placeholder 주입 필요.
+// 동일 잡 내 여러 빈 이미지 필드는 1회 업로드 후 재사용 (cache 인자로 전달).
 const uploadBlankWhitePngToComfyUI = async (serverUrl, cache) => {
   if (cache.blankFilename) return cache.blankFilename;
-  const buffer = await sharp({
-    create: {
-      width: 1024,
-      height: 1024,
-      channels: 3,
-      background: { r: 255, g: 255, b: 255 },
-    },
-  }).png().toBuffer();
+  const buffer = await getBlankWhitePngBuffer();
   const filename = `vcc_blank_white_${Date.now()}.png`;
   const uploadResult = await comfyUIService.uploadImage(serverUrl, buffer, filename);
   cache.blankFilename = uploadResult.name;


### PR DESCRIPTION
## Summary
ComfyUI 의 LoadImage 노드는 입력 이미지가 없으면 워크플로우 실행 자체가 실패 (조건부 분기로도 회피 불가). 작업판의 이미지 입력을 옵션처럼 다루기 위해 미첨부 시 1024x1024 흰색 PNG placeholder 를 자동 주입.

## 변경
### 백엔드
- `queueService.uploadImageFieldsToComfyUI` 가 빈 image 필드에 대해 \`sharp\` 로 1024x1024 흰색 PNG 를 메모리 상에서 생성·ComfyUI 에 업로드
- 동일 잡 내 여러 빈 필드는 1회 업로드 후 재사용 (`blankCache` 로 잡 단위 캐싱)
- 처리 케이스: `imageId` 부재 / 빈 배열 / 미입력 모두 동일하게 placeholder 주입

### 프론트엔드
- `CustomImageField` 가 `isComfyUI` prop 받아 ComfyUI 작업판일 경우 dropzone 하단에 "미첨부 시 1024×1024 흰색 이미지가 자동으로 사용됩니다" 안내 표시

## 후속 (v2.0)
\`#199\` 작업판 customFields 일반화 단계에서 admin 이 흰색 외 다른 placeholder (검정 / 투명 / 특정 패턴) 를 image 필드 별로 지정할 수 있도록 확장 예정.

## Test plan
- [x] frontend / backend Docker build 성공
- [x] backend `/health` 200
- [ ] ComfyUI 작업판: 이미지 필드 비워두고 생성 요청 → 흰색 placeholder 로 워크플로우 실행 (이전: 에러)
- [ ] ComfyUI 작업판: 이미지 첨부하고 생성 요청 → 정상 동작 (회귀 없음)
- [ ] 동일 잡 내 빈 image 필드 2개 이상이면 ComfyUI 업로드는 1회만 수행 (로그 확인)
- [ ] OpenAI / Gemini / OpenAI Compatible 작업판 영향 없음 (해당 함수 호출 안 됨)
- [ ] ComfyUI 작업판 사용자 폼에 안내 텍스트 노출, 비-ComfyUI 작업판은 미노출

closes #230