### PR TITLE
feat: 서비스 코드 role 기반 lookup 마이그레이션 (#199 Phase C)

### DIFF
--- a/src/constants/fieldRoles.js
+++ b/src/constants/fieldRoles.js
@@ -55,9 +55,24 @@ const LEGACY_BASE_FIELD_TO_ROLE = Object.freeze({
   maxTokens: FIELD_ROLES.MAX_TOKENS
 });
 
+// well-known 필드 이름 → role 매핑 (superset).
+// LEGACY_BASE_FIELD_TO_ROLE 의 baseInputFields 키 + additionalInputFields 에서 자주 쓰이는 이름.
+// 서비스 코드 fallback 및 Phase C 의 additionalInputFields role 자동 부여 마이그레이션에서 사용.
+const WELL_KNOWN_FIELD_NAME_TO_ROLE = Object.freeze({
+  ...LEGACY_BASE_FIELD_TO_ROLE,
+  prompt: FIELD_ROLES.PROMPT,
+  negativePrompt: FIELD_ROLES.NEGATIVE_PROMPT,
+  seed: FIELD_ROLES.SEED,
+  referenceImageMethod: FIELD_ROLES.REFERENCE_IMAGE_METHOD,
+  stylePreset: FIELD_ROLES.STYLE_PRESET,
+  upscaleMethod: FIELD_ROLES.UPSCALE_METHOD,
+  referenceImage: FIELD_ROLES.REFERENCE_IMAGE
+});
+
 module.exports = {
   FIELD_ROLES,
   FIELD_ROLE_VALUES,
   FIELD_ROLE_LABELS,
-  LEGACY_BASE_FIELD_TO_ROLE
+  LEGACY_BASE_FIELD_TO_ROLE,
+  WELL_KNOWN_FIELD_NAME_TO_ROLE
 };

--- a/src/migrations/assignRoleToAdditionalFields.js
+++ b/src/migrations/assignRoleToAdditionalFields.js
@@ -1,0 +1,57 @@
+const Workboard = require('../models/Workboard');
+const { WELL_KNOWN_FIELD_NAME_TO_ROLE } = require('../constants/fieldRoles');
+
+// #199 Phase C: additionalInputFields 의 well-known 이름을 가진 항목에 role 부여.
+//
+// Phase B 는 baseInputFields 의 well-known 키를 마이그레이션했지만, additionalInputFields 에
+// 처음부터 정의된 prompt / negativePrompt / seed / aiModel 등은 role 이 없는 상태.
+// 이 마이그레이션은 그런 entry 에 role 을 부여해 Phase C 의 서비스 코드 (role 기반 lookup) 가
+// 모든 기존 작업판에서 정상 동작하게 한다.
+//
+// 멱등 — 같은 role 이 이미 있거나 entry 에 role 이 이미 있으면 skip.
+
+async function assignRoleToAdditionalFields() {
+  try {
+    const workboards = await Workboard.find({});
+    let workboardCount = 0;
+    let assignedCount = 0;
+
+    for (const wb of workboards) {
+      const fields = wb.additionalInputFields || [];
+      if (fields.length === 0) continue;
+
+      const occupiedRoles = new Set(fields.filter((f) => f && f.role).map((f) => f.role));
+      let dirty = false;
+
+      for (const field of fields) {
+        if (!field || !field.name) continue;
+        if (field.role) continue;  // already has role
+
+        const targetRole = WELL_KNOWN_FIELD_NAME_TO_ROLE[field.name];
+        if (!targetRole) continue;
+        if (occupiedRoles.has(targetRole)) continue;  // 다른 entry 가 이미 이 role 점유
+
+        field.role = targetRole;
+        occupiedRoles.add(targetRole);
+        assignedCount += 1;
+        dirty = true;
+      }
+
+      if (dirty) {
+        wb.markModified('additionalInputFields');
+        await wb.save();
+        workboardCount += 1;
+      }
+    }
+
+    if (workboardCount > 0) {
+      console.log(`[Migration] additionalInputFields role 부여 — 작업판 ${workboardCount}건, ${assignedCount}개 필드`);
+    } else {
+      console.log('[Migration] additionalInputFields role 부여 불필요 (모두 최신)');
+    }
+  } catch (error) {
+    console.error('[Migration] additionalInputFields role 부여 오류:', error);
+  }
+}
+
+module.exports = assignRoleToAdditionalFields;

--- a/src/server.js
+++ b/src/server.js
@@ -36,6 +36,7 @@ const cleanupStuckSyncs = require('./migrations/cleanupStuckSyncs');
 const initializeDefaultGroup = require('./migrations/initializeDefaultGroup');
 const assignDefaultGroupToWorkboards = require('./migrations/assignDefaultGroupToWorkboards');
 const backfillCustomFieldRoles = require('./migrations/backfillCustomFieldRoles');
+const assignRoleToAdditionalFields = require('./migrations/assignRoleToAdditionalFields');
 
 dotenv.config();
 
@@ -187,6 +188,7 @@ const startServer = async () => {
     await initializeDefaultGroup();
     await assignDefaultGroupToWorkboards();
     await backfillCustomFieldRoles();
+    await assignRoleToAdditionalFields();
 
     // Initialize job queues after database connection
     console.log('Initializing job queues...');

--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -11,6 +11,8 @@ const ImageGenerationJob = require('../models/ImageGenerationJob');
 const GeneratedImage = require('../models/GeneratedImage');
 const GeneratedVideo = require('../models/GeneratedVideo');
 const UploadedImage = require('../models/UploadedImage');
+const { getFieldValueByRole } = require('../utils/customFieldHelpers');
+const { FIELD_ROLES } = require('../constants/fieldRoles');
 
 let imageGenerationQueue;
 let redisClient;
@@ -144,10 +146,10 @@ async function handleGeminiImage({ workboardData, inputData, job }) {
   const result = await geminiService.generateImage(
     workboardData.serverUrl,
     workboardData.apiKey || process.env.GEMINI_API_KEY,
-    buildGeminiPrompt(inputData),
+    buildGeminiPrompt(inputData, workboardData),
     {
-      model: inputData.aiModel,
-      aspectRatio: deriveAspectRatio(extractOptionValue(inputData.imageSize)),
+      model: getFieldValueByRole(workboardData, inputData, FIELD_ROLES.MODEL),
+      aspectRatio: deriveAspectRatio(extractOptionValue(getFieldValueByRole(workboardData, inputData, FIELD_ROLES.IMAGE_SIZE))),
       resolution: extractOptionValue(inputData.additionalParams?.resolution),
       images: geminiImages,
       timeout: workboardData.timeout,
@@ -161,10 +163,10 @@ async function handleOpenAIImage({ workboardData, inputData, job }) {
   const result = await gptImageService.generateImage(
     workboardData.serverUrl,
     workboardData.apiKey || process.env.OPENAI_IMAGE_API_KEY,
-    buildGeminiPrompt(inputData),
+    buildGeminiPrompt(inputData, workboardData),
     {
-      model: inputData.aiModel,
-      size: extractOptionValue(inputData.imageSize),
+      model: getFieldValueByRole(workboardData, inputData, FIELD_ROLES.MODEL),
+      size: extractOptionValue(getFieldValueByRole(workboardData, inputData, FIELD_ROLES.IMAGE_SIZE)),
       quality: extractOptionValue(
         inputData.additionalParams?.quality || inputData.quality
       ),
@@ -278,13 +280,13 @@ const processImageGeneration = async (job) => {
     
     if (hasImages) {
       console.log(`💾 Starting to save ${generationResult.images.length} images...`);
-      savedImages = await saveGeneratedMedia(jobId, generationResult.images, enhancedInputData, 'image');
+      savedImages = await saveGeneratedMedia(jobId, generationResult.images, enhancedInputData, 'image', workboardData);
       console.log(`✅ Saved ${savedImages.length} images successfully`);
     }
-    
+
     if (hasVideos) {
       console.log(`🎬 Starting to save ${generationResult.videos.length} videos...`);
-      savedVideos = await saveGeneratedMedia(jobId, generationResult.videos, enhancedInputData, 'video');
+      savedVideos = await saveGeneratedMedia(jobId, generationResult.videos, enhancedInputData, 'video', workboardData);
       console.log(`✅ Saved ${savedVideos.length} videos successfully`);
     }
     
@@ -321,11 +323,13 @@ const deriveAspectRatio = (imageSize) => {
   return `${width / divisor}:${height / divisor}`;
 };
 
-const buildGeminiPrompt = (inputData) => {
-  const segments = [inputData.prompt];
+const buildGeminiPrompt = (inputData, workboard) => {
+  const prompt = getFieldValueByRole(workboard, inputData, FIELD_ROLES.PROMPT);
+  const negativePrompt = getFieldValueByRole(workboard, inputData, FIELD_ROLES.NEGATIVE_PROMPT);
+  const segments = [prompt];
 
-  if (inputData.negativePrompt) {
-    segments.push(`Avoid: ${inputData.negativePrompt}`);
+  if (negativePrompt) {
+    segments.push(`Avoid: ${negativePrompt}`);
   }
 
   return segments.filter(Boolean).join('\n\n');
@@ -358,6 +362,8 @@ const loadImageInput = async (imageId) => {
 const loadImageInputs = async (additionalInputFields, inputData) => {
   const loadedImages = [];
 
+  // role 기반 lookup 은 workboard 전체가 필요한데 여기선 fields 만 받음 — 호환성 위해 직접 access.
+  // 모든 호출처가 inputData.referenceImages 를 사용 중이므로 fallback 만 유지.
   if (Array.isArray(inputData.referenceImages)) {
     for (const referenceImage of inputData.referenceImages) {
       const loaded = await loadImageInput(referenceImage?.imageId);
@@ -518,9 +524,10 @@ const injectInputsIntoWorkflow = async (workflowTemplate, inputData, workboard =
   
   // 시드 값 처리: 사용자 지정 또는 랜덤 생성
   let seedValue;
-  if (inputData.seed !== undefined && inputData.seed !== null && inputData.seed !== '') {
+  const seedFromRole = getFieldValueByRole(workboard, inputData, FIELD_ROLES.SEED);
+  if (seedFromRole !== undefined && seedFromRole !== null && seedFromRole !== '') {
     // extractValue를 사용하여 키-값 객체에서 값 추출
-    const extractedSeed = extractValue(inputData.seed);
+    const extractedSeed = extractValue(seedFromRole);
     const parsedSeed = parseInt(extractedSeed);
     
     // 유효한 정수인지 확인 및 UInt64 범위 보정
@@ -543,7 +550,7 @@ const injectInputsIntoWorkflow = async (workflowTemplate, inputData, workboard =
   console.log('🎲 Processed seed value:', seedValue);
   
   // 이미지 크기 추출 (예: "512x768" 또는 {key: "512x768", value: "512x768"})
-  const extractedImageSize = extractValue(inputData.imageSize) || '512x512';
+  const extractedImageSize = extractValue(getFieldValueByRole(workboard, inputData, FIELD_ROLES.IMAGE_SIZE)) || '512x512';
   console.log('📐 Extracted image size:', extractedImageSize);
   
   let width = 512, height = 512;
@@ -559,10 +566,11 @@ const injectInputsIntoWorkflow = async (workflowTemplate, inputData, workboard =
   console.log('📏 Parsed dimensions:', { width, height });
   
   // 기본 고정 형식 문자열들과 타입 정보
-  // 업스케일 메서드 값 추출 (다양한 필드명과 소스에서 시도)
+  // 업스케일 메서드 값 추출 (role 기반 + additionalParams fallback)
   let upscaleMethodValue = '';
-  if (inputData.upscaleMethod) {
-    upscaleMethodValue = extractValue(inputData.upscaleMethod);
+  const upscaleFromRole = getFieldValueByRole(workboard, inputData, FIELD_ROLES.UPSCALE_METHOD);
+  if (upscaleFromRole) {
+    upscaleMethodValue = extractValue(upscaleFromRole);
   } else if (inputData.additionalParams?.upscaleMethod) {
     upscaleMethodValue = extractValue(inputData.additionalParams.upscaleMethod);
   } else if (inputData.additionalParams?.upscale) {
@@ -579,10 +587,15 @@ const injectInputsIntoWorkflow = async (workflowTemplate, inputData, workboard =
   // 유저 ID 해시 생성
   const hashedUserId = hashUserId(inputData.userId);
 
+  const promptValue = getFieldValueByRole(workboard, inputData, FIELD_ROLES.PROMPT) || '';
+  const negativePromptValue = getFieldValueByRole(workboard, inputData, FIELD_ROLES.NEGATIVE_PROMPT) || '';
+  const modelValue = getFieldValueByRole(workboard, inputData, FIELD_ROLES.MODEL);
+  const referenceMethodValue = getFieldValueByRole(workboard, inputData, FIELD_ROLES.REFERENCE_IMAGE_METHOD);
+
   const replacements = {
-    '{{##prompt##}}': { value: inputData.prompt || '', type: 'string' },
-    '{{##negative_prompt##}}': { value: inputData.negativePrompt || '', type: 'string' },
-    '{{##model##}}': { value: extractValue(inputData.aiModel), type: 'string' },
+    '{{##prompt##}}': { value: promptValue, type: 'string' },
+    '{{##negative_prompt##}}': { value: negativePromptValue, type: 'string' },
+    '{{##model##}}': { value: extractValue(modelValue), type: 'string' },
     '{{##width##}}': { value: width, type: 'number' },
     '{{##height##}}': { value: height, type: 'number' },
     '{{##seed##}}': { value: seedValue, type: 'number' },
@@ -590,7 +603,7 @@ const injectInputsIntoWorkflow = async (workflowTemplate, inputData, workboard =
     '{{##cfg##}}': { value: parseFloat(inputData.additionalParams?.cfg) || 7, type: 'number' },
     '{{##sampler##}}': { value: inputData.additionalParams?.sampler || 'euler', type: 'string' },
     '{{##scheduler##}}': { value: inputData.additionalParams?.scheduler || 'normal', type: 'string' },
-    '{{##reference_method##}}': { value: extractValue(inputData.referenceImageMethod), type: 'string' },
+    '{{##reference_method##}}': { value: extractValue(referenceMethodValue), type: 'string' },
     '{{##upscale_method##}}': { value: upscaleMethodValue, type: 'string' },
     '{{##upscale##}}': { value: upscaleMethodValue, type: 'string' },  // 별칭 추가
     '{{##base_style##}}': { value: extractValue(inputData.baseStyle), type: 'string' },
@@ -754,7 +767,7 @@ const getExtensionFromMimeType = (mimeType) => {
   return mimeToExt[mimeType] || 'bin';
 };
 
-const saveGeneratedMedia = async (jobId, mediaItems, inputData, mediaType) => {
+const saveGeneratedMedia = async (jobId, mediaItems, inputData, mediaType, workboard = null) => {
   const typeLabel = mediaType === 'video' ? 'videos' : 'images';
   console.log(`🖼️ Starting to save ${mediaItems?.length || 0} generated ${typeLabel} for job ${jobId}`);
   console.log('📊 Media data:', mediaItems);
@@ -841,14 +854,14 @@ const saveGeneratedMedia = async (jobId, mediaItems, inputData, mediaType) => {
         metadata,
         tags: mediaTags,
         generationParams: {
-          prompt: inputData.prompt,
-          negativePrompt: inputData.negativePrompt,
-          model: inputData.aiModel,
-          seed: inputData.seed,
-          imageSize: inputData.imageSize,
-          stylePreset: inputData.stylePreset,
-          upscaleMethod: inputData.upscaleMethod,
-          referenceImageMethod: inputData.referenceImageMethod,
+          prompt: getFieldValueByRole(workboard, inputData, FIELD_ROLES.PROMPT),
+          negativePrompt: getFieldValueByRole(workboard, inputData, FIELD_ROLES.NEGATIVE_PROMPT),
+          model: getFieldValueByRole(workboard, inputData, FIELD_ROLES.MODEL),
+          seed: getFieldValueByRole(workboard, inputData, FIELD_ROLES.SEED),
+          imageSize: getFieldValueByRole(workboard, inputData, FIELD_ROLES.IMAGE_SIZE),
+          stylePreset: getFieldValueByRole(workboard, inputData, FIELD_ROLES.STYLE_PRESET),
+          upscaleMethod: getFieldValueByRole(workboard, inputData, FIELD_ROLES.UPSCALE_METHOD),
+          referenceImageMethod: getFieldValueByRole(workboard, inputData, FIELD_ROLES.REFERENCE_IMAGE_METHOD),
           additionalParams: inputData.additionalParams
         }
       };

--- a/src/tests/customFieldHelpers.test.js
+++ b/src/tests/customFieldHelpers.test.js
@@ -58,6 +58,14 @@ describe('customFieldHelpers (#199 Phase A)', () => {
       expect(getFieldValueByRole(workboard, {}, FIELD_ROLES.MODEL)).toBeUndefined();
     });
 
+    test('well-known additionalInputFields 이름 (prompt/negativePrompt/seed) 도 fallback', () => {
+      const wbEmpty = { additionalInputFields: [] };
+      const inputData = { prompt: 'cat', negativePrompt: 'blur', seed: 42 };
+      expect(getFieldValueByRole(wbEmpty, inputData, FIELD_ROLES.PROMPT)).toBe('cat');
+      expect(getFieldValueByRole(wbEmpty, inputData, FIELD_ROLES.NEGATIVE_PROMPT)).toBe('blur');
+      expect(getFieldValueByRole(wbEmpty, inputData, FIELD_ROLES.SEED)).toBe(42);
+    });
+
     test('legacy systemPrompt 와 referenceImageMethod 매핑', () => {
       const inputData = {
         systemPrompt: 'You are helpful',

--- a/src/utils/customFieldHelpers.js
+++ b/src/utils/customFieldHelpers.js
@@ -4,7 +4,7 @@
 // role 기반으로 필드를 찾을 수 있게 해주는 read-only 헬퍼들.
 // Phase C 에서 서비스 코드가 이 헬퍼로 마이그레이션됨.
 
-const { LEGACY_BASE_FIELD_TO_ROLE } = require('../constants/fieldRoles');
+const { WELL_KNOWN_FIELD_NAME_TO_ROLE } = require('../constants/fieldRoles');
 
 /**
  * 작업판에서 특정 role 을 가진 첫 번째 필드 메타데이터를 반환.
@@ -41,10 +41,11 @@ function getFieldValueByRole(workboard, inputData, role) {
     return inputData[field.name];
   }
 
-  // Legacy fallback — baseInputFields well-known key
-  for (const [legacyKey, mappedRole] of Object.entries(LEGACY_BASE_FIELD_TO_ROLE)) {
-    if (mappedRole === role && Object.prototype.hasOwnProperty.call(inputData, legacyKey)) {
-      return inputData[legacyKey];
+  // Well-known name fallback — additionalInputFields entry 에 role 이 없거나 부분 마이그레이션 상태 대비.
+  // 또한 prompt / negativePrompt / seed 처럼 v1.x 에서 additionalInputFields 가 있지만 role 이 부여되지 않은 케이스.
+  for (const [knownName, mappedRole] of Object.entries(WELL_KNOWN_FIELD_NAME_TO_ROLE)) {
+    if (mappedRole === role && Object.prototype.hasOwnProperty.call(inputData, knownName)) {
+      return inputData[knownName];
     }
   }
   return undefined;


### PR DESCRIPTION
## Summary

#199 Phase C — \`queueService\` 의 well-known 키 직접 access (\`inputData.aiModel\` 등) 를 role 기반 헬퍼 lookup 으로 마이그레이션.

행위 보존 — 헬퍼의 legacy fallback 으로 v1.x 데이터 그대로 호환.

## Changes

**Constants / Helpers:**
- \`fieldRoles.js\` — \`WELL_KNOWN_FIELD_NAME_TO_ROLE\` superset 추가 (prompt/negativePrompt/seed 포함)
- \`customFieldHelpers.js\` — fallback 을 WELL_KNOWN 으로 확장

**Migration:**
- \`assignRoleToAdditionalFields.js\` — 기존 additionalInputFields 의 well-known 이름에 role 자동 부여, 멱등

**Service code (queueService.js):**
- \`handleGeminiImage\` — model / imageSize role 기반 lookup
- \`handleOpenAIImage\` — model / imageSize role 기반 lookup
- \`buildGeminiPrompt\` — workboard 인자 추가, prompt / negativePrompt role 기반
- \`injectInputsIntoWorkflow\` — seed / imageSize / prompt / negativePrompt / model / referenceImageMethod / upscaleMethod role 기반
- \`saveGeneratedMedia\` — workboard 인자 추가, generationParams 메타데이터 role 기반

## Scope notes

- \`routes/jobs.js\` / \`routes/images.js\` 의 MongoDB 쿼리는 그대로 — legacy 필드명 기반 인덱스 호환 유지
- \`mcp-server\` 는 별도 패키지 — 후속 작업 (별도 PR / Phase 외 항목)

## Test plan

- [x] 14 assertions 통과 — well-known fallback 포함
- [x] 로컬 dev DB: 기존 마이그레이션 (Phase B 결과) 위에 새 마이그레이션 실행 — 신규 작업판 없으므로 \"불필요\" 로그
- [x] --no-cache 백엔드 빌드 통과
- [ ] 실제 작업 실행 테스트 (사용자 확인 필요) — Gemini/OpenAI/ComfyUI 각 1회

🤖 Generated with [Claude Code](https://claude.com/claude-code)