### PR TITLE
feat: Workboard 권한 + 노출 정책 + 마이그레이션 — #198 Phase B (backend)

### DIFF
--- a/src/migrations/assignDefaultGroupToWorkboards.js
+++ b/src/migrations/assignDefaultGroupToWorkboards.js
@@ -1,0 +1,35 @@
+const Group = require('../models/Group');
+const Workboard = require('../models/Workboard');
+
+// #198 Phase B: allowedGroupIds 가 비어있는 기존 작업판 전부에 기본 그룹 자동 할당.
+// 마이그레이션 후 v2.0 의 권한 미들웨어 (Phase C) 가 활성화돼도 기존 사용자의
+// 작업판 접근이 깨지지 않도록 보장.
+async function assignDefaultGroupToWorkboards() {
+  try {
+    const defaultGroup = await Group.findDefault();
+    if (!defaultGroup) {
+      console.log('[Migration] 기본 그룹 없음 — initializeDefaultGroup 이 먼저 실행돼야 함. skip.');
+      return;
+    }
+
+    const result = await Workboard.updateMany(
+      {
+        $or: [
+          { allowedGroupIds: { $exists: false } },
+          { allowedGroupIds: { $size: 0 } }
+        ]
+      },
+      { $set: { allowedGroupIds: [defaultGroup._id] } }
+    );
+
+    if (result.modifiedCount > 0) {
+      console.log(`[Migration] Workboard.allowedGroupIds 기본 그룹 자동 할당 (${result.modifiedCount}건)`);
+    } else {
+      console.log('[Migration] Workboard 기본 그룹 자동 할당 불필요 (대상 없음)');
+    }
+  } catch (error) {
+    console.error('[Migration] Workboard 기본 그룹 할당 오류:', error);
+  }
+}
+
+module.exports = assignDefaultGroupToWorkboards;

--- a/src/models/Workboard.js
+++ b/src/models/Workboard.js
@@ -125,6 +125,33 @@ const workboardSchema = new mongoose.Schema({
     type: [String],
     default: []
   },
+  // 이 작업판에 접근 가능한 사용자 그룹 (#198). 빈 배열이면 admin 외 접근 불가.
+  // admin 은 implicit all-access (이 필드 무관). 마이그레이션 시 기본 그룹 1개 자동 할당.
+  allowedGroupIds: [{
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Group'
+  }],
+  // 모델 노출 정책 (#198) — 작업판이 사용하는 서버의 모델 중 사용자에게 노출할 범위.
+  // 'full': 모든 모델 노출 (기본). 'whitelist': modelWhitelist 에 명시된 모델만 노출.
+  modelExposurePolicy: {
+    type: String,
+    enum: ['full', 'whitelist'],
+    default: 'full'
+  },
+  modelWhitelist: {
+    type: [String],
+    default: []
+  },
+  // LoRA 노출 정책 (#198) — 동일 패턴.
+  loraExposurePolicy: {
+    type: String,
+    enum: ['full', 'whitelist'],
+    default: 'full'
+  },
+  loraWhitelist: {
+    type: [String],
+    default: []
+  },
   workflowData: {
     type: String,
     default: ''

--- a/src/routes/workboards.js
+++ b/src/routes/workboards.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const { requireAuth, requireAdmin } = require('../middleware/auth');
 const Workboard = require('../models/Workboard');
 const Server = require('../models/Server');
+const Group = require('../models/Group');
 const ServerLoraCache = require('../models/ServerLoraCache');
 const loraMetadataService = require('../services/loraMetadataService');
 const { escapeRegex } = require('../utils/escapeRegex');
@@ -166,6 +167,9 @@ router.post('/import', requireAdmin, async (req, res) => {
     const wb = data.workboard;
     const server = await Server.findById(matchedServerId);
 
+    // import 시 allowedGroupIds 는 기본 그룹으로 자동 할당 (export 에는 미포함, ObjectId 매칭 불가)
+    const defaultGroupForImport = await Group.findDefault();
+
     const newWorkboard = new Workboard({
       name: wb.name,
       description: wb.description,
@@ -177,6 +181,11 @@ router.post('/import', requireAdmin, async (req, res) => {
       additionalInputFields: wb.additionalInputFields || [],
       workflowData: wb.workflowData || '',
       allowedModelTypes: wb.allowedModelTypes || [],
+      allowedGroupIds: defaultGroupForImport ? [defaultGroupForImport._id] : [],
+      modelExposurePolicy: wb.modelExposurePolicy === 'whitelist' ? 'whitelist' : 'full',
+      modelWhitelist: Array.isArray(wb.modelWhitelist) ? wb.modelWhitelist : [],
+      loraExposurePolicy: wb.loraExposurePolicy === 'whitelist' ? 'whitelist' : 'full',
+      loraWhitelist: Array.isArray(wb.loraWhitelist) ? wb.loraWhitelist : [],
       createdBy: req.user._id,
       version: 1,
       usageCount: 0,
@@ -257,7 +266,12 @@ router.post('/', requireAdmin, async (req, res) => {
       baseInputFields,
       additionalInputFields,
       workflowData,
-      allowedModelTypes
+      allowedModelTypes,
+      allowedGroupIds,
+      modelExposurePolicy,
+      modelWhitelist,
+      loraExposurePolicy,
+      loraWhitelist
     } = req.body;
 
     const resolvedOutputFormat = outputFormat || (workboardType === 'prompt' ? 'text' : 'image');
@@ -292,6 +306,14 @@ router.post('/', requireAdmin, async (req, res) => {
     }
 
     const isComfyUI = server.serverType === 'ComfyUI';
+
+    // 작업판 생성 시 allowedGroupIds 가 명시되지 않으면 기본 그룹 자동 할당 (#198)
+    let resolvedAllowedGroupIds = Array.isArray(allowedGroupIds) ? allowedGroupIds : null;
+    if (!resolvedAllowedGroupIds) {
+      const defaultGroup = await Group.findDefault();
+      resolvedAllowedGroupIds = defaultGroup ? [defaultGroup._id] : [];
+    }
+
     const workboard = new Workboard({
       name: name.trim(),
       description: description?.trim(),
@@ -303,6 +325,11 @@ router.post('/', requireAdmin, async (req, res) => {
       additionalInputFields: additionalInputFields || [],
       workflowData: isComfyUI ? workflowData : '',
       allowedModelTypes: isComfyUI ? (allowedModelTypes || []) : [],
+      allowedGroupIds: resolvedAllowedGroupIds,
+      modelExposurePolicy: modelExposurePolicy === 'whitelist' ? 'whitelist' : 'full',
+      modelWhitelist: Array.isArray(modelWhitelist) ? modelWhitelist : [],
+      loraExposurePolicy: isComfyUI && loraExposurePolicy === 'whitelist' ? 'whitelist' : 'full',
+      loraWhitelist: isComfyUI && Array.isArray(loraWhitelist) ? loraWhitelist : [],
       createdBy: req.user._id
     });
 
@@ -336,6 +363,11 @@ router.put('/:id', requireAdmin, async (req, res) => {
       additionalInputFields,
       workflowData,
       allowedModelTypes,
+      allowedGroupIds,
+      modelExposurePolicy,
+      modelWhitelist,
+      loraExposurePolicy,
+      loraWhitelist,
       isActive
     } = req.body;
 
@@ -397,6 +429,25 @@ router.put('/:id', requireAdmin, async (req, res) => {
       // ComfyUI 작업판만 의미 있음 — 다른 serverType 은 빈 배열 강제
       const wbServer = await Server.findById(workboard.serverId);
       workboard.allowedModelTypes = wbServer?.serverType === 'ComfyUI' ? (allowedModelTypes || []) : [];
+    }
+    // 권한 / 노출 정책 (#198)
+    if (Array.isArray(allowedGroupIds)) {
+      workboard.allowedGroupIds = allowedGroupIds;
+    }
+    if (modelExposurePolicy === 'full' || modelExposurePolicy === 'whitelist') {
+      workboard.modelExposurePolicy = modelExposurePolicy;
+    }
+    if (Array.isArray(modelWhitelist)) {
+      workboard.modelWhitelist = modelWhitelist;
+    }
+    if (loraExposurePolicy === 'full' || loraExposurePolicy === 'whitelist') {
+      // LoRA 정책은 ComfyUI 만 의미 있음
+      const wbServer = await Server.findById(workboard.serverId);
+      workboard.loraExposurePolicy = wbServer?.serverType === 'ComfyUI' ? loraExposurePolicy : 'full';
+    }
+    if (Array.isArray(loraWhitelist)) {
+      const wbServer = await Server.findById(workboard.serverId);
+      workboard.loraWhitelist = wbServer?.serverType === 'ComfyUI' ? loraWhitelist : [];
     }
     if (isActive !== undefined) workboard.isActive = isActive;
     
@@ -505,6 +556,11 @@ router.post('/:id/duplicate', requireAdmin, async (req, res) => {
       additionalInputFields: originalWorkboard.additionalInputFields,
       workflowData: originalWorkboard.workflowData,
       allowedModelTypes: originalWorkboard.allowedModelTypes || [],
+      allowedGroupIds: originalWorkboard.allowedGroupIds || [],
+      modelExposurePolicy: originalWorkboard.modelExposurePolicy || 'full',
+      modelWhitelist: originalWorkboard.modelWhitelist || [],
+      loraExposurePolicy: originalWorkboard.loraExposurePolicy || 'full',
+      loraWhitelist: originalWorkboard.loraWhitelist || [],
       createdBy: req.user._id
     });
     
@@ -553,6 +609,12 @@ router.get('/:id/export', requireAdmin, async (req, res) => {
         additionalInputFields: workboard.additionalInputFields,
         workflowData: workboard.workflowData,
         allowedModelTypes: workboard.allowedModelTypes || [],
+        // allowedGroupIds 는 export 에서 제외 — ObjectId 가 instance 간 매칭 안 됨.
+        // import 시 기본 그룹 자동 할당으로 안전한 default 적용.
+        modelExposurePolicy: workboard.modelExposurePolicy || 'full',
+        modelWhitelist: workboard.modelWhitelist || [],
+        loraExposurePolicy: workboard.loraExposurePolicy || 'full',
+        loraWhitelist: workboard.loraWhitelist || [],
         version: workboard.version
       },
       server: serverInfo

--- a/src/server.js
+++ b/src/server.js
@@ -34,6 +34,7 @@ const dropWorkboardApiFormat = require('./migrations/dropWorkboardApiFormat');
 const dropLegacyModelCacheCollection = require('./migrations/dropLegacyModelCacheCollection');
 const cleanupStuckSyncs = require('./migrations/cleanupStuckSyncs');
 const initializeDefaultGroup = require('./migrations/initializeDefaultGroup');
+const assignDefaultGroupToWorkboards = require('./migrations/assignDefaultGroupToWorkboards');
 
 dotenv.config();
 
@@ -183,6 +184,7 @@ const startServer = async () => {
     await dropLegacyModelCacheCollection();
     await cleanupStuckSyncs();
     await initializeDefaultGroup();
+    await assignDefaultGroupToWorkboards();
 
     // Initialize job queues after database connection
     console.log('Initializing job queues...');


### PR DESCRIPTION
## Summary
- 작업판 단위 접근 권한 (\`allowedGroupIds\`) + 모델/LoRA 노출 정책 추가
- 기존 작업판 전부 기본 그룹에 자동 할당으로 **무중단 마이그레이션** — 현재 사용자 (모두 기본 그룹 소속) 의 작업판 접근 그대로 유지
- Phase A (Group 모델) 위에 빌드, Phase C 의 권한 미들웨어 활성화 전까지는 schema 만 채워둠 (실제 권한 평가는 Phase C)

## Schema
**Workboard** 신규 필드:
| 필드 | 타입 | default | 비고 |
|---|---|---|---|
| \`allowedGroupIds\` | [ObjectId(Group)] | (마이그레이션 시 기본 그룹) | 빈 배열이면 admin 외 접근 불가 |
| \`modelExposurePolicy\` | 'full' \\| 'whitelist' | 'full' | |
| \`modelWhitelist\` | [String] | [] | |
| \`loraExposurePolicy\` | 'full' \\| 'whitelist' | 'full' | ComfyUI 만 의미 |
| \`loraWhitelist\` | [String] | [] | ComfyUI 만 |

## 마이그레이션
\`assignDefaultGroupToWorkboards\` (idempotent):
- allowedGroupIds 비어있는 작업판 전부에 기본 그룹 할당
- Phase A 의 initializeDefaultGroup 다음에 실행

## routes/workboards.js
- POST: allowedGroupIds 미지정 시 기본 그룹 자동. 모델/LoRA 정책 + whitelist 처리 (LoRA 는 ComfyUI 만)
- PUT: 5개 권한 필드 부분 업데이트
- duplicate: 5개 필드 보존
- export: 정책/whitelist 포함, allowedGroupIds 제외 (ObjectId instance 간 매칭 불가)
- import: 기본 그룹 자동 할당 + 정책/whitelist 복원

## 검증 (제 환경)
- 마이그레이션 로그: \`Workboard.allowedGroupIds 기본 그룹 자동 할당 (7건)\` ✅
- backend 부팅 정상

## 후속 Phase
- **B-frontend**: WorkboardManagement 폼에 그룹 multi-select + 노출 정책 toggle + whitelist UI
- **C**: 권한 미들웨어 + GET /workboards 필터 (UNION)
- **D**: 모델/LoRA 조회 시 노출 정책 적용
- **E**: 프론트 그룹 관리 페이지

Refs #198