### PR TITLE
feat: customField role 자동 마이그레이션 (#199 Phase B)

### DIFF
--- a/src/migrations/backfillCustomFieldRoles.js
+++ b/src/migrations/backfillCustomFieldRoles.js
@@ -1,0 +1,142 @@
+const Workboard = require('../models/Workboard');
+const { FIELD_ROLES, LEGACY_BASE_FIELD_TO_ROLE } = require('../constants/fieldRoles');
+
+// #199 Phase B: 기존 baseInputFields well-known 키 → additionalInputFields 의 role-부여 항목으로 마이그레이션.
+//
+// 동작:
+// 1) Workboard 마다 baseInputFields 의 well-known 키 검사
+// 2) 같은 role 이 additionalInputFields 에 이미 있으면 skip (idempotent)
+// 3) 같은 name 의 entry 가 있지만 role 이 없으면 → 해당 entry 에 role 만 부여
+// 4) 그 외 → baseInputFields 의 값을 풀어 새 entry 추가
+//
+// baseInputFields 자체는 건드리지 않음 (Phase F 에서 제거 예정). 따라서 v1.x 코드와도 호환.
+
+// 각 legacy key → field schema 변환 헬퍼
+function buildEntryFromLegacy(legacyKey, legacyValue) {
+  const role = LEGACY_BASE_FIELD_TO_ROLE[legacyKey];
+  if (!role) return null;
+
+  const labels = {
+    aiModel: 'AI 모델',
+    imageSizes: '이미지 크기',
+    referenceImageMethods: '참조 이미지 처리',
+    stylePresets: '스타일 프리셋',
+    upscaleMethods: '업스케일 방식',
+    systemPrompt: '시스템 프롬프트',
+    referenceImages: '참조 이미지',
+    temperature: 'Temperature',
+    maxTokens: 'Max Tokens'
+  };
+
+  // selectOption 배열 (aiModel / imageSizes / referenceImageMethods / stylePresets / upscaleMethods / referenceImages)
+  if (Array.isArray(legacyValue)) {
+    return {
+      name: legacyKey,
+      label: labels[legacyKey] || legacyKey,
+      type: legacyKey === 'referenceImages' ? 'image' : 'select',
+      role,
+      options: legacyValue.map((opt) => ({ key: opt.key, value: opt.value })),
+      required: false
+    };
+  }
+
+  // number (temperature / maxTokens)
+  if (typeof legacyValue === 'number') {
+    return {
+      name: legacyKey,
+      label: labels[legacyKey] || legacyKey,
+      type: 'number',
+      role,
+      defaultValue: legacyValue,
+      required: false
+    };
+  }
+
+  // string (systemPrompt)
+  if (typeof legacyValue === 'string') {
+    return {
+      name: legacyKey,
+      label: labels[legacyKey] || legacyKey,
+      type: 'string',
+      role,
+      defaultValue: legacyValue,
+      required: false
+    };
+  }
+
+  return null;
+}
+
+async function backfillCustomFieldRoles() {
+  try {
+    const workboards = await Workboard.find({});
+    let migratedCount = 0;
+    let roleAssignedCount = 0;
+    let appendedCount = 0;
+
+    for (const wb of workboards) {
+      const base = wb.baseInputFields || {};
+      const existing = wb.additionalInputFields || [];
+      const existingRoles = new Set(existing.filter((f) => f && f.role).map((f) => f.role));
+      const existingByName = new Map(existing.filter((f) => f && f.name).map((f) => [f.name, f]));
+      let dirty = false;
+
+      for (const [legacyKey, role] of Object.entries(LEGACY_BASE_FIELD_TO_ROLE)) {
+        if (existingRoles.has(role)) continue;  // 이미 마이그레이션 됨
+        if (!Object.prototype.hasOwnProperty.call(base, legacyKey)) continue;
+
+        const legacyValue = base[legacyKey];
+
+        // 같은 name 이 있지만 role 이 없는 경우 — role 만 부여
+        if (existingByName.has(legacyKey)) {
+          const target = existingByName.get(legacyKey);
+          if (!target.role) {
+            target.role = role;
+            roleAssignedCount += 1;
+            dirty = true;
+          }
+          existingRoles.add(role);
+          continue;
+        }
+
+        // 새 entry 생성
+        const entry = buildEntryFromLegacy(legacyKey, legacyValue);
+        if (!entry) continue;
+        // 빈 옵션 배열은 의미 없으므로 skip (select 타입 한정)
+        if (entry.type === 'select' && (!entry.options || entry.options.length === 0)) continue;
+        // 빈 문자열 systemPrompt 도 skip (사용자가 채우지 않은 케이스)
+        if (entry.type === 'string' && (entry.defaultValue === undefined || entry.defaultValue === '')) continue;
+
+        wb.additionalInputFields.push(entry);
+        existingRoles.add(role);
+        appendedCount += 1;
+        dirty = true;
+      }
+
+      if (dirty) {
+        wb.markModified('additionalInputFields');
+        await wb.save();
+        migratedCount += 1;
+      }
+    }
+
+    if (migratedCount > 0) {
+      console.log(`[Migration] Workboard customField role backfill — 작업판 ${migratedCount}건 갱신 (role 부여 ${roleAssignedCount}, 신규 추가 ${appendedCount})`);
+    } else {
+      console.log('[Migration] Workboard customField role backfill 불필요 (모두 최신)');
+    }
+
+    // 사용된 role 카운트 (필요시 디버깅용)
+    return {
+      migratedCount,
+      roleAssignedCount,
+      appendedCount,
+      knownRoles: Object.values(FIELD_ROLES)
+    };
+  } catch (error) {
+    console.error('[Migration] customField role backfill 오류:', error);
+  }
+}
+
+module.exports = backfillCustomFieldRoles;
+module.exports.buildEntryFromLegacy = buildEntryFromLegacy;

--- a/src/server.js
+++ b/src/server.js
@@ -35,6 +35,7 @@ const dropLegacyModelCacheCollection = require('./migrations/dropLegacyModelCach
 const cleanupStuckSyncs = require('./migrations/cleanupStuckSyncs');
 const initializeDefaultGroup = require('./migrations/initializeDefaultGroup');
 const assignDefaultGroupToWorkboards = require('./migrations/assignDefaultGroupToWorkboards');
+const backfillCustomFieldRoles = require('./migrations/backfillCustomFieldRoles');
 
 dotenv.config();
 
@@ -185,6 +186,7 @@ const startServer = async () => {
     await cleanupStuckSyncs();
     await initializeDefaultGroup();
     await assignDefaultGroupToWorkboards();
+    await backfillCustomFieldRoles();
 
     // Initialize job queues after database connection
     console.log('Initializing job queues...');

--- a/src/tests/backfillCustomFieldRoles.test.js
+++ b/src/tests/backfillCustomFieldRoles.test.js
@@ -1,0 +1,109 @@
+const migration = require('../migrations/backfillCustomFieldRoles');
+const { buildEntryFromLegacy } = migration;
+const { LEGACY_BASE_FIELD_TO_ROLE, FIELD_ROLES } = require('../constants/fieldRoles');
+
+describe('backfillCustomFieldRoles — buildEntryFromLegacy (#199 Phase B)', () => {
+  describe('legacy 매핑 메타', () => {
+    test('모든 legacy key → role 매핑이 FIELD_ROLES 의 값', () => {
+      const validRoles = new Set(Object.values(FIELD_ROLES));
+      for (const [_, role] of Object.entries(LEGACY_BASE_FIELD_TO_ROLE)) {
+        expect(validRoles.has(role)).toBe(true);
+      }
+    });
+
+    test('baseInputFields 의 well-known 키 9개 모두 매핑됨', () => {
+      const expectedKeys = [
+        'aiModel', 'imageSizes', 'referenceImageMethods', 'stylePresets',
+        'upscaleMethods', 'systemPrompt', 'referenceImages', 'temperature', 'maxTokens'
+      ];
+      for (const k of expectedKeys) {
+        expect(LEGACY_BASE_FIELD_TO_ROLE).toHaveProperty(k);
+      }
+    });
+
+    test('마이그레이션 함수 export', () => {
+      expect(typeof migration).toBe('function');
+    });
+  });
+
+  describe('selectOption 배열 → select 필드', () => {
+    test('aiModel 변환', () => {
+      const entry = buildEntryFromLegacy('aiModel', [
+        { key: 'sdxl', value: 'SDXL 1.0' },
+        { key: 'flux', value: 'Flux Dev' }
+      ]);
+      expect(entry).toEqual({
+        name: 'aiModel',
+        label: 'AI 모델',
+        type: 'select',
+        role: FIELD_ROLES.MODEL,
+        options: [
+          { key: 'sdxl', value: 'SDXL 1.0' },
+          { key: 'flux', value: 'Flux Dev' }
+        ],
+        required: false
+      });
+    });
+
+    test('referenceImages 는 image 타입', () => {
+      const entry = buildEntryFromLegacy('referenceImages', [{ key: 'ref1', value: 'reference image 1' }]);
+      expect(entry.type).toBe('image');
+      expect(entry.role).toBe(FIELD_ROLES.REFERENCE_IMAGE);
+    });
+
+    test('imageSizes / referenceImageMethods / stylePresets / upscaleMethods 모두 select', () => {
+      const opts = [{ key: 'a', value: 'A' }];
+      expect(buildEntryFromLegacy('imageSizes', opts).type).toBe('select');
+      expect(buildEntryFromLegacy('imageSizes', opts).role).toBe(FIELD_ROLES.IMAGE_SIZE);
+      expect(buildEntryFromLegacy('referenceImageMethods', opts).role).toBe(FIELD_ROLES.REFERENCE_IMAGE_METHOD);
+      expect(buildEntryFromLegacy('stylePresets', opts).role).toBe(FIELD_ROLES.STYLE_PRESET);
+      expect(buildEntryFromLegacy('upscaleMethods', opts).role).toBe(FIELD_ROLES.UPSCALE_METHOD);
+    });
+  });
+
+  describe('number → number 필드 + defaultValue', () => {
+    test('temperature', () => {
+      const entry = buildEntryFromLegacy('temperature', 0.7);
+      expect(entry).toEqual({
+        name: 'temperature',
+        label: 'Temperature',
+        type: 'number',
+        role: FIELD_ROLES.TEMPERATURE,
+        defaultValue: 0.7,
+        required: false
+      });
+    });
+
+    test('maxTokens', () => {
+      const entry = buildEntryFromLegacy('maxTokens', 2048);
+      expect(entry.type).toBe('number');
+      expect(entry.defaultValue).toBe(2048);
+      expect(entry.role).toBe(FIELD_ROLES.MAX_TOKENS);
+    });
+  });
+
+  describe('string → string 필드 + defaultValue', () => {
+    test('systemPrompt', () => {
+      const entry = buildEntryFromLegacy('systemPrompt', 'You are helpful');
+      expect(entry).toEqual({
+        name: 'systemPrompt',
+        label: '시스템 프롬프트',
+        type: 'string',
+        role: FIELD_ROLES.SYSTEM_PROMPT,
+        defaultValue: 'You are helpful',
+        required: false
+      });
+    });
+  });
+
+  describe('알 수 없는 키 / 잘못된 값', () => {
+    test('legacy 매핑에 없는 키는 null', () => {
+      expect(buildEntryFromLegacy('unknownKey', 'foo')).toBeNull();
+    });
+
+    test('boolean / object 값은 null', () => {
+      expect(buildEntryFromLegacy('aiModel', true)).toBeNull();
+      expect(buildEntryFromLegacy('aiModel', { foo: 'bar' })).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

#199 Phase B — 기존 \`baseInputFields\` 의 well-known 키 9개를 \`additionalInputFields\` 의 role 부여된 항목으로 자동 마이그레이션.

서버 부팅 시 \`backfillCustomFieldRoles\` 마이그레이션이 실행됨. Phase A 의 헬퍼 (\`getFieldByRole\`) 가 이제 모든 기존 작업판에서 의미있는 값을 반환하게 됨 — Phase C (서비스 코드 마이그레이션) 의 전제조건.

## Conversion 규칙

| Legacy key | Role | Type | 비고 |
|---|---|---|---|
| aiModel | model | select | options 그대로 |
| imageSizes | imageSize | select | options 그대로 |
| referenceImageMethods | referenceImageMethod | select | options 그대로 |
| stylePresets | stylePreset | select | options 그대로 |
| upscaleMethods | upscaleMethod | select | options 그대로 |
| systemPrompt | systemPrompt | string | defaultValue |
| referenceImages | referenceImage | image | options 그대로 |
| temperature | temperature | number | defaultValue |
| maxTokens | maxTokens | number | defaultValue |

## Idempotency 보장

- 같은 role 이 이미 있으면 skip
- 같은 name 의 entry 가 있고 role 만 빠진 경우 → role 만 부여
- 빈 옵션 / 빈 문자열 defaultValue → skip
- \`baseInputFields\` 자체는 건드리지 않음 (v1.x 코드와 공존)

## Test plan

- [x] 11 assertions 통과 — buildEntryFromLegacy 변환 로직
- [x] 로컬 dev DB: 7개 작업판 → 33 entry 자동 마이그레이션
- [x] 재기동 시 \"불필요 (모두 최신)\" — 멱등성 검증
- [x] --no-cache 백엔드 빌드 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)