### PR TITLE
feat: 사용자 페이지 baseModel/lora 입력 타입 렌더링 (#199 Phase E)

### DIFF
--- a/frontend/src/components/PromptGeneratorPanel.js
+++ b/frontend/src/components/PromptGeneratorPanel.js
@@ -29,6 +29,7 @@ import { useForm, Controller } from 'react-hook-form';
 import { useDropzone } from 'react-dropzone';
 import toast from 'react-hot-toast';
 import { workboardAPI, jobAPI, imageAPI } from '../services/api';
+import MetadataFieldInput from './common/MetadataFieldInput';
 
 function ImageUploadField({ label, description, images, onImagesChange, maxImages = 1 }) {
   const onDrop = useCallback((acceptedFiles) => {
@@ -346,6 +347,23 @@ function PromptGeneratorPanel({
                             ))}
                           </Select>
                         </FormControl>
+                      )}
+                    />
+                  )}
+                  {(field.type === 'baseModel' || field.type === 'lora') && (
+                    <Controller
+                      name={field.name}
+                      control={control}
+                      rules={{ required: field.required ? `${field.label}을(를) 선택해주세요` : false }}
+                      render={({ field: formField }) => (
+                        <MetadataFieldInput
+                          kind={field.type === 'baseModel' ? 'model' : 'lora'}
+                          field={field}
+                          value={formField.value || ''}
+                          onChange={formField.onChange}
+                          workboardId={workboard._id}
+                          serverId={workboard?.serverId?._id || workboard?.serverId}
+                        />
                       )}
                     />
                   )}

--- a/frontend/src/components/common/MetadataFieldInput.js
+++ b/frontend/src/components/common/MetadataFieldInput.js
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  TextField,
+  Button,
+  Typography
+} from '@mui/material';
+import { Search as SearchIcon, Clear as ClearIcon } from '@mui/icons-material';
+import MetadataPickerModal from './MetadataPickerModal';
+
+// 작업판 사용자 페이지의 type='baseModel' / 'lora' 필드 렌더러 (#199 Phase E).
+// "선택" 버튼으로 MetadataPickerModal 을 열어 서버의 모델 / LoRA 목록에서 단건 선택.
+// workboardId 를 picker 에 전달 → backend 가 작업판의 modelExposurePolicy / loraExposurePolicy 적용.
+//
+// props:
+//   kind: 'model' | 'lora'
+//   field: customField 정의 ({ name, label, ... })
+//   value: 현재 선택된 filename (또는 '')
+//   onChange: (filename) => void
+//   workboardId: string
+//   serverId: string
+function MetadataFieldInput({ kind, field, value, onChange, workboardId, serverId }) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const placeholder = kind === 'model' ? '베이스 모델을 선택하세요' : 'LoRA 를 선택하세요';
+
+  return (
+    <Box>
+      {field.label && (
+        <Typography variant="body2" gutterBottom>
+          {field.label}
+          {field.required && <span style={{ color: '#d32f2f' }}> *</span>}
+        </Typography>
+      )}
+      <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+        <TextField
+          value={value || ''}
+          fullWidth
+          size="small"
+          placeholder={placeholder}
+          InputProps={{ readOnly: true }}
+          helperText={field.description}
+        />
+        {value && (
+          <Button
+            variant="outlined"
+            size="small"
+            startIcon={<ClearIcon />}
+            onClick={() => onChange('')}
+          >
+            해제
+          </Button>
+        )}
+        <Button
+          variant="contained"
+          size="small"
+          startIcon={<SearchIcon />}
+          onClick={() => setPickerOpen(true)}
+          disabled={!serverId && !workboardId}
+        >
+          선택
+        </Button>
+      </Box>
+      <MetadataPickerModal
+        kind={kind}
+        open={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        workboardId={workboardId}
+        serverId={serverId}
+        mode="select-single"
+        selectedItem={value}
+        onPrimary={(rawItem) => {
+          if (rawItem?.filename) onChange(rawItem.filename);
+        }}
+      />
+    </Box>
+  );
+}
+
+export default MetadataFieldInput;

--- a/frontend/src/pages/ImageGeneration.js
+++ b/frontend/src/pages/ImageGeneration.js
@@ -47,6 +47,7 @@ import { useDropzone } from 'react-dropzone';
 import toast from 'react-hot-toast';
 import { workboardAPI, jobAPI, imageAPI, promptDataAPI, userAPI, projectAPI } from '../services/api';
 import MetadataPickerModal from '../components/common/MetadataPickerModal';
+import MetadataFieldInput from '../components/common/MetadataFieldInput';
 import { extractLoraName, insertLoraTag, insertTriggerWordWithLora } from '../utils/promptUtils';
 import Pagination from '../components/common/Pagination';
 import ImageSelectDialog from '../components/common/ImageSelectDialog';
@@ -1323,6 +1324,15 @@ function ImageGeneration() {
                               onChange={formField.onChange}
                               maxImages={field.imageConfig?.maxImages || 1}
                               isComfyUI={workboardData?.serverId?.serverType === 'ComfyUI'}
+                            />
+                          ) : field.type === 'baseModel' || field.type === 'lora' ? (
+                            <MetadataFieldInput
+                              kind={field.type === 'baseModel' ? 'model' : 'lora'}
+                              field={field}
+                              value={formField.value || ''}
+                              onChange={formField.onChange}
+                              workboardId={id}
+                              serverId={workboardData?.serverId?._id || workboardData?.serverId}
                             />
                           ) : (
                             <TextField


### PR DESCRIPTION
## Summary

#199 Phase E — 작업판 사용자 페이지가 \`type='baseModel'\` / \`'lora'\` 커스텀 필드를 picker 모달로 렌더링.

## Changes

**신규 컴포넌트:**
- \`frontend/src/components/common/MetadataFieldInput.js\` — TextField + 선택 / 해제 버튼 + \`MetadataPickerModal\` (select-single). \`workboardId\` 전달로 작업판의 modelExposurePolicy / loraExposurePolicy 가 자동 적용됨 (#198).

**Wiring:**
- \`ImageGeneration.js\` — 동적 필드 렌더 분기에 baseModel/lora 추가
- \`PromptGeneratorPanel.js\` — 동일

## 동작

1. admin 이 작업판 편집 → 커스텀 필드 → 새 필드 추가 → 타입 \"베이스 모델\" 또는 \"LoRA\" 선택
2. 사용자 페이지에서 해당 필드 위치에 \"선택\" 버튼 표시
3. 클릭 시 picker 가 열리고, 작업판 노출 정책에 따라 필터링된 목록에서 단건 선택
4. 선택된 filename 이 \`inputData[field.name]\` 에 저장
5. Phase C 의 헬퍼 (\`getFieldByRole\`) 가 \`type='baseModel'\` → \`role=model\` 매핑으로 service 코드에서 인식

## 호환성

- 기존 baseInputFields.aiModel 의 hardcoded 모델 선택 UI 는 그대로 유지
- Phase F 에서 baseInputFields 정리 시 한 곳으로 통합 예정

## Test plan

- [x] --no-cache frontend 빌드 통과
- [ ] admin 으로 작업판 편집 → 커스텀 필드 → 새 필드 추가 → 타입 \"베이스 모델\" → 저장
- [ ] 사용자 페이지에서 해당 작업판 진입 → \"선택\" 버튼 → 모달 → 모델 선택 → filename 이 input 에 표시
- [ ] 작업 실행 → 백엔드가 선택된 모델로 처리 (Phase C 헬퍼 경유)
- [ ] type=lora 도 동일 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)