### PR TITLE
fix: Civitai 썸네일 다운로드 속도 — /original=true/ → /width=N/

### DIFF
--- a/frontend/src/components/common/MetadataMediaThumbnail.js
+++ b/frontend/src/components/common/MetadataMediaThumbnail.js
@@ -5,6 +5,9 @@ import { Box } from '@mui/material';
 // 메모리 절약 포인트:
 // - 이미지: `loading="lazy"` 로 viewport 밖 카드는 fetch 안 함
 // - 비디오: `preload="metadata"` 만 받고, hover 시에만 재생 (idle 메모리 최소화)
+// 다운로드 절약 포인트 (#268):
+// - Civitai 의 `/original=true/` 경로 → `/width=N/` 으로 자동 치환. CDN 측에서
+//   resize 된 썸네일 반환 (수 MB → 수십 KB). 카드 크기 (140px) 에 맞춰 default 300
 
 export function isVideoMedia(img) {
   if (img?.type === 'video') return true;
@@ -12,17 +15,34 @@ export function isVideoMedia(img) {
   return /\.(mp4|webm|mov)(\?|$)/i.test(img.url);
 }
 
+// Civitai CDN URL 의 transform segment 를 width 기반 thumbnail 로 치환.
+// 비-Civitai URL 은 변경 없이 통과.
+export function civitaiThumbnailUrl(url, width = 300) {
+  if (!url || typeof url !== 'string') return url;
+  // image.civitai.com 의 URL 만 처리
+  if (!url.includes('image.civitai.com')) return url;
+  // /original=true/  → /width=N/
+  // 또는 /width=NN/ 이미 있으면 그대로 (사용자 명시 size 존중)
+  if (/\/width=\d+/.test(url)) return url;
+  return url.replace(/\/original=true\//, `/width=${width}/`);
+}
+
 function MetadataMediaThumbnail({ image, alt, height, width, sx }) {
   const videoRef = useRef(null);
 
   if (!image?.url) return null;
+
+  // Civitai 의 /original=true/ → /width=N/ 자동 치환 (이미지). 비디오는 transform 무관.
+  // height 가 명시된 경우 그 값을 width 보다 약간 크게 잡아 quality 보장 (CDN 은 long-edge 기준).
+  const targetWidth = Math.max((height || 140) * 2, 300);  // retina 대응 + 최소 300
+  const optimizedUrl = isVideoMedia(image) ? image.url : civitaiThumbnailUrl(image.url, targetWidth);
 
   if (isVideoMedia(image)) {
     return (
       <Box
         component="video"
         ref={videoRef}
-        src={image.url}
+        src={optimizedUrl}
         muted
         loop
         playsInline
@@ -44,7 +64,7 @@ function MetadataMediaThumbnail({ image, alt, height, width, sx }) {
   return (
     <Box
       component="img"
-      src={image.url}
+      src={optimizedUrl}
       alt={alt}
       loading="lazy"
       sx={{


### PR DESCRIPTION
## 증상
LoRA / Model picker 의 카드 썸네일이 로컬 환경에서도 너무 느리게 로딩.

## 원인
Civitai 가 반환하는 image URL 이 \`/original=true/\` 경로 — 즉 **원본 풀 사이즈** 이미지/비디오를 직접 다운로드 중.

\`\`\`
DB에 저장된 URL 예:
  https://image.civitai.com/.../original=true/75423327.jpeg
  → 원본 사이즈 (수 MB)
\`\`\`

카드 크기는 140px 인데 풀 사이즈를 받으면 그리드 50카드 로딩 시 수백 MB 대역폭 + 느린 응답. lazy loading (#258) 으로 메모리 압박은 해결됐지만 **각 이미지 자체의 다운로드 속도** 는 여전히 원본 크기 그대로.

## 수정
\`MetadataMediaThumbnail\` 이 src 사용 전에 자동으로 \`/original=true/\` → \`/width=N/\` 치환. Civitai CDN 이 server-side 에서 resize 된 썸네일 반환.

\`\`\`js
export function civitaiThumbnailUrl(url, width = 300) {
  if (!url.includes('image.civitai.com')) return url;
  if (/\\/width=\\d+/.test(url)) return url;  // 이미 width 명시 시 보존
  return url.replace(/\\/original=true\\//, \`/width=\${width}/\`);
}
\`\`\`

기본 width 는 \`(height || 140) * 2\` 또는 최소 300 — retina 대응.

## 효과
| 항목 | Before | After |
|---|---|---|
| 이미지 썸네일 size | 수 MB | 수십 KB |
| 50카드 그리드 대역폭 | 수백 MB | 수 MB |
| 응답시간 | 느림 | 즉시 |

비디오 (.mp4) 는 CDN transform 효과 미미 — 별도 최적화 필요 시 후속 (썸네일 이미지 추출 등).

## 회귀
- 비-Civitai URL: 변경 없이 통과
- 이미 \`/width=N/\` 명시된 URL: 보존

## Test plan
- [x] frontend rebuild --no-cache 통과
- [ ] (사용자 환경) LoRA picker / Model picker 썸네일 즉시 로드
- [ ] 원본 보기 (Civitai 외부 링크 클릭) 는 영향 없음

Refs #260