### PR TITLE
feat: 공통 MetadataItemCard + 두 픽업 모달 통합 — #260 Phase 2

### DIFF
--- a/frontend/src/components/LoraListModal.js
+++ b/frontend/src/components/LoraListModal.js
@@ -12,9 +12,6 @@ import {
   Chip,
   TextField,
   InputAdornment,
-  Card,
-  CardContent,
-  CardActions,
   Grid,
   IconButton,
   LinearProgress,
@@ -28,14 +25,9 @@ import {
   FormControlLabel
 } from '@mui/material';
 import {
-  Add as AddIcon,
   Refresh as RefreshIcon,
   Search as SearchIcon,
   Close as CloseIcon,
-  ExpandMore as ExpandMoreIcon,
-  ExpandLess as ExpandLessIcon,
-  OpenInNew as OpenInNewIcon,
-  Info as InfoIcon,
   Warning as WarningIcon,
   VisibilityOff as VisibilityOffIcon,
   Block as BlockIcon
@@ -49,11 +41,8 @@ import {
   insertLoraTag,
   insertTriggerWordWithLora
 } from '../utils/promptUtils';
-import { sanitizeHtml } from '../utils/sanitizeHtml';
-import MetadataMediaThumbnail from './common/MetadataMediaThumbnail';
-
-// LoraThumbnail 의 alias — 기존 호출부 호환성 유지. 신규 코드는 MetadataMediaThumbnail 직접 사용.
-const LoraThumbnail = MetadataMediaThumbnail;
+import MetadataItemCard from './common/MetadataItemCard';
+import { normalizeLora } from '../utils/metadataItem';
 
 function LoraListModal({
   open,
@@ -322,15 +311,6 @@ function LoraListModal({
     return new Date(dateString).toLocaleString('ko-KR');
   };
 
-  const getBaseModelColor = (baseModel) => {
-    if (!baseModel) return 'default';
-    if (baseModel.includes('SDXL')) return 'primary';
-    if (baseModel.includes('SD 1.5') || baseModel.includes('SD1')) return 'secondary';
-    if (baseModel.includes('Pony')) return 'warning';
-    if (baseModel.includes('Flux')) return 'info';
-    return 'default';
-  };
-
   // NSFW 필터링 적용 (클라이언트 사이드)
   const filteredLoraModels = nsfwLoraFilter
     ? loraModels.filter(lora => !lora.civitai?.nsfw)
@@ -513,22 +493,25 @@ function LoraListModal({
         ) : (
           <>
             <Grid container spacing={2}>
-              {filteredLoraModels.map((lora, index) => (
-                <Grid item xs={12} sm={6} md={4} key={lora.filename || index}>
-                  <LoraCard
-                    lora={lora}
-                    expanded={expandedLora === lora.filename}
-                    onToggleExpand={() => setExpandedLora(
-                      expandedLora === lora.filename ? null : lora.filename
-                    )}
-                    onAddLora={handleAddLora}
-                    onCopyTriggerWord={(word) => handleCopyTriggerWord(word, lora)}
-                    getBaseModelColor={getBaseModelColor}
-                    nsfwImageFilter={nsfwImageFilter}
-                    isPromptInsertMode={isPromptInsertMode}
-                  />
-                </Grid>
-              ))}
+              {filteredLoraModels.map((lora, index) => {
+                const item = normalizeLora(lora);
+                return (
+                  <Grid item xs={12} sm={6} md={4} key={item.id || index}>
+                    <MetadataItemCard
+                      item={item}
+                      expanded={expandedLora === item.filename}
+                      onToggleExpand={() => setExpandedLora(
+                        expandedLora === item.filename ? null : item.filename
+                      )}
+                      onPrimary={() => handleAddLora(lora)}
+                      primaryVariant={isPromptInsertMode ? 'insert' : 'add'}
+                      onTrainedWordClick={(word) => handleCopyTriggerWord(word, lora)}
+                      trainedWordInsertMode={isPromptInsertMode}
+                      nsfwImageFilter={nsfwImageFilter}
+                    />
+                  </Grid>
+                );
+              })}
             </Grid>
 
             {/* 페이지네이션 */}
@@ -557,201 +540,5 @@ function LoraListModal({
     </Dialog>
   );
 }
-
-// LoRA 카드 컴포넌트 (React.memo — 카드가 많을 때 (예: 수백 개) re-render 비용 절감)
-const LoraCard = React.memo(function LoraCard({
-  lora,
-  expanded,
-  onToggleExpand,
-  onAddLora,
-  onCopyTriggerWord,
-  getBaseModelColor,
-  nsfwImageFilter,
-  isPromptInsertMode
-}) {
-  const hasCivitai = lora.civitai?.found;
-
-  // NSFW 이미지 필터링
-  const filteredImages = nsfwImageFilter
-    ? (lora.civitai?.images || []).filter(img => !img.nsfw)
-    : (lora.civitai?.images || []);
-  const previewImage = filteredImages[0];
-  const name = lora.civitai?.name || lora.filename.replace(/\.[^/.]+$/, '');
-  const trainedWords = lora.civitai?.trainedWords || [];
-
-  return (
-    <Card
-      variant="outlined"
-      sx={{
-        height: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-        transition: 'border-color 0.2s',
-        '&:hover': { borderColor: 'primary.main' }
-      }}
-    >
-      {/* 미리보기 이미지 */}
-      {previewImage?.url ? (
-        <LoraThumbnail image={previewImage} alt={name} height={140} />
-      ) : (
-        <Box
-          sx={{
-            height: 140,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            bgcolor: 'action.hover'
-          }}
-        >
-          <Typography variant="body2" color="text.secondary">
-            미리보기 없음
-          </Typography>
-        </Box>
-      )}
-
-      <CardContent sx={{ flexGrow: 1, pb: 1 }}>
-        {/* 이름 */}
-        <Typography variant="subtitle2" noWrap title={name}>
-          {name}
-        </Typography>
-
-        {/* 파일명 (Civitai 정보가 있을 경우) */}
-        {hasCivitai && (
-          <Typography variant="caption" color="text.secondary" noWrap display="block">
-            {lora.filename}
-          </Typography>
-        )}
-
-        {/* 기본 모델 배지 */}
-        <Box sx={{ mt: 1, display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
-          {lora.civitai?.baseModel && (
-            <Chip
-              label={lora.civitai.baseModel}
-              size="small"
-              color={getBaseModelColor(lora.civitai.baseModel)}
-              variant="outlined"
-            />
-          )}
-          {!hasCivitai && !lora.hash && (
-            <Tooltip title={lora.hashError || '해시 정보 없음'}>
-              <Chip
-                icon={<InfoIcon />}
-                label="메타데이터 없음"
-                size="small"
-                variant="outlined"
-              />
-            </Tooltip>
-          )}
-          {lora.hash && !hasCivitai && (
-            <Tooltip title="Civitai에서 찾을 수 없음">
-              <Chip
-                label="미등록"
-                size="small"
-                variant="outlined"
-              />
-            </Tooltip>
-          )}
-        </Box>
-
-        {/* 트리거 워드 */}
-        {trainedWords.length > 0 && (
-          <Box sx={{ mt: 1 }}>
-            <Typography variant="caption" color="text.secondary">
-              트리거 워드{isPromptInsertMode ? ' (클릭시 프롬프트에 삽입)' : ' (클릭시 복사)'}:
-            </Typography>
-            <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', mt: 0.5 }}>
-              {trainedWords.slice(0, expanded ? undefined : 3).map((word, i) => (
-                <Chip
-                  key={i}
-                  label={word}
-                  size="small"
-                  onClick={() => onCopyTriggerWord(word)}
-                  sx={{ cursor: 'pointer' }}
-                  color={isPromptInsertMode ? 'primary' : 'default'}
-                  variant={isPromptInsertMode ? 'outlined' : 'filled'}
-                />
-              ))}
-              {!expanded && trainedWords.length > 3 && (
-                <Chip
-                  label={`+${trainedWords.length - 3}`}
-                  size="small"
-                  variant="outlined"
-                />
-              )}
-            </Box>
-          </Box>
-        )}
-      </CardContent>
-
-      {/* 확장 영역 - 펼쳐진 경우에만 렌더링 */}
-      {expanded && (
-        <CardContent sx={{ pt: 0 }}>
-          {lora.civitai?.description && (
-            <Typography
-              variant="body2"
-              color="text.secondary"
-              sx={{
-                maxHeight: 100,
-                overflow: 'auto',
-                mb: 1,
-                '& p': { margin: 0 }
-              }}
-              dangerouslySetInnerHTML={{
-                __html: sanitizeHtml(lora.civitai.description.substring(0, 500))
-              }}
-            />
-          )}
-
-          {/* 추가 미리보기 이미지 */}
-          {filteredImages.length > 1 && (
-            <Box sx={{ display: 'flex', gap: 1, overflow: 'auto', mt: 1 }}>
-              {filteredImages.slice(1).map((img, i) => (
-                <LoraThumbnail
-                  key={i}
-                  image={img}
-                  alt={`Preview ${i + 2}`}
-                  width={60}
-                  height={60}
-                  sx={{ borderRadius: 1, flexShrink: 0 }}
-                />
-              ))}
-            </Box>
-          )}
-        </CardContent>
-      )}
-
-      <CardActions sx={{ justifyContent: 'space-between', pt: 0 }}>
-        <Stack direction="row" spacing={0.5}>
-          {hasCivitai && (
-            <IconButton
-              size="small"
-              onClick={onToggleExpand}
-            >
-              {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-            </IconButton>
-          )}
-          {lora.civitai?.modelUrl && (
-            <Tooltip title="Civitai에서 보기">
-              <IconButton
-                size="small"
-                onClick={() => window.open(lora.civitai.modelUrl, '_blank')}
-              >
-                <OpenInNewIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-          )}
-        </Stack>
-        <Button
-          size="small"
-          startIcon={<AddIcon />}
-          onClick={() => onAddLora(lora)}
-          variant={isPromptInsertMode ? 'contained' : 'text'}
-        >
-          {isPromptInsertMode ? '프롬프트에 추가' : '추가'}
-        </Button>
-      </CardActions>
-    </Card>
-  );
-});
 
 export default LoraListModal;

--- a/frontend/src/components/ModelPickerGrid.js
+++ b/frontend/src/components/ModelPickerGrid.js
@@ -12,9 +12,6 @@ import {
   Chip,
   TextField,
   InputAdornment,
-  Card,
-  CardContent,
-  CardActions,
   Grid,
   IconButton,
   LinearProgress,
@@ -30,151 +27,14 @@ import {
 import {
   Refresh as RefreshIcon,
   Search as SearchIcon,
-  Close as CloseIcon,
-  OpenInNew as OpenInNewIcon,
-  CheckCircle as CheckCircleIcon
+  Close as CloseIcon
 } from '@mui/icons-material';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import toast from 'react-hot-toast';
 import { serverAPI, userAPI } from '../services/api';
 import Pagination from './common/Pagination';
-import MetadataMediaThumbnail from './common/MetadataMediaThumbnail';
-
-// ─── ModelCard ───────────────────────────────────────────────────
-// ComfyUI checkpoint 와 SaaS provider 모델을 동일 카드로 렌더.
-// ComfyUI: civitai.{name, baseModel, images, modelUrl}
-// SaaS:    provider.{name, capabilities, contextWindow, description}
-const ModelCard = React.memo(function ModelCard({ model, selected, onSelect, nsfwImageFilter }) {
-  const civ = model.civitai || {};
-  const prov = model.provider || {};
-
-  const hasCivitai = civ.found === true;
-  const hasProvider = prov.found === true;
-
-  const filteredImages = nsfwImageFilter
-    ? (civ.images || []).filter((img) => !img.nsfw)
-    : (civ.images || []);
-  const previewImage = filteredImages[0];
-
-  // 표시 이름: civitai → provider → filename (확장자 제거)
-  const displayName =
-    civ.name ||
-    prov.name ||
-    model.filename.replace(/\.[^/.]+$/, '');
-
-  const baseModel = civ.baseModel;
-  const capabilities = prov.capabilities || [];
-  const description = civ.description || prov.description;
-
-  return (
-    <Card
-      variant={selected ? 'elevation' : 'outlined'}
-      elevation={selected ? 8 : 0}
-      sx={{
-        height: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-        cursor: 'pointer',
-        transition: 'border-color 0.2s, box-shadow 0.2s',
-        borderColor: selected ? 'primary.main' : undefined,
-        borderWidth: selected ? 2 : 1,
-        '&:hover': { borderColor: 'primary.main' }
-      }}
-      onClick={() => onSelect(model)}
-    >
-      {previewImage?.url ? (
-        <MetadataMediaThumbnail image={previewImage} alt={displayName} />
-      ) : (
-        <Box
-          sx={{
-            height: 140,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            bgcolor: 'action.hover'
-          }}
-        >
-          <Typography variant="body2" color="text.secondary">
-            미리보기 없음
-          </Typography>
-        </Box>
-      )}
-
-      <CardContent sx={{ flexGrow: 1, pb: 1 }}>
-        <Stack direction="row" alignItems="center" spacing={0.5}>
-          {selected && <CheckCircleIcon color="primary" fontSize="small" />}
-          <Typography variant="subtitle2" noWrap title={displayName} sx={{ flexGrow: 1 }}>
-            {displayName}
-          </Typography>
-        </Stack>
-
-        {(hasCivitai || hasProvider) && (
-          <Typography variant="caption" color="text.secondary" noWrap display="block">
-            {model.filename}
-          </Typography>
-        )}
-
-        <Box sx={{ mt: 1, display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
-          {baseModel && (
-            <Chip label={baseModel} size="small" color="primary" variant="outlined" />
-          )}
-          {capabilities.slice(0, 3).map((c) => (
-            <Chip key={c} label={c} size="small" variant="outlined" />
-          ))}
-          {!hasCivitai && !hasProvider && !model.hash && (
-            <Tooltip title={model.hashError || '메타데이터 없음 — sync 가 아직 안 됐거나 Civitai/provider 미등록'}>
-              <Chip label="메타데이터 없음" size="small" variant="outlined" />
-            </Tooltip>
-          )}
-          {model.hash && !hasCivitai && (
-            <Tooltip title="Civitai 미등록 (custom merge / private 모델)">
-              <Chip label="미등록" size="small" variant="outlined" />
-            </Tooltip>
-          )}
-        </Box>
-
-        {prov.contextWindow && (
-          <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 1 }}>
-            context: {prov.contextWindow.toLocaleString()} tokens
-          </Typography>
-        )}
-
-        {description && (
-          <Typography
-            variant="caption"
-            color="text.secondary"
-            display="block"
-            sx={{
-              mt: 1,
-              overflow: 'hidden',
-              display: '-webkit-box',
-              WebkitLineClamp: 2,
-              WebkitBoxOrient: 'vertical'
-            }}
-          >
-            {description}
-          </Typography>
-        )}
-      </CardContent>
-
-      {civ.modelUrl && (
-        <CardActions sx={{ pt: 0 }}>
-          <Tooltip title="Civitai 에서 보기">
-            <IconButton
-              size="small"
-              onClick={(e) => {
-                e.stopPropagation();
-                window.open(civ.modelUrl, '_blank');
-              }}
-            >
-              <OpenInNewIcon fontSize="small" />
-            </IconButton>
-          </Tooltip>
-        </CardActions>
-      )}
-    </Card>
-  );
-});
+import MetadataItemCard from './common/MetadataItemCard';
+import { normalizeModel } from '../utils/metadataItem';
 
 // ─── ModelPickerGrid ─────────────────────────────────────────────
 // ComfyUI checkpoint + SaaS provider 모델 통합 picker.
@@ -481,16 +341,20 @@ function ModelPickerGrid({
               </Box>
             )}
             <Grid container spacing={2}>
-              {models.map((model) => (
-                <Grid item xs={12} sm={6} md={4} lg={3} key={model.filename}>
-                  <ModelCard
-                    model={model}
-                    selected={selectedModel === model.filename}
-                    onSelect={handleSelect}
-                    nsfwImageFilter={nsfwImageFilter}
-                  />
-                </Grid>
-              ))}
+              {models.map((model) => {
+                const item = normalizeModel(model);
+                return (
+                  <Grid item xs={12} sm={6} md={4} lg={3} key={item.id}>
+                    <MetadataItemCard
+                      item={item}
+                      selected={selectedModel === item.filename}
+                      onPrimary={() => handleSelect(model)}
+                      cardClickable
+                      nsfwImageFilter={nsfwImageFilter}
+                    />
+                  </Grid>
+                );
+              })}
             </Grid>
             {pagination.pages > 1 && (
               <Box mt={2} display="flex" justifyContent="center">

--- a/frontend/src/components/common/MetadataItemCard.js
+++ b/frontend/src/components/common/MetadataItemCard.js
@@ -1,0 +1,285 @@
+import React from 'react';
+import {
+  Card,
+  CardContent,
+  CardActions,
+  Box,
+  Typography,
+  Chip,
+  Stack,
+  IconButton,
+  Tooltip,
+  Button
+} from '@mui/material';
+import {
+  Info as InfoIcon,
+  ExpandMore as ExpandMoreIcon,
+  ExpandLess as ExpandLessIcon,
+  OpenInNew as OpenInNewIcon,
+  CheckCircle as CheckCircleIcon,
+  Add as AddIcon
+} from '@mui/icons-material';
+import MetadataMediaThumbnail from './MetadataMediaThumbnail';
+import { sanitizeHtml } from '../../utils/sanitizeHtml';
+import { getKindLabel } from '../../utils/metadataItem';
+
+// baseModel → MUI color 매핑 — LoRA / Model 공용. 기존 LoraListModal 의 정책 그대로.
+export function getBaseModelColor(baseModel) {
+  if (!baseModel) return 'default';
+  if (baseModel.includes('SDXL')) return 'primary';
+  if (baseModel.includes('SD 1.5') || baseModel.includes('SD1')) return 'secondary';
+  if (baseModel.includes('Pony')) return 'warning';
+  if (baseModel.includes('Flux')) return 'info';
+  if (baseModel.includes('Illustrious')) return 'primary';
+  if (baseModel.includes('NoobAI')) return 'secondary';
+  return 'default';
+}
+
+/**
+ * 공통 메타데이터 카드 — LoRA / Checkpoint / Provider 모델 모두 지원.
+ *
+ * @param {Object} props
+ * @param {import('../../utils/metadataItem').MetadataItem} props.item
+ * @param {boolean} [props.selected] — 선택 표시 (단일 선택 picker)
+ * @param {boolean} [props.expanded] — 확장 영역 (description + 추가 이미지) 표시
+ * @param {() => void} [props.onToggleExpand]
+ * @param {(item) => void} [props.onPrimary] — 카드 전체 클릭 또는 primary 버튼 액션. 미지정 시 클릭 비활성
+ * @param {string} [props.primaryLabel] — primary 버튼 라벨 (기본 '선택')
+ * @param {'select'|'add'|'insert'} [props.primaryVariant] — 버튼 스타일 힌트
+ * @param {(word, item) => void} [props.onTrainedWordClick] — 트리거 워드 (LoRA) 클릭 콜백. 미지정 시 chip 클릭 무효
+ * @param {boolean} [props.trainedWordInsertMode] — 트리거 워드를 "프롬프트에 삽입" 안내로 표시 (LoRA picker 의 prompt 삽입 모드)
+ * @param {boolean} [props.cardClickable] — 카드 전체 영역 클릭으로 onPrimary 호출 (default: false. true 시 picker 용)
+ * @param {boolean} [props.nsfwImageFilter] — NSFW 미리보기 이미지 숨김
+ * @param {Function} [props.baseModelColorFn] — baseModel → color 매핑 (default: getBaseModelColor)
+ */
+const MetadataItemCard = React.memo(function MetadataItemCard({
+  item,
+  selected = false,
+  expanded = false,
+  onToggleExpand,
+  onPrimary,
+  primaryLabel,
+  primaryVariant = 'select',
+  onTrainedWordClick,
+  trainedWordInsertMode = false,
+  cardClickable = false,
+  nsfwImageFilter = true,
+  baseModelColorFn = getBaseModelColor
+}) {
+  if (!item) return null;
+
+  const filteredImages = nsfwImageFilter
+    ? (item.images || []).filter((img) => !img.nsfw)
+    : (item.images || []);
+  const previewImage = filteredImages[0];
+
+  const hasCivitai = item.metadataSource === 'civitai';
+  const hasProvider = item.metadataSource === 'provider';
+
+  const handleCardClick = cardClickable && onPrimary ? () => onPrimary(item) : undefined;
+
+  const resolvedPrimaryLabel = primaryLabel || (primaryVariant === 'insert' ? '프롬프트에 추가' : primaryVariant === 'add' ? '추가' : '선택');
+
+  return (
+    <Card
+      variant={selected ? 'elevation' : 'outlined'}
+      elevation={selected ? 8 : 0}
+      onClick={handleCardClick}
+      sx={{
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        cursor: cardClickable ? 'pointer' : 'default',
+        transition: 'border-color 0.2s, box-shadow 0.2s',
+        borderColor: selected ? 'primary.main' : undefined,
+        borderWidth: selected ? 2 : 1,
+        '&:hover': { borderColor: 'primary.main' }
+      }}
+    >
+      {/* 미리보기 */}
+      {previewImage?.url ? (
+        <MetadataMediaThumbnail image={previewImage} alt={item.displayName} />
+      ) : (
+        <Box
+          sx={{
+            height: 140,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            bgcolor: 'action.hover'
+          }}
+        >
+          <Typography variant="body2" color="text.secondary">
+            미리보기 없음
+          </Typography>
+        </Box>
+      )}
+
+      <CardContent sx={{ flexGrow: 1, pb: 1 }}>
+        {/* 이름 + 선택 표시 */}
+        <Stack direction="row" alignItems="center" spacing={0.5}>
+          {selected && <CheckCircleIcon color="primary" fontSize="small" />}
+          <Typography variant="subtitle2" noWrap title={item.displayName} sx={{ flexGrow: 1 }}>
+            {item.displayName}
+          </Typography>
+        </Stack>
+
+        {/* 파일명 (메타데이터 있을 때만 별도 표시) */}
+        {item.hasMetadata && item.filename !== item.displayName && (
+          <Typography variant="caption" color="text.secondary" noWrap display="block">
+            {item.filename}
+          </Typography>
+        )}
+
+        {/* 배지: kind + baseModel + capabilities + 메타데이터 상태 */}
+        <Box sx={{ mt: 1, display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+          <Chip label={getKindLabel(item.kind)} size="small" variant="outlined" />
+          {item.baseModel && (
+            <Chip
+              label={item.baseModel}
+              size="small"
+              color={baseModelColorFn(item.baseModel)}
+              variant="outlined"
+            />
+          )}
+          {item.capabilities.slice(0, 3).map((c) => (
+            <Chip key={c} label={c} size="small" variant="outlined" />
+          ))}
+          {!item.hasMetadata && !item.hash && (
+            <Tooltip title={item.hashError || '메타데이터 없음 — sync 가 아직 안 됐거나 Civitai/provider 미등록'}>
+              <Chip icon={<InfoIcon />} label="메타데이터 없음" size="small" variant="outlined" />
+            </Tooltip>
+          )}
+          {item.hash && !item.hasMetadata && (
+            <Tooltip title="Civitai 미등록 (custom merge / private 모델)">
+              <Chip label="미등록" size="small" variant="outlined" />
+            </Tooltip>
+          )}
+        </Box>
+
+        {/* contextWindow (provider 만) */}
+        {item.contextWindow && (
+          <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 1 }}>
+            context: {item.contextWindow.toLocaleString()} tokens
+          </Typography>
+        )}
+
+        {/* 트리거 워드 (LoRA / civitai trainedWords) */}
+        {item.trainedWords?.length > 0 && (
+          <Box sx={{ mt: 1 }}>
+            <Typography variant="caption" color="text.secondary">
+              트리거 워드{onTrainedWordClick ? (trainedWordInsertMode ? ' (클릭시 프롬프트에 삽입)' : ' (클릭시 복사)') : ''}:
+            </Typography>
+            <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', mt: 0.5 }}>
+              {item.trainedWords.slice(0, expanded ? undefined : 3).map((word, i) => (
+                <Chip
+                  key={i}
+                  label={word}
+                  size="small"
+                  onClick={onTrainedWordClick ? (e) => {
+                    e.stopPropagation();
+                    onTrainedWordClick(word, item);
+                  } : undefined}
+                  sx={{ cursor: onTrainedWordClick ? 'pointer' : 'default' }}
+                  color={trainedWordInsertMode ? 'primary' : 'default'}
+                  variant={trainedWordInsertMode ? 'outlined' : 'filled'}
+                />
+              ))}
+              {!expanded && item.trainedWords.length > 3 && (
+                <Chip label={`+${item.trainedWords.length - 3}`} size="small" variant="outlined" />
+              )}
+            </Box>
+          </Box>
+        )}
+      </CardContent>
+
+      {/* 확장 영역 (description + 추가 이미지) */}
+      {expanded && (
+        <CardContent sx={{ pt: 0 }}>
+          {item.description && hasCivitai && (
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{
+                maxHeight: 100,
+                overflow: 'auto',
+                mb: 1,
+                '& p': { margin: 0 }
+              }}
+              dangerouslySetInnerHTML={{
+                __html: sanitizeHtml(item.description.substring(0, 500))
+              }}
+            />
+          )}
+          {item.description && hasProvider && (
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ maxHeight: 100, overflow: 'auto', mb: 1 }}
+            >
+              {item.description.substring(0, 500)}
+            </Typography>
+          )}
+          {filteredImages.length > 1 && (
+            <Box sx={{ display: 'flex', gap: 1, overflow: 'auto', mt: 1 }}>
+              {filteredImages.slice(1).map((img, i) => (
+                <MetadataMediaThumbnail
+                  key={i}
+                  image={img}
+                  alt={`Preview ${i + 2}`}
+                  width={60}
+                  height={60}
+                  sx={{ borderRadius: 1, flexShrink: 0 }}
+                />
+              ))}
+            </Box>
+          )}
+        </CardContent>
+      )}
+
+      <CardActions sx={{ justifyContent: 'space-between', pt: 0 }}>
+        <Stack direction="row" spacing={0.5}>
+          {(item.hasMetadata || item.description) && onToggleExpand && (
+            <IconButton
+              size="small"
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggleExpand();
+              }}
+            >
+              {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+            </IconButton>
+          )}
+          {item.modelUrl && (
+            <Tooltip title="Civitai 에서 보기">
+              <IconButton
+                size="small"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  window.open(item.modelUrl, '_blank');
+                }}
+              >
+                <OpenInNewIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          )}
+        </Stack>
+        {onPrimary && !cardClickable && (
+          <Button
+            size="small"
+            startIcon={primaryVariant === 'select' ? null : <AddIcon />}
+            onClick={(e) => {
+              e.stopPropagation();
+              onPrimary(item);
+            }}
+            variant={primaryVariant === 'insert' ? 'contained' : 'text'}
+          >
+            {resolvedPrimaryLabel}
+          </Button>
+        )}
+      </CardActions>
+    </Card>
+  );
+});
+
+export default MetadataItemCard;


### PR DESCRIPTION
## Summary
- Phase 1 의 `MetadataItem` normalize helper 위에 **공통 카드 컴포넌트** 빌드
- `LoraListModal` 의 `LoraCard` (196 라인) + `ModelPickerGrid` 의 `ModelCard` (130 라인) 제거하고 단일 `MetadataItemCard` 로 통합
- LoRA 의 풍부한 기능 (확장 영역, 트리거 워드 chip, modelUrl 링크) 이 자동으로 모델 카드에도 적용됨 — 사용자 지적 사항 ("모델 그리드가 lora 대비 빠진 기능 많다") 해결

## 신규 컴포넌트
`frontend/src/components/common/MetadataItemCard.js`

**Props 요약**:
- `item`: MetadataItem (Phase 1)
- `selected` / `expanded` / `nsfwImageFilter`
- `onToggleExpand` / `onPrimary`
- `primaryLabel` / `primaryVariant`: `'select'` / `'add'` / `'insert'`
- `onTrainedWordClick` + `trainedWordInsertMode`: LoRA 트리거 워드 동작
- `cardClickable`: true 시 카드 전체 클릭 → onPrimary (단일 선택 picker 용)

**렌더**: 썸네일 / kind badge / baseModel chip / capabilities chips (provider 만) / 트리거 워드 chips (LoRA 만) / contextWindow (provider 만) / 메타데이터 상태 chip / 확장 영역 (description + 추가 이미지) / 액션 (확장 토글 + Civitai 링크 + primary 버튼)

추가 export: `getBaseModelColor(baseModel)` — MUI color 매핑 (공용 정책)

## 변경
| 파일 | 라인 변동 |
|---|---|
| `MetadataItemCard.js` (신규) | +250 |
| `LoraListModal.js` | 807 → 561 (-246) |
| `ModelPickerGrid.js` | 530 → 360 (-170) |
| **순합** | **+323 / -387** |

## 회귀 영역 검토
- LoRA picker (prompt 삽입 모드): `primaryVariant='insert'` + `onTrainedWordClick` 으로 기존 UX 유지
- LoRA picker (다중 add 모드): `primaryVariant='add'` 로 유지
- Model picker (단일 선택): `cardClickable=true` + `onPrimary` 로 유지
- 메모리: React.memo + lazy 썸네일 그대로 (#258 정책 유지)
- 베이스 모델 색상: 기존 LoRA 정책 유지 + Illustrious/NoobAI 추가

## Test plan
- [x] frontend nginx 빌드 성공
- [ ] (사용자 환경) LoRA picker — 카드 표시 / 확장 / 트리거 워드 클릭 / Civitai 링크 / 추가 버튼 (prompt 삽입 모드 포함)
- [ ] (사용자 환경) Model picker — 카드 표시 / 단일 선택 (카드 클릭) / 확장 / capabilities chips / Civitai 링크 / NSFW 필터
- [ ] 50+ 카드 렌더 시 메모리 회귀 없음 (#258 fix 보존 확인)

## 후속
- **Phase 3**: 검색/필터/페이지네이션/sync 까지 포함한 공통 picker modal — 두 모달 자체가 합쳐짐
- **Phase 4**: 공통 admin 페이지 + LoRA 즐겨찾기 기능을 모델에도 적용

Refs #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)