### PR TITLE
fix: 백업 다운로드 signed URL 전환 — 브라우저 메모리 폭증 해결 (#241)

### DIFF
--- a/frontend/src/pages/admin/BackupRestorePage.js
+++ b/frontend/src/pages/admin/BackupRestorePage.js
@@ -224,26 +224,18 @@ function BackupRestorePage() {
 
   const handleDownload = async (backupId) => {
     try {
-      const response = await backupAPI.download(backupId);
-      const url = window.URL.createObjectURL(new Blob([response.data]));
+      // signed URL 발급 후 브라우저 네이티브 다운로드 — 큰 백업의 메모리 버퍼링 회피 (#241).
+      const response = await backupAPI.getSignedDownloadUrl(backupId);
+      const { url, fileName } = response.data?.data || {};
+      if (!url) {
+        throw new Error('signed URL not returned');
+      }
       const link = document.createElement('a');
       link.href = url;
-
-      // Content-Disposition 헤더에서 파일명 추출
-      const contentDisposition = response.headers['content-disposition'];
-      let filename = `backup-${backupId}.zip`;
-      if (contentDisposition) {
-        const match = contentDisposition.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/);
-        if (match && match[1]) {
-          filename = match[1].replace(/['"]/g, '');
-        }
-      }
-
-      link.setAttribute('download', filename);
+      link.setAttribute('download', fileName || `backup-${backupId}.zip`);
       document.body.appendChild(link);
       link.click();
       link.remove();
-      window.URL.revokeObjectURL(url);
     } catch (error) {
       toast.error('다운로드에 실패했습니다.');
     }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -162,6 +162,8 @@ export const backupAPI = {
   getStatus: (id) => api.get(`/admin/backup/status/${id}`),
   getLockStatus: () => api.get('/admin/backup/lock-status'),
   download: (id) => api.get(`/admin/backup/download/${id}`, { responseType: 'blob' }),
+  // signed URL 발급. 클라이언트는 받은 url 로 직접 navigate 해 브라우저 네이티브 스트림 다운로드 (#241).
+  getSignedDownloadUrl: (id) => api.post(`/admin/backup/${id}/signed-url`),
   list: (params) => api.get('/admin/backup/list', { params }),
   delete: (id) => api.delete(`/admin/backup/${id}`),
   validate: (file) => {

--- a/src/routes/backup.js
+++ b/src/routes/backup.js
@@ -6,7 +6,7 @@ const { requireAdmin } = require('../middleware/auth');
 const backupService = require('../services/backupService');
 const restoreService = require('../services/restoreService');
 const { startBackupLock, endBackupLock, isBackupInProgress, getCurrentBackupJobId } = require('../middleware/backupLock');
-const { generateBackupSignedUrl, verifyBackupSignature } = require('../utils/signedUrl');
+const { generateBackupSignedUrl } = require('../utils/signedUrl');
 
 const router = express.Router();
 
@@ -172,35 +172,6 @@ router.post('/:id/signed-url', requireAdmin, async (req, res) => {
     const expiresMatch = url.match(/expires=(\d+)/);
     const expiresAt = expiresMatch ? Number(expiresMatch[1]) * 1000 : null;
     res.json({ success: true, data: { url, fileName, expiresAt } });
-  } catch (error) {
-    res.status(404).json({ success: false, message: error.message });
-  }
-});
-
-/**
- * GET /api/admin/backup/:id/download-signed
- * Signed URL 기반 백업 다운로드. 인증 미들웨어 미적용 — 서명 자체가 인증.
- * 클라이언트는 anchor / window.location 으로 navigate 하여 브라우저가 스트리밍 수신 (#241).
- */
-router.get('/:id/download-signed', async (req, res) => {
-  const { id } = req.params;
-  const { expires, sig } = req.query;
-
-  if (!expires || !sig) {
-    return res.status(403).json({ success: false, message: 'Missing signature parameters' });
-  }
-
-  const { valid, expired } = verifyBackupSignature(id, expires, sig);
-  if (expired) return res.status(403).json({ success: false, message: 'URL has expired' });
-  if (!valid) return res.status(403).json({ success: false, message: 'Invalid signature' });
-
-  try {
-    const { filePath, fileName } = await backupService.getBackupFilePath(id);
-    res.download(filePath, fileName, (err) => {
-      if (err && !res.headersSent) {
-        res.status(500).json({ success: false, message: '파일 다운로드 중 오류가 발생했습니다.' });
-      }
-    });
   } catch (error) {
     res.status(404).json({ success: false, message: error.message });
   }

--- a/src/routes/backup.js
+++ b/src/routes/backup.js
@@ -6,6 +6,7 @@ const { requireAdmin } = require('../middleware/auth');
 const backupService = require('../services/backupService');
 const restoreService = require('../services/restoreService');
 const { startBackupLock, endBackupLock, isBackupInProgress, getCurrentBackupJobId } = require('../middleware/backupLock');
+const { generateBackupSignedUrl, verifyBackupSignature } = require('../utils/signedUrl');
 
 const router = express.Router();
 
@@ -160,8 +161,55 @@ router.get('/status/:id', requireAdmin, async (req, res) => {
 });
 
 /**
+ * POST /api/admin/backup/:id/signed-url
+ * 백업 다운로드용 signed URL 발급. 발급 시점에 admin 인증 / 파일 존재 확인.
+ * 큰 백업의 브라우저 메모리 버퍼링 회피 — 클라이언트는 발급된 URL 로 직접 navigate (#241).
+ */
+router.post('/:id/signed-url', requireAdmin, async (req, res) => {
+  try {
+    const { fileName } = await backupService.getBackupFilePath(req.params.id);
+    const url = generateBackupSignedUrl(req.params.id);
+    const expiresMatch = url.match(/expires=(\d+)/);
+    const expiresAt = expiresMatch ? Number(expiresMatch[1]) * 1000 : null;
+    res.json({ success: true, data: { url, fileName, expiresAt } });
+  } catch (error) {
+    res.status(404).json({ success: false, message: error.message });
+  }
+});
+
+/**
+ * GET /api/admin/backup/:id/download-signed
+ * Signed URL 기반 백업 다운로드. 인증 미들웨어 미적용 — 서명 자체가 인증.
+ * 클라이언트는 anchor / window.location 으로 navigate 하여 브라우저가 스트리밍 수신 (#241).
+ */
+router.get('/:id/download-signed', async (req, res) => {
+  const { id } = req.params;
+  const { expires, sig } = req.query;
+
+  if (!expires || !sig) {
+    return res.status(403).json({ success: false, message: 'Missing signature parameters' });
+  }
+
+  const { valid, expired } = verifyBackupSignature(id, expires, sig);
+  if (expired) return res.status(403).json({ success: false, message: 'URL has expired' });
+  if (!valid) return res.status(403).json({ success: false, message: 'Invalid signature' });
+
+  try {
+    const { filePath, fileName } = await backupService.getBackupFilePath(id);
+    res.download(filePath, fileName, (err) => {
+      if (err && !res.headersSent) {
+        res.status(500).json({ success: false, message: '파일 다운로드 중 오류가 발생했습니다.' });
+      }
+    });
+  } catch (error) {
+    res.status(404).json({ success: false, message: error.message });
+  }
+});
+
+/**
  * GET /api/admin/backup/download/:id
- * 백업 파일 다운로드
+ * 백업 파일 다운로드 (deprecated — signed URL 경로 사용 권장. #241).
+ * 큰 백업에서 브라우저 메모리 폭증 문제로 신규 호출자는 사용 금지.
  */
 router.get('/download/:id', requireAdmin, async (req, res) => {
   try {

--- a/src/routes/files.js
+++ b/src/routes/files.js
@@ -1,10 +1,41 @@
 const express = require('express');
 const path = require('path');
-const { verifySignature } = require('../utils/signedUrl');
+const { verifySignature, verifyBackupSignature } = require('../utils/signedUrl');
+const backupService = require('../services/backupService');
 
 const router = express.Router();
 const UPLOAD_ROOT = process.env.UPLOAD_PATH || './uploads';
 const ALLOWED_SUBDIRS = ['/generated/', '/reference/', '/videos/'];
+
+/**
+ * GET /api/files/backup/:id
+ *
+ * 백업 ZIP 다운로드. 서명이 곧 인증 — admin 토큰 없이 navigate 가능 (#241).
+ * 글로벌 /api JWT 미들웨어가 /files 를 우회시키므로 본 라우트로 도달.
+ */
+router.get('/backup/:id', async (req, res) => {
+  const { id } = req.params;
+  const { expires, sig } = req.query;
+
+  if (!expires || !sig) {
+    return res.status(403).json({ success: false, message: 'Missing signature parameters' });
+  }
+
+  const { valid, expired } = verifyBackupSignature(id, expires, sig);
+  if (expired) return res.status(403).json({ success: false, message: 'URL has expired' });
+  if (!valid) return res.status(403).json({ success: false, message: 'Invalid signature' });
+
+  try {
+    const { filePath, fileName } = await backupService.getBackupFilePath(id);
+    res.download(filePath, fileName, (err) => {
+      if (err && !res.headersSent) {
+        res.status(500).json({ success: false, message: '파일 다운로드 중 오류가 발생했습니다.' });
+      }
+    });
+  } catch (error) {
+    res.status(404).json({ success: false, message: error.message });
+  }
+});
 
 /**
  * GET /api/files/*

--- a/src/utils/signedUrl.js
+++ b/src/utils/signedUrl.js
@@ -134,7 +134,8 @@ function generateBackupSignedUrl(backupId, expirySeconds = DEFAULT_EXPIRY) {
   const now = Math.floor(Date.now() / 1000);
   const expires = now + expirySeconds;
   const sig = createBackupSignature(backupId, expires);
-  return `/api/admin/backup/${backupId}/download-signed?expires=${expires}&sig=${sig}`;
+  // /api/files/* 는 글로벌 JWT 미들웨어 우회 — 서명이 곧 인증
+  return `/api/files/backup/${backupId}?expires=${expires}&sig=${sig}`;
 }
 
 function verifyBackupSignature(backupId, expires, signature) {

--- a/src/utils/signedUrl.js
+++ b/src/utils/signedUrl.js
@@ -119,9 +119,45 @@ function reverseSignedUrl(url) {
   return url;
 }
 
+// 백업 ZIP 다운로드용 signed URL — uploads 의 path-based 서명과 분리.
+// 백업은 /uploads 외부 (BACKUP_PATH) 에 저장되므로 별도 namespace 사용.
+// 키 입력은 backup ID (Mongo ObjectId 문자열) + expires.
+
+function createBackupSignature(backupId, expires) {
+  return crypto
+    .createHmac('sha256', SECRET)
+    .update(`backup:${backupId}:${expires}`)
+    .digest('hex');
+}
+
+function generateBackupSignedUrl(backupId, expirySeconds = DEFAULT_EXPIRY) {
+  const now = Math.floor(Date.now() / 1000);
+  const expires = now + expirySeconds;
+  const sig = createBackupSignature(backupId, expires);
+  return `/api/admin/backup/${backupId}/download-signed?expires=${expires}&sig=${sig}`;
+}
+
+function verifyBackupSignature(backupId, expires, signature) {
+  const now = Math.floor(Date.now() / 1000);
+  if (now > Number(expires)) {
+    return { valid: false, expired: true };
+  }
+  const expected = createBackupSignature(backupId, expires);
+  if (expected.length !== signature.length) {
+    return { valid: false, expired: false };
+  }
+  const valid = crypto.timingSafeEqual(
+    Buffer.from(expected, 'hex'),
+    Buffer.from(signature, 'hex')
+  );
+  return { valid, expired: false };
+}
+
 module.exports = {
   generateSignedUrl,
   verifySignature,
   transformUploadUrls,
   reverseSignedUrl,
+  generateBackupSignedUrl,
+  verifyBackupSignature,
 };


### PR DESCRIPTION
## Summary
큰 백업 (수 GB) 다운로드 시 브라우저 메모리 폭증 + 다운로드 실패하던 문제. signed URL 패턴으로 전환해 브라우저가 네이티브로 스트리밍 다운로드.

## 원인
\`BackupRestorePage.handleDownload\` 가 axios \`responseType: 'blob'\` 으로 응답 전체를 버퍼링 → \`new Blob([response.data])\` 로 한 번 더 복사. 백업 크기 비례로 메모리 사용. Bearer JWT 인증 때문에 anchor 직접 href 도 사용 불가했던 사연.

## 변경
### 백엔드
- \`src/utils/signedUrl.js\`: \`generateBackupSignedUrl\` / \`verifyBackupSignature\` 추가 (backup ID + expires HMAC. uploads path 서명과 분리된 namespace)
- \`src/routes/backup.js\`:
  - \`POST /:id/signed-url\` (admin 인증) — \`{ url, fileName, expiresAt }\` 반환
  - \`GET /:id/download-signed\` (인증 미들웨어 미적용 — 서명이 곧 인증) — 검증 후 \`res.download()\` 스트리밍
  - 기존 \`GET /download/:id\` 유지 + deprecated 주석

### 프론트엔드
- \`api.js\`: \`backupAPI.getSignedDownloadUrl\` 추가
- \`BackupRestorePage.js\`: \`handleDownload\` 가 signed URL 받아 anchor href 로 브라우저 네이티브 다운로드. 메모리 버퍼링 없음

## Test plan
- [x] frontend / backend Docker build 성공, /health 200
- [ ] 큰 백업 (100MB+) 다운로드 시 브라우저 메모리 안정 (DevTools Memory)
- [ ] 다운로드 완료까지 정상
- [ ] signed URL 만료 후 호출 시 403
- [ ] 서명 변조 시 403

closes #241