### PR TITLE
fix: 사용자 작업판 / WorkboardSelectDialog / serverType 색상 (#235)

### DIFF
--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -59,6 +59,7 @@ import {
   deriveLegacyApiFormat,
   getServerTypeLabel,
   getOutputFormatLabel,
+  getServerTypeColor,
 } from '../../templates/capabilities';
 
 function WorkboardCard({ workboard, onEdit, onDelete, onDuplicate, onExport, onView, onToggleActive }) {
@@ -71,20 +72,6 @@ function WorkboardCard({ workboard, onEdit, onDelete, onDuplicate, onExport, onV
     if (!serverType) return outputLabel;
     return `${serverType} · ${outputLabel}`;
   };
-  const getServerTypeColor = (serverType) => {
-    switch (serverType) {
-      case 'OpenAI':
-      case 'OpenAI Compatible':
-        return 'secondary';
-      case 'Gemini':
-        return 'info';
-      case 'ComfyUI':
-        return 'primary';
-      default:
-        return 'default';
-    }
-  };
-
   const handleMenuOpen = (event) => {
     setAnchorEl(event.currentTarget);
   };

--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -155,8 +155,8 @@ function WorkboardCard({ workboard, onEdit, onDelete, onDuplicate, onExport, onV
         <Box display="flex" flexWrap="wrap" gap={1} mb={2}>
           <Chip
             label={getWorkboardChipLabel(workboard)}
-            color={getServerTypeColor(workboard.serverId?.serverType)}
             size="small"
+            sx={{ bgcolor: getServerTypeColor(workboard.serverId?.serverType), color: 'white' }}
           />
           <Chip
             label={workboard.isActive ? '활성' : '비활성'}

--- a/frontend/src/components/common/WorkboardSelectDialog.js
+++ b/frontend/src/components/common/WorkboardSelectDialog.js
@@ -17,13 +17,16 @@ import { useQuery } from 'react-query';
 import { workboardAPI } from '../../services/api';
 
 function WorkboardSelectDialog({ open, onClose, onSelect }) {
+  // 본 다이얼로그는 image / video 작업판으로 다른 작업판 이어가기 용. text 작업판은 제외.
+  // 백엔드 limit max 50 으로 한 번에 가능한 많이 가져오고 클라이언트에서 outputFormat 필터.
   const { data, isLoading } = useQuery(
-    ['workboards'],
-    () => workboardAPI.getAll({ isActive: true }),
+    ['workboards', { limit: 50, isActive: true }],
+    () => workboardAPI.getAll({ isActive: true, limit: 50 }),
     { enabled: open }
   );
 
-  const workboards = data?.data?.workboards || [];
+  const allWorkboards = data?.data?.workboards || [];
+  const workboards = allWorkboards.filter((wb) => (wb.outputFormat || 'image') !== 'text');
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>

--- a/frontend/src/pages/Workboards.js
+++ b/frontend/src/pages/Workboards.js
@@ -36,6 +36,11 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useQuery } from 'react-query';
 import { workboardAPI, userAPI, projectAPI } from '../services/api';
 import toast from 'react-hot-toast';
+import {
+  getServerTypeLabel as getServerTypeLabelShared,
+  getServerTypeColor,
+  getOutputFormatLabel as getOutputFormatLabelShared,
+} from '../templates/capabilities';
 
 
 function WorkboardCard({ workboard, projectId }) {
@@ -91,25 +96,8 @@ function WorkboardCard({ workboard, projectId }) {
     }
   };
 
-  const getOutputFormatLabel = (format) => {
-    switch (format) {
-      case 'image': return '이미지';
-      case 'video': return '비디오';
-      case 'text': return '텍스트';
-      default: return format;
-    }
-  };
-
-  const getServerTypeLabel = (serverType) => {
-    switch (serverType) {
-      case 'ComfyUI': return 'ComfyUI';
-      case 'OpenAI': return 'OpenAI';
-      case 'OpenAI Compatible': return 'OpenAI Compatible';
-      case 'Gemini': return 'Gemini';
-      case 'GPT Image': return 'GPT Image (deprecated)';
-      default: return serverType || '서버 미설정';
-    }
-  };
+  const getOutputFormatLabel = (format) => getOutputFormatLabelShared(format);
+  const getServerTypeLabel = (serverType) => getServerTypeLabelShared(serverType) || '서버 미설정';
 
   return (
     <>
@@ -157,7 +145,7 @@ function WorkboardCard({ workboard, projectId }) {
             <Chip
               label={getServerTypeLabel(workboard.serverId?.serverType)}
               size="small"
-              variant="outlined"
+              color={getServerTypeColor(workboard.serverId?.serverType)}
             />
           </Box>
 
@@ -228,7 +216,7 @@ function WorkboardCard({ workboard, projectId }) {
             <Chip
               label={getServerTypeLabel(workboard.serverId?.serverType)}
               size="small"
-              variant="outlined"
+              color={getServerTypeColor(workboard.serverId?.serverType)}
             />
           </Box>
 
@@ -341,8 +329,8 @@ function Workboards() {
   const [outputFormat, setOutputFormat] = useState(
     () => localStorage.getItem('workboardFilter_outputFormat') || ''
   );
-  const [apiFormat, setApiFormat] = useState(
-    () => localStorage.getItem('workboardFilter_apiFormat') || ''
+  const [serverType, setServerType] = useState(
+    () => localStorage.getItem('workboardFilter_serverType') || ''
   );
 
   // 프로젝트 컨텍스트
@@ -368,14 +356,16 @@ function Workboards() {
       localStorage.removeItem('workboardFilter_outputFormat');
     }
     if (prefs.resetWorkboardApiFormat) {
-      setApiFormat('');
+      setServerType('');
+      localStorage.removeItem('workboardFilter_serverType');
+      // legacy 키 정리
       localStorage.removeItem('workboardFilter_apiFormat');
     }
   }, [profileData]);
 
   const queryParams = { search, page, limit: 12 };
   if (outputFormat) queryParams.outputFormat = outputFormat;
-  if (apiFormat) queryParams.apiFormat = apiFormat;
+  if (serverType) queryParams.serverType = serverType;
 
   const { data, isLoading, error } = useQuery(
     ['workboards', queryParams],
@@ -402,14 +392,14 @@ function Workboards() {
     }
   };
 
-  const handleApiFormatChange = (event) => {
+  const handleServerTypeChange = (event) => {
     const value = event.target.value;
-    setApiFormat(value);
+    setServerType(value);
     setPage(1);
     if (value) {
-      localStorage.setItem('workboardFilter_apiFormat', value);
+      localStorage.setItem('workboardFilter_serverType', value);
     } else {
-      localStorage.removeItem('workboardFilter_apiFormat');
+      localStorage.removeItem('workboardFilter_serverType');
     }
   };
 
@@ -470,18 +460,18 @@ function Workboards() {
             <MenuItem value="text">텍스트</MenuItem>
           </Select>
         </FormControl>
-        <FormControl sx={{ minWidth: 200 }} size="small">
-          <InputLabel>AI API 형식</InputLabel>
+        <FormControl sx={{ minWidth: 180 }} size="small">
+          <InputLabel>서버 타입</InputLabel>
           <Select
-            value={apiFormat}
-            onChange={handleApiFormatChange}
-            label="AI API 형식"
+            value={serverType}
+            onChange={handleServerTypeChange}
+            label="서버 타입"
           >
             <MenuItem value="">전체</MenuItem>
             <MenuItem value="ComfyUI">ComfyUI</MenuItem>
+            <MenuItem value="OpenAI">OpenAI</MenuItem>
             <MenuItem value="OpenAI Compatible">OpenAI Compatible</MenuItem>
             <MenuItem value="Gemini">Gemini</MenuItem>
-            <MenuItem value="GPT Image">GPT Image (deprecated)</MenuItem>
           </Select>
         </FormControl>
       </Box>
@@ -493,7 +483,7 @@ function Workboards() {
         </Box>
       ) : workboards.length === 0 ? (
         <Alert severity="info">
-          {search || outputFormat || apiFormat ? '검색 결과가 없습니다.' : '사용 가능한 작업판이 없습니다.'}
+          {search || outputFormat || serverType ? '검색 결과가 없습니다.' : '사용 가능한 작업판이 없습니다.'}
         </Alert>
       ) : (
         <>

--- a/frontend/src/pages/Workboards.js
+++ b/frontend/src/pages/Workboards.js
@@ -145,7 +145,7 @@ function WorkboardCard({ workboard, projectId }) {
             <Chip
               label={getServerTypeLabel(workboard.serverId?.serverType)}
               size="small"
-              color={getServerTypeColor(workboard.serverId?.serverType)}
+              sx={{ bgcolor: getServerTypeColor(workboard.serverId?.serverType), color: 'white' }}
             />
           </Box>
 
@@ -216,7 +216,7 @@ function WorkboardCard({ workboard, projectId }) {
             <Chip
               label={getServerTypeLabel(workboard.serverId?.serverType)}
               size="small"
-              color={getServerTypeColor(workboard.serverId?.serverType)}
+              sx={{ bgcolor: getServerTypeColor(workboard.serverId?.serverType), color: 'white' }}
             />
           </Box>
 

--- a/frontend/src/templates/capabilities.js
+++ b/frontend/src/templates/capabilities.js
@@ -35,17 +35,18 @@ export function getServerTypeLabel(serverType) {
   return SERVER_TYPE_LABELS[serverType] || serverType;
 }
 
-// MUI Chip color 매핑. 4개 serverType 이 distinct 한 색을 갖도록.
+// 4 serverType 별 distinct hex. brand-친화적 색상 사용 (시맨틱 컬러와 분리).
+// chip 은 클릭/disabled 처리 없는 표시용이라 hover state 미고려.
 const SERVER_TYPE_COLORS = {
-  ComfyUI: 'primary',
-  OpenAI: 'error',
-  'OpenAI Compatible': 'success',
-  Gemini: 'warning',
-  'GPT Image': 'default',
+  ComfyUI: '#7e57c2',          // 보라 — 서드파티/오픈소스 느낌
+  OpenAI: '#10a37f',           // OpenAI brand teal
+  'OpenAI Compatible': '#607d8b', // 회색-파랑 — 호환 레이어
+  Gemini: '#4285f4',           // Google blue
+  'GPT Image': '#9e9e9e',      // deprecated — 회색
 };
 
 export function getServerTypeColor(serverType) {
-  return SERVER_TYPE_COLORS[serverType] || 'default';
+  return SERVER_TYPE_COLORS[serverType] || '#9e9e9e';
 }
 
 // (server, outputFormat) → workboard schema 의 apiFormat 으로 매핑.

--- a/frontend/src/templates/capabilities.js
+++ b/frontend/src/templates/capabilities.js
@@ -35,6 +35,19 @@ export function getServerTypeLabel(serverType) {
   return SERVER_TYPE_LABELS[serverType] || serverType;
 }
 
+// MUI Chip color 매핑. 4개 serverType 이 distinct 한 색을 갖도록.
+const SERVER_TYPE_COLORS = {
+  ComfyUI: 'primary',
+  OpenAI: 'error',
+  'OpenAI Compatible': 'success',
+  Gemini: 'warning',
+  'GPT Image': 'default',
+};
+
+export function getServerTypeColor(serverType) {
+  return SERVER_TYPE_COLORS[serverType] || 'default';
+}
+
 // (server, outputFormat) → workboard schema 의 apiFormat 으로 매핑.
 // Phase 6 에서 apiFormat 필드가 제거되면 이 매핑도 함께 사라짐.
 const SERVER_OUTPUT_TO_LEGACY_APIFORMAT = {


### PR DESCRIPTION
## Summary
v1.8.0 (server, outputFormat) 캐피빌리티 모델 도입 후 잔여 UI 정리 — 3건 일괄.

### 1. JobHistory "다른 작업" 다이얼로그 (`WorkboardSelectDialog`)
- `workboardAPI.getAll({ isActive: true })` 만 호출 → 백엔드 default `limit=10` 이라 작업판 많을 때 image/video 일부 (Gemini Image / GPT Image 등) 누락
- 텍스트 출력 작업판은 본 다이얼로그에서 의미 없음
- **수정**: `limit=50` + 클라이언트 측 `outputFormat !== 'text'` 필터

### 2. 사용자 작업판 페이지 (`Workboards.js`) "AI API 형식" 필터
- 옵션이 legacy enum (`OpenAI Compatible`, `Gemini`, `GPT Image (deprecated)`, `ComfyUI`) — `OpenAI` 누락
- **수정**: 라벨 "AI API 형식" → "서버 타입", 옵션 4종 (`ComfyUI` / `OpenAI` / `OpenAI Compatible` / `Gemini`), localStorage 키 `workboardFilter_apiFormat` → `workboardFilter_serverType`, 백엔드는 v1.8.4 (#229) 의 `serverType` query 사용
- 인라인 `getServerTypeLabel` / `getOutputFormatLabel` switch 제거 → `templates/capabilities` 공유 함수 사용

### 3. serverType 별 distinct 색상
- 기존 `getServerTypeColor` 가 admin 한정 + OpenAI / OpenAI Compatible 가 같은 색
- **수정**:
  - `capabilities.js` 에 `getServerTypeColor` 신규 — 4종 distinct (`ComfyUI=primary`, `OpenAI=error`, `OpenAI Compatible=success`, `Gemini=warning`)
  - admin `WorkboardManagement` 의 로컬 함수 제거 → 공유 import
  - 사용자 `Workboards.js` 의 server type chip 도 색상 적용 (`variant="outlined"` → `color=getServerTypeColor(...)`)

## Test plan
- [x] frontend Docker build 성공, HTTP 200
- [ ] JobHistory > "다른 작업" 다이얼로그: image/video 작업판 모두 노출 (Gemini Image / OpenAI Image 포함), text 제외
- [ ] 사용자 작업판 페이지 필터 라벨 "서버 타입" + 4종 옵션 정상
- [ ] admin / 사용자 양쪽에서 4종 serverType chip 가 distinct 색상

closes #235