### PR TITLE
fix: 서버 목록 useQuery 키 통일 — 캐시 공유 (#233)

### DIFF
--- a/frontend/src/components/admin/ServerManagement.js
+++ b/frontend/src/components/admin/ServerManagement.js
@@ -458,9 +458,9 @@ function ServerManagement() {
 
   const queryClient = useQueryClient();
 
-  // 서버 목록 조회
+  // 서버 목록 조회 (admin: 비활성 포함)
   const { data: serversData, isLoading } = useQuery(
-    ['servers'],
+    ['servers', { includeInactive: true }],
     () => serverAPI.getServers({ includeInactive: true }),
     { refetchInterval: 30000 } // 30초마다 갱신
   );

--- a/frontend/src/components/admin/WorkboardBasicInfoForm.js
+++ b/frontend/src/components/admin/WorkboardBasicInfoForm.js
@@ -25,8 +25,8 @@ function WorkboardBasicInfoForm({ control, setValue, errors, showActiveSwitch = 
   const outputFormat = useWatch({ control, name: 'outputFormat' }) || 'image';
 
   const { data: serversData } = useQuery(
-    'servers-all-active',
-    () => serverAPI.getServers({}),
+    ['servers', { includeInactive: false }],
+    () => serverAPI.getServers({ includeInactive: false }),
     { enabled: isDialogOpen }
   );
 

--- a/frontend/src/pages/LoraList.js
+++ b/frontend/src/pages/LoraList.js
@@ -498,7 +498,7 @@ function LoraList() {
 
   // ComfyUI 서버 목록 조회
   const { data: serversData, isLoading: serversLoading } = useQuery(
-    ['servers'],
+    ['servers', { includeInactive: false }],
     () => serverAPI.getServers({ includeInactive: false }),
     {
       onSuccess: (data) => {

--- a/frontend/src/pages/admin/LoraManagementPage.js
+++ b/frontend/src/pages/admin/LoraManagementPage.js
@@ -509,7 +509,7 @@ function LoraManagementPage() {
 
   // ComfyUI 서버 목록 조회
   const { data: serversData, isLoading: serversLoading } = useQuery(
-    ['servers'],
+    ['servers', { includeInactive: false }],
     () => serverAPI.getServers({ includeInactive: false }),
     {
       onSuccess: (data) => {


### PR DESCRIPTION
## Summary
서버 목록을 사용하는 4개 컴포넌트의 \`useQuery\` 키가 통일되지 않아 페이지 간 캐시 공유가 안 되고 캐시 미스가 잦던 문제 수정.

## Before
| 파일 | 키 | 파라미터 |
| --- | --- | --- |
| `WorkboardBasicInfoForm` | `'servers-all-active'` | `{}` |
| `ServerManagement` | `['servers']` | `{ includeInactive: true }` |
| `LoraList` | `['servers']` | `{ includeInactive: false }` |
| `LoraManagementPage` | `['servers']` | `{ includeInactive: false }` |

문제:
1. `WorkboardBasicInfoForm` 만 별도 키라 다른 페이지의 캐시를 공유 못 함 → 작업판 다이얼로그 열 때마다 fetch
2. 나머지 셋은 같은 `['servers']` 키지만 파라미터가 달라 admin 의 invalidate 가 일반 사용자 캐시를 어떻게 처리할지 불분명

## After
React Query 의 표준 패턴 — 키에 파라미터 포함:
- `WorkboardBasicInfoForm`: `['servers', { includeInactive: false }]`
- `LoraList` / `LoraManagementPage`: `['servers', { includeInactive: false }]`
- `ServerManagement`: `['servers', { includeInactive: true }]`

\`invalidateQueries(['servers'])\` 는 React Query v3 의 prefix 매칭으로 두 변종 모두 무효화 → 서버 관리에서 mutate 시 다른 페이지 캐시도 자동 갱신.

## 효과
- 작업판 추가/편집 다이얼로그가 LoRA 페이지의 서버 캐시를 공유 (작업판 다이얼로그 열기 → 서버 fetch 안 함)
- admin 서버 관리에서 변경 시 자동으로 사용자 측 캐시도 invalidate

## Test plan
- [x] frontend Docker build 성공, HTTP 200
- [ ] LoRA 페이지 → 작업판 관리 → "추가" 다이얼로그: 네트워크 패널에서 `/servers` 추가 호출 없는지 확인
- [ ] 서버 관리에서 서버 수정 → 작업판 다이얼로그가 갱신된 목록 사용

closes #233