### PR TITLE
feat: Group 모델 + User.groupIds + 기본 그룹 — #198 Phase A

### DIFF
--- a/src/config/passport.js
+++ b/src/config/passport.js
@@ -1,6 +1,7 @@
 const passport = require('passport');
 const GoogleStrategy = require('passport-google-oauth20').Strategy;
 const User = require('../models/User');
+const Group = require('../models/Group');
 
 passport.use(new GoogleStrategy({
   clientID: process.env.GOOGLE_CLIENT_ID,
@@ -16,16 +17,24 @@ passport.use(new GoogleStrategy({
       return done(null, user);
     }
 
+    // 기본 그룹 자동 가입 (#198) — Google OAuth 신규 사용자도 동일 정책
+    const defaultGroup = await Group.findDefault();
+    const initialGroupIds = defaultGroup ? [defaultGroup._id] : [];
+
     const newUser = new User({
       googleId: profile.id,
       email: profile.emails[0].value,
       nickname: profile.displayName,
       avatar: profile.photos[0]?.value,
       authProvider: 'google',
-      isEmailVerified: true // Google users are pre-verified
+      isEmailVerified: true, // Google users are pre-verified
+      groupIds: initialGroupIds
     });
 
     await newUser.updateAdminStatus();
+    if (newUser.isAdmin) {
+      newUser.groupIds = [];
+    }
     await newUser.save();
     
     return done(null, newUser);

--- a/src/migrations/initializeDefaultGroup.js
+++ b/src/migrations/initializeDefaultGroup.js
@@ -1,0 +1,45 @@
+const Group = require('../models/Group');
+const User = require('../models/User');
+
+// #198 Phase A: 기본 그룹 (isDefault: true) 1개 자동 생성 + 모든 비-admin 사용자에게
+// 그룹 자동 추가. 이후 신규 가입은 routes/auth.js 의 signup 핸들러가 자동 가입 처리.
+//
+// 멱등 (idempotent) — 이미 기본 그룹이 있으면 skip. 사용자 groupIds 도 이미 default 가
+// 포함돼있으면 skip.
+async function initializeDefaultGroup() {
+  try {
+    // 1. 기본 그룹 확인 / 생성
+    let defaultGroup = await Group.findDefault();
+    if (!defaultGroup) {
+      defaultGroup = await Group.create({
+        name: '기본',
+        description: '신규 사용자가 자동으로 가입되는 기본 그룹. 마이그레이션 시점의 모든 작업판도 이 그룹에 자동 할당됨.',
+        permissions: [],
+        isDefault: true,
+        createdBy: null
+      });
+      console.log(`[Migration] 기본 그룹 생성 (id: ${defaultGroup._id})`);
+    } else {
+      console.log(`[Migration] 기본 그룹 이미 존재 (id: ${defaultGroup._id})`);
+    }
+
+    // 2. 비-admin 사용자에게 기본 그룹 자동 추가 (groupIds 에 없으면)
+    const result = await User.updateMany(
+      {
+        isAdmin: { $ne: true },
+        groupIds: { $ne: defaultGroup._id }
+      },
+      { $addToSet: { groupIds: defaultGroup._id } }
+    );
+
+    if (result.modifiedCount > 0) {
+      console.log(`[Migration] 기본 그룹에 사용자 ${result.modifiedCount}명 자동 가입`);
+    } else {
+      console.log('[Migration] 기본 그룹 사용자 가입 추가 불필요');
+    }
+  } catch (error) {
+    console.error('[Migration] 기본 그룹 초기화 오류:', error);
+  }
+}
+
+module.exports = initializeDefaultGroup;

--- a/src/models/Group.js
+++ b/src/models/Group.js
@@ -1,0 +1,57 @@
+const mongoose = require('mongoose');
+
+// 사용자 그룹 — 작업판 단위 접근 권한 + capability flag (#198 Phase A).
+// admin 은 implicit all-access 라 그룹 무관. 일반 사용자만 그룹 소속 → 작업판 접근 매핑.
+const groupSchema = new mongoose.Schema({
+  name: {
+    type: String,
+    required: true,
+    trim: true,
+    unique: true
+  },
+  description: {
+    type: String,
+    trim: true,
+    default: ''
+  },
+  // capability flag (예: 'workboard:create', 'admin:userManagement') — 향후 세밀화 위한 슬롯.
+  // Phase A 에서는 빈 배열로만 동작. 권한 평가 미들웨어 (Phase C) 가 사용 시작.
+  permissions: {
+    type: [String],
+    default: []
+  },
+  // 신규 사용자 자동 가입 + 마이그레이션 시 기존 작업판 자동 할당의 기본값.
+  // 시스템 전체에 isDefault=true 그룹은 0 또는 1 개 (코드 가드).
+  isDefault: {
+    type: Boolean,
+    default: false
+  },
+  createdBy: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User'
+  }
+}, {
+  timestamps: true
+});
+
+groupSchema.index({ isDefault: 1 });
+
+// 기본 그룹 1 개만 허용 — 다중 default 방지.
+groupSchema.pre('save', async function(next) {
+  if (this.isDefault) {
+    const existing = await this.constructor.findOne({
+      isDefault: true,
+      _id: { $ne: this._id }
+    });
+    if (existing) {
+      return next(new Error('isDefault 그룹은 시스템에 하나만 존재할 수 있습니다.'));
+    }
+  }
+  next();
+});
+
+groupSchema.statics.findDefault = function() {
+  return this.findOne({ isDefault: true });
+};
+
+module.exports = mongoose.model('Group', groupSchema);

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -105,6 +105,12 @@ const userSchema = new mongoose.Schema({
     type: mongoose.Schema.Types.ObjectId,
     ref: 'Project'
   }],
+  // 사용자 그룹 (#198) — 작업판 단위 접근 권한 매핑.
+  // admin 은 implicit all-access (이 필드 무관). 일반 사용자는 신규 가입 시 isDefault 그룹 자동 추가.
+  groupIds: [{
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Group'
+  }],
   passwordResetToken: {
     type: String
   },

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -5,6 +5,7 @@ const rateLimit = require('express-rate-limit');
 const { generateJWT, requireAuth, verifyJWT, authRateLimit, signupRateLimit } = require('../middleware/auth');
 const { validate, signupSchema, signinSchema } = require('../utils/validation');
 const User = require('../models/User');
+const Group = require('../models/Group');
 const { sendPasswordResetEmail } = require('../services/emailService');
 const router = express.Router();
 
@@ -93,16 +94,25 @@ router.post('/signup', signupRateLimit, validate(signupSchema), async (req, res)
       });
     }
     
+    // 기본 그룹 자동 가입 (#198) — 비-admin 사용자만 적용. admin 은 implicit all-access.
+    const defaultGroup = await Group.findDefault();
+    const initialGroupIds = defaultGroup ? [defaultGroup._id] : [];
+
     // Create new user
     const newUser = new User({
       email: email.toLowerCase(),
       password,
       nickname: nickname.trim(),
       authProvider: 'local',
-      isEmailVerified: false // Email verification can be implemented later
+      isEmailVerified: false, // Email verification can be implemented later
+      groupIds: initialGroupIds
     });
-    
+
     await newUser.updateAdminStatus();
+    // admin 으로 승격된 경우 그룹 클리어 (admin 은 그룹 무관)
+    if (newUser.isAdmin) {
+      newUser.groupIds = [];
+    }
     await newUser.save();
     
     // Generate JWT token

--- a/src/routes/groups.js
+++ b/src/routes/groups.js
@@ -1,0 +1,183 @@
+const express = require('express');
+const router = express.Router();
+const Group = require('../models/Group');
+const User = require('../models/User');
+const { requireAdmin, verifyJWT } = require('../middleware/auth');
+
+// 사용자 본인의 소속 그룹 조회 (일반 사용자도 호출 가능 — 자기 그룹만)
+router.get('/me', verifyJWT, async (req, res) => {
+  try {
+    const user = await User.findById(req.user.id).populate('groupIds', 'name description isDefault');
+    res.json({
+      success: true,
+      data: {
+        groups: user?.groupIds || [],
+        isAdmin: !!user?.isAdmin
+      }
+    });
+  } catch (error) {
+    console.error('내 그룹 조회 오류:', error);
+    res.status(500).json({ success: false, message: '그룹 조회 실패' });
+  }
+});
+
+// 그룹 목록 조회 (admin only)
+router.get('/', requireAdmin, async (req, res) => {
+  try {
+    const groups = await Group.find({}).sort({ isDefault: -1, name: 1 }).populate('createdBy', 'email nickname');
+    // 각 그룹의 사용자 수 (admin 포함, isAdmin: false 만으로 줄이는 건 다음 라운드)
+    const groupIds = groups.map((g) => g._id);
+    const userCounts = await User.aggregate([
+      { $match: { groupIds: { $in: groupIds } } },
+      { $unwind: '$groupIds' },
+      { $group: { _id: '$groupIds', count: { $sum: 1 } } }
+    ]);
+    const countMap = new Map(userCounts.map((c) => [String(c._id), c.count]));
+    const enriched = groups.map((g) => ({
+      ...g.toObject(),
+      memberCount: countMap.get(String(g._id)) || 0
+    }));
+    res.json({ success: true, data: { groups: enriched } });
+  } catch (error) {
+    console.error('그룹 목록 조회 오류:', error);
+    res.status(500).json({ success: false, message: '그룹 목록 조회 실패' });
+  }
+});
+
+// 그룹 상세 조회 (admin)
+router.get('/:id', requireAdmin, async (req, res) => {
+  try {
+    const group = await Group.findById(req.params.id).populate('createdBy', 'email nickname');
+    if (!group) {
+      return res.status(404).json({ success: false, message: '그룹을 찾을 수 없습니다.' });
+    }
+    res.json({ success: true, data: { group } });
+  } catch (error) {
+    console.error('그룹 상세 조회 오류:', error);
+    res.status(500).json({ success: false, message: '그룹 조회 실패' });
+  }
+});
+
+// 그룹 생성 (admin)
+router.post('/', requireAdmin, async (req, res) => {
+  try {
+    const { name, description, permissions, isDefault } = req.body;
+
+    if (!name || !name.trim()) {
+      return res.status(400).json({ success: false, message: '그룹 이름은 필수입니다.' });
+    }
+
+    const existing = await Group.findOne({ name: name.trim() });
+    if (existing) {
+      return res.status(400).json({ success: false, message: '같은 이름의 그룹이 이미 존재합니다.' });
+    }
+
+    const group = new Group({
+      name: name.trim(),
+      description: description?.trim() || '',
+      permissions: Array.isArray(permissions) ? permissions : [],
+      isDefault: !!isDefault,
+      createdBy: req.user.id
+    });
+
+    await group.save();
+
+    res.status(201).json({ success: true, data: { group }, message: '그룹이 생성되었습니다.' });
+  } catch (error) {
+    console.error('그룹 생성 오류:', error);
+    res.status(400).json({ success: false, message: error.message || '그룹 생성 실패' });
+  }
+});
+
+// 그룹 수정 (admin)
+router.put('/:id', requireAdmin, async (req, res) => {
+  try {
+    const group = await Group.findById(req.params.id);
+    if (!group) {
+      return res.status(404).json({ success: false, message: '그룹을 찾을 수 없습니다.' });
+    }
+
+    const { name, description, permissions, isDefault } = req.body;
+
+    if (name !== undefined && name.trim() !== group.name) {
+      const dup = await Group.findOne({ name: name.trim(), _id: { $ne: group._id } });
+      if (dup) {
+        return res.status(400).json({ success: false, message: '같은 이름의 그룹이 이미 존재합니다.' });
+      }
+      group.name = name.trim();
+    }
+    if (description !== undefined) group.description = description.trim();
+    if (Array.isArray(permissions)) group.permissions = permissions;
+    if (isDefault !== undefined) group.isDefault = !!isDefault;
+
+    await group.save();
+    res.json({ success: true, data: { group }, message: '그룹이 수정되었습니다.' });
+  } catch (error) {
+    console.error('그룹 수정 오류:', error);
+    res.status(400).json({ success: false, message: error.message || '그룹 수정 실패' });
+  }
+});
+
+// 그룹 삭제 (admin) — 기본 그룹은 차단
+router.delete('/:id', requireAdmin, async (req, res) => {
+  try {
+    const group = await Group.findById(req.params.id);
+    if (!group) {
+      return res.status(404).json({ success: false, message: '그룹을 찾을 수 없습니다.' });
+    }
+    if (group.isDefault) {
+      return res.status(400).json({
+        success: false,
+        message: '기본 그룹은 삭제할 수 없습니다. 다른 그룹을 기본으로 지정한 후 다시 시도하세요.'
+      });
+    }
+
+    // 사용자에게서 이 그룹 제거
+    await User.updateMany(
+      { groupIds: group._id },
+      { $pull: { groupIds: group._id } }
+    );
+
+    await Group.findByIdAndDelete(group._id);
+
+    res.json({ success: true, message: '그룹이 삭제되었습니다.' });
+  } catch (error) {
+    console.error('그룹 삭제 오류:', error);
+    res.status(500).json({ success: false, message: '그룹 삭제 실패' });
+  }
+});
+
+// 사용자에게 그룹 추가 / 제거 (admin)
+router.post('/:id/members', requireAdmin, async (req, res) => {
+  try {
+    const { userId, action = 'add' } = req.body;
+    if (!userId) {
+      return res.status(400).json({ success: false, message: 'userId 가 필요합니다.' });
+    }
+    const group = await Group.findById(req.params.id);
+    if (!group) {
+      return res.status(404).json({ success: false, message: '그룹을 찾을 수 없습니다.' });
+    }
+    const user = await User.findById(userId);
+    if (!user) {
+      return res.status(404).json({ success: false, message: '사용자를 찾을 수 없습니다.' });
+    }
+    if (action === 'remove') {
+      user.groupIds = user.groupIds.filter((g) => String(g) !== String(group._id));
+    } else {
+      if (!user.groupIds.some((g) => String(g) === String(group._id))) {
+        user.groupIds.push(group._id);
+      }
+    }
+    await user.save();
+    res.json({
+      success: true,
+      message: action === 'remove' ? '사용자가 그룹에서 제거되었습니다.' : '사용자가 그룹에 추가되었습니다.'
+    });
+  } catch (error) {
+    console.error('그룹 멤버 변경 오류:', error);
+    res.status(500).json({ success: false, message: '그룹 멤버 변경 실패' });
+  }
+});
+
+module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -21,6 +21,7 @@ const backupRoutes = require('./routes/backup');
 const updatelogRoutes = require('./routes/updatelog');
 const apiKeyRoutes = require('./routes/apikeys');
 const filesRoutes = require('./routes/files');
+const groupRoutes = require('./routes/groups');
 const errorHandler = require('./middleware/errorHandler');
 const { verifyJWT, verifyApiKey } = require('./middleware/auth');
 const { blockDuringBackup } = require('./middleware/backupLock');
@@ -32,6 +33,7 @@ const dropBackupJobTTL = require('./migrations/dropBackupJobTTL');
 const dropWorkboardApiFormat = require('./migrations/dropWorkboardApiFormat');
 const dropLegacyModelCacheCollection = require('./migrations/dropLegacyModelCacheCollection');
 const cleanupStuckSyncs = require('./migrations/cleanupStuckSyncs');
+const initializeDefaultGroup = require('./migrations/initializeDefaultGroup');
 
 dotenv.config();
 
@@ -125,6 +127,7 @@ app.use('/api/projects', projectRoutes);
 app.use('/api/admin/backup', backupRoutes);
 app.use('/api/updatelog', updatelogRoutes);
 app.use('/api/apikeys', apiKeyRoutes);
+app.use('/api/groups', groupRoutes);
 
 // Health check endpoint
 app.get('/health', (req, res) => {
@@ -179,6 +182,7 @@ const startServer = async () => {
     await dropWorkboardApiFormat();
     await dropLegacyModelCacheCollection();
     await cleanupStuckSyncs();
+    await initializeDefaultGroup();
 
     // Initialize job queues after database connection
     console.log('Initializing job queues...');


### PR DESCRIPTION
## Summary
- v2.0 의 유저 그룹 + 작업판 단위 접근 권한 (#198) 의 인프라 첫 단계
- Group 모델 / User.groupIds / 기본 그룹 마이그레이션 / 신규 사용자 자동 가입 / admin 라우트
- Phase B~E 의 토대 — Phase A 머지 후 작업판 권한 / 권한 미들웨어 / UI 진행

## 결정사항 (이슈 #198 의 권장안 그대로)
1. 참조 방향: **Workboard.allowedGroupIds** (Phase B)
2. 다중 그룹 합성: UNION (Phase C)
3. 기본 그룹: \`isDefault: true\` 1개. 신규 사용자 + 마이그레이션 시점 작업판 자동 할당
4. admin: implicit all-access (그룹 무관)
5. 모델/LoRA 노출 정책 기본값: \`'full'\` (Phase B)

## Phase A 변경

**Group 모델** (\`src/models/Group.js\`):
- name (unique), description, permissions[], isDefault, createdBy
- pre-save: isDefault 단일 보장
- findDefault() static

**User 확장**:
- \`groupIds: [ObjectId(Group)]\`

**마이그레이션** (\`initializeDefaultGroup.js\`, idempotent):
- 기본 그룹 자동 생성
- 모든 비-admin 사용자에게 자동 추가

**신규 사용자 가입**:
- routes/auth.js (signup) + config/passport.js (Google OAuth) → 비-admin 만 자동 가입

**Admin API** (\`/api/groups\`):
- GET /me, GET /, GET /:id, POST /, PUT /:id, DELETE /:id, POST /:id/members
- 기본 그룹 삭제 차단

## 검증
- 마이그레이션 실행 → 기본 그룹 생성 (id: 6a00be...) ✅
- GET /api/groups → 1개 (기본, memberCount 0) ✅
- POST 그룹 생성 → 201 ✅
- DELETE 일반 그룹 → 200 ✅
- DELETE 기본 그룹 → 400 (차단) ✅
- GET /me (admin) → groups: [], isAdmin: true ✅

## 후속 Phase
- B: Workboard.allowedGroupIds + 노출 정책 + admin 폼 UI
- C: 권한 미들웨어 (requireWorkboardAccess) + GET /workboards 필터
- D: 모델/LoRA 노출 정책 적용 (작업판 컨텍스트 기반)
- E: 프론트 그룹 관리 페이지

Refs #198