### PR TITLE
feat: 공통 MetadataItemGrid wrapper — Phase 6 (#260)

### DIFF
--- a/frontend/src/components/common/MetadataItemGrid.js
+++ b/frontend/src/components/common/MetadataItemGrid.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+
+/**
+ * 메타데이터 아이템 카드 그리드 — auto-fill 기반의 일관된 layout.
+ * LoRA admin / Model admin / Picker modal 에서 공용.
+ *
+ * 정책:
+ * - `display: grid` + `auto-fill` 로 화면 폭에 따라 자동 채움
+ * - xs (모바일): minmax(150px, 1fr) — 좁은 화면 효율
+ * - sm+ (태블릿/데스크탑): minmax(200px, 1fr)
+ * - 카드 max width 280 (sm+) — 너무 늘어나는 것 방지
+ *
+ * @param {Object} props
+ * @param {Array} props.items — 렌더할 아이템 배열
+ * @param {(item, index) => React.Node} props.renderItem — 카드 렌더 콜백
+ * @param {(item, index) => string|number} [props.getKey] — key 추출 (default: item.id || index)
+ * @param {React.Node} [props.empty] — items.length === 0 일 때 렌더할 컨텐츠
+ * @param {Object} [props.sx] — 추가 스타일
+ */
+function MetadataItemGrid({ items, renderItem, getKey, empty, sx }) {
+  if (!items || items.length === 0) {
+    if (empty) return empty;
+    return (
+      <Box textAlign="center" py={4}>
+        <Typography variant="body2" color="text.secondary">
+          항목이 없습니다.
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: {
+          xs: 'repeat(auto-fill, minmax(150px, 1fr))',
+          sm: 'repeat(auto-fill, minmax(200px, 1fr))'
+        },
+        gap: 2,
+        '& > *': {
+          maxWidth: { xs: 'none', sm: 280 }
+        },
+        ...sx
+      }}
+    >
+      {items.map((item, index) => {
+        const key = getKey ? getKey(item, index) : (item?.id ?? index);
+        return <Box key={key}>{renderItem(item, index)}</Box>;
+      })}
+    </Box>
+  );
+}
+
+export default MetadataItemGrid;

--- a/frontend/src/components/common/MetadataPickerModal.js
+++ b/frontend/src/components/common/MetadataPickerModal.js
@@ -34,6 +34,7 @@ import toast from 'react-hot-toast';
 import { serverAPI, workboardAPI, userAPI } from '../../services/api';
 import Pagination from './Pagination';
 import MetadataItemCard from './MetadataItemCard';
+import MetadataItemGrid from './MetadataItemGrid';
 import { normalizeLora, normalizeModel } from '../../utils/metadataItem';
 
 // ─── Per-kind API adapters ────────────────────────────────────────
@@ -451,28 +452,28 @@ function MetadataPickerModal({
           </Box>
         ) : (
           <>
-            <Grid container spacing={2}>
-              {filteredItems.map((rawItem, index) => {
+            <MetadataItemGrid
+              items={filteredItems}
+              getKey={(rawItem, index) => rawItem.filename || index}
+              renderItem={(rawItem) => {
                 const item = adapter.normalize(rawItem);
                 if (!item) return null;
                 return (
-                  <Grid item xs={12} sm={6} md={4} lg={3} key={item.id || index}>
-                    <MetadataItemCard
-                      item={item}
-                      selected={selectedItem === item.filename}
-                      expanded={expandedId === item.id}
-                      onToggleExpand={() => setExpandedId(expandedId === item.id ? null : item.id)}
-                      onPrimary={() => handlePrimary(rawItem)}
-                      primaryVariant={cardPrimaryVariant}
-                      cardClickable={cardClickable}
-                      onTrainedWordClick={onTrainedWordClick ? (word) => onTrainedWordClick(word, rawItem) : undefined}
-                      trainedWordInsertMode={mode === 'prompt-insert'}
-                      nsfwImageFilter={nsfwImageFilter}
-                    />
-                  </Grid>
+                  <MetadataItemCard
+                    item={item}
+                    selected={selectedItem === item.filename}
+                    expanded={expandedId === item.id}
+                    onToggleExpand={() => setExpandedId(expandedId === item.id ? null : item.id)}
+                    onPrimary={() => handlePrimary(rawItem)}
+                    primaryVariant={cardPrimaryVariant}
+                    cardClickable={cardClickable}
+                    onTrainedWordClick={onTrainedWordClick ? (word) => onTrainedWordClick(word, rawItem) : undefined}
+                    trainedWordInsertMode={mode === 'prompt-insert'}
+                    nsfwImageFilter={nsfwImageFilter}
+                  />
                 );
-              })}
-            </Grid>
+              }}
+            />
             {pagination.pages > 1 && (
               <Box mt={2} display="flex" justifyContent="center">
                 <Pagination

--- a/frontend/src/pages/admin/LoraManagementPage.js
+++ b/frontend/src/pages/admin/LoraManagementPage.js
@@ -54,6 +54,7 @@ import { serverAPI, adminAPI } from '../../services/api';
 import Pagination from '../../components/common/Pagination';
 import { sanitizeHtml } from '../../utils/sanitizeHtml';
 import MetadataItemCard from '../../components/common/MetadataItemCard';
+import MetadataItemGrid from '../../components/common/MetadataItemGrid';
 import { normalizeLora } from '../../utils/metadataItem';
 
 // LoRA 리스트 아이템 컴포넌트
@@ -773,38 +774,26 @@ function LoraManagementPage() {
             return (
               <>
                 {viewMode === 'grid' ? (
-                  // 그리드 뷰 — 공통 MetadataItemCard (#260) 사용
-                  <Box
-                    sx={{
-                      display: 'grid',
-                      gridTemplateColumns: {
-                        xs: 'repeat(auto-fill, minmax(150px, 1fr))',
-                        sm: 'repeat(auto-fill, minmax(200px, 1fr))'
-                      },
-                      gap: 2,
-                      '& > *': {
-                        maxWidth: { xs: 'none', sm: 280 }
-                      }
-                    }}
-                  >
-                    {filteredLoraModels.map((lora, index) => {
+                  // 그리드 뷰 — 공통 MetadataItemGrid + MetadataItemCard (#260)
+                  <MetadataItemGrid
+                    items={filteredLoraModels}
+                    getKey={(lora, index) => lora.filename || index}
+                    renderItem={(lora) => {
                       const item = normalizeLora(lora);
                       if (!item) return null;
                       return (
-                        <Box key={item.id || index}>
-                          <MetadataItemCard
-                            item={item}
-                            expanded={expandedLora === item.filename}
-                            onToggleExpand={() => setExpandedLora(
-                              expandedLora === item.filename ? null : item.filename
-                            )}
-                            onTrainedWordClick={(word) => handleCopyTriggerWord(word)}
-                            nsfwImageFilter={nsfwFilter}
-                          />
-                        </Box>
+                        <MetadataItemCard
+                          item={item}
+                          expanded={expandedLora === item.filename}
+                          onToggleExpand={() => setExpandedLora(
+                            expandedLora === item.filename ? null : item.filename
+                          )}
+                          onTrainedWordClick={(word) => handleCopyTriggerWord(word)}
+                          nsfwImageFilter={nsfwFilter}
+                        />
                       );
-                    })}
-                  </Box>
+                    }}
+                  />
                 ) : (
                   // 리스트 뷰 — 기존 LoraListItem 유지 (LoRA admin 전용 컴팩트 뷰)
                   <Box sx={{ width: '100%', overflow: 'hidden' }}>

--- a/frontend/src/pages/admin/ModelManagementPage.js
+++ b/frontend/src/pages/admin/ModelManagementPage.js
@@ -30,6 +30,7 @@ import toast from 'react-hot-toast';
 import { serverAPI } from '../../services/api';
 import Pagination from '../../components/common/Pagination';
 import MetadataItemCard from '../../components/common/MetadataItemCard';
+import MetadataItemGrid from '../../components/common/MetadataItemGrid';
 import { normalizeModel } from '../../utils/metadataItem';
 
 // 모델 동기화를 지원하는 serverType 목록 (#200 의 모든 4종)
@@ -327,22 +328,22 @@ function ModelManagementPage() {
         </Box>
       ) : (
         <>
-          <Grid container spacing={2}>
-            {models.map((rawModel, index) => {
+          <MetadataItemGrid
+            items={models}
+            getKey={(rawModel, index) => rawModel.filename || index}
+            renderItem={(rawModel) => {
               const item = normalizeModel(rawModel, { serverType: selectedServer?.serverType });
               if (!item) return null;
               return (
-                <Grid item xs={12} sm={6} md={4} lg={3} key={item.id || index}>
-                  <MetadataItemCard
-                    item={item}
-                    expanded={expandedId === item.id}
-                    onToggleExpand={() => setExpandedId(expandedId === item.id ? null : item.id)}
-                    nsfwImageFilter={false}  // admin 페이지 — NSFW 필터 비활성
-                  />
-                </Grid>
+                <MetadataItemCard
+                  item={item}
+                  expanded={expandedId === item.id}
+                  onToggleExpand={() => setExpandedId(expandedId === item.id ? null : item.id)}
+                  nsfwImageFilter={false}
+                />
               );
-            })}
-          </Grid>
+            }}
+          />
           {pagination.pages > 1 && (
             <Box mt={3} display="flex" justifyContent="center">
               <Pagination


### PR DESCRIPTION
## Summary
- LoRA admin 과 Model admin 의 카드 그리드가 시각적으로 달라보이던 문제 해결
- 공통 \`MetadataItemGrid\` wrapper 컴포넌트 추출 — auto-fill 정책으로 통일
- LoRA admin / Model admin / Picker modal 모두 동일 layout 사용

## 신규 컴포넌트
\`MetadataItemGrid.js\` — \`display: grid\` + auto-fill (xs minmax(150px), sm+ minmax(200px), maxWidth 280)

## 변경 사용처 (3곳)
- \`MetadataPickerModal\`: MUI Grid container → MetadataItemGrid
- \`ModelManagementPage\`: 동일 변경
- \`LoraManagementPage\` 그리드 뷰: 인라인 Box display:grid → MetadataItemGrid

## 회귀
- LoRA admin 그리드 layout 유지 (정책 그대로 채택)
- Model admin / picker 그리드 폭 변경 (12-column → auto-fill) — 사용자 요청

## 후속 (Phase 7~)
- LoRA + Model admin 통합 페이지 + Sidebar 단일 "모델 관리"
- 라벨 통일 ("모델" → "베이스 모델")

Refs #260