### PR TITLE
feat: SaaS provider 모델 sync 추가 — Phase C (#200)

### DIFF
--- a/src/routes/servers.js
+++ b/src/routes/servers.js
@@ -412,7 +412,8 @@ router.get('/:id/loras', verifyJWT, async (req, res) => {
   }
 });
 
-// Model (Checkpoint) 동기화 (메타데이터 포함) - 관리자만 — Phase B (#200)
+// Model 동기화 (메타데이터 포함) - 관리자만.
+// Phase B: ComfyUI checkpoint. Phase C: OpenAI / OpenAI Compatible / Gemini provider 모델.
 // 신규 ServerModelCache 기반. 기존 GET /:id/models 는 구 ModelCache 사용 중 (Phase D 에서 마이그레이션 예정).
 router.post('/:id/models/sync', requireAdmin, async (req, res) => {
   try {
@@ -426,19 +427,20 @@ router.post('/:id/models/sync', requireAdmin, async (req, res) => {
       });
     }
 
-    if (server.serverType !== 'ComfyUI') {
+    const SUPPORTED = ['ComfyUI', 'OpenAI', 'OpenAI Compatible', 'Gemini'];
+    if (!SUPPORTED.includes(server.serverType)) {
       return res.status(400).json({
         success: false,
-        message: '모델 동기화는 ComfyUI 서버에서만 사용할 수 있습니다.'
+        message: `모델 동기화는 ${SUPPORTED.join(' / ')} 서버에서만 사용할 수 있습니다.`
       });
     }
 
-    modelMetadataService.syncServerCheckpoints(server._id, server.serverUrl, { forceRefresh })
+    modelMetadataService.syncServerModels(server, { forceRefresh })
       .then(() => {
-        console.log(`Checkpoint sync completed for server ${server.name}`);
+        console.log(`Model sync completed for server ${server.name} (${server.serverType})`);
       })
       .catch((err) => {
-        console.error(`Checkpoint sync failed for server ${server.name}:`, err);
+        console.error(`Model sync failed for server ${server.name}:`, err);
       });
 
     res.json({

--- a/src/services/modelMetadataService.js
+++ b/src/services/modelMetadataService.js
@@ -154,8 +154,136 @@ const fetchCivitaiMetadataByHash = async (hash, apiKey = null, retryCount = 0) =
 };
 
 /**
+ * OpenAI / OpenAI Compatible 서버의 모델 목록 조회 (`GET /v1/models`).
+ * 응답 스펙: { data: [{ id, object, created, owned_by, ... }] }
+ */
+const getOpenAIProviderModels = async (serverUrl, apiKey) => {
+  const headers = {};
+  if (apiKey) {
+    headers['Authorization'] = `Bearer ${apiKey}`;
+  }
+  try {
+    const response = await axios.get(`${serverUrl}/v1/models`, {
+      timeout: 30000,
+      headers
+    });
+    const list = response.data?.data || [];
+    return list.map(m => ({
+      id: m.id,
+      name: m.id,
+      description: m.description || '',
+      capabilities: [],
+      contextWindow: m.context_window || null,
+      ownedBy: m.owned_by || null
+    }));
+  } catch (error) {
+    throw new Error(`Failed to fetch OpenAI models: ${error.message}`);
+  }
+};
+
+/**
+ * Gemini 서버의 모델 목록 조회 (`GET /v1beta/models`).
+ * 응답 스펙: { models: [{ name, displayName, description, supportedGenerationMethods, inputTokenLimit, outputTokenLimit, ... }] }
+ */
+const getGeminiProviderModels = async (serverUrl, apiKey) => {
+  try {
+    const response = await axios.get(`${serverUrl}/v1beta/models`, {
+      timeout: 30000,
+      params: apiKey ? { key: apiKey } : undefined
+    });
+    const list = response.data?.models || [];
+    return list.map(m => ({
+      // name 형식이 'models/gemini-...' 라 prefix 제거
+      id: typeof m.name === 'string' ? m.name.replace(/^models\//, '') : m.name,
+      name: m.displayName || m.name,
+      description: m.description || '',
+      capabilities: m.supportedGenerationMethods || [],
+      contextWindow: m.inputTokenLimit || null
+    }));
+  } catch (error) {
+    throw new Error(`Failed to fetch Gemini models: ${error.message}`);
+  }
+};
+
+/**
+ * SaaS provider (OpenAI / OpenAI Compatible / Gemini) 모델 목록 동기화.
+ * Civitai / hash 무관 — provider 의 `/models` 응답을 그대로 캐시.
+ * @param {Object} server — Server document (serverType / serverUrl / configuration.apiKey 사용)
+ */
+const syncServerProviderModels = async (server, { progressCallback = null } = {}) => {
+  const cache = await ServerModelCache.findOrCreateByServerId(server._id, server.serverUrl);
+
+  if (cache.status === 'fetching') {
+    throw new Error('Sync already in progress');
+  }
+
+  const apiKey = server.configuration?.apiKey;
+
+  try {
+    await cache.startSync();
+
+    if (progressCallback) progressCallback('fetching_list', 0, 0);
+    await cache.updateProgress(0, 0, 'fetching_list');
+
+    let providerModels = [];
+    if (server.serverType === 'OpenAI' || server.serverType === 'OpenAI Compatible') {
+      providerModels = await getOpenAIProviderModels(server.serverUrl, apiKey);
+    } else if (server.serverType === 'Gemini') {
+      providerModels = await getGeminiProviderModels(server.serverUrl, apiKey);
+    } else {
+      throw new Error(`Unsupported serverType for provider sync: ${server.serverType}`);
+    }
+
+    console.log(`[ModelSync] ${server.serverType}: ${providerModels.length} models from /models endpoint`);
+
+    const totalSteps = providerModels.length;
+    if (progressCallback) progressCallback('fetching_metadata', totalSteps, totalSteps);
+    await cache.updateProgress(totalSteps, totalSteps, 'fetching_metadata');
+
+    cache.hashNodeAvailable = false; // SaaS provider 는 hash 무관
+    cache.models = providerModels.map(pm => ({
+      filename: pm.id, // SaaS 의 식별자는 모델 ID
+      hash: null,
+      hashError: null,
+      civitai: { found: false },
+      provider: {
+        found: true,
+        id: pm.id,
+        name: pm.name,
+        description: pm.description,
+        capabilities: pm.capabilities,
+        contextWindow: pm.contextWindow,
+        fetchedAt: new Date()
+      }
+    }));
+    cache.lastMetadataSync = new Date();
+    await cache.completeSync();
+
+    return cache;
+  } catch (error) {
+    console.error('[ModelSync] Provider sync error:', error);
+    await cache.failSync(error.message);
+    throw error;
+  }
+};
+
+/**
+ * server.serverType 에 따라 적절한 sync 함수로 분기.
+ * 호출자는 이 단일 진입점만 알면 됨.
+ */
+const syncServerModels = async (server, opts = {}) => {
+  if (server.serverType === 'ComfyUI') {
+    return syncServerCheckpoints(server._id, server.serverUrl, opts);
+  }
+  if (server.serverType === 'OpenAI' || server.serverType === 'OpenAI Compatible' || server.serverType === 'Gemini') {
+    return syncServerProviderModels(server, opts);
+  }
+  throw new Error(`Unsupported serverType for model sync: ${server.serverType}`);
+};
+
+/**
  * 서버의 checkpoint 목록 + 메타데이터 동기화.
- * ComfyUI 서버에 한해 동작. 다른 serverType 은 별도 흐름 (Phase C).
+ * ComfyUI 전용. SaaS provider 는 syncServerProviderModels 사용.
  */
 const syncServerCheckpoints = async (serverId, serverUrl, { progressCallback = null, forceRefresh = false } = {}) => {
   const cache = await ServerModelCache.findOrCreateByServerId(serverId, serverUrl);
@@ -391,6 +519,10 @@ module.exports = {
   fetchCivitaiMetadataByHash,
   getCivitaiApiKey,
   syncServerCheckpoints,
+  getOpenAIProviderModels,
+  getGeminiProviderModels,
+  syncServerProviderModels,
+  syncServerModels,
   getServerCheckpoints,
   getSyncStatus,
   searchServerCheckpoints


### PR DESCRIPTION
## Summary
- ComfyUI 외 OpenAI / OpenAI Compatible / Gemini 서버의 모델 목록을 provider 의 `/models` endpoint 에서 직접 조회해 `ServerModelCache` 에 저장
- 라우트는 `syncServerModels(server, opts)` 단일 진입점으로 dispatch — server.serverType 에 따라 ComfyUI checkpoint flow 또는 SaaS provider flow 선택
- Civitai / hash 무관 — provider subdoc 에 `id` / `name` / `description` / `capabilities` / `contextWindow` 채움

## 변경 파일
- `src/services/modelMetadataService.js` — `getOpenAIProviderModels`, `getGeminiProviderModels`, `syncServerProviderModels`, `syncServerModels` 추가 (+134 라인)
- `src/routes/servers.js` — `POST /:id/models/sync` 의 가드를 4종 serverType 화이트리스트로 확장, 단일 진입점 호출

## 검증 (제 환경)

**Gemini server sync**:
```
status=completed  50/50  hashNode=False  lastFetched=2026-05-08T01:38:28
샘플:
  filename: gemini-2.5-flash
  provider.name: Gemini 2.5 Flash
  provider.capabilities: [generateContent, countTokens, ...]
  provider.contextWindow: 1048576
```

**OpenAI server sync**:
```
status=completed  136/136
샘플 (text-embedding-ada-002, whisper-1, gpt-3.5-turbo 등 모든 모델 포함)
  → 워크보드별 화이트리스트 (#198) 가 도입되면 노출 모델 큐레이션 가능
```

## 알려진 제약
- OpenAI `/v1/models` 응답에 displayName 이 없어 `name` = `id` (그대로 사용). 화이트리스트 + UI 라벨 커스터마이즈는 #198 / Phase E 영역
- OpenAI 의 모든 모델 (embeddings / whisper / 텍스트 LLM / image / etc) 이 응답에 포함됨. capability 별 필터링은 후속 단계
- Gemini 의 `name` (raw) 는 `models/gemini-...` 형식이라 prefix 제거 후 `id` 로 저장

## Test plan
- [x] Gemini sync end-to-end
- [x] OpenAI sync end-to-end
- [x] non-supported serverType (만약 향후 추가될) 에 대해 적절한 400 응답
- [ ] (사용자 환경) ComfyUI 서버 회귀 — Phase B 에서 검증한 sync 흐름이 깨지지 않았는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)