### PR TITLE
feat: 작업판 접근 권한 미들웨어 + GET 필터 — #198 Phase C

### DIFF
--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -47,6 +47,67 @@ const optionalAuth = (req, res, next) => {
   next();
 };
 
+// #198: 작업판 단위 접근 권한 평가.
+//
+// 정책:
+// - admin (isAdmin: true) → 모든 작업판 implicit all-access. bypass.
+// - 일반 사용자 → workboard.allowedGroupIds ∩ user.groupIds ≠ ∅ 이어야 통과 (UNION 규칙).
+// - 작업판 미발견 시 404.
+
+/**
+ * 사용자가 특정 작업판에 접근 가능한지 검사.
+ * @param {Object} user — req.user (User document)
+ * @param {Object} workboard — Workboard document
+ * @returns {boolean}
+ */
+function userHasWorkboardAccess(user, workboard) {
+  if (!user || !workboard) return false;
+  if (user.isAdmin) return true;
+  const allowed = (workboard.allowedGroupIds || []).map(String);
+  const mine = (user.groupIds || []).map(String);
+  return mine.some((g) => allowed.includes(g));
+}
+
+/**
+ * 사용자가 접근 가능한 작업판들을 추리는 Mongoose 쿼리 조건.
+ * admin 은 빈 객체 (모든 작업판) 반환. 일반 사용자는 allowedGroupIds 가
+ * user.groupIds 와 교집합이 있는 것만.
+ * @param {Object} user — req.user
+ * @returns {Object} mongo filter
+ */
+function buildWorkboardAccessFilter(user) {
+  if (!user) return { _id: null };  // 차단
+  if (user.isAdmin) return {};
+  const groupIds = (user.groupIds || []).map((g) => g);
+  if (groupIds.length === 0) return { _id: null };  // 어느 그룹에도 안 속함 → 차단
+  return { allowedGroupIds: { $in: groupIds } };
+}
+
+/**
+ * Express 미들웨어 — req.params.id 로 식별된 작업판에 대해 사용자 권한 검사.
+ * 통과 시 req.workboard 에 작업판을 attach.
+ * (라우트 내부에서 다시 findById 호출할 필요 없도록 캐시)
+ */
+const requireWorkboardAccess = async (req, res, next) => {
+  try {
+    const Workboard = require('../models/Workboard');
+    const workboard = await Workboard.findById(req.params.id)
+      .populate('createdBy', 'nickname email')
+      .populate('serverId', 'name serverType serverUrl isActive');
+    if (!workboard) {
+      return res.status(404).json({ message: 'Workboard not found' });
+    }
+    if (!userHasWorkboardAccess(req.user, workboard)) {
+      return res.status(403).json({ message: '이 작업판에 접근할 권한이 없습니다.' });
+    }
+    req.workboard = workboard;
+    return next();
+  } catch (error) {
+    console.error('requireWorkboardAccess error:', error);
+    return res.status(500).json({ message: error.message });
+  }
+};
+
 const authRateLimit = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
   max: 5, // limit each IP to 5 requests per windowMs
@@ -195,5 +256,8 @@ module.exports = {
   verifyApiKey,
   requireNonApiKeyAuth,
   authRateLimit,
-  signupRateLimit
+  signupRateLimit,
+  requireWorkboardAccess,
+  userHasWorkboardAccess,
+  buildWorkboardAccessFilter
 };

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { requireAuth } = require('../middleware/auth');
+const { requireAuth, userHasWorkboardAccess } = require('../middleware/auth');
 const { addImageGenerationJob, getQueueStats } = require('../services/queueService');
 const openAIChatService = require('../services/openAIChatService');
 const geminiService = require('../services/geminiService');
@@ -50,7 +50,16 @@ router.post('/generate', requireAuth, async (req, res) => {
         message: 'Missing required fields: workboardId, prompt, aiModel'
       });
     }
-    
+
+    // 작업판 접근 권한 검사 (#198)
+    const wb = await Workboard.findById(workboardId);
+    if (!wb) {
+      return res.status(404).json({ message: 'Workboard not found' });
+    }
+    if (!userHasWorkboardAccess(req.user, wb)) {
+      return res.status(403).json({ message: '이 작업판에 접근할 권한이 없습니다.' });
+    }
+
     if (referenceImages && referenceImages.length > 0) {
       for (const refImg of referenceImages) {
         const image = await UploadedImage.findById(refImg.imageId);
@@ -380,7 +389,12 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
     if (!workboard) {
       return res.status(404).json({ message: 'Workboard not found' });
     }
-    
+
+    // 작업판 접근 권한 검사 (#198)
+    if (!userHasWorkboardAccess(req.user, workboard)) {
+      return res.status(403).json({ message: '이 작업판에 접근할 권한이 없습니다.' });
+    }
+
     if (workboard.outputFormat !== 'text' && workboard.workboardType !== 'prompt') {
       return res.status(400).json({ message: 'This workboard is not a prompt workboard' });
     }

--- a/src/routes/workboards.js
+++ b/src/routes/workboards.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const mongoose = require('mongoose');
-const { requireAuth, requireAdmin } = require('../middleware/auth');
+const { requireAuth, requireAdmin, buildWorkboardAccessFilter, userHasWorkboardAccess } = require('../middleware/auth');
 const Workboard = require('../models/Workboard');
 const Server = require('../models/Server');
 const Group = require('../models/Group');
@@ -34,6 +34,9 @@ router.get('/', requireAuth, async (req, res) => {
     if (includeInactive !== 'true') {
       filter.isActive = true;
     }
+
+    // 접근 권한 필터 (#198) — admin 은 모든 작업판, 일반 사용자는 자기 그룹 작업판만
+    Object.assign(filter, buildWorkboardAccessFilter(req.user));
 
     if (outputFormat) filter.outputFormat = outputFormat;
 
@@ -218,11 +221,16 @@ router.get('/:id', requireAuth, async (req, res) => {
     if (!workboard) {
       return res.status(404).json({ message: 'Workboard not found' });
     }
-    
+
     if (!workboard.isActive) {
       return res.status(403).json({ message: 'Workboard is not active' });
     }
-    
+
+    // 권한 검사 (#198) — admin 은 implicit all-access
+    if (!userHasWorkboardAccess(req.user, workboard)) {
+      return res.status(403).json({ message: '이 작업판에 접근할 권한이 없습니다.' });
+    }
+
     res.json({ workboard });
   } catch (error) {
     res.status(500).json({ message: error.message });


### PR DESCRIPTION
## Summary
- Phase A/B 위에서 **권한 평가 실제 활성화**
- 일반 사용자: 자기 그룹 소속 작업판만 보이고 접근 가능
- admin: implicit all-access (bypass)
- UNION 규칙: \`workboard.allowedGroupIds ∩ user.groupIds ≠ ∅\` → 통과

## 신규 미들웨어 (\`src/middleware/auth.js\`)
- \`userHasWorkboardAccess(user, workboard)\` — 동기 평가
- \`buildWorkboardAccessFilter(user)\` — Mongoose 쿼리 필터
  - admin → \`{}\`
  - 그룹 소속 → \`{ allowedGroupIds: { $in: user.groupIds } }\`
  - 그룹 미소속 → \`{ _id: null }\` (차단)
- \`requireWorkboardAccess\` — Express 미들웨어 (id 기반)

## routes/workboards.js
- GET / : 필터 적용
- GET /:id : 접근 검사 + 403

## routes/jobs.js
- POST /generate : 작업판 접근 검사 + 403
- POST /generate-prompt : 동일

## 무중단 보장
- Phase A 마이그레이션: 모든 사용자 기본 그룹 자동 가입
- Phase B 마이그레이션: 모든 기존 작업판 기본 그룹 자동 할당
- → 권한 활성화돼도 기존 사용자의 작업판 접근 그대로 유지

## 검증
- admin: GET /workboards 7개 모두 반환 (bypass 정상) ✅

## Test plan
- [x] admin 무영향
- [ ] (사용자 환경) 새 비-admin 사용자 가입 → 기본 그룹 자동 가입 확인 → 기존 작업판 모두 보임
- [ ] admin 이 작업판의 allowedGroupIds 를 비우면 일반 사용자에게서 즉시 사라짐
- [ ] 새 그룹 생성 후 작업판 그룹 변경 → 그룹 멤버만 접근 가능
- [ ] 일반 사용자가 권한 없는 작업판 ID 로 GET / generate 시도 → 403

## 후속
- D: 모델/LoRA 조회 시 노출 정책 (modelExposurePolicy/Whitelist) 적용
- E: 프론트 그룹 관리 페이지

Refs #198