### PR TITLE
feat: stuck sync 자동 정리 + 수동 reset (#256)

### DIFF
--- a/frontend/src/components/admin/ServerManagement.js
+++ b/frontend/src/components/admin/ServerManagement.js
@@ -37,7 +37,8 @@ import {
   TextFields,
   Computer,
   Sync as SyncIcon,
-  CloudSync as CloudSyncIcon
+  CloudSync as CloudSyncIcon,
+  RestartAlt as RestartAltIcon
 } from '@mui/icons-material';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import toast from 'react-hot-toast';
@@ -56,13 +57,17 @@ function ServerCard({
   onHealthCheck,
   onLoraSync,
   loraSyncStatus,
+  onLoraResetSync,
   onModelSync,
   modelSyncStatus,
+  onModelResetSync,
 }) {
   const [healthChecking, setHealthChecking] = useState(false);
   const isComfyUI = server.serverType === 'ComfyUI';
   const isLoraSyncing = loraSyncStatus?.status === 'fetching';
   const isModelSyncing = modelSyncStatus?.status === 'fetching';
+  const loraFailed = loraSyncStatus?.status === 'failed';
+  const modelFailed = modelSyncStatus?.status === 'failed';
   const supportsModelSync = ['ComfyUI', 'OpenAI', 'OpenAI Compatible', 'Gemini'].includes(server.serverType);
 
   const getStatusIcon = (status) => {
@@ -256,6 +261,15 @@ function ServerCard({
             </span>
           </Tooltip>
         )}
+        {isComfyUI && loraFailed && onLoraResetSync && (
+          <Tooltip title={`LoRA 동기화 강제 리셋 (실패 상태 해제)\n오류: ${loraSyncStatus?.errorMessage || '알 수 없음'}`}>
+            <span>
+              <IconButton size="small" onClick={() => onLoraResetSync(server._id)} color="warning">
+                <RestartAltIcon />
+              </IconButton>
+            </span>
+          </Tooltip>
+        )}
         {supportsModelSync && (
           <Tooltip title={isModelSyncing ? `모델 동기화 중... (${modelSyncStatus?.progress?.current || 0}/${modelSyncStatus?.progress?.total || 0})` : '모델 동기화'}>
             <span>
@@ -266,6 +280,15 @@ function ServerCard({
                 color={modelSyncStatus?.totalModels > 0 ? 'primary' : 'default'}
               >
                 {isModelSyncing ? <CircularProgress size={20} /> : <CloudSyncIcon />}
+              </IconButton>
+            </span>
+          </Tooltip>
+        )}
+        {supportsModelSync && modelFailed && onModelResetSync && (
+          <Tooltip title={`모델 동기화 강제 리셋 (실패 상태 해제)\n오류: ${modelSyncStatus?.errorMessage || '알 수 없음'}`}>
+            <span>
+              <IconButton size="small" onClick={() => onModelResetSync(server._id)} color="warning">
+                <RestartAltIcon />
               </IconButton>
             </span>
           </Tooltip>
@@ -670,6 +693,32 @@ function ServerManagement() {
     }
   );
 
+  // LoRA / 모델 sync 상태 강제 리셋 mutation (#256)
+  const loraResetMutation = useMutation(
+    (serverId) => serverAPI.resetLorasSync(serverId),
+    {
+      onSuccess: () => {
+        toast.success('LoRA 동기화 상태가 초기화되었습니다.');
+        queryClient.invalidateQueries(['loraSyncStatuses']);
+      },
+      onError: (error) => {
+        toast.error(error.response?.data?.message || '리셋 실패');
+      }
+    }
+  );
+  const modelResetMutation = useMutation(
+    (serverId) => serverAPI.resetModelsSync(serverId),
+    {
+      onSuccess: () => {
+        toast.success('모델 동기화 상태가 초기화되었습니다.');
+        queryClient.invalidateQueries(['modelSyncStatuses']);
+      },
+      onError: (error) => {
+        toast.error(error.response?.data?.message || '리셋 실패');
+      }
+    }
+  );
+
   const handleAddServer = () => {
     setSelectedServer(null);
     setDialogOpen(true);
@@ -699,6 +748,14 @@ function ServerManagement() {
 
   const handleModelSync = (serverId) => {
     modelSyncMutation.mutate(serverId);
+  };
+
+  const handleLoraResetSync = (serverId) => {
+    loraResetMutation.mutate(serverId);
+  };
+
+  const handleModelResetSync = (serverId) => {
+    modelResetMutation.mutate(serverId);
   };
 
   if (isLoading) {
@@ -747,8 +804,10 @@ function ServerManagement() {
                 onHealthCheck={handleHealthCheck}
                 onLoraSync={handleLoraSync}
                 loraSyncStatus={loraSyncStatuses[server._id]}
+                onLoraResetSync={handleLoraResetSync}
                 onModelSync={handleModelSync}
                 modelSyncStatus={modelSyncStatuses[server._id]}
+                onModelResetSync={handleModelResetSync}
               />
             </Grid>
           ))}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -191,10 +191,12 @@ export const serverAPI = {
   getDetailedModels: (id, params) => api.get(`/servers/${id}/models`, { params: { ...params, detailed: true } }),
   syncModels: (id, options = {}) => api.post(`/servers/${id}/models/sync`, options),
   getModelsSyncStatus: (id) => api.get(`/servers/${id}/models/status`),
+  resetModelsSync: (id) => api.post(`/servers/${id}/models/sync/reset`),
   // LoRA 메타데이터 API
   getLoras: (id, params) => api.get(`/servers/${id}/loras`, { params }),
   syncLoras: (id, options = {}) => api.post(`/servers/${id}/loras/sync`, options),
   getLorasSyncStatus: (id) => api.get(`/servers/${id}/loras/status`),
+  resetLorasSync: (id) => api.post(`/servers/${id}/loras/sync/reset`),
 };
 
 export const promptDataAPI = {

--- a/src/migrations/cleanupStuckSyncs.js
+++ b/src/migrations/cleanupStuckSyncs.js
@@ -1,0 +1,35 @@
+const ServerLoraCache = require('../models/ServerLoraCache');
+const ServerModelCache = require('../models/ServerModelCache');
+
+// #256: backend 재시작 시 in-flight sync 는 fire-and-forget 이라 죽지만,
+// cache 의 status='fetching' 은 그대로 남아 무한 "동기화 중" 상태로 보임.
+// 시작 시점에 모두 실패로 정리 — admin 이 다시 sync 트리거 가능.
+async function cleanupStuckSyncs() {
+  try {
+    const reason = 'Sync interrupted by server restart';
+
+    const loraResult = await ServerLoraCache.updateMany(
+      { status: 'fetching' },
+      { $set: { status: 'failed', errorMessage: reason } }
+    );
+    if (loraResult.modifiedCount > 0) {
+      console.log(`[Migration] ServerLoraCache stuck sync 정리: ${loraResult.modifiedCount}건`);
+    }
+
+    const modelResult = await ServerModelCache.updateMany(
+      { status: 'fetching' },
+      { $set: { status: 'failed', errorMessage: reason } }
+    );
+    if (modelResult.modifiedCount > 0) {
+      console.log(`[Migration] ServerModelCache stuck sync 정리: ${modelResult.modifiedCount}건`);
+    }
+
+    if (loraResult.modifiedCount === 0 && modelResult.modifiedCount === 0) {
+      console.log('[Migration] stuck sync cleanup 불필요 (대상 없음)');
+    }
+  } catch (error) {
+    console.error('[Migration] stuck sync cleanup 오류:', error);
+  }
+}
+
+module.exports = cleanupStuckSyncs;

--- a/src/routes/servers.js
+++ b/src/routes/servers.js
@@ -584,6 +584,44 @@ router.get('/:id/loras/status', verifyJWT, async (req, res) => {
   }
 });
 
+// LoRA 동기화 상태 강제 reset (#256) — stuck/failed 상태에서 다시 sync 가능하게 만들기
+router.post('/:id/loras/sync/reset', requireAdmin, async (req, res) => {
+  try {
+    const server = await Server.findById(req.params.id);
+    if (!server) {
+      return res.status(404).json({ success: false, message: '서버를 찾을 수 없습니다.' });
+    }
+    const cache = await loraMetadataService.resetSyncStatus(server._id);
+    res.json({
+      success: true,
+      data: cache ? { status: cache.status } : { status: 'idle' },
+      message: 'LoRA 동기화 상태가 초기화되었습니다.'
+    });
+  } catch (error) {
+    console.error('LoRA 동기화 reset 오류:', error);
+    res.status(500).json({ success: false, message: 'reset 실패', error: error.message });
+  }
+});
+
+// 모델 동기화 상태 강제 reset (#256)
+router.post('/:id/models/sync/reset', requireAdmin, async (req, res) => {
+  try {
+    const server = await Server.findById(req.params.id);
+    if (!server) {
+      return res.status(404).json({ success: false, message: '서버를 찾을 수 없습니다.' });
+    }
+    const cache = await modelMetadataService.resetSyncStatus(server._id);
+    res.json({
+      success: true,
+      data: cache ? { status: cache.status } : { status: 'idle' },
+      message: '모델 동기화 상태가 초기화되었습니다.'
+    });
+  } catch (error) {
+    console.error('모델 동기화 reset 오류:', error);
+    res.status(500).json({ success: false, message: 'reset 실패', error: error.message });
+  }
+});
+
 // 서버 삭제 시 LoRA 캐시도 함께 삭제
 router.delete('/:id', requireAdmin, async (req, res) => {
   try {

--- a/src/server.js
+++ b/src/server.js
@@ -31,6 +31,7 @@ const migrateServerTypeToOpenAI = require('./migrations/migrateServerTypeToOpenA
 const dropBackupJobTTL = require('./migrations/dropBackupJobTTL');
 const dropWorkboardApiFormat = require('./migrations/dropWorkboardApiFormat');
 const dropLegacyModelCacheCollection = require('./migrations/dropLegacyModelCacheCollection');
+const cleanupStuckSyncs = require('./migrations/cleanupStuckSyncs');
 
 dotenv.config();
 
@@ -177,6 +178,7 @@ const startServer = async () => {
     await dropBackupJobTTL();
     await dropWorkboardApiFormat();
     await dropLegacyModelCacheCollection();
+    await cleanupStuckSyncs();
 
     // Initialize job queues after database connection
     console.log('Initializing job queues...');

--- a/src/services/loraMetadataService.js
+++ b/src/services/loraMetadataService.js
@@ -350,11 +350,15 @@ const getServerLoras = async (serverId, serverUrl) => {
   return cache;
 };
 
+// #256: stale 감지 임계 — fetching 중 progress 갱신이 없으면 죽었다고 판단.
+// Civitai rate limit 1초 + hash 계산 + 네트워크 오버헤드 = 항목당 ~5초 평균 → 5분 무진척이면 stuck.
+const STALE_FETCHING_MS = 5 * 60 * 1000;
+
 /**
- * 동기화 상태 조회
+ * 동기화 상태 조회 — stale 감지 자동 cleanup 포함
  */
 const getSyncStatus = async (serverId) => {
-  const cache = await ServerLoraCache.findOne({ serverId });
+  let cache = await ServerLoraCache.findOne({ serverId });
 
   if (!cache) {
     return {
@@ -362,6 +366,21 @@ const getSyncStatus = async (serverId) => {
       progress: { current: 0, total: 0, stage: 'idle' },
       lastFetched: null
     };
+  }
+
+  // Stale 감지: status='fetching' 인데 updatedAt 이 오래 전이면 sync 가 죽은 것.
+  // 자동으로 failed 로 전환해 admin 이 다시 sync 가능하게 함.
+  if (cache.status === 'fetching' && cache.updatedAt) {
+    const staleMs = Date.now() - new Date(cache.updatedAt).getTime();
+    if (staleMs > STALE_FETCHING_MS) {
+      cache.status = 'failed';
+      cache.errorMessage = `Sync stalled (no progress for ${Math.round(staleMs / 1000)}s)`;
+      try {
+        await cache.save();
+      } catch (e) {
+        console.error('[LoRA stale cleanup] save error:', e.message);
+      }
+    }
   }
 
   return {
@@ -375,6 +394,20 @@ const getSyncStatus = async (serverId) => {
     lorasWithHash: cache.loraModels.filter(l => l.hash).length,
     errorMessage: cache.errorMessage
   };
+};
+
+/**
+ * 동기화 상태를 idle 로 강제 reset.
+ * stuck 또는 failed 상태에서 다시 sync 가능하게 하려는 admin manual action.
+ */
+const resetSyncStatus = async (serverId) => {
+  const cache = await ServerLoraCache.findOne({ serverId });
+  if (!cache) return null;
+  cache.status = 'idle';
+  cache.progress = { current: 0, total: 0, stage: 'idle' };
+  cache.errorMessage = null;
+  await cache.save();
+  return cache;
 };
 
 /**
@@ -462,5 +495,6 @@ module.exports = {
   syncServerLoras,
   getServerLoras,
   getSyncStatus,
+  resetSyncStatus,
   searchServerLoras
 };

--- a/src/services/modelMetadataService.js
+++ b/src/services/modelMetadataService.js
@@ -426,8 +426,11 @@ const getServerCheckpoints = async (serverId, serverUrl) => {
   return cache;
 };
 
+// #256: stale 감지 임계 — LoRA service 와 동일 정책.
+const STALE_FETCHING_MS = 5 * 60 * 1000;
+
 const getSyncStatus = async (serverId) => {
-  const cache = await ServerModelCache.findOne({ serverId });
+  let cache = await ServerModelCache.findOne({ serverId });
 
   if (!cache) {
     return {
@@ -437,6 +440,19 @@ const getSyncStatus = async (serverId) => {
     };
   }
 
+  if (cache.status === 'fetching' && cache.updatedAt) {
+    const staleMs = Date.now() - new Date(cache.updatedAt).getTime();
+    if (staleMs > STALE_FETCHING_MS) {
+      cache.status = 'failed';
+      cache.errorMessage = `Sync stalled (no progress for ${Math.round(staleMs / 1000)}s)`;
+      try {
+        await cache.save();
+      } catch (e) {
+        console.error('[Model stale cleanup] save error:', e.message);
+      }
+    }
+  }
+
   return {
     status: cache.status,
     progress: cache.progress,
@@ -444,10 +460,23 @@ const getSyncStatus = async (serverId) => {
     lastMetadataSync: cache.lastMetadataSync,
     hashNodeAvailable: cache.hashNodeAvailable,
     totalModels: cache.models.length,
-    modelsWithMetadata: cache.models.filter(m => m.civitai?.found).length,
+    modelsWithMetadata: cache.models.filter(m => m.civitai?.found || m.provider?.found).length,
     modelsWithHash: cache.models.filter(m => m.hash).length,
     errorMessage: cache.errorMessage
   };
+};
+
+/**
+ * 동기화 상태를 idle 로 강제 reset.
+ */
+const resetSyncStatus = async (serverId) => {
+  const cache = await ServerModelCache.findOne({ serverId });
+  if (!cache) return null;
+  cache.status = 'idle';
+  cache.progress = { current: 0, total: 0, stage: 'idle' };
+  cache.errorMessage = null;
+  await cache.save();
+  return cache;
 };
 
 /**
@@ -541,5 +570,6 @@ module.exports = {
   syncServerModels,
   getServerCheckpoints,
   getSyncStatus,
+  resetSyncStatus,
   searchServerModels
 };


### PR DESCRIPTION
## Summary
- backend 재시작 시 in-flight sync 가 죽으면서 cache 의 `status='fetching'` 이 영원히 남는 문제 해결 (#256)
- LoRA + Model 양쪽에 동일 적용
- 3 단계 방어선 — startup cleanup / lazy stale 감지 / 수동 reset

## (a) Backend startup cleanup
**신규**: `src/migrations/cleanupStuckSyncs.js`
- ServerLoraCache + ServerModelCache 의 모든 `status='fetching'` → `failed` 일괄 전환
- `errorMessage = "Sync interrupted by server restart"`
- server.js 에 등록 — 매 부팅마다 자동 실행

## (b) Lazy stale 감지 (in `getSyncStatus`)
**LoRA + Model service** 양쪽에 추가:
- `status='fetching'` 이고 `updatedAt` 이 5분 이상 된 경우 → 자동 `failed` 전환
- 폴링이 일어날 때마다 lazy 하게 정리 (backend 재시작 없이도 복구 가능)
- 임계: 5분 (Civitai rate limit + hash + 네트워크 = 항목당 ~5초이라 안전)

## (c) 수동 reset 엔드포인트 + UI
**신규 routes** (admin only):
- `POST /api/servers/:id/loras/sync/reset`
- `POST /api/servers/:id/models/sync/reset`

**신규 service 메서드**: `resetSyncStatus(serverId)` — 강제 idle + progress/errorMessage 초기화

**Frontend ServerManagement**:
- ServerCard 에 `RestartAltIcon` 버튼 추가 (status='failed' 일 때만 표시)
- tooltip 에 `errorMessage` 노출
- LoRA / Model 각각 별도 버튼

## 검증 (제 환경)
- backend 재시작 → 자동 cleanup 마이그레이션 호출됨 (현재는 대상 없음 — 이미 사전 정리)
- stuck LoRA cache 를 reset endpoint 로 idle 전환:
  ```
  GET status: failed (errorMessage: "Sync interrupted...")
  POST .../loras/sync/reset → 200
  GET status: idle (progress 0/0, errorMessage null) ✅
  ```

## 사용자 흐름
| 시나리오 | 자동 복구 |
|---|---|
| backend 재시작 | (a) 즉시 |
| sync 가 죽었지만 backend 살아있음 (예: ComfyUI 서버 다운) | (b) 5분 후 폴링 시 자동 failed 전환 |
| failed 상태 / 즉시 재시도하고 싶을 때 | (c) 강제 리셋 버튼 |

## Test plan
- [x] Backend startup migration 실행 + 정상 메시지 출력
- [x] Reset endpoint 동작 (failed → idle 전환)
- [x] Reset 후 다시 sync 트리거 가능
- [ ] (사용자 환경) ServerManagement UI 의 RestartAltIcon 버튼 노출 + 클릭 동작
- [ ] (사용자 환경) sync 가 5분 이상 멈추면 자동으로 failed 로 전환되는지 (실제 ComfyUI 서버 다운시켜 확인 가능)

Refs #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)