### PR TITLE
fix: MetadataPickerModal 무한 fetch loop — allowedModelTypes default 안정화

### DIFF
--- a/frontend/src/components/common/MetadataPickerModal.js
+++ b/frontend/src/components/common/MetadataPickerModal.js
@@ -38,6 +38,10 @@ import { normalizeLora, normalizeModel } from '../../utils/metadataItem';
 
 // ─── Per-kind API adapters ────────────────────────────────────────
 // kind 별 fetch / sync / status / normalize / 응답 필드명을 한 곳에서 관리.
+// 안정적인 빈 배열 reference — `allowedModelTypes = []` default 가 매 render 마다 새 array 를
+// 만들어 useCallback / useEffect 의존성을 깨면서 무한 fetch loop 를 일으키던 버그 수정.
+const EMPTY_ALLOWED_MODEL_TYPES = Object.freeze([]);
+
 const KIND_ADAPTERS = {
   lora: {
     fetch: ({ serverId, workboardId, search, baseModel, allowedBaseModels, page, limit }) => {
@@ -116,7 +120,7 @@ function MetadataPickerModal({
   selectedItem,
   onPrimary,
   onTrainedWordClick,
-  allowedModelTypes = [],
+  allowedModelTypes = EMPTY_ALLOWED_MODEL_TYPES,
   title
 }) {
   // 잘못된 kind 는 internal API 위반 — KIND_ADAPTERS 에 없으면 빈 객체로 fallback,


### PR DESCRIPTION
## 증상
LoRA picker 모달 호출 시 화면 높이가 "커졌다 작아졌다" 를 무한 반복. 데이터가 깜박이며 페이지가 멈출 정도.

## 원인 분석
\`MetadataPickerModal\` 의 props default:
\`\`\`js
function MetadataPickerModal({
  allowedModelTypes = [],  // ← 매 render 마다 새 array literal
  ...
})
\`\`\`

이 새 array reference 가 \`useCallback\` 의존성에 포함되어:

1. \`fetchItems\` (useCallback) 가 매 render 마다 새 함수 identity
2. \`useEffect(..., [fetchItems])\` 가 fetchItems 변경 감지 → 재실행
3. fetchItems 가 \`setLoading(true)\` → re-render → 새 [] → loop

**LoRA picker 한정 발현**: ImageGeneration 에서 \`allowedModelTypes\` prop 을 LoRA picker 에는 전달 안 함 → default 활성화. Model picker 는 prop 전달돼서 안 보임.

## 수정
default 를 module-level 의 frozen stable reference 로:

\`\`\`js
const EMPTY_ALLOWED_MODEL_TYPES = Object.freeze([]);

function MetadataPickerModal({
  ...,
  allowedModelTypes = EMPTY_ALLOWED_MODEL_TYPES,
  ...
})
\`\`\`

이제 prop 미전달 시 항상 같은 reference → useCallback 안정 → useEffect 안정 → 1회 fetch + 검색/필터 시에만 재 fetch.

## 회귀 영역
- LoRA picker: 무한 loop 해소
- Model picker: prop 전달 시 동작 동일, 미전달 시도 안정

## Test plan
- [x] frontend rebuild 통과 (--no-cache)
- [ ] (사용자 환경) LoRA picker 호출 시 정상 1회 로드 + 깜박임 없음
- [ ] (사용자 환경) Model picker 회귀 없음

## 잠재 위험
다른 hook 의존성 배열에 같은 패턴 (\`= []\` / \`= {}\` default) 이 있는지 추후 점검 권장. 이번에 수정한 곳만 즉시 영향이 있었음.

Refs #260