### PR TITLE
feat: 모델/LoRA 노출 정책 적용 (workboard 컨텍스트) — #198 Phase D

### DIFF
--- a/frontend/src/components/common/MetadataPickerModal.js
+++ b/frontend/src/components/common/MetadataPickerModal.js
@@ -45,11 +45,13 @@ const EMPTY_ALLOWED_MODEL_TYPES = Object.freeze([]);
 
 const KIND_ADAPTERS = {
   lora: {
-    fetch: ({ serverId, workboardId, search, baseModel, allowedBaseModels, page, limit }) => {
+    fetch: ({ serverId, workboardId, search, baseModel, page, limit }) => {
       if (serverId) {
-        return serverAPI.getLoras(serverId, { search, baseModel, page, limit });
+        // workboardId 전달 시 backend 가 작업판의 loraExposurePolicy / loraWhitelist 적용 (#198 Phase D)
+        const params = { search, baseModel, page, limit };
+        if (workboardId) params.workboardId = workboardId;
+        return serverAPI.getLoras(serverId, params);
       }
-      // workboardId fallback (admin 외 일반 사용자용)
       return workboardAPI.getLoraModels(workboardId);
     },
     extractList: (responseData) => responseData?.loraModels || [],
@@ -73,11 +75,13 @@ const KIND_ADAPTERS = {
     nsfwItemPreference: 'nsfwLoraFilter',  // 사용자 preferences key — NSFW LoRA item 자체 숨김
   },
   model: {
-    fetch: ({ serverId, search, baseModel, allowedBaseModels, page, limit }) => {
+    fetch: ({ serverId, workboardId, search, baseModel, allowedBaseModels, page, limit }) => {
       const params = { search, baseModel, page, limit };
       if (allowedBaseModels && allowedBaseModels.length > 0) {
         params.allowedBaseModels = allowedBaseModels;
       }
+      // workboardId 전달 시 backend 가 작업판의 modelExposurePolicy / modelWhitelist 적용 (#198 Phase D)
+      if (workboardId) params.workboardId = workboardId;
       return serverAPI.getDetailedModels(serverId, params);
     },
     extractList: (responseData) => responseData?.models || [],

--- a/frontend/src/pages/ImageGeneration.js
+++ b/frontend/src/pages/ImageGeneration.js
@@ -1409,6 +1409,7 @@ function ImageGeneration() {
           kind="model"
           open={modelModalOpen}
           onClose={handleModelModalClose}
+          workboardId={id}
           serverId={workboardData?.serverId?._id || workboardData?.serverId}
           mode="select-single"
           selectedItem={selectedCheckpointModel}

--- a/src/routes/servers.js
+++ b/src/routes/servers.js
@@ -3,7 +3,8 @@ const router = express.Router();
 const Server = require('../models/Server');
 const ServerLoraCache = require('../models/ServerLoraCache');
 const ServerModelCache = require('../models/ServerModelCache');
-const { verifyJWT, requireAdmin } = require('../middleware/auth');
+const Workboard = require('../models/Workboard');
+const { verifyJWT, requireAdmin, userHasWorkboardAccess } = require('../middleware/auth');
 const loraMetadataService = require('../services/loraMetadataService');
 const modelMetadataService = require('../services/modelMetadataService');
 const comfyUIService = require('../services/comfyUIService');
@@ -324,9 +325,8 @@ router.get('/:id/models', verifyJWT, async (req, res) => {
         });
       }
 
-      const { search, hasMetadata, baseModel, page = 1, limit = 50 } = req.query;
+      const { search, hasMetadata, baseModel, workboardId, page = 1, limit = 50 } = req.query;
       // allowedBaseModels: query string 으로 array 또는 single 둘 다 받기.
-      // express 가 ?allowedBaseModels=A&allowedBaseModels=B 를 array 로 파싱.
       let allowedBaseModels = req.query.allowedBaseModels;
       if (typeof allowedBaseModels === 'string') {
         allowedBaseModels = [allowedBaseModels];
@@ -334,11 +334,29 @@ router.get('/:id/models', verifyJWT, async (req, res) => {
         allowedBaseModels = undefined;
       }
 
+      // 작업판 컨텍스트의 모델 노출 정책 적용 (#198 Phase D)
+      let whitelist = undefined;
+      if (workboardId) {
+        const wb = await Workboard.findById(workboardId);
+        if (!wb) {
+          return res.status(404).json({ success: false, message: '작업판을 찾을 수 없습니다.' });
+        }
+        if (!userHasWorkboardAccess(req.user, wb)) {
+          return res.status(403).json({ success: false, message: '이 작업판에 접근할 권한이 없습니다.' });
+        }
+        if (wb.modelExposurePolicy === 'whitelist') {
+          whitelist = wb.modelWhitelist || [];
+          // 빈 whitelist 면 정책상 0개 노출 — sentinel 로 빈 배열 대신 '__none__' 매칭 안 됨
+          if (whitelist.length === 0) whitelist = ['__no_models_in_whitelist__'];
+        }
+      }
+
       const result = await modelMetadataService.searchServerModels(server._id, {
         search,
         hasMetadata: hasMetadata === 'true' ? true : hasMetadata === 'false' ? false : undefined,
         baseModel,
         allowedBaseModels,
+        whitelist,
         page: parseInt(page),
         limit: parseInt(limit)
       });
@@ -425,12 +443,29 @@ router.get('/:id/loras', verifyJWT, async (req, res) => {
       });
     }
 
-    const { search, hasMetadata, baseModel, page = 1, limit = 50 } = req.query;
+    const { search, hasMetadata, baseModel, workboardId, page = 1, limit = 50 } = req.query;
+
+    // 작업판 컨텍스트의 LoRA 노출 정책 적용 (#198 Phase D)
+    let whitelist = undefined;
+    if (workboardId) {
+      const wb = await Workboard.findById(workboardId);
+      if (!wb) {
+        return res.status(404).json({ success: false, message: '작업판을 찾을 수 없습니다.' });
+      }
+      if (!userHasWorkboardAccess(req.user, wb)) {
+        return res.status(403).json({ success: false, message: '이 작업판에 접근할 권한이 없습니다.' });
+      }
+      if (wb.loraExposurePolicy === 'whitelist') {
+        whitelist = wb.loraWhitelist || [];
+        if (whitelist.length === 0) whitelist = ['__no_loras_in_whitelist__'];
+      }
+    }
 
     const result = await loraMetadataService.searchServerLoras(server._id, {
       search,
       hasMetadata: hasMetadata === 'true' ? true : hasMetadata === 'false' ? false : undefined,
       baseModel,
+      whitelist,
       page: parseInt(page),
       limit: parseInt(limit)
     });

--- a/src/services/loraMetadataService.js
+++ b/src/services/loraMetadataService.js
@@ -413,7 +413,7 @@ const resetSyncStatus = async (serverId) => {
 /**
  * 검색 필터를 적용한 LoRA 목록 조회
  */
-const searchServerLoras = async (serverId, { search, hasMetadata, baseModel, page = 1, limit = 50 } = {}) => {
+const searchServerLoras = async (serverId, { search, hasMetadata, baseModel, whitelist, page = 1, limit = 50 } = {}) => {
   const cache = await ServerLoraCache.findOne({ serverId });
 
   if (!cache) {
@@ -461,6 +461,12 @@ const searchServerLoras = async (serverId, { search, hasMetadata, baseModel, pag
     filtered = filtered.filter(lora =>
       lora.civitai?.baseModel === baseModel
     );
+  }
+
+  // whitelist (#198 Phase D): 작업판의 loraExposurePolicy='whitelist' + loraWhitelist 적용
+  if (Array.isArray(whitelist) && whitelist.length > 0) {
+    const wlSet = new Set(whitelist);
+    filtered = filtered.filter(lora => wlSet.has(lora.filename));
   }
 
   // 페이지네이션

--- a/src/services/modelMetadataService.js
+++ b/src/services/modelMetadataService.js
@@ -492,7 +492,7 @@ const resetSyncStatus = async (serverId) => {
  * @param {string[]} opts.allowedBaseModels — civitai.baseModel 다중 매칭 + baseModel 미상 fallback
  *   (작업판의 allowedModelTypes 와 매핑 — Civitai 미등록 모델은 항상 통과)
  */
-const searchServerModels = async (serverId, { search, hasMetadata, baseModel, allowedBaseModels, page = 1, limit = 50 } = {}) => {
+const searchServerModels = async (serverId, { search, hasMetadata, baseModel, allowedBaseModels, whitelist, page = 1, limit = 50 } = {}) => {
   const cache = await ServerModelCache.findOne({ serverId });
 
   if (!cache) {
@@ -548,6 +548,13 @@ const searchServerModels = async (serverId, { search, hasMetadata, baseModel, al
       if (!m.civitai?.baseModel) return true;
       return allowedBaseModels.includes(m.civitai.baseModel);
     });
+  }
+
+  // whitelist: 작업판의 modelExposurePolicy='whitelist' + modelWhitelist 적용 (#198 Phase D).
+  // filename 정확 매칭. 빈 배열/미설정은 제약 없음.
+  if (Array.isArray(whitelist) && whitelist.length > 0) {
+    const wlSet = new Set(whitelist);
+    filtered = filtered.filter(m => wlSet.has(m.filename));
   }
 
   const total = filtered.length;


### PR DESCRIPTION
## Summary
- 작업판의 \`modelExposurePolicy='whitelist'\` + \`modelWhitelist\` 가 사용자 picker 에서 실제로 적용
- LoRA 도 동일 패턴 (\`loraExposurePolicy\`, \`loraWhitelist\`)
- workboard 컨텍스트의 picker 만 적용 — admin 페이지의 전체 목록은 영향 없음

## Backend

**서비스 함수**:
- \`modelMetadataService.searchServerModels\` 에 \`whitelist: [String]\` 옵션 추가
- \`loraMetadataService.searchServerLoras\` 도 동일

**라우트**:
- \`GET /servers/:id/models?detailed=true&workboardId=X\`
- \`GET /servers/:id/loras?workboardId=X\`

workboardId 가 전달되면:
1. 작업판 조회 + 사용자 권한 검사
2. \`modelExposurePolicy === 'whitelist'\` 이면 \`modelWhitelist\` 적용
3. 빈 whitelist 는 sentinel 로 처리해 "정책 활성 + 빈 목록 = 0개 노출" 정확히 표현

## Frontend
- \`MetadataPickerModal\` 의 KIND_ADAPTERS fetch 가 workboardId 받으면 query param 으로 전달
- \`ImageGeneration\` 의 모델 picker 에 workboardId 추가

## 검증
- whitelist 작업판 생성 (modelWhitelist: 2개) → workboardId 전달 시 2개만 반환 ✅
- workboardId 미전달 → 전체 50개 ✅
- admin 페이지의 모델 그리드 (workboardId 없음) → 전체 노출 (기존 동작 유지)

## 후속
- Phase E: 프론트 그룹 관리 페이지

Refs #198