### PR TITLE
feat: ComfyUI 작업판 폼 + ModelPickerGrid 에 allowedModelTypes 연동 — #252 Phase 2 (frontend)

### DIFF
--- a/frontend/src/components/ModelPickerGrid.js
+++ b/frontend/src/components/ModelPickerGrid.js
@@ -204,7 +204,10 @@ function ModelPickerGrid({
   serverId,
   selectedModel,
   onSelectModel,
-  isAdmin = false
+  isAdmin = false,
+  // 작업판이 허용하는 base 모델 타입 (#252).
+  // 빈 배열 또는 미설정 = 제약 없음. 설정 시 해당 타입 매칭 모델 + baseModel 미상 모델만 노출.
+  allowedModelTypes = []
 }) {
   const [models, setModels] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -473,17 +476,37 @@ function ModelPickerGrid({
           </Box>
         ) : (
           <>
+            {allowedModelTypes.length > 0 && (
+              <Box sx={{ mb: 2, display: 'flex', flexWrap: 'wrap', gap: 0.5, alignItems: 'center' }}>
+                <Typography variant="caption" color="text.secondary">
+                  작업판 허용 타입:
+                </Typography>
+                {allowedModelTypes.map((t) => (
+                  <Chip key={t} label={t} size="small" color="primary" variant="outlined" />
+                ))}
+                <Typography variant="caption" color="text.secondary">
+                  + 메타데이터 없는 모델
+                </Typography>
+              </Box>
+            )}
             <Grid container spacing={2}>
-              {models.map((model) => (
-                <Grid item xs={12} sm={6} md={4} lg={3} key={model.filename}>
-                  <ModelCard
-                    model={model}
-                    selected={selectedModel === model.filename}
-                    onSelect={handleSelect}
-                    nsfwImageFilter={nsfwImageFilter}
-                  />
-                </Grid>
-              ))}
+              {models
+                .filter((m) => {
+                  if (allowedModelTypes.length === 0) return true;
+                  // baseModel 미상 (Civitai 미등록 / hash 없음) 은 항상 노출 (Phase 1 결정 b)
+                  if (!m.civitai?.baseModel) return true;
+                  return allowedModelTypes.includes(m.civitai.baseModel);
+                })
+                .map((model) => (
+                  <Grid item xs={12} sm={6} md={4} lg={3} key={model.filename}>
+                    <ModelCard
+                      model={model}
+                      selected={selectedModel === model.filename}
+                      onSelect={handleSelect}
+                      nsfwImageFilter={nsfwImageFilter}
+                    />
+                  </Grid>
+                ))}
             </Grid>
             {pagination.pages > 1 && (
               <Box mt={2} display="flex" justifyContent="center">

--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -26,7 +26,8 @@ import {
   AccordionSummary,
   AccordionDetails,
   FormControlLabel,
-  Switch
+  Switch,
+  Autocomplete
 } from '@mui/material';
 import {
   Add,
@@ -235,6 +236,7 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
   const [fullWorkboard, setFullWorkboard] = useState(null);
   const [loading, setLoading] = useState(false);
   const [copiedVariable, setCopiedVariable] = useState('');
+  const [availableBaseModels, setAvailableBaseModels] = useState([]);
   const copyResetTimerRef = React.useRef(null);
   const { control, handleSubmit, reset, watch, setValue, formState: { errors } } = useForm({
     defaultValues: {
@@ -244,6 +246,7 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
       serverType: '',
       outputFormat: 'image',
       workflowData: '',
+      allowedModelTypes: [],
       isActive: true,
       aiModels: [],
       imageSizes: [],
@@ -259,11 +262,26 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
 
   const serverType = watch('serverType');
   const outputFormat = watch('outputFormat');
+  const watchedServerId = watch('serverId');
   const isComfyUI = serverType === 'ComfyUI';
   const isGemini = serverType === 'Gemini';
   const isOpenAIImage = (serverType === 'OpenAI' || serverType === 'OpenAI Compatible') && outputFormat === 'image';
   const isPromptFormat = outputFormat === 'text';
   const isImageFormat = outputFormat === 'image';
+
+  // ComfyUI 서버의 availableBaseModels (#252) — allowedModelTypes 옵션 풀.
+  // ServerModelCache 의 detailed endpoint 에서 derived (limit 1 로 가벼운 호출).
+  React.useEffect(() => {
+    if (!open || !isComfyUI || !watchedServerId) {
+      setAvailableBaseModels([]);
+      return;
+    }
+    serverAPI.getDetailedModels(watchedServerId, { limit: 1 })
+      .then((res) => {
+        setAvailableBaseModels(res.data?.data?.availableBaseModels || []);
+      })
+      .catch(() => setAvailableBaseModels([]));
+  }, [open, isComfyUI, watchedServerId]);
 
   React.useEffect(() => {
     return () => {
@@ -327,6 +345,7 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
             serverType: fullData.serverId?.serverType || '',
             outputFormat: fullData.outputFormat || (fullData.workboardType === 'prompt' ? 'text' : 'image'),
             workflowData: fullData.workflowData || '',
+            allowedModelTypes: fullData.allowedModelTypes || [],
             isActive: fullData.isActive ?? true,
             aiModels: fullData.baseInputFields?.aiModel?.map(m => ({ key: m.key || '', value: m.value || '' })) || [],
             imageSizes: fullData.baseInputFields?.imageSizes?.map(s => ({ key: s.key || '', value: s.value || '' })) || [],
@@ -461,6 +480,7 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
       serverId: data.serverId,
       outputFormat: normalizedOutputFormat,
       workflowData: isComfyUIServer ? data.workflowData : '',
+      allowedModelTypes: isComfyUIServer ? (data.allowedModelTypes || []) : [],
       isActive: Boolean(data.isActive),
       baseInputFields: {
         aiModel: (data.aiModels || []).filter(m => m.key && m.value),
@@ -1439,23 +1459,66 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
               </Accordion>
 
               {isComfyUI && (
-                <Controller
-                  name="workflowData"
-                  control={control}
-                  rules={{ required: isComfyUI ? 'Workflow JSON을 입력해주세요' : false }}
-                  render={({ field }) => (
-                    <TextField
-                      {...field}
-                      fullWidth
-                      multiline
-                      rows={20}
-                      label="ComfyUI Workflow JSON"
-                      error={!!errors.workflowData}
-                      helperText={errors.workflowData?.message || "위 변수 목록을 참고하여 워크플로우를 작성하세요"}
-                      sx={{ fontFamily: 'monospace' }}
+                <>
+                  <Box sx={{ mb: 2 }}>
+                    <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+                      허용 모델 타입 (선택)
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1 }}>
+                      이 작업판에서 사용 가능한 base 모델 타입을 다중 지정. 비워두면 모든 모델이 표시됩니다. Civitai 미등록 모델 (메타데이터 없음) 은 제약과 무관하게 항상 노출됩니다.
+                    </Typography>
+                    <Controller
+                      name="allowedModelTypes"
+                      control={control}
+                      render={({ field }) => (
+                        <Autocomplete
+                          {...field}
+                          multiple
+                          freeSolo
+                          options={availableBaseModels}
+                          value={field.value || []}
+                          onChange={(_, newValue) => field.onChange(newValue)}
+                          renderTags={(value, getTagProps) =>
+                            value.map((option, index) => (
+                              <Chip
+                                {...getTagProps({ index })}
+                                key={option}
+                                label={option}
+                                size="small"
+                                color="primary"
+                                variant="outlined"
+                              />
+                            ))
+                          }
+                          renderInput={(params) => (
+                            <TextField
+                              {...params}
+                              size="small"
+                              placeholder={availableBaseModels.length === 0 ? '서버 모델 sync 후 baseModel 자동 채움' : '예: SDXL, Illustrious, Pony'}
+                            />
+                          )}
+                        />
+                      )}
                     />
-                  )}
-                />
+                  </Box>
+                  <Controller
+                    name="workflowData"
+                    control={control}
+                    rules={{ required: isComfyUI ? 'Workflow JSON을 입력해주세요' : false }}
+                    render={({ field }) => (
+                      <TextField
+                        {...field}
+                        fullWidth
+                        multiline
+                        rows={20}
+                        label="ComfyUI Workflow JSON"
+                        error={!!errors.workflowData}
+                        helperText={errors.workflowData?.message || "위 변수 목록을 참고하여 워크플로우를 작성하세요"}
+                        sx={{ fontFamily: 'monospace' }}
+                      />
+                    )}
+                  />
+                </>
               )}
               {isGemini && (
                 <Alert severity="info">

--- a/frontend/src/pages/ImageGeneration.js
+++ b/frontend/src/pages/ImageGeneration.js
@@ -1360,6 +1360,7 @@ function ImageGeneration() {
           serverId={workboardData?.serverId?._id || workboardData?.serverId}
           selectedModel={selectedCheckpointModel}
           onSelectModel={handleCheckpointModelSelect}
+          allowedModelTypes={workboardData?.allowedModelTypes || []}
         />
       )}
 


### PR DESCRIPTION
## Summary
- Phase 1 (backend) 에서 들어간 `Workboard.allowedModelTypes` 를 admin UI 에서 편집 가능하게 + 사용자 측 ModelPickerGrid 가 자동 필터하게 와이어업
- ComfyUI 작업판 편집 폼의 워크플로우 탭에 "허용 모델 타입" 다중 선택 입력 신규 추가
- Civitai 미등록 모델은 항상 노출 (Phase 1 결정 b — custom merge 케이스 대응)

## 변경 파일

**`WorkboardManagement.js`**:
- 폼 defaultValues 에 `allowedModelTypes: []` 추가
- 기존 작업판 hydration 시 fullData 의 값 복사
- onSubmit 시 ComfyUI 만 저장 (다른 serverType 은 빈 배열 강제)
- 워크플로우 탭에 `Autocomplete multiple freeSolo` 입력 추가:
  - 옵션 풀: 해당 server 의 `availableBaseModels` 자동 채움 (가벼운 `getDetailedModels(id, {limit:1})` 호출)
  - chip 으로 선택 표시, 사용자가 새 값 추가도 가능 (freeSolo)
  - 안내 문구: "Civitai 미등록 모델은 제약과 무관하게 항상 노출됩니다."

**`ModelPickerGrid.js`**:
- 신규 prop `allowedModelTypes` (default `[]`)
- 그리드 상단에 "작업판 허용 타입: [chips] + 메타데이터 없는 모델" 안내 표시
- 클라이언트 사이드 필터:
  - 빈 배열 → 모두 통과
  - `civitai.baseModel` 미상 → 항상 통과 (custom merge 케이스)
  - 매칭 → 통과

**`ImageGeneration.js`**:
- ComfyUI 작업판일 때 `workboardData?.allowedModelTypes` 를 ModelPickerGrid 에 전달

## 검증
- ✅ Frontend nginx 빌드 성공, bundle 200 OK
- ✅ Backend 회귀 영향 없음 (Phase 1 의 backend 그대로 사용)

## 사용자 환경 통합 테스트 (이 PR 머지 후)
1. **admin** — 작업판 관리 → ComfyUI 작업판 편집 → 워크플로우 탭
   - "허용 모델 타입" Autocomplete 표시 ✓
   - 옵션 풀이 server 의 availableBaseModels 로 채워짐 (sync 안 된 서버면 빈 옵션)
   - chip 다중 선택 / 빈 상태로 저장 모두 정상
2. **사용자** — ImageGeneration → ComfyUI 작업판 → "모델 선택"
   - 작업판에 allowedModelTypes 가 설정돼 있으면 그리드 상단에 chip 안내
   - 해당 타입 + 메타데이터 없는 모델만 카드 그리드에 표시
   - 빈 배열 작업판은 모든 모델 표시 (기존 동작과 동일)

## 알려진 제약
- **클라이언트 사이드 필터**: 페이지당 카드 수가 필터링 후 줄 수 있음 (예: 50 모델 중 SDXL 만 30개 → 페이지 1 에 30개 카드만). 정확한 페이지네이션 정합은 Phase 3 (backend `searchServerModels` 가 baseModel 다중 매칭 지원하도록 확장) 에서 개선 가능. 현 단계에서는 기능 검증 우선.
- Autocomplete `freeSolo` 라 admin 이 typo / 없는 baseModel 입력 가능 — 그 경우 매칭되는 모델이 없어 사실상 모든 모델이 미상 fallback 으로 노출됨

Refs #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)