### PR TITLE
feat: ServerModelCache 모델 추가 — Phase A (#200)

### DIFF
--- a/src/models/ServerModelCache.js
+++ b/src/models/ServerModelCache.js
@@ -1,0 +1,161 @@
+const mongoose = require('mongoose');
+
+// 모델 개별 아이템 스키마.
+// ComfyUI checkpoint: filename + hash + civitai 메타데이터
+// SaaS provider (OpenAI / Gemini): filename 슬롯에 모델 ID, provider 메타데이터
+const modelItemSchema = new mongoose.Schema({
+  filename: {
+    type: String,
+    required: true
+  },
+  hash: {
+    type: String,
+    default: null
+  },
+  hashError: {
+    type: String,
+    default: null
+  },
+  civitai: {
+    found: {
+      type: Boolean,
+      default: false
+    },
+    modelId: Number,
+    modelVersionId: Number,
+    name: String,
+    description: String,
+    baseModel: String,
+    trainedWords: [String],
+    images: [{
+      url: String,
+      nsfw: Boolean,
+      type: {
+        type: String,
+        enum: ['image', 'video'],
+        default: 'image'
+      }
+    }],
+    nsfw: {
+      type: Boolean,
+      default: false
+    },
+    modelUrl: String,
+    fetchedAt: Date,
+    error: String
+  },
+  provider: {
+    found: {
+      type: Boolean,
+      default: false
+    },
+    id: String,
+    name: String,
+    description: String,
+    capabilities: [String],
+    contextWindow: Number,
+    fetchedAt: Date,
+    error: String
+  }
+}, { _id: false });
+
+const serverModelCacheSchema = new mongoose.Schema({
+  serverId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Server',
+    required: true,
+    unique: true
+  },
+  serverUrl: {
+    type: String,
+    required: true
+  },
+  models: [modelItemSchema],
+  status: {
+    type: String,
+    enum: ['idle', 'fetching', 'completed', 'failed'],
+    default: 'idle'
+  },
+  progress: {
+    current: {
+      type: Number,
+      default: 0
+    },
+    total: {
+      type: Number,
+      default: 0
+    },
+    stage: {
+      type: String,
+      enum: ['idle', 'checking_node', 'fetching_list', 'fetching_metadata', 'completed', 'failed'],
+      default: 'idle'
+    }
+  },
+  hashNodeAvailable: {
+    type: Boolean,
+    default: false
+  },
+  lastFetched: {
+    type: Date,
+    default: null
+  },
+  lastMetadataSync: {
+    type: Date,
+    default: null
+  },
+  errorMessage: {
+    type: String,
+    default: null
+  }
+}, {
+  timestamps: true
+});
+
+serverModelCacheSchema.index({ serverId: 1 });
+serverModelCacheSchema.index({ serverUrl: 1 });
+
+serverModelCacheSchema.statics.findOrCreateByServerId = async function(serverId, serverUrl) {
+  let cache = await this.findOne({ serverId });
+  if (!cache) {
+    cache = new this({
+      serverId,
+      serverUrl,
+      models: [],
+      status: 'idle'
+    });
+    await cache.save();
+  }
+  return cache;
+};
+
+serverModelCacheSchema.methods.updateProgress = async function(current, total, stage) {
+  this.progress = { current, total, stage };
+  return this.save();
+};
+
+serverModelCacheSchema.methods.startSync = async function() {
+  this.status = 'fetching';
+  this.progress = { current: 0, total: 0, stage: 'fetching_list' };
+  this.errorMessage = null;
+  return this.save();
+};
+
+serverModelCacheSchema.methods.completeSync = async function() {
+  this.status = 'completed';
+  this.progress.stage = 'completed';
+  this.lastFetched = new Date();
+  return this.save();
+};
+
+serverModelCacheSchema.methods.failSync = async function(errorMessage) {
+  this.status = 'failed';
+  this.progress.stage = 'failed';
+  this.errorMessage = errorMessage;
+  return this.save();
+};
+
+serverModelCacheSchema.methods.findModelByFilename = function(filename) {
+  return this.models.find(model => model.filename === filename);
+};
+
+module.exports = mongoose.model('ServerModelCache', serverModelCacheSchema);


### PR DESCRIPTION
## Summary
- #200 의 첫 단계. 모델 메타데이터 인프라의 schema 만 정의 — 기존 `ServerLoraCache` 패턴을 그대로 미러
- `models[]` 아이템에 ComfyUI 전용 (`hash`, `civitai`) + SaaS 전용 (`provider`) 메타데이터 subdoc 양쪽 보유
- 인스턴스 / static 메서드 (`findOrCreateByServerId`, `startSync`, `completeSync`, `findModelByFilename` 등) 모두 LoRA cache 와 동일 시그니처

## 코드 변경
- 신규: `src/models/ServerModelCache.js` (161 라인)
- 미변경: 기존 `src/models/ModelCache.js`, `routes/servers.js` 의 `/servers/:id/models` — 후속 Phase D 에서 마이그레이션 + 구 모델 제거

## 후속 Phase 로드맵
- **B**: `modelMetadataService.js` — ComfyUI checkpoint 목록 + SHA256 hash + Civitai 메타데이터 fetch + sync 흐름. ComfyUI 측 hash 노드는 기존 `comfyui-vcc-lora-hash` 를 generalize (작업 시작 시 폴더/엔드포인트 네이밍 한 번 더 확인)
- **C**: OpenAI / Gemini provider `/v1/models` 어댑터를 동일 service 에 통합
- **D**: `/servers/:id/models` GET 확장 + 신규 `POST /models/sync`, `GET /models/status` 라우트. 구 `ModelCache.js` 제거
- **E**: 프론트 `ModelPickerGrid` 컴포넌트 + 작업판 폼의 모델 dropdown 교체

## 결정사항 (#200 ADR)
1-4. 기존 LoRA 구현과 완전 동일 (외부 URL 직접 / 명시적 새로고침 / SHA256 hash / 즐겨찾기 미도입)
5. Checkpoint 만 (LoRA 외 다른 타입은 후속)
6. OpenAI/Gemini → provider `/v1/models` + 사용자 수동 갱신

## Test plan
- [ ] docker-compose 기동 후 mongoose 가 신규 schema 를 로드하는지 (`db.servermodelcaches.getIndexes()` 인덱스 정상)
- [ ] (현 단계에서는 데이터 들어가는 흐름 없음 — 기존 `/models` 라우트는 구 ModelCache 사용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)