### PR TITLE
feat: ModelPickerGrid 컴포넌트 추가 — Phase E2 (#200)

### DIFF
--- a/frontend/src/components/ModelPickerGrid.js
+++ b/frontend/src/components/ModelPickerGrid.js
@@ -1,0 +1,508 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  CircularProgress,
+  Alert,
+  Box,
+  Chip,
+  TextField,
+  InputAdornment,
+  Card,
+  CardContent,
+  CardActions,
+  Grid,
+  IconButton,
+  LinearProgress,
+  Tooltip,
+  Stack,
+  FormControl,
+  Select,
+  MenuItem,
+  InputLabel,
+  Switch,
+  FormControlLabel
+} from '@mui/material';
+import {
+  Refresh as RefreshIcon,
+  Search as SearchIcon,
+  Close as CloseIcon,
+  OpenInNew as OpenInNewIcon,
+  CheckCircle as CheckCircleIcon
+} from '@mui/icons-material';
+import { useQuery, useMutation, useQueryClient } from 'react-query';
+import toast from 'react-hot-toast';
+import { serverAPI, userAPI } from '../services/api';
+import Pagination from './common/Pagination';
+
+// ─── ModelThumbnail ──────────────────────────────────────────────
+function ModelThumbnail({ image, alt, height = 140, width = '100%', sx = {} }) {
+  if (!image?.url) return null;
+  return (
+    <Box
+      component="img"
+      src={image.url}
+      alt={alt}
+      sx={{
+        width,
+        height,
+        objectFit: 'cover',
+        display: 'block',
+        ...sx
+      }}
+    />
+  );
+}
+
+// ─── ModelCard ───────────────────────────────────────────────────
+// ComfyUI checkpoint 와 SaaS provider 모델을 동일 카드로 렌더.
+// ComfyUI: civitai.{name, baseModel, images, modelUrl}
+// SaaS:    provider.{name, capabilities, contextWindow, description}
+function ModelCard({ model, selected, onSelect, nsfwImageFilter }) {
+  const civ = model.civitai || {};
+  const prov = model.provider || {};
+
+  const hasCivitai = civ.found === true;
+  const hasProvider = prov.found === true;
+
+  const filteredImages = nsfwImageFilter
+    ? (civ.images || []).filter((img) => !img.nsfw)
+    : (civ.images || []);
+  const previewImage = filteredImages[0];
+
+  // 표시 이름: civitai → provider → filename (확장자 제거)
+  const displayName =
+    civ.name ||
+    prov.name ||
+    model.filename.replace(/\.[^/.]+$/, '');
+
+  const baseModel = civ.baseModel;
+  const capabilities = prov.capabilities || [];
+  const description = civ.description || prov.description;
+
+  return (
+    <Card
+      variant={selected ? 'elevation' : 'outlined'}
+      elevation={selected ? 8 : 0}
+      sx={{
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        cursor: 'pointer',
+        transition: 'border-color 0.2s, box-shadow 0.2s',
+        borderColor: selected ? 'primary.main' : undefined,
+        borderWidth: selected ? 2 : 1,
+        '&:hover': { borderColor: 'primary.main' }
+      }}
+      onClick={() => onSelect(model)}
+    >
+      {previewImage?.url ? (
+        <ModelThumbnail image={previewImage} alt={displayName} />
+      ) : (
+        <Box
+          sx={{
+            height: 140,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            bgcolor: 'action.hover'
+          }}
+        >
+          <Typography variant="body2" color="text.secondary">
+            미리보기 없음
+          </Typography>
+        </Box>
+      )}
+
+      <CardContent sx={{ flexGrow: 1, pb: 1 }}>
+        <Stack direction="row" alignItems="center" spacing={0.5}>
+          {selected && <CheckCircleIcon color="primary" fontSize="small" />}
+          <Typography variant="subtitle2" noWrap title={displayName} sx={{ flexGrow: 1 }}>
+            {displayName}
+          </Typography>
+        </Stack>
+
+        {(hasCivitai || hasProvider) && (
+          <Typography variant="caption" color="text.secondary" noWrap display="block">
+            {model.filename}
+          </Typography>
+        )}
+
+        <Box sx={{ mt: 1, display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+          {baseModel && (
+            <Chip label={baseModel} size="small" color="primary" variant="outlined" />
+          )}
+          {capabilities.slice(0, 3).map((c) => (
+            <Chip key={c} label={c} size="small" variant="outlined" />
+          ))}
+          {!hasCivitai && !hasProvider && !model.hash && (
+            <Tooltip title={model.hashError || '메타데이터 없음 — sync 가 아직 안 됐거나 Civitai/provider 미등록'}>
+              <Chip label="메타데이터 없음" size="small" variant="outlined" />
+            </Tooltip>
+          )}
+          {model.hash && !hasCivitai && (
+            <Tooltip title="Civitai 미등록 (custom merge / private 모델)">
+              <Chip label="미등록" size="small" variant="outlined" />
+            </Tooltip>
+          )}
+        </Box>
+
+        {prov.contextWindow && (
+          <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 1 }}>
+            context: {prov.contextWindow.toLocaleString()} tokens
+          </Typography>
+        )}
+
+        {description && (
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            display="block"
+            sx={{
+              mt: 1,
+              overflow: 'hidden',
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical'
+            }}
+          >
+            {description}
+          </Typography>
+        )}
+      </CardContent>
+
+      {civ.modelUrl && (
+        <CardActions sx={{ pt: 0 }}>
+          <Tooltip title="Civitai 에서 보기">
+            <IconButton
+              size="small"
+              onClick={(e) => {
+                e.stopPropagation();
+                window.open(civ.modelUrl, '_blank');
+              }}
+            >
+              <OpenInNewIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </CardActions>
+      )}
+    </Card>
+  );
+}
+
+// ─── ModelPickerGrid ─────────────────────────────────────────────
+// ComfyUI checkpoint + SaaS provider 모델 통합 picker.
+// open / onClose / serverId / selectedModel (filename) / onSelectModel(filename) — drop-in 호환 props.
+// `?detailed=true` 응답을 카드 그리드로 렌더, search + baseModel 필터 + 페이지네이션 + admin sync 트리거.
+function ModelPickerGrid({
+  open,
+  onClose,
+  serverId,
+  selectedModel,
+  onSelectModel,
+  isAdmin = false
+}) {
+  const [models, setModels] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+  const [error, setError] = useState(null);
+  const [cacheInfo, setCacheInfo] = useState(null);
+  const [syncStatus, setSyncStatus] = useState(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [baseModelFilter, setBaseModelFilter] = useState('');
+  const [availableBaseModels, setAvailableBaseModels] = useState([]);
+  const [pagination, setPagination] = useState({ current: 1, pages: 0, total: 0 });
+
+  const queryClient = useQueryClient();
+
+  const { data: profileData } = useQuery('userProfile', () => userAPI.getProfile(), {
+    enabled: open && !isAdmin
+  });
+  const userPreferences = profileData?.data?.user?.preferences || {};
+  const nsfwImageFilter = isAdmin ? false : (userPreferences.nsfwImageFilter ?? true);
+
+  const updatePreferencesMutation = useMutation(
+    (preferences) => userAPI.updateProfile({ preferences }),
+    {
+      onSuccess: () => queryClient.invalidateQueries('userProfile')
+    }
+  );
+
+  const handleNsfwToggle = () => {
+    const newValue = !nsfwImageFilter;
+    updatePreferencesMutation.mutate({ nsfwImageFilter: newValue });
+  };
+
+  const fetchModels = useCallback(
+    async (page = 1) => {
+      if (!serverId) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await serverAPI.getDetailedModels(serverId, {
+          search: searchQuery,
+          baseModel: baseModelFilter,
+          page,
+          limit: 20
+        });
+        const data = response.data.data;
+        setModels(data.models || []);
+        setPagination(data.pagination || { current: 1, pages: 0, total: 0 });
+        setCacheInfo(data.cacheInfo);
+        if (data.availableBaseModels) {
+          setAvailableBaseModels(data.availableBaseModels);
+        }
+      } catch (err) {
+        console.error('Failed to fetch models:', err);
+        setError(err.response?.data?.message || '모델 목록을 가져오는데 실패했습니다.');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [serverId, searchQuery, baseModelFilter]
+  );
+
+  // 동기화 상태 폴링
+  useEffect(() => {
+    let interval;
+    if (syncing && serverId) {
+      interval = setInterval(async () => {
+        try {
+          const response = await serverAPI.getModelsSyncStatus(serverId);
+          const status = response.data.data;
+          setSyncStatus(status);
+          if (status.status === 'completed' || status.status === 'failed' || status.status === 'idle') {
+            setSyncing(false);
+            if (status.status === 'completed') {
+              toast.success('모델 동기화가 완료되었습니다.');
+              fetchModels();
+            } else if (status.status === 'failed') {
+              toast.error(`동기화 실패: ${status.errorMessage || '알 수 없는 오류'}`);
+            }
+          }
+        } catch (err) {
+          console.error('Failed to get sync status:', err);
+        }
+      }, 2000);
+    }
+    return () => clearInterval(interval);
+  }, [syncing, serverId, fetchModels]);
+
+  // 모달 open 시 모델 fetch + 진행 중인 sync 확인
+  useEffect(() => {
+    if (open && serverId) {
+      fetchModels();
+      serverAPI.getModelsSyncStatus(serverId)
+        .then((response) => {
+          const status = response.data.data;
+          setSyncStatus(status);
+          if (status.status === 'fetching') {
+            setSyncing(true);
+          }
+        })
+        .catch(console.error);
+    }
+  }, [open, serverId, fetchModels]);
+
+  // search/filter 변경 시 debounce
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (open) fetchModels(1);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [searchQuery, baseModelFilter, open, fetchModels]);
+
+  const handleSync = async (forceRefresh = false) => {
+    if (!serverId) return;
+    try {
+      setSyncing(true);
+      await serverAPI.syncModels(serverId, { forceRefresh });
+      toast.success('모델 동기화를 시작했습니다.');
+    } catch (err) {
+      console.error('Sync failed:', err);
+      toast.error(err.response?.data?.message || '동기화 시작 실패');
+      setSyncing(false);
+    }
+  };
+
+  const handleSelect = (model) => {
+    onSelectModel(model.filename);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth>
+      <DialogTitle sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Typography variant="h6">모델 선택</Typography>
+        <IconButton onClick={onClose} size="small">
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent dividers>
+        {/* 컨트롤 영역 */}
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} sx={{ mb: 2 }}>
+          <TextField
+            placeholder="이름 / 파일명 / 트리거워드 검색"
+            size="small"
+            fullWidth
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon fontSize="small" />
+                </InputAdornment>
+              )
+            }}
+          />
+          {availableBaseModels.length > 0 && (
+            <FormControl size="small" sx={{ minWidth: 160 }}>
+              <InputLabel>베이스 모델</InputLabel>
+              <Select
+                value={baseModelFilter}
+                label="베이스 모델"
+                onChange={(e) => setBaseModelFilter(e.target.value)}
+              >
+                <MenuItem value="">전체</MenuItem>
+                {availableBaseModels.map((bm) => (
+                  <MenuItem key={bm} value={bm}>
+                    {bm}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+          <Tooltip title="모델 메타데이터 동기화 (관리자만)">
+            <span>
+              <Button
+                variant="outlined"
+                startIcon={<RefreshIcon />}
+                onClick={() => handleSync(false)}
+                disabled={syncing || !isAdmin}
+              >
+                {syncing ? '동기화 중...' : '동기화'}
+              </Button>
+            </span>
+          </Tooltip>
+        </Stack>
+
+        {!isAdmin && (
+          <FormControlLabel
+            control={
+              <Switch
+                size="small"
+                checked={nsfwImageFilter}
+                onChange={handleNsfwToggle}
+                disabled={updatePreferencesMutation.isLoading}
+              />
+            }
+            label={
+              <Typography variant="caption">
+                NSFW 미리보기 이미지 숨기기
+              </Typography>
+            }
+            sx={{ mb: 1 }}
+          />
+        )}
+
+        {/* 캐시 정보 */}
+        {cacheInfo && (
+          <Box sx={{ mb: 2 }}>
+            <Typography variant="caption" color="text.secondary">
+              {cacheInfo.lastFetched && `마지막 조회: ${new Date(cacheInfo.lastFetched).toLocaleString('ko-KR')}`}
+              {cacheInfo.lastMetadataSync && ` · 메타 동기화: ${new Date(cacheInfo.lastMetadataSync).toLocaleString('ko-KR')}`}
+              {cacheInfo.hashNodeAvailable === false && (
+                <Alert severity="info" sx={{ mt: 1 }}>
+                  ComfyUI 의 vcc-file-hash 노드가 설치되지 않아 해시 기반 메타데이터를 가져올 수 없습니다.
+                </Alert>
+              )}
+            </Typography>
+          </Box>
+        )}
+
+        {/* 동기화 진행 표시 */}
+        {syncing && syncStatus && (
+          <Box sx={{ mb: 2 }}>
+            <Stack direction="row" justifyContent="space-between" sx={{ mb: 0.5 }}>
+              <Typography variant="caption">
+                {syncStatus.progress?.stage === 'checking_node' && '노드 확인 중...'}
+                {syncStatus.progress?.stage === 'fetching_list' && '모델 목록 조회 중...'}
+                {syncStatus.progress?.stage === 'fetching_metadata' && '메타데이터 가져오는 중...'}
+              </Typography>
+              {syncStatus.progress?.total > 0 && (
+                <Typography variant="caption">
+                  {syncStatus.progress.current} / {syncStatus.progress.total}
+                </Typography>
+              )}
+            </Stack>
+            <LinearProgress
+              variant={syncStatus.progress?.total > 0 ? 'determinate' : 'indeterminate'}
+              value={
+                syncStatus.progress?.total > 0
+                  ? (syncStatus.progress.current / syncStatus.progress.total) * 100
+                  : 0
+              }
+            />
+          </Box>
+        )}
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+
+        {loading ? (
+          <Box display="flex" justifyContent="center" alignItems="center" minHeight={200}>
+            <CircularProgress />
+          </Box>
+        ) : models.length === 0 ? (
+          <Box textAlign="center" py={4}>
+            <Typography variant="body2" color="text.secondary" gutterBottom>
+              모델이 없습니다.
+            </Typography>
+            {isAdmin && (
+              <Typography variant="caption" color="text.secondary">
+                상단 "동기화" 버튼으로 모델 목록을 가져오세요.
+              </Typography>
+            )}
+          </Box>
+        ) : (
+          <>
+            <Grid container spacing={2}>
+              {models.map((model) => (
+                <Grid item xs={12} sm={6} md={4} lg={3} key={model.filename}>
+                  <ModelCard
+                    model={model}
+                    selected={selectedModel === model.filename}
+                    onSelect={handleSelect}
+                    nsfwImageFilter={nsfwImageFilter}
+                  />
+                </Grid>
+              ))}
+            </Grid>
+            {pagination.pages > 1 && (
+              <Box mt={2} display="flex" justifyContent="center">
+                <Pagination
+                  currentPage={pagination.current}
+                  totalPages={pagination.pages}
+                  totalItems={pagination.total}
+                  onPageChange={(p) => fetchModels(p)}
+                />
+              </Box>
+            )}
+          </>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>닫기</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export default ModelPickerGrid;

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -187,6 +187,10 @@ export const serverAPI = {
   checkServerHealth: (id) => api.post(`/servers/${id}/health-check`),
   checkAllServersHealth: () => api.post('/servers/health-check/all'),
   getCheckpointModels: (id, params) => api.get(`/servers/${id}/models`, { params }),
+  // 모델 메타데이터 API (Phase E1+ - ServerModelCache 기반 detailed 응답)
+  getDetailedModels: (id, params) => api.get(`/servers/${id}/models`, { params: { ...params, detailed: true } }),
+  syncModels: (id, options = {}) => api.post(`/servers/${id}/models/sync`, options),
+  getModelsSyncStatus: (id) => api.get(`/servers/${id}/models/status`),
   // LoRA 메타데이터 API
   getLoras: (id, params) => api.get(`/servers/${id}/loras`, { params }),
   syncLoras: (id, options = {}) => api.post(`/servers/${id}/loras/sync`, options),


### PR DESCRIPTION
## Summary
- Phase E1 의 detailed endpoint (`?detailed=true`) 를 카드 그리드 UI 로 렌더링하는 frontend 컴포넌트 신규 추가
- ComfyUI checkpoint (civitai 메타데이터) + SaaS provider 모델 (provider 메타데이터) 을 동일 카드 구조로 통합 표시
- 기존 `ModelListModal` 과 drop-in 호환되는 props 시그니처 (`open / onClose / serverId / selectedModel / onSelectModel / isAdmin`)

## 컴포넌트 (`ModelPickerGrid.js`, 508 라인)
**카드 구성**:
- 썸네일 (`civitai.images[0].url`, NSFW 필터링)
- 표시 이름: `civitai.name` → `provider.name` → filename(확장자 제거)
- baseModel chip (ComfyUI 만)
- capabilities chip (SaaS provider — generateContent / countTokens 등)
- context window 표시 (provider 만)
- 짧은 description (2줄 ellipsis)
- Civitai 외부 링크 버튼
- 선택된 모델 시각적 highlight (border + 체크 아이콘)

**기능**:
- 검색 입력 (filename + civitai/provider 통합 매칭, 300ms debounce)
- baseModel 필터 dropdown (ComfyUI 만 의미 있음)
- 페이지네이션 (limit 20)
- admin 만 sync 트리거 + 진행률 LinearProgress
- sync 상태 자동 폴링 (2초)
- NSFW 미리보기 이미지 토글 (`userPreferences.nsfwImageFilter` 동기화)

## API 추가 (`services/api.js`)
```js
serverAPI.getDetailedModels(id, params)  // ?detailed=true 자동
serverAPI.syncModels(id, options)        // POST .../models/sync
serverAPI.getModelsSyncStatus(id)        // GET  .../models/status
```

## 미연결
이 PR 은 **컴포넌트 정의만** 추가. 실제 사용처 (`ImageGeneration` 의 ModelListModal, `WorkboardManagement` 의 모델 dropdown, `ServerManagement` admin sync 버튼) 교체는 Phase E3 에서 진행.

→ 단독 PR 로 분리한 이유: 컴포넌트 코드 자체가 큼 (508 라인) — 리뷰어가 wiring 변경에 시야가 흐려지지 않도록.

## Test plan
- [x] frontend nginx 빌드 성공 — bundle 정상 (500 라인 추가, 빌드 에러 없음)
- [ ] (E3 머지 후 수동 테스트) ComfyUI 작업판에서 ModelPickerGrid 가 카드 그리드로 모델 표시
- [ ] baseModel 필터 / 검색 / 페이지네이션 동작
- [ ] admin sync 버튼 클릭 시 진행률 표시 및 완료 후 자동 새로고침
- [ ] NSFW 토글이 미리보기 이미지에 즉시 반영

## 후속
- **E3**: 기존 `ModelListModal` 사용처를 `ModelPickerGrid` 로 교체 + admin `ServerManagement` 에 model sync 버튼 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)