### PR TITLE
fix: 텍스트 생성 timeout 이 서버 설정 무시 + nginx 60초 default (#238)

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -24,6 +24,10 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_cache_bypass $http_upgrade;
+        # 로컬 LLM / 긴 추론 요청을 위해 nginx 기본 60초 → 5분으로 확장.
+        # 텍스트 생성 (prompt-generate) 이 Bull queue 미사용으로 sync 응답 대기.
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
     }
 
     # Block direct access to uploads — all media served via signed URLs (/api/files/*)

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -419,7 +419,7 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
       server.serverUrl,
       server.configuration?.apiKey,
       messages,
-      { model, temperature, maxTokens, timeout: 60000 }
+      { model, temperature, maxTokens, timeout: server.configuration?.timeout || 60000 }
     );
 
     await workboard.incrementUsage();


### PR DESCRIPTION
## Summary
로컬 LLM 서버 (configuration.timeout=300000) 로 텍스트 워크보드 실행 시 60초 후 504 발생하던 문제. 백엔드 라우트의 하드코딩된 60초 + nginx default 60초 조합.

## 변경
### `src/routes/jobs.js`
- prompt-generate 라우트가 `chatService.complete(..., { timeout: 60000 })` 으로 하드코딩 → 서버 모델의 `configuration.timeout` 을 읽지 않던 버그 수정
- `timeout: server.configuration?.timeout || 60000` 으로 변경

### `nginx.conf`
- `/api` location 에 `proxy_read_timeout 300s` + `proxy_send_timeout 300s` 추가 (default 60초)
- 텍스트 생성이 Bull queue 미사용으로 sync 응답 대기 — nginx 가 먼저 끊어버리면 백엔드 타임아웃 늘려도 무의미

## 장기 (별도, v2.0)
텍스트 생성도 Bull queue 로 비동기화 + 작업 히스토리 적재. nginx 타임아웃 제약 완전 무관해짐. #201 v2.0 트래킹 코멘트로 추가됨.

## Test plan
- [x] frontend / backend Docker build 성공, /health 200
- [ ] 서버 모델 timeout=300000 설정 후 로컬 LLM 텍스트 생성 시 60초 이후에도 응답 받음
- [ ] 일반 OpenAI / Gemini 텍스트 생성 (빠른 응답) 회귀 없음
- [ ] image / video 생성 (Bull queue 사용) 영향 없음

closes #238