### PR TITLE
feat: 통합 모델 admin 페이지 + 라벨 통일 (LoRA + 베이스 모델 단일 메뉴) — #260 Phase 7

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -35,8 +35,7 @@ import {
   ServerManagementPage,
   SystemStatsPage,
   BackupRestorePage,
-  LoraManagementPage,
-  ModelManagementPage
+  MetadataManagementPage
 } from './pages/admin';
 import AuthCallback from './pages/AuthCallback';
 
@@ -174,20 +173,16 @@ function MainLayout() {
               }
             />
             <Route
-              path="/admin/loras"
+              path="/admin/models"
               element={
                 <AdminRoute>
-                  <LoraManagementPage />
+                  <MetadataManagementPage />
                 </AdminRoute>
               }
             />
             <Route
-              path="/admin/models"
-              element={
-                <AdminRoute>
-                  <ModelManagementPage />
-                </AdminRoute>
-              }
+              path="/admin/loras"
+              element={<Navigate to="/admin/models" replace />}
             />
             <Route
               path="/admin/stats"

--- a/frontend/src/components/Sidebar.js
+++ b/frontend/src/components/Sidebar.js
@@ -117,15 +117,9 @@ const adminMenuItems = [
     roles: ['admin']
   },
   {
-    text: 'LoRA 관리',
-    path: '/admin/loras',
-    icon: <AutoFixHigh />,
-    roles: ['admin']
-  },
-  {
     text: '모델 관리',
     path: '/admin/models',
-    icon: <Image />,
+    icon: <AutoFixHigh />,
     roles: ['admin']
   },
   {

--- a/frontend/src/components/common/MetadataPickerModal.js
+++ b/frontend/src/components/common/MetadataPickerModal.js
@@ -87,8 +87,8 @@ const KIND_ADAPTERS = {
     sync: (serverId) => serverAPI.syncModels(serverId),
     getStatus: (serverId) => serverAPI.getModelsSyncStatus(serverId),
     normalize: normalizeModel,
-    label: '모델',
-    listLabel: '모델',
+    label: '베이스 모델',
+    listLabel: '베이스 모델',
     nsfwItemPreference: null  // model 은 현재 NSFW item 필터 없음
   }
 };

--- a/frontend/src/pages/admin/LoraManagementPage.js
+++ b/frontend/src/pages/admin/LoraManagementPage.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import {
-  Container,
   Typography,
   Box,
   FormControl,
@@ -455,11 +454,7 @@ function LoraManagementPage() {
   const selectedServer = comfyUIServers.find(s => s._id === selectedServerId);
 
   return (
-    <Container maxWidth="xl" sx={{ py: 3, overflow: 'hidden' }}>
-      <Typography variant="h5" gutterBottom>
-        LoRA 관리
-      </Typography>
-
+    <Box sx={{ overflow: 'hidden' }}>
       {/* 전역 설정 패널 */}
       <Paper variant="outlined" sx={{ p: 2, mb: 3, overflow: 'hidden' }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
@@ -829,7 +824,7 @@ function LoraManagementPage() {
           })()}
         </>
       )}
-    </Container>
+    </Box>
   );
 }
 

--- a/frontend/src/pages/admin/MetadataManagementPage.js
+++ b/frontend/src/pages/admin/MetadataManagementPage.js
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import { Container, Box, Typography, Tabs, Tab } from '@mui/material';
+import LoraManagementPage from './LoraManagementPage';
+import ModelManagementPage from './ModelManagementPage';
+
+// 통합 모델 admin 페이지 (#260 Phase 7).
+// LoRA 와 베이스 모델 (체크포인트) 을 단일 메뉴로 통합. 향후 Upscaler / VAE
+// 등이 추가되면 탭으로 확장.
+function MetadataManagementPage() {
+  const [tab, setTab] = useState('checkpoint');
+
+  return (
+    <Container maxWidth="xl" sx={{ py: 3, overflow: 'hidden' }}>
+      <Typography variant="h5" gutterBottom>
+        모델 관리
+      </Typography>
+
+      <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 2 }}>
+        <Tabs value={tab} onChange={(_, v) => setTab(v)}>
+          <Tab value="checkpoint" label="베이스 모델" />
+          <Tab value="lora" label="LoRA" />
+        </Tabs>
+      </Box>
+
+      {tab === 'checkpoint' && <ModelManagementPage />}
+      {tab === 'lora' && <LoraManagementPage />}
+    </Container>
+  );
+}
+
+export default MetadataManagementPage;

--- a/frontend/src/pages/admin/ModelManagementPage.js
+++ b/frontend/src/pages/admin/ModelManagementPage.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import {
-  Container,
   Typography,
   Box,
   FormControl,
@@ -169,12 +168,11 @@ function ModelManagementPage() {
   };
 
   return (
-    <Container maxWidth="xl" sx={{ py: 3 }}>
+    <Box>
       <Stack direction={{ xs: 'column', md: 'row' }} justifyContent="space-between" alignItems={{ md: 'center' }} spacing={2} mb={3}>
         <Box>
-          <Typography variant="h5">모델 관리</Typography>
           <Typography variant="body2" color="text.secondary">
-            ComfyUI / OpenAI / Gemini 서버의 모델 메타데이터 (Civitai / provider) 를 동기화하고 검색합니다.
+            ComfyUI / OpenAI / Gemini 서버의 베이스 모델 메타데이터 (Civitai / provider) 를 동기화하고 검색합니다.
           </Typography>
         </Box>
         <Stack direction="row" spacing={1} alignItems="center">
@@ -356,7 +354,7 @@ function ModelManagementPage() {
           )}
         </>
       )}
-    </Container>
+    </Box>
   );
 }
 

--- a/frontend/src/pages/admin/index.js
+++ b/frontend/src/pages/admin/index.js
@@ -6,3 +6,4 @@ export { default as SystemStatsPage } from './SystemStatsPage';
 export { default as BackupRestorePage } from './BackupRestorePage';
 export { default as LoraManagementPage } from './LoraManagementPage';
 export { default as ModelManagementPage } from './ModelManagementPage';
+export { default as MetadataManagementPage } from './MetadataManagementPage';

--- a/frontend/src/utils/metadataItem.js
+++ b/frontend/src/utils/metadataItem.js
@@ -142,7 +142,7 @@ export function normalizeModelList(rawList, options) {
 export function getKindLabel(kind) {
   switch (kind) {
     case 'lora': return 'LoRA';
-    case 'checkpoint': return 'Checkpoint';
+    case 'checkpoint': return '베이스 모델';
     case 'provider-model': return 'API Model';
     default: return kind || '';
   }


### PR DESCRIPTION
## Summary
- LoRA 관리 / 모델 관리 메뉴를 **단일 "모델 관리" 로 통합**
- 카드의 kind chip 및 picker 제목도 **"베이스 모델"** 로 통일
- LoRA, 체크포인트, 업스케일러 모두 원론적으로는 모델이므로 사용자 멘탈모델에 부합

## 신규 페이지
\`pages/admin/MetadataManagementPage.js\`
- 단일 Container 안에 Tabs (베이스 모델 / LoRA) + 선택된 panel
- 기존 LoRA admin / Model admin 컴포넌트를 그대로 panel 로 재사용
- 향후 Upscaler / VAE 추가 시 탭만 추가

## 라우트
- \`/admin/models\` → MetadataManagementPage (통합)
- \`/admin/loras\` → \`/admin/models\` 로 redirect (북마크 호환)

## Sidebar
- "LoRA 관리" + "모델 관리" → 단일 "모델 관리"

## 라벨 통일
- \`getKindLabel('checkpoint')\`: "Checkpoint" → "베이스 모델"
- Picker (kind="model") 제목: "모델 선택" → "베이스 모델 선택"
- sync 토스트 / 진행률 등 일관 표기

## 기존 페이지 변환
- \`LoraManagementPage\` / \`ModelManagementPage\`: outer Container + 페이지 타이틀 제거 → panel 형태로 재사용. 자체 라우트는 없어졌지만 컴포넌트 자체는 유지

## v2.0 릴리스 노트 권장
- "관리자 메뉴: LoRA 관리 / 모델 관리 → 단일 '모델 관리' 통합" 명시
- "모델" → "베이스 모델" 용어 명확화

## Test plan
- [x] frontend rebuild 통과 (--no-cache 동등)
- [ ] (사용자 환경) /admin/models 접속 시 탭으로 LoRA / 베이스 모델 전환
- [ ] /admin/loras 접속 시 /admin/models 로 redirect
- [ ] LoRA 탭의 전역 설정 (Civitai API 키, NSFW 토글) 정상 동작
- [ ] 베이스 모델 탭의 서버 picker / 동기화 / 검색 정상
- [ ] 카드의 kind chip 에 "베이스 모델" 표시
- [ ] LoRA picker / 베이스 모델 picker 의 카드 그리드 layout 동일
- [ ] 베이스 모델 picker 제목 "베이스 모델 선택" 표시

Refs #260