### PR TITLE
feat: 작업판 필드 role + 헬퍼 (#199 Phase A)

### DIFF
--- a/src/constants/fieldRoles.js
+++ b/src/constants/fieldRoles.js
@@ -1,0 +1,63 @@
+// 작업판 필드 role 정의 (#199 작업판 풀 커스텀화)
+//
+// 작업판의 입력 필드 (additionalInputFields) 가 어떤 의미로 서비스 코드에 사용되는지를
+// 명시하는 메타데이터. 서비스 코드는 필드 이름 (e.g. inputData.aiModel) 대신 role 로
+// 필드를 찾아 의미적 분리를 달성한다 — 작업판마다 같은 의미를 다른 필드명으로 사용 가능.
+//
+// 호환성: 모든 role 은 optional. role 이 지정되지 않은 필드는 단순 사용자 입력으로 처리.
+// 한 작업판 안에서 같은 role 을 갖는 필드는 0개 또는 1개여야 함 (소프트 컨벤션 — 첫 매치 우선).
+
+const FIELD_ROLES = Object.freeze({
+  MODEL: 'model',                                  // AI 모델 식별자 (filename or model id)
+  PROMPT: 'prompt',                                // 주 prompt
+  NEGATIVE_PROMPT: 'negativePrompt',               // negative prompt (image gen)
+  SYSTEM_PROMPT: 'systemPrompt',                   // system prompt (text gen)
+  IMAGE_SIZE: 'imageSize',                         // 이미지 크기 / aspect ratio
+  SEED: 'seed',                                    // random seed
+  TEMPERATURE: 'temperature',                      // sampling temperature
+  MAX_TOKENS: 'maxTokens',                         // 토큰 상한 (text gen)
+  LORA: 'lora',                                    // LoRA 선택 (ComfyUI)
+  REFERENCE_IMAGE: 'referenceImage',               // 참조 이미지 input
+  REFERENCE_IMAGE_METHOD: 'referenceImageMethod',  // 참조 이미지 처리 방식
+  STYLE_PRESET: 'stylePreset',                     // 스타일 프리셋
+  UPSCALE_METHOD: 'upscaleMethod'                  // 업스케일 방식
+});
+
+const FIELD_ROLE_VALUES = Object.freeze(Object.values(FIELD_ROLES));
+
+// role → 한국어 라벨 (admin UI 표시용)
+const FIELD_ROLE_LABELS = Object.freeze({
+  [FIELD_ROLES.MODEL]: '모델',
+  [FIELD_ROLES.PROMPT]: '프롬프트',
+  [FIELD_ROLES.NEGATIVE_PROMPT]: '네거티브 프롬프트',
+  [FIELD_ROLES.SYSTEM_PROMPT]: '시스템 프롬프트',
+  [FIELD_ROLES.IMAGE_SIZE]: '이미지 크기',
+  [FIELD_ROLES.SEED]: '시드',
+  [FIELD_ROLES.TEMPERATURE]: 'Temperature',
+  [FIELD_ROLES.MAX_TOKENS]: 'Max Tokens',
+  [FIELD_ROLES.LORA]: 'LoRA',
+  [FIELD_ROLES.REFERENCE_IMAGE]: '참조 이미지',
+  [FIELD_ROLES.REFERENCE_IMAGE_METHOD]: '참조 이미지 처리 방식',
+  [FIELD_ROLES.STYLE_PRESET]: '스타일 프리셋',
+  [FIELD_ROLES.UPSCALE_METHOD]: '업스케일 방식'
+});
+
+// 기존 baseInputFields well-known 키 → role 매핑 (Phase B 마이그레이션에서 사용)
+const LEGACY_BASE_FIELD_TO_ROLE = Object.freeze({
+  aiModel: FIELD_ROLES.MODEL,
+  imageSizes: FIELD_ROLES.IMAGE_SIZE,
+  referenceImageMethods: FIELD_ROLES.REFERENCE_IMAGE_METHOD,
+  stylePresets: FIELD_ROLES.STYLE_PRESET,
+  upscaleMethods: FIELD_ROLES.UPSCALE_METHOD,
+  systemPrompt: FIELD_ROLES.SYSTEM_PROMPT,
+  referenceImages: FIELD_ROLES.REFERENCE_IMAGE,
+  temperature: FIELD_ROLES.TEMPERATURE,
+  maxTokens: FIELD_ROLES.MAX_TOKENS
+});
+
+module.exports = {
+  FIELD_ROLES,
+  FIELD_ROLE_VALUES,
+  FIELD_ROLE_LABELS,
+  LEGACY_BASE_FIELD_TO_ROLE
+};

--- a/src/models/Workboard.js
+++ b/src/models/Workboard.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const { FIELD_ROLE_VALUES } = require('../constants/fieldRoles');
 
 const selectOptionSchema = new mongoose.Schema({
   key: {
@@ -24,6 +25,13 @@ const inputFieldSchema = new mongoose.Schema({
     type: String,
     enum: ['string', 'select', 'file', 'number', 'boolean', 'image'],
     required: true
+  },
+  // 필드 role (#199) — 서비스 코드가 필드 이름 대신 role 로 의미를 찾는다.
+  // null/undefined 이면 단순 사용자 입력으로 처리. 한 작업판 안에서 같은 role 은 1회만 권장.
+  role: {
+    type: String,
+    enum: [...FIELD_ROLE_VALUES, null],
+    default: null
   },
   required: {
     type: Boolean,

--- a/src/tests/customFieldHelpers.test.js
+++ b/src/tests/customFieldHelpers.test.js
@@ -1,0 +1,105 @@
+const {
+  getFieldByRole,
+  getFieldValueByRole,
+  indexFieldsByRole
+} = require('../utils/customFieldHelpers');
+const { FIELD_ROLES } = require('../constants/fieldRoles');
+
+describe('customFieldHelpers (#199 Phase A)', () => {
+  const workboard = {
+    additionalInputFields: [
+      { name: 'mainModel', label: '모델', type: 'select', role: FIELD_ROLES.MODEL },
+      { name: 'userPrompt', label: '프롬프트', type: 'string', role: FIELD_ROLES.PROMPT },
+      { name: 'note', label: '메모', type: 'string' }  // role 없음
+    ]
+  };
+
+  describe('getFieldByRole', () => {
+    test('role 매치되는 필드 반환', () => {
+      const f = getFieldByRole(workboard, FIELD_ROLES.MODEL);
+      expect(f).toBeTruthy();
+      expect(f.name).toBe('mainModel');
+    });
+
+    test('role 없는 필드는 무시', () => {
+      const f = getFieldByRole(workboard, FIELD_ROLES.SEED);
+      expect(f).toBeNull();
+    });
+
+    test('workboard / role 누락 시 null', () => {
+      expect(getFieldByRole(null, FIELD_ROLES.MODEL)).toBeNull();
+      expect(getFieldByRole(workboard, null)).toBeNull();
+    });
+
+    test('additionalInputFields 가 없어도 안전', () => {
+      expect(getFieldByRole({}, FIELD_ROLES.MODEL)).toBeNull();
+    });
+  });
+
+  describe('getFieldValueByRole', () => {
+    test('필드 이름으로 inputData 에서 값 추출', () => {
+      const inputData = { mainModel: 'SDXL/illustrious.safetensors', userPrompt: 'a cat' };
+      expect(getFieldValueByRole(workboard, inputData, FIELD_ROLES.MODEL)).toBe('SDXL/illustrious.safetensors');
+      expect(getFieldValueByRole(workboard, inputData, FIELD_ROLES.PROMPT)).toBe('a cat');
+    });
+
+    test('legacy baseInputFields 키 fallback', () => {
+      const inputData = { aiModel: 'legacy-model-id' };
+      const wbWithoutRole = { additionalInputFields: [] };
+      expect(getFieldValueByRole(wbWithoutRole, inputData, FIELD_ROLES.MODEL)).toBe('legacy-model-id');
+    });
+
+    test('customFields 매치 우선, legacy 는 fallback', () => {
+      const inputData = { mainModel: 'new', aiModel: 'legacy' };
+      expect(getFieldValueByRole(workboard, inputData, FIELD_ROLES.MODEL)).toBe('new');
+    });
+
+    test('값 없으면 undefined', () => {
+      expect(getFieldValueByRole(workboard, {}, FIELD_ROLES.MODEL)).toBeUndefined();
+    });
+
+    test('legacy systemPrompt 와 referenceImageMethod 매핑', () => {
+      const inputData = {
+        systemPrompt: 'You are helpful',
+        referenceImageMethods: 'inpaint',
+        temperature: 0.5,
+        maxTokens: 1024
+      };
+      const wbEmpty = { additionalInputFields: [] };
+      expect(getFieldValueByRole(wbEmpty, inputData, FIELD_ROLES.SYSTEM_PROMPT)).toBe('You are helpful');
+      expect(getFieldValueByRole(wbEmpty, inputData, FIELD_ROLES.REFERENCE_IMAGE_METHOD)).toBe('inpaint');
+      expect(getFieldValueByRole(wbEmpty, inputData, FIELD_ROLES.TEMPERATURE)).toBe(0.5);
+      expect(getFieldValueByRole(wbEmpty, inputData, FIELD_ROLES.MAX_TOKENS)).toBe(1024);
+    });
+
+    test('null/undefined 입력 안전', () => {
+      expect(getFieldValueByRole(null, {}, FIELD_ROLES.MODEL)).toBeUndefined();
+      expect(getFieldValueByRole(workboard, null, FIELD_ROLES.MODEL)).toBeUndefined();
+      expect(getFieldValueByRole(workboard, {}, null)).toBeUndefined();
+    });
+  });
+
+  describe('indexFieldsByRole', () => {
+    test('role 별 필드 인덱싱', () => {
+      const map = indexFieldsByRole(workboard);
+      expect(map[FIELD_ROLES.MODEL].name).toBe('mainModel');
+      expect(map[FIELD_ROLES.PROMPT].name).toBe('userPrompt');
+      expect(map[FIELD_ROLES.SEED]).toBeUndefined();
+    });
+
+    test('중복 role 은 첫 번째 매치만', () => {
+      const wb = {
+        additionalInputFields: [
+          { name: 'first', role: FIELD_ROLES.MODEL },
+          { name: 'second', role: FIELD_ROLES.MODEL }
+        ]
+      };
+      expect(indexFieldsByRole(wb)[FIELD_ROLES.MODEL].name).toBe('first');
+    });
+
+    test('빈 / null 입력 안전', () => {
+      expect(indexFieldsByRole(null)).toEqual({});
+      expect(indexFieldsByRole({})).toEqual({});
+    });
+  });
+});

--- a/src/utils/customFieldHelpers.js
+++ b/src/utils/customFieldHelpers.js
@@ -1,0 +1,75 @@
+// 작업판 customFields 헬퍼 (#199 Phase A)
+//
+// 서비스 코드 (queueService, gptImageService 등) 가 작업판의 필드 이름에 직접 의존하지 않고
+// role 기반으로 필드를 찾을 수 있게 해주는 read-only 헬퍼들.
+// Phase C 에서 서비스 코드가 이 헬퍼로 마이그레이션됨.
+
+const { LEGACY_BASE_FIELD_TO_ROLE } = require('../constants/fieldRoles');
+
+/**
+ * 작업판에서 특정 role 을 가진 첫 번째 필드 메타데이터를 반환.
+ * 같은 role 의 필드가 여러 개일 경우 첫 번째 매치만 반환 (소프트 컨벤션).
+ *
+ * @param {Object} workboard — Workboard document or POJO
+ * @param {string} role — FIELD_ROLES 의 값
+ * @returns {Object|null} field schema or null
+ */
+function getFieldByRole(workboard, role) {
+  if (!workboard || !role) return null;
+  const fields = workboard.additionalInputFields || [];
+  return fields.find((f) => f && f.role === role) || null;
+}
+
+/**
+ * 작업판의 입력값 (inputData) 에서 특정 role 에 해당하는 값을 추출.
+ * 1) additionalInputFields 에서 role 매치되는 필드 이름으로 inputData 조회
+ * 2) 매치 실패 시 legacy baseInputFields well-known 키를 fallback 으로 조회
+ *
+ * Phase B 마이그레이션 후 모든 작업판에 role 이 부여되면 fallback 은 dead-code.
+ * Phase F 에서 baseInputFields 자체 제거 시 fallback 도 함께 제거됨.
+ *
+ * @param {Object} workboard — Workboard document or POJO
+ * @param {Object} inputData — 사용자가 제출한 입력값 (job.inputData)
+ * @param {string} role — FIELD_ROLES 의 값
+ * @returns {*} 값 또는 undefined
+ */
+function getFieldValueByRole(workboard, inputData, role) {
+  if (!workboard || !inputData || !role) return undefined;
+
+  const field = getFieldByRole(workboard, role);
+  if (field && field.name && Object.prototype.hasOwnProperty.call(inputData, field.name)) {
+    return inputData[field.name];
+  }
+
+  // Legacy fallback — baseInputFields well-known key
+  for (const [legacyKey, mappedRole] of Object.entries(LEGACY_BASE_FIELD_TO_ROLE)) {
+    if (mappedRole === role && Object.prototype.hasOwnProperty.call(inputData, legacyKey)) {
+      return inputData[legacyKey];
+    }
+  }
+  return undefined;
+}
+
+/**
+ * 작업판의 customFields 를 role 별로 인덱싱한 맵 반환.
+ * 같은 role 의 중복 필드가 있으면 첫 번째만 채택 (마지막 매치 무시).
+ *
+ * @param {Object} workboard
+ * @returns {Object<string, Object>} role → field
+ */
+function indexFieldsByRole(workboard) {
+  const fields = (workboard && workboard.additionalInputFields) || [];
+  const map = {};
+  for (const f of fields) {
+    if (f && f.role && !map[f.role]) {
+      map[f.role] = f;
+    }
+  }
+  return map;
+}
+
+module.exports = {
+  getFieldByRole,
+  getFieldValueByRole,
+  indexFieldsByRole
+};


### PR DESCRIPTION
## Summary

#199 (작업판 풀 커스텀화) 의 Phase A — schema 확장 + read-only 헬퍼.

행위 변경 없음. 기존 baseInputFields / additionalInputFields 그대로 동작. Phase B (마이그레이션), Phase C (서비스 코드 마이그레이션) 의 토대.

## Changes

- \`src/constants/fieldRoles.js\` — 13개 role enum + 한국어 라벨 + legacy key → role 매핑 테이블
- \`src/models/Workboard.js\` — \`inputFieldSchema\` 에 \`role\` 필드 추가 (enum, nullable)
- \`src/utils/customFieldHelpers.js\` — \`getFieldByRole\` / \`getFieldValueByRole\` / \`indexFieldsByRole\`
- \`src/tests/customFieldHelpers.test.js\` — 13 assertions

## Role enum

\`model\`, \`prompt\`, \`negativePrompt\`, \`systemPrompt\`, \`imageSize\`, \`seed\`, \`temperature\`, \`maxTokens\`, \`lora\`, \`referenceImage\`, \`referenceImageMethod\`, \`stylePreset\`, \`upscaleMethod\`

## Naming note

이슈 본문에서는 \`customFields[]\` 라는 이름을 사용하지만, 코드에서는 기존 \`additionalInputFields\` 를 그대로 사용 (22개 파일에 분포 — 단순 rename 으로 인한 churn 회피). 의미적으로 둘은 같음. Phase F (정리) 단계에서 rename 여부 재검토.

## Test plan

- [x] customFieldHelpers 13 assertions 모두 통과 (docker compose run backend npx jest)
- [x] 전체 백엔드 테스트 — 기존 통과 41/42, 사전 존재 실패 1 (prodComposeSecrets) — 회귀 없음
- [x] --no-cache backend 빌드 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)