### PR TITLE
feat: GET /:id/models 의 detailed 모드 추가 — Phase E1 (#200)

### DIFF
--- a/src/routes/servers.js
+++ b/src/routes/servers.js
@@ -296,11 +296,11 @@ router.post('/health-check/all', requireAdmin, async (req, res) => {
 // ===== LoRA 메타데이터 API =====
 
 // Checkpoint 모델 목록 조회
-// ComfyUI checkpoint 목록 조회 — frontend 의 ModelListModal 이 사용.
+// ComfyUI checkpoint 목록 조회 — frontend 의 ModelListModal / ModelPickerGrid 가 사용.
 // Phase D 부터 신규 ServerModelCache (#200) 를 storage 로 사용.
-// 응답 shape 은 backward-compat (`checkpointModels: string[]`) 으로 유지 —
-// rich 메타데이터 (hash, civitai 등) 는 Phase E 의 ModelPickerGrid 가 별도
-// 엔드포인트 또는 detailed 파라미터로 노출.
+// - 기본 응답 shape (`checkpointModels: string[]`) 은 backward-compat 유지 — frontend ModelListModal 호환
+// - `?detailed=true` 파라미터: LoRA 와 동일 패턴의 rich 데이터 (search/pagination/baseModel 필터) 반환 — Phase E 의 ModelPickerGrid 가 사용
+// - SaaS provider (OpenAI / Gemini) 의 모델 목록도 detailed 모드에서 동일 응답 구조로 노출 (hash 무관, provider subdoc 사용)
 router.get('/:id/models', verifyJWT, async (req, res) => {
   try {
     const server = await Server.findById(req.params.id);
@@ -312,6 +312,34 @@ router.get('/:id/models', verifyJWT, async (req, res) => {
       });
     }
 
+    const detailed = req.query.detailed === 'true';
+
+    // detailed 모드: 4종 serverType 모두 동일 응답 구조로 처리 (LoRA `/loras` 와 동일 패턴)
+    if (detailed) {
+      const SUPPORTED = ['ComfyUI', 'OpenAI', 'OpenAI Compatible', 'Gemini'];
+      if (!SUPPORTED.includes(server.serverType)) {
+        return res.status(400).json({
+          success: false,
+          message: `상세 모델 목록은 ${SUPPORTED.join(' / ')} 서버에서만 조회할 수 있습니다.`
+        });
+      }
+
+      const { search, hasMetadata, baseModel, page = 1, limit = 50 } = req.query;
+      const result = await modelMetadataService.searchServerModels(server._id, {
+        search,
+        hasMetadata: hasMetadata === 'true' ? true : hasMetadata === 'false' ? false : undefined,
+        baseModel,
+        page: parseInt(page),
+        limit: parseInt(limit)
+      });
+
+      return res.json({
+        success: true,
+        data: result
+      });
+    }
+
+    // 기본 모드 (backward-compat): ComfyUI 만, filename 배열만 반환
     if (server.serverType !== 'ComfyUI') {
       return res.status(400).json({
         success: false,

--- a/src/services/modelMetadataService.js
+++ b/src/services/modelMetadataService.js
@@ -450,7 +450,18 @@ const getSyncStatus = async (serverId) => {
   };
 };
 
-const searchServerCheckpoints = async (serverId, { search, hasMetadata, baseModel, page = 1, limit = 50 } = {}) => {
+/**
+ * 검색 / 페이지네이션 / baseModel 필터를 적용한 모델 목록 조회.
+ * ComfyUI checkpoint (civitai 메타데이터) + SaaS provider 모델 (provider 메타데이터)
+ * 양쪽을 통합 검색.
+ *
+ * @param {ObjectId} serverId
+ * @param {Object} opts
+ * @param {string} opts.search — filename / civitai 메타 / provider 메타 통합 검색
+ * @param {boolean} opts.hasMetadata — civitai 또는 provider 메타데이터 보유 여부
+ * @param {string} opts.baseModel — civitai.baseModel 매칭 (ComfyUI 만 의미 있음)
+ */
+const searchServerModels = async (serverId, { search, hasMetadata, baseModel, page = 1, limit = 50 } = {}) => {
   const cache = await ServerModelCache.findOne({ serverId });
 
   if (!cache) {
@@ -472,22 +483,27 @@ const searchServerCheckpoints = async (serverId, { search, hasMetadata, baseMode
   if (search) {
     const s = search.toLowerCase();
     filtered = filtered.filter(m => {
-      const filename = m.filename.toLowerCase();
-      const name = (m.civitai?.name || '').toLowerCase();
-      const description = (m.civitai?.description || '').toLowerCase();
-      const trainedWords = (m.civitai?.trainedWords || []).join(' ').toLowerCase();
+      const filename = (m.filename || '').toLowerCase();
+      const civName = (m.civitai?.name || '').toLowerCase();
+      const civDesc = (m.civitai?.description || '').toLowerCase();
+      const civTrained = (m.civitai?.trainedWords || []).join(' ').toLowerCase();
+      const provName = (m.provider?.name || '').toLowerCase();
+      const provDesc = (m.provider?.description || '').toLowerCase();
 
       return filename.includes(s) ||
-             name.includes(s) ||
-             description.includes(s) ||
-             trainedWords.includes(s);
+             civName.includes(s) ||
+             civDesc.includes(s) ||
+             civTrained.includes(s) ||
+             provName.includes(s) ||
+             provDesc.includes(s);
     });
   }
 
   if (hasMetadata !== undefined) {
-    filtered = filtered.filter(m =>
-      hasMetadata ? m.civitai?.found : !m.civitai?.found
-    );
+    filtered = filtered.filter(m => {
+      const has = (m.civitai?.found === true) || (m.provider?.found === true);
+      return hasMetadata ? has : !has;
+    });
   }
 
   if (baseModel) {
@@ -525,5 +541,5 @@ module.exports = {
   syncServerModels,
   getServerCheckpoints,
   getSyncStatus,
-  searchServerCheckpoints
+  searchServerModels
 };


### PR DESCRIPTION
## Summary
- Phase E 의 첫 단계 — backend. `ServerModelCache` 의 풍부한 메타데이터를 detailed 모드 (`?detailed=true`) 로 노출
- 4종 serverType (ComfyUI / OpenAI / OpenAI Compatible / Gemini) 모두 동일 응답 구조 — frontend 가 단일 컴포넌트로 처리 가능
- 기본 모드 (no `detailed`) 는 backward-compat 유지 → 프론트 ModelListModal 미변경

## 변경
**`routes/servers.js`** — `GET /:id/models`:
- `?detailed=true` 분기 추가. LoRA `/loras` 와 동일한 `search` / `hasMetadata` / `baseModel` / `page` / `limit` 쿼리 파라미터
- ComfyUI/OpenAI/OpenAI Compatible/Gemini 4종 모두 지원
- `cache.models[]` 통째로 반환 (hash + civitai + provider 모두 포함)

**`services/modelMetadataService.js`**:
- `searchServerCheckpoints` → `searchServerModels` 로 rename (SaaS 모델도 처리)
- `search` 가 `filename` + `civitai.{name,description,trainedWords}` + `provider.{name,description}` 통합 매칭
- `hasMetadata` 필터가 `civitai.found || provider.found` OR 평가

## 검증 (제 환경)

**ComfyUI detailed**:
```
50 models, 17 pages × 3
availableBaseModels: [Anima, Illustrious, LTXV 2.3, NoobAI, Pony]
샘플 [1] Audio\ace_step_1.5_turbo_aio.safetensors
  hash: 67b0f43aa5c51c84...
  civitai.name: None (Audio 모델은 Civitai 미등록)
샘플 [2] IXL\JANKUTrainedNoobaiRouwei_v60.safetensors
  hash: 70ba3a56ff2550...
  civitai.name: "✨ JANKU Trained + Chenkin & NoobAI..."
  civitai.images count: 5
```

**Gemini detailed**:
```
50 models
샘플 [1] gemini-2.5-flash
  provider.name: Gemini 2.5 Flash
  provider.capabilities: [generateContent, countTokens, createCachedContent, batchGenerateContent]
  provider.contextWindow: 1048576
```

**Search**: `?detailed=true&search=janku` → 6 매칭
**Backward-compat**: 기존 `GET /:id/models` 가 50 filename 배열 그대로 반환

## 후속
- **E2**: 프론트 `ModelPickerGrid` 컴포넌트 (이 detailed 응답을 카드 그리드로 렌더링, 썸네일/메타데이터 카드)
- **E3**: ModelListModal 교체 + admin ServerManagement 에 model sync 버튼/상태 UI

## Test plan
- [x] ComfyUI detailed: 50 models 응답, civitai 메타데이터 + hash 포함
- [x] Gemini/OpenAI detailed: provider 메타데이터 응답
- [x] Search: filename 매칭 동작 (Civitai/provider 필드도 OR 매칭)
- [x] Backward-compat: 기존 ModelListModal 호출 (no `?detailed`) 동일 응답
- [ ] (사용자 환경) baseModel 필터 동작 (`?detailed=true&baseModel=Illustrious`)
- [ ] (사용자 환경) hasMetadata 필터 동작 (`?detailed=true&hasMetadata=true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)