### PR TITLE
feat: Workboard.allowedModelTypes 필드 추가 — #252 Phase 1 (backend)

### DIFF
--- a/src/models/Workboard.js
+++ b/src/models/Workboard.js
@@ -118,6 +118,13 @@ const workboardSchema = new mongoose.Schema({
     }
   },
   additionalInputFields: [inputFieldSchema],
+  // ComfyUI 작업판이 허용하는 base 모델 타입 (#252).
+  // civitai.baseModel 과 매칭. 빈 배열이면 제약 없음 (모든 모델 허용).
+  // baseModel 미상 (Civitai 미등록 / hash 없음) 모델은 노출 (custom merge 등 일상적 케이스).
+  allowedModelTypes: {
+    type: [String],
+    default: []
+  },
   workflowData: {
     type: String,
     default: ''

--- a/src/routes/workboards.js
+++ b/src/routes/workboards.js
@@ -176,6 +176,7 @@ router.post('/import', requireAdmin, async (req, res) => {
       baseInputFields: wb.baseInputFields,
       additionalInputFields: wb.additionalInputFields || [],
       workflowData: wb.workflowData || '',
+      allowedModelTypes: wb.allowedModelTypes || [],
       createdBy: req.user._id,
       version: 1,
       usageCount: 0,
@@ -255,7 +256,8 @@ router.post('/', requireAdmin, async (req, res) => {
       outputFormat,
       baseInputFields,
       additionalInputFields,
-      workflowData
+      workflowData,
+      allowedModelTypes
     } = req.body;
 
     const resolvedOutputFormat = outputFormat || (workboardType === 'prompt' ? 'text' : 'image');
@@ -300,6 +302,7 @@ router.post('/', requireAdmin, async (req, res) => {
       baseInputFields,
       additionalInputFields: additionalInputFields || [],
       workflowData: isComfyUI ? workflowData : '',
+      allowedModelTypes: isComfyUI ? (allowedModelTypes || []) : [],
       createdBy: req.user._id
     });
 
@@ -332,6 +335,7 @@ router.put('/:id', requireAdmin, async (req, res) => {
       baseInputFields,
       additionalInputFields,
       workflowData,
+      allowedModelTypes,
       isActive
     } = req.body;
 
@@ -388,6 +392,11 @@ router.put('/:id', requireAdmin, async (req, res) => {
         return res.status(400).json({ message: 'Invalid workflow data format' });
       }
       workboard.version += 1;
+    }
+    if (allowedModelTypes !== undefined) {
+      // ComfyUI 작업판만 의미 있음 — 다른 serverType 은 빈 배열 강제
+      const wbServer = await Server.findById(workboard.serverId);
+      workboard.allowedModelTypes = wbServer?.serverType === 'ComfyUI' ? (allowedModelTypes || []) : [];
     }
     if (isActive !== undefined) workboard.isActive = isActive;
     
@@ -495,6 +504,7 @@ router.post('/:id/duplicate', requireAdmin, async (req, res) => {
       baseInputFields: originalWorkboard.baseInputFields,
       additionalInputFields: originalWorkboard.additionalInputFields,
       workflowData: originalWorkboard.workflowData,
+      allowedModelTypes: originalWorkboard.allowedModelTypes || [],
       createdBy: req.user._id
     });
     
@@ -542,6 +552,7 @@ router.get('/:id/export', requireAdmin, async (req, res) => {
         baseInputFields: workboard.baseInputFields,
         additionalInputFields: workboard.additionalInputFields,
         workflowData: workboard.workflowData,
+        allowedModelTypes: workboard.allowedModelTypes || [],
         version: workboard.version
       },
       server: serverInfo


### PR DESCRIPTION
## Summary
- 신규 이슈 #252 의 backend 작업. ComfyUI 작업판이 어떤 base 모델 타입을 허용할지 admin 이 다중 지정 가능
- `Workboard.allowedModelTypes: [String]` (default `[]`) — 빈 배열은 제약 없음 (기존 동작)
- 마이그레이션 불필요 (default `[]` 가 누락 필드를 자동 처리)

## 결정사항
1. **다중값** — `[String]` (multi-select chips)
2. **enum** — civitai `baseModel` 그대로 (별도 enum 없음)
3. **Civitai 미등록 모델** — 노출 + 경고 (Phase 2 에서 카드에 "메타데이터 없음" chip 으로 인지)

## Routes (`routes/workboards.js`)
- POST: ComfyUI 면 `allowedModelTypes` 저장, 그 외 빈 배열 강제
- PUT: 동일 가드 (workflowData 분기와 별도 처리)
- duplicate / import / export: 보존

## 검증 (제 환경)
```
POST  Workboard (ComfyUI, allowedModelTypes: [SDXL, Illustrious, Pony])
  → 201 + allowedModelTypes: [SDXL, Illustrious, Pony] ✅
PUT   { allowedModelTypes: [FLUX] }
  → 200 + allowedModelTypes: [FLUX] ✅
PUT   { allowedModelTypes: [] }
  → 200 + allowedModelTypes: [] (제약 해제) ✅
POST  Workboard (Gemini, allowedModelTypes: [SDXL])
  → allowedModelTypes: [] (강제) ✅
```

## 후속
**Phase 2 (frontend)**:
- `WorkboardManagement.js` 폼: multi-select chips (서버의 `availableBaseModels` 에서 옵션 채움)
- `ModelPickerGrid.js`: `allowedModelTypes` prop 받아 필터 (baseModel 매칭 OR baseModel 미상)
- `ImageGeneration.js`: workboardData.allowedModelTypes 를 ModelPickerGrid 에 전달

## Test plan
- [x] POST/PUT/duplicate/import/export 회귀
- [x] ComfyUI 외 serverType 에 대해 빈 배열 강제
- [ ] (Phase 2 머지 후 사용자 환경) 폼에서 chips 로 선택 → 저장 → ModelPicker 에서 필터 적용

Refs #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)