### PR TITLE
feat: allowedBaseModels backend filter + 정확한 페이지네이션 — #252 Phase 3

### DIFF
--- a/frontend/src/components/ModelPickerGrid.js
+++ b/frontend/src/components/ModelPickerGrid.js
@@ -246,12 +246,18 @@ function ModelPickerGrid({
       setLoading(true);
       setError(null);
       try {
-        const response = await serverAPI.getDetailedModels(serverId, {
+        const params = {
           search: searchQuery,
           baseModel: baseModelFilter,
           page,
           limit: 20
-        });
+        };
+        // 작업판 제약을 backend 로 전달 (server-side 필터 + 페이지네이션 정합).
+        // baseModel 미상 모델은 backend 에서 항상 통과 처리됨.
+        if (allowedModelTypes.length > 0) {
+          params.allowedBaseModels = allowedModelTypes;
+        }
+        const response = await serverAPI.getDetailedModels(serverId, params);
         const data = response.data.data;
         setModels(data.models || []);
         setPagination(data.pagination || { current: 1, pages: 0, total: 0 });
@@ -266,7 +272,7 @@ function ModelPickerGrid({
         setLoading(false);
       }
     },
-    [serverId, searchQuery, baseModelFilter]
+    [serverId, searchQuery, baseModelFilter, allowedModelTypes]
   );
 
   // 동기화 상태 폴링
@@ -371,7 +377,10 @@ function ModelPickerGrid({
                 onChange={(e) => setBaseModelFilter(e.target.value)}
               >
                 <MenuItem value="">전체</MenuItem>
-                {availableBaseModels.map((bm) => (
+                {(allowedModelTypes.length > 0
+                  ? availableBaseModels.filter((bm) => allowedModelTypes.includes(bm))
+                  : availableBaseModels
+                ).map((bm) => (
                   <MenuItem key={bm} value={bm}>
                     {bm}
                   </MenuItem>
@@ -490,23 +499,16 @@ function ModelPickerGrid({
               </Box>
             )}
             <Grid container spacing={2}>
-              {models
-                .filter((m) => {
-                  if (allowedModelTypes.length === 0) return true;
-                  // baseModel 미상 (Civitai 미등록 / hash 없음) 은 항상 노출 (Phase 1 결정 b)
-                  if (!m.civitai?.baseModel) return true;
-                  return allowedModelTypes.includes(m.civitai.baseModel);
-                })
-                .map((model) => (
-                  <Grid item xs={12} sm={6} md={4} lg={3} key={model.filename}>
-                    <ModelCard
-                      model={model}
-                      selected={selectedModel === model.filename}
-                      onSelect={handleSelect}
-                      nsfwImageFilter={nsfwImageFilter}
-                    />
-                  </Grid>
-                ))}
+              {models.map((model) => (
+                <Grid item xs={12} sm={6} md={4} lg={3} key={model.filename}>
+                  <ModelCard
+                    model={model}
+                    selected={selectedModel === model.filename}
+                    onSelect={handleSelect}
+                    nsfwImageFilter={nsfwImageFilter}
+                  />
+                </Grid>
+              ))}
             </Grid>
             {pagination.pages > 1 && (
               <Box mt={2} display="flex" justifyContent="center">

--- a/src/routes/servers.js
+++ b/src/routes/servers.js
@@ -325,10 +325,20 @@ router.get('/:id/models', verifyJWT, async (req, res) => {
       }
 
       const { search, hasMetadata, baseModel, page = 1, limit = 50 } = req.query;
+      // allowedBaseModels: query string 으로 array 또는 single 둘 다 받기.
+      // express 가 ?allowedBaseModels=A&allowedBaseModels=B 를 array 로 파싱.
+      let allowedBaseModels = req.query.allowedBaseModels;
+      if (typeof allowedBaseModels === 'string') {
+        allowedBaseModels = [allowedBaseModels];
+      } else if (!Array.isArray(allowedBaseModels)) {
+        allowedBaseModels = undefined;
+      }
+
       const result = await modelMetadataService.searchServerModels(server._id, {
         search,
         hasMetadata: hasMetadata === 'true' ? true : hasMetadata === 'false' ? false : undefined,
         baseModel,
+        allowedBaseModels,
         page: parseInt(page),
         limit: parseInt(limit)
       });

--- a/src/services/modelMetadataService.js
+++ b/src/services/modelMetadataService.js
@@ -459,9 +459,11 @@ const getSyncStatus = async (serverId) => {
  * @param {Object} opts
  * @param {string} opts.search — filename / civitai 메타 / provider 메타 통합 검색
  * @param {boolean} opts.hasMetadata — civitai 또는 provider 메타데이터 보유 여부
- * @param {string} opts.baseModel — civitai.baseModel 매칭 (ComfyUI 만 의미 있음)
+ * @param {string} opts.baseModel — civitai.baseModel 단일 매칭 (사용자 dropdown 필터용)
+ * @param {string[]} opts.allowedBaseModels — civitai.baseModel 다중 매칭 + baseModel 미상 fallback
+ *   (작업판의 allowedModelTypes 와 매핑 — Civitai 미등록 모델은 항상 통과)
  */
-const searchServerModels = async (serverId, { search, hasMetadata, baseModel, page = 1, limit = 50 } = {}) => {
+const searchServerModels = async (serverId, { search, hasMetadata, baseModel, allowedBaseModels, page = 1, limit = 50 } = {}) => {
   const cache = await ServerModelCache.findOne({ serverId });
 
   if (!cache) {
@@ -508,6 +510,15 @@ const searchServerModels = async (serverId, { search, hasMetadata, baseModel, pa
 
   if (baseModel) {
     filtered = filtered.filter(m => m.civitai?.baseModel === baseModel);
+  }
+
+  // allowedBaseModels: 작업판의 allowedModelTypes 적용. 빈 배열/미설정은 제약 없음.
+  // baseModel 미상 모델 (Civitai 미등록 / hash 없음) 은 항상 통과 (custom merge 대응).
+  if (Array.isArray(allowedBaseModels) && allowedBaseModels.length > 0) {
+    filtered = filtered.filter(m => {
+      if (!m.civitai?.baseModel) return true;
+      return allowedBaseModels.includes(m.civitai.baseModel);
+    });
   }
 
   const total = filtered.length;


### PR DESCRIPTION
## Summary
- Phase 2 의 클라이언트 사이드 필터를 server-side 로 이전. 페이지당 카드 수 변동 / 총합 표시 부정확 문제 해결
- Backend `searchServerModels` 에 `allowedBaseModels: [String]` 옵션 추가 (single `baseModel` dropdown 필터와 독립)
- Frontend ModelPickerGrid 가 query param 으로 전달 + 사용자 dropdown 옵션을 작업판 제약과 정합

## 변경

**Backend** — `services/modelMetadataService.js`, `routes/servers.js`:
- `searchServerModels({ allowedBaseModels })` 신규 옵션
  - 빈 배열/미설정 → 제약 없음
  - 비어있지 않으면: `civitai.baseModel` 매칭 OR baseModel 미상 (Civitai 미등록) 통과
- 라우트가 query string 의 `allowedBaseModels` 를 array/single 모두 array 로 정규화

**Frontend** — `components/ModelPickerGrid.js`:
- `allowedModelTypes` prop → `params.allowedBaseModels` 로 backend 에 전달
- 클라이언트 사이드 `.filter()` 제거
- "베이스 모델" dropdown 옵션을 `availableBaseModels ∩ allowedModelTypes` 로 제한 (사용자가 허용 외 타입 선택 방지)

## 검증 (제 환경)

```
서버: 50 models, 8 baseModels
  [Anima, Illustrious, LTXV 2.3, NoobAI, Pony, SDXL 1.0, ZImageBase, ZImageTurbo]

allowedBaseModels=Illustrious&allowedBaseModels=Pony
  → total 38 = 32 Illustrious + 4 Pony + 2 baseModel 미상 ✅

allowedBaseModels=NoobAI
  → total 6 = 4 NoobAI + 2 baseModel 미상 ✅
```

페이지네이션 totalPages 도 정확.

## Phase 2 vs 3 차이
| 항목 | Phase 2 | Phase 3 |
|---|---|---|
| 필터 위치 | 클라이언트 (`.filter()` after fetch) | Backend (`searchServerModels` 인자) |
| 페이지당 카드 수 | 가변 (필터로 줄어듦) | 고정 limit |
| Pagination 정합 | 부정확 | 정확 |
| 사용자 dropdown 옵션 | 전체 baseModels | 허용된 baseModels 만 |

## Test plan
- [x] backend filter 동작 (multi / single)
- [x] baseModel 미상 fallback (custom merge 케이스)
- [x] 단일 `baseModel` (사용자 dropdown) 과 `allowedBaseModels` AND 적용
- [ ] (사용자 환경) ModelPicker 의 chip 안내 + dropdown 옵션 제한 + 페이지네이션 정확

#252 Phase 3 — 마지막 단계. 이 PR 머지로 #252 완료.

Refs #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)