### PR TITLE
feat: workflow 무결성 + 템플릿 customField (#199 Phase F1)

### DIFF
--- a/frontend/src/components/PromptGeneratorPanel.js
+++ b/frontend/src/components/PromptGeneratorPanel.js
@@ -30,6 +30,7 @@ import { useDropzone } from 'react-dropzone';
 import toast from 'react-hot-toast';
 import { workboardAPI, jobAPI, imageAPI } from '../services/api';
 import MetadataFieldInput from './common/MetadataFieldInput';
+import { filterVisibleCustomFields } from '../utils/customFieldVisibility';
 
 function ImageUploadField({ label, description, images, onImagesChange, maxImages = 1 }) {
   const onDrop = useCallback((acceptedFiles) => {
@@ -309,7 +310,7 @@ function PromptGeneratorPanel({
                 </Box>
               ))}
 
-              {workboard.additionalInputFields?.map((field) => (
+              {filterVisibleCustomFields(workboard).map((field) => (
                 <Box key={field.name} sx={{ mb: 2 }}>
                   {field.type === 'string' && (
                     <Controller

--- a/frontend/src/pages/ImageGeneration.js
+++ b/frontend/src/pages/ImageGeneration.js
@@ -48,6 +48,7 @@ import toast from 'react-hot-toast';
 import { workboardAPI, jobAPI, imageAPI, promptDataAPI, userAPI, projectAPI } from '../services/api';
 import MetadataPickerModal from '../components/common/MetadataPickerModal';
 import MetadataFieldInput from '../components/common/MetadataFieldInput';
+import { filterVisibleCustomFields } from '../utils/customFieldVisibility';
 import { extractLoraName, insertLoraTag, insertTriggerWordWithLora } from '../utils/promptUtils';
 import Pagination from '../components/common/Pagination';
 import ImageSelectDialog from '../components/common/ImageSelectDialog';
@@ -1275,14 +1276,14 @@ function ImageGeneration() {
               </Paper>
             </Paper>
 
-            {/* 추가 설정 */}
-            {workboardData?.additionalInputFields?.length > 0 && (
+            {/* 추가 설정 — Phase F1: baseInputFields 에 데이터 남아있는 legacy 키 중복 hide */}
+            {filterVisibleCustomFields(workboardData).length > 0 && (
               <Paper sx={{ p: 3, mb: 3 }}>
                 <Typography variant="h6" gutterBottom>
                   고급 설정
                 </Typography>
                 <Grid container spacing={2}>
-                  {workboardData.additionalInputFields.map((field) => (
+                  {filterVisibleCustomFields(workboardData).map((field) => (
                     <Grid item xs={12} sm={field.type === 'image' ? 12 : 6} key={field.name}>
                       <Controller
                         name={`additionalParams.${field.name}`}

--- a/frontend/src/templates/ComfyUI-image.json
+++ b/frontend/src/templates/ComfyUI-image.json
@@ -1,22 +1,40 @@
 {
-  "baseInputFields": {
-    "aiModel": [
-      { "key": "Default Model", "value": "default.safetensors" }
-    ],
-    "imageSizes": [
-      { "key": "1024x1024", "value": "1024x1024" },
-      { "key": "896x1152", "value": "896x1152" },
-      { "key": "1152x896", "value": "1152x896" },
-      { "key": "832x1216", "value": "832x1216" },
-      { "key": "1216x832", "value": "1216x832" },
-      { "key": "768x1344", "value": "768x1344" },
-      { "key": "1344x768", "value": "1344x768" }
-    ],
-    "referenceImageMethods": [
-      { "key": "Image to Image", "value": "img2img" },
-      { "key": "ControlNet Canny", "value": "controlnet_canny" }
-    ]
-  },
-  "additionalInputFields": [],
+  "baseInputFields": {},
+  "additionalInputFields": [
+    {
+      "name": "aiModel",
+      "label": "베이스 모델",
+      "type": "baseModel",
+      "required": true,
+      "formatString": "{{##model##}}",
+      "description": "서버의 모델 목록에서 선택. 작업판의 모델 노출 정책이 적용됩니다."
+    },
+    {
+      "name": "imageSize",
+      "label": "이미지 크기",
+      "type": "select",
+      "required": true,
+      "defaultValue": "1024x1024",
+      "options": [
+        { "key": "1024x1024", "value": "1024x1024" },
+        { "key": "896x1152", "value": "896x1152" },
+        { "key": "1152x896", "value": "1152x896" },
+        { "key": "832x1216", "value": "832x1216" },
+        { "key": "1216x832", "value": "1216x832" },
+        { "key": "768x1344", "value": "768x1344" },
+        { "key": "1344x768", "value": "1344x768" }
+      ]
+    },
+    {
+      "name": "referenceImageMethod",
+      "label": "참조 이미지 처리",
+      "type": "select",
+      "required": false,
+      "options": [
+        { "key": "Image to Image", "value": "img2img" },
+        { "key": "ControlNet Canny", "value": "controlnet_canny" }
+      ]
+    }
+  ],
   "workflowData": "{\n  \"prompt\": \"{{##prompt##}}\",\n  \"negative_prompt\": \"{{##negative_prompt##}}\",\n  \"model\": \"{{##model##}}\",\n  \"width\": \"{{##width##}}\",\n  \"height\": \"{{##height##}}\"\n}"
 }

--- a/frontend/src/templates/ComfyUI-video.json
+++ b/frontend/src/templates/ComfyUI-video.json
@@ -1,22 +1,40 @@
 {
-  "baseInputFields": {
-    "aiModel": [
-      { "key": "Default Model", "value": "default.safetensors" }
-    ],
-    "imageSizes": [
-      { "key": "1024x1024", "value": "1024x1024" },
-      { "key": "896x1152", "value": "896x1152" },
-      { "key": "1152x896", "value": "1152x896" },
-      { "key": "832x1216", "value": "832x1216" },
-      { "key": "1216x832", "value": "1216x832" },
-      { "key": "768x1344", "value": "768x1344" },
-      { "key": "1344x768", "value": "1344x768" }
-    ],
-    "referenceImageMethods": [
-      { "key": "Image to Image", "value": "img2img" },
-      { "key": "ControlNet Canny", "value": "controlnet_canny" }
-    ]
-  },
-  "additionalInputFields": [],
+  "baseInputFields": {},
+  "additionalInputFields": [
+    {
+      "name": "aiModel",
+      "label": "베이스 모델",
+      "type": "baseModel",
+      "required": true,
+      "formatString": "{{##model##}}",
+      "description": "서버의 모델 목록에서 선택. 작업판의 모델 노출 정책이 적용됩니다."
+    },
+    {
+      "name": "imageSize",
+      "label": "프레임 크기",
+      "type": "select",
+      "required": true,
+      "defaultValue": "1024x1024",
+      "options": [
+        { "key": "1024x1024", "value": "1024x1024" },
+        { "key": "896x1152", "value": "896x1152" },
+        { "key": "1152x896", "value": "1152x896" },
+        { "key": "832x1216", "value": "832x1216" },
+        { "key": "1216x832", "value": "1216x832" },
+        { "key": "768x1344", "value": "768x1344" },
+        { "key": "1344x768", "value": "1344x768" }
+      ]
+    },
+    {
+      "name": "referenceImageMethod",
+      "label": "참조 이미지 처리",
+      "type": "select",
+      "required": false,
+      "options": [
+        { "key": "Image to Image", "value": "img2img" },
+        { "key": "ControlNet Canny", "value": "controlnet_canny" }
+      ]
+    }
+  ],
   "workflowData": "{\n  \"prompt\": \"{{##prompt##}}\",\n  \"negative_prompt\": \"{{##negative_prompt##}}\",\n  \"model\": \"{{##model##}}\",\n  \"width\": \"{{##width##}}\",\n  \"height\": \"{{##height##}}\"\n}"
 }

--- a/frontend/src/templates/Gemini-image.json
+++ b/frontend/src/templates/Gemini-image.json
@@ -1,21 +1,28 @@
 {
-  "baseInputFields": {
-    "aiModel": [
-      { "key": "Nano Banana", "value": "gemini-2.5-flash-image" },
-      { "key": "Nano Banana Pro", "value": "gemini-3-pro-image-preview" },
-      { "key": "Nano Banana 2", "value": "gemini-3.1-flash-image-preview" }
-    ],
-    "imageSizes": [
-      { "key": "정사각 (1:1)", "value": "1:1" },
-      { "key": "가로 와이드 (16:9)", "value": "16:9" },
-      { "key": "세로 와이드 (9:16)", "value": "9:16" },
-      { "key": "가로 (4:3)", "value": "4:3" },
-      { "key": "세로 (3:4)", "value": "3:4" },
-      { "key": "영화 (21:9)", "value": "21:9" }
-    ],
-    "referenceImageMethods": []
-  },
+  "baseInputFields": {},
   "additionalInputFields": [
+    {
+      "name": "aiModel",
+      "label": "베이스 모델",
+      "type": "baseModel",
+      "required": true,
+      "description": "서버의 모델 목록에서 선택. 작업판의 모델 노출 정책이 적용됩니다."
+    },
+    {
+      "name": "imageSize",
+      "label": "이미지 비율",
+      "type": "select",
+      "required": true,
+      "defaultValue": "1:1",
+      "options": [
+        { "key": "정사각 (1:1)", "value": "1:1" },
+        { "key": "가로 와이드 (16:9)", "value": "16:9" },
+        { "key": "세로 와이드 (9:16)", "value": "9:16" },
+        { "key": "가로 (4:3)", "value": "4:3" },
+        { "key": "세로 (3:4)", "value": "3:4" },
+        { "key": "영화 (21:9)", "value": "21:9" }
+      ]
+    },
     {
       "name": "resolution",
       "label": "해상도",

--- a/frontend/src/templates/Gemini-text.json
+++ b/frontend/src/templates/Gemini-text.json
@@ -1,14 +1,35 @@
 {
-  "baseInputFields": {
-    "aiModel": [
-      { "key": "Gemini 3.1 Pro Preview (latest)", "value": "gemini-3.1-pro-preview" },
-      { "key": "Gemini 3 Flash Preview", "value": "gemini-3-flash-preview" },
-      { "key": "Gemini 3.1 Flash Lite Preview", "value": "gemini-3.1-flash-lite-preview" },
-      { "key": "Gemini 3.1 Flash Live Preview", "value": "gemini-3.1-flash-live-preview" }
-    ],
-    "systemPrompt": "",
-    "referenceImages": []
-  },
-  "additionalInputFields": [],
+  "baseInputFields": {},
+  "additionalInputFields": [
+    {
+      "name": "aiModel",
+      "label": "베이스 모델",
+      "type": "baseModel",
+      "required": true,
+      "description": "서버의 모델 목록에서 선택. 작업판의 모델 노출 정책이 적용됩니다."
+    },
+    {
+      "name": "systemPrompt",
+      "label": "시스템 프롬프트",
+      "type": "string",
+      "required": false,
+      "placeholder": "AI 의 역할 / 컨텍스트를 정의..."
+    },
+    {
+      "name": "temperature",
+      "label": "Temperature",
+      "type": "number",
+      "required": false,
+      "defaultValue": 0.7,
+      "description": "0.0 ~ 1.0. 높을수록 창의적, 낮을수록 일관적."
+    },
+    {
+      "name": "maxTokens",
+      "label": "Max Tokens",
+      "type": "number",
+      "required": false,
+      "defaultValue": 2000
+    }
+  ],
   "workflowData": ""
 }

--- a/frontend/src/templates/OpenAI Compatible-text.json
+++ b/frontend/src/templates/OpenAI Compatible-text.json
@@ -1,12 +1,34 @@
 {
-  "baseInputFields": {
-    "aiModel": [
-      { "key": "GPT-4", "value": "gpt-4" },
-      { "key": "GPT-3.5 Turbo", "value": "gpt-3.5-turbo" }
-    ],
-    "systemPrompt": "",
-    "referenceImages": []
-  },
-  "additionalInputFields": [],
+  "baseInputFields": {},
+  "additionalInputFields": [
+    {
+      "name": "aiModel",
+      "label": "베이스 모델",
+      "type": "baseModel",
+      "required": true,
+      "description": "서버의 모델 목록에서 선택. 작업판의 모델 노출 정책이 적용됩니다."
+    },
+    {
+      "name": "systemPrompt",
+      "label": "시스템 프롬프트",
+      "type": "string",
+      "required": false,
+      "placeholder": "AI 의 역할 / 컨텍스트를 정의..."
+    },
+    {
+      "name": "temperature",
+      "label": "Temperature",
+      "type": "number",
+      "required": false,
+      "defaultValue": 0.7
+    },
+    {
+      "name": "maxTokens",
+      "label": "Max Tokens",
+      "type": "number",
+      "required": false,
+      "defaultValue": 2000
+    }
+  ],
   "workflowData": ""
 }

--- a/frontend/src/templates/OpenAI-image.json
+++ b/frontend/src/templates/OpenAI-image.json
@@ -1,20 +1,26 @@
 {
-  "baseInputFields": {
-    "aiModel": [
-      { "key": "GPT Image 2 (조직 인증 필요)", "value": "gpt-image-2" },
-      { "key": "GPT Image 1.5", "value": "gpt-image-1.5" },
-      { "key": "GPT Image 1", "value": "gpt-image-1" },
-      { "key": "GPT Image 1 Mini", "value": "gpt-image-1-mini" }
-    ],
-    "imageSizes": [
-      { "key": "자동 (auto)", "value": "auto" },
-      { "key": "1024x1024", "value": "1024x1024" },
-      { "key": "1024x1536", "value": "1024x1536" },
-      { "key": "1536x1024", "value": "1536x1024" }
-    ],
-    "referenceImageMethods": []
-  },
+  "baseInputFields": {},
   "additionalInputFields": [
+    {
+      "name": "aiModel",
+      "label": "베이스 모델",
+      "type": "baseModel",
+      "required": true,
+      "description": "서버의 모델 목록에서 선택. 작업판의 모델 노출 정책이 적용됩니다."
+    },
+    {
+      "name": "imageSize",
+      "label": "이미지 크기",
+      "type": "select",
+      "required": true,
+      "defaultValue": "auto",
+      "options": [
+        { "key": "자동 (auto)", "value": "auto" },
+        { "key": "1024x1024", "value": "1024x1024" },
+        { "key": "1024x1536", "value": "1024x1536" },
+        { "key": "1536x1024", "value": "1536x1024" }
+      ]
+    },
     {
       "name": "quality",
       "label": "품질",

--- a/frontend/src/templates/OpenAI-text.json
+++ b/frontend/src/templates/OpenAI-text.json
@@ -1,20 +1,35 @@
 {
-  "baseInputFields": {
-    "aiModel": [
-      { "key": "GPT-5.5 (latest)", "value": "gpt-5.5" },
-      { "key": "GPT-5.4", "value": "gpt-5.4" },
-      { "key": "GPT-5.4 mini", "value": "gpt-5.4-mini" },
-      { "key": "GPT-5.4 nano", "value": "gpt-5.4-nano" },
-      { "key": "GPT-5.2", "value": "gpt-5.2" },
-      { "key": "GPT-5.2 Pro", "value": "gpt-5.2-pro" },
-      { "key": "GPT-5.1", "value": "gpt-5.1" },
-      { "key": "GPT-5", "value": "gpt-5" },
-      { "key": "GPT-5 mini", "value": "gpt-5-mini" },
-      { "key": "GPT-5 nano", "value": "gpt-5-nano" }
-    ],
-    "systemPrompt": "",
-    "referenceImages": []
-  },
-  "additionalInputFields": [],
+  "baseInputFields": {},
+  "additionalInputFields": [
+    {
+      "name": "aiModel",
+      "label": "베이스 모델",
+      "type": "baseModel",
+      "required": true,
+      "description": "서버의 모델 목록에서 선택. 작업판의 모델 노출 정책이 적용됩니다."
+    },
+    {
+      "name": "systemPrompt",
+      "label": "시스템 프롬프트",
+      "type": "string",
+      "required": false,
+      "placeholder": "AI 의 역할 / 컨텍스트를 정의..."
+    },
+    {
+      "name": "temperature",
+      "label": "Temperature",
+      "type": "number",
+      "required": false,
+      "defaultValue": 0.7,
+      "description": "0.0 ~ 1.0. 높을수록 창의적, 낮을수록 일관적."
+    },
+    {
+      "name": "maxTokens",
+      "label": "Max Tokens",
+      "type": "number",
+      "required": false,
+      "defaultValue": 2000
+    }
+  ],
   "workflowData": ""
 }

--- a/frontend/src/utils/customFieldVisibility.js
+++ b/frontend/src/utils/customFieldVisibility.js
@@ -1,0 +1,45 @@
+// 작업판 사용자 페이지의 customField 가시성 필터 (#199 Phase F1).
+//
+// Phase B 마이그레이션이 baseInputFields 의 well-known 키를 additionalInputFields 로
+// 복사해 둔 결과로, 기존 작업판에서 같은 필드가 두 번 렌더링되는 회귀가 발생.
+// 이 헬퍼는 dynamic loop 에서 \"legacy 데이터가 남아있는 baseInputFields 키\" 의 customField 를
+// 숨겨서 회귀 해소.
+//
+// 신규 작업판 (template F1 갱신 후) 은 baseInputFields 가 비어 있어 필터를 통과 → customField 로 렌더.
+// 기존 작업판은 baseInputFields 가 채워져 있어 customField 가 숨김 → hardcoded UI 만 보임.
+// Phase F2 에서 hardcoded UI 자체 제거 후 이 필터도 불필요해짐.
+
+const LEGACY_BASE_KEYS = Object.freeze([
+  'aiModel',
+  'imageSizes',
+  'referenceImageMethods',
+  'stylePresets',
+  'upscaleMethods',
+  'systemPrompt',
+  'referenceImages',
+  'temperature',
+  'maxTokens'
+]);
+
+function hasLegacyBaseValue(baseInputFields, key) {
+  const v = baseInputFields?.[key];
+  if (v === undefined || v === null) return false;
+  if (Array.isArray(v)) return v.length > 0;
+  if (typeof v === 'string') return v.length > 0;
+  if (typeof v === 'number') return true;
+  return Boolean(v);
+}
+
+export function filterVisibleCustomFields(workboardData) {
+  const fields = workboardData?.additionalInputFields || [];
+  const base = workboardData?.baseInputFields;
+  return fields.filter((f) => {
+    if (!f || !f.name) return false;
+    if (LEGACY_BASE_KEYS.includes(f.name) && hasLegacyBaseValue(base, f.name)) {
+      return false;
+    }
+    return true;
+  });
+}
+
+export const LEGACY_BASE_FIELD_KEYS = LEGACY_BASE_KEYS;

--- a/src/constants/fieldRoles.js
+++ b/src/constants/fieldRoles.js
@@ -63,6 +63,8 @@ const WELL_KNOWN_FIELD_NAME_TO_ROLE = Object.freeze({
   prompt: FIELD_ROLES.PROMPT,
   negativePrompt: FIELD_ROLES.NEGATIVE_PROMPT,
   seed: FIELD_ROLES.SEED,
+  // 신규 템플릿 (Phase F1) 는 단수형 이름 사용 — legacy plural 과 동등.
+  imageSize: FIELD_ROLES.IMAGE_SIZE,
   referenceImageMethod: FIELD_ROLES.REFERENCE_IMAGE_METHOD,
   stylePreset: FIELD_ROLES.STYLE_PRESET,
   upscaleMethod: FIELD_ROLES.UPSCALE_METHOD,

--- a/src/tests/customFieldHelpers.test.js
+++ b/src/tests/customFieldHelpers.test.js
@@ -66,6 +66,18 @@ describe('customFieldHelpers (#199 Phase A)', () => {
       expect(getFieldValueByRole(wbEmpty, inputData, FIELD_ROLES.SEED)).toBe(42);
     });
 
+    test('additionalParams 네임스페이스 fallback — 사용자 페이지 동적 필드 loop 값 인식', () => {
+      const wb = { additionalInputFields: [{ name: 'aiModel', type: 'baseModel' }] };
+      const inputData = { additionalParams: { aiModel: 'sdxl-from-dynamic' } };
+      expect(getFieldValueByRole(wb, inputData, FIELD_ROLES.MODEL)).toBe('sdxl-from-dynamic');
+    });
+
+    test('top-level 값이 additionalParams 보다 우선', () => {
+      const wb = { additionalInputFields: [{ name: 'aiModel', type: 'baseModel' }] };
+      const inputData = { aiModel: 'top', additionalParams: { aiModel: 'nested' } };
+      expect(getFieldValueByRole(wb, inputData, FIELD_ROLES.MODEL)).toBe('top');
+    });
+
     test('legacy systemPrompt 와 referenceImageMethod 매핑', () => {
       const inputData = {
         systemPrompt: 'You are helpful',

--- a/src/tests/customFieldHelpers.test.js
+++ b/src/tests/customFieldHelpers.test.js
@@ -72,6 +72,18 @@ describe('customFieldHelpers (#199 Phase A)', () => {
       expect(getFieldValueByRole(wb, inputData, FIELD_ROLES.MODEL)).toBe('sdxl-from-dynamic');
     });
 
+    test('well-known fallback 도 additionalParams 네임스페이스 확인', () => {
+      const wbEmpty = { additionalInputFields: [] };
+      const inputData = { additionalParams: { imageSize: '768x768', prompt: 'cat' } };
+      expect(getFieldValueByRole(wbEmpty, inputData, FIELD_ROLES.IMAGE_SIZE)).toBe('768x768');
+      expect(getFieldValueByRole(wbEmpty, inputData, FIELD_ROLES.PROMPT)).toBe('cat');
+    });
+
+    test('imageSize 단수형도 인식 (신규 템플릿 호환)', () => {
+      const wb = { additionalInputFields: [{ name: 'imageSize', type: 'select' }] };
+      expect(getFieldValueByRole(wb, { additionalParams: { imageSize: '1024x1024' } }, FIELD_ROLES.IMAGE_SIZE)).toBe('1024x1024');
+    });
+
     test('top-level 값이 additionalParams 보다 우선', () => {
       const wb = { additionalInputFields: [{ name: 'aiModel', type: 'baseModel' }] };
       const inputData = { aiModel: 'top', additionalParams: { aiModel: 'nested' } };

--- a/src/utils/customFieldHelpers.js
+++ b/src/utils/customFieldHelpers.js
@@ -48,8 +48,15 @@ function getFieldValueByRole(workboard, inputData, role) {
   if (!workboard || !inputData || !role) return undefined;
 
   const field = getFieldByRole(workboard, role);
-  if (field && field.name && Object.prototype.hasOwnProperty.call(inputData, field.name)) {
-    return inputData[field.name];
+  if (field && field.name) {
+    // Top-level path (legacy hardcoded UI: inputData.aiModel 등)
+    if (Object.prototype.hasOwnProperty.call(inputData, field.name)) {
+      return inputData[field.name];
+    }
+    // additionalParams 네임스페이스 (사용자 페이지 동적 필드 loop 의 저장 위치)
+    if (inputData.additionalParams && Object.prototype.hasOwnProperty.call(inputData.additionalParams, field.name)) {
+      return inputData.additionalParams[field.name];
+    }
   }
 
   // Well-known name fallback — additionalInputFields entry 에 role 이 없거나 부분 마이그레이션 상태 대비.

--- a/src/utils/customFieldHelpers.js
+++ b/src/utils/customFieldHelpers.js
@@ -62,8 +62,12 @@ function getFieldValueByRole(workboard, inputData, role) {
   // Well-known name fallback — additionalInputFields entry 에 role 이 없거나 부분 마이그레이션 상태 대비.
   // 또한 prompt / negativePrompt / seed 처럼 v1.x 에서 additionalInputFields 가 있지만 role 이 부여되지 않은 케이스.
   for (const [knownName, mappedRole] of Object.entries(WELL_KNOWN_FIELD_NAME_TO_ROLE)) {
-    if (mappedRole === role && Object.prototype.hasOwnProperty.call(inputData, knownName)) {
+    if (mappedRole !== role) continue;
+    if (Object.prototype.hasOwnProperty.call(inputData, knownName)) {
       return inputData[knownName];
+    }
+    if (inputData.additionalParams && Object.prototype.hasOwnProperty.call(inputData.additionalParams, knownName)) {
+      return inputData.additionalParams[knownName];
     }
   }
   return undefined;


### PR DESCRIPTION
## Summary

#199 Phase F1 — 데이터 무결성 핵심 fix + dynamic field 중복 렌더링 해소 + 5개 템플릿을 customField 기반으로 갱신.

## Critical fix — ComfyUI workflow 데이터 무결성

\`getFieldValueByRole\` 가 \`inputData.additionalParams[fieldName]\` 도 fallback 으로 조회.

**왜 critical**: 사용자 페이지의 dynamic field loop 는 Controller name 이 \`additionalParams.${field.name}\` 이라 값을 nested 네임스페이스에 저장. 종전 helper 는 top-level inputData 만 확인 → ComfyUI workflow 의 \`{{##model##}}\` 등이 빈 값으로 치환되어 작업 실패 가능. 이제 양쪽 모두 확인.

우선순위: top-level (legacy hardcoded UI) > additionalParams (신규 dynamic loop).

## 중복 렌더링 회귀 해소

Phase B 마이그레이션이 \`baseInputFields.aiModel\` 등을 \`additionalInputFields\` 로도 복사 → 기존 작업판에서 같은 필드가 \"기본 UI\" + \"고급 설정\" 에 2번 표시되던 회귀를 \`filterVisibleCustomFields\` 로 해소.

규칙: baseInputFields 에 데이터가 남아있는 legacy 키 의 customField 는 dynamic loop 에서 hide.
- 기존 작업판: baseInputFields 채워짐 → customField hide, hardcoded UI 만
- 신규 작업판 (template F1 갱신 후): baseInputFields 비어있음 → customField 만 렌더

## 템플릿 5종 → customField 화

| 파일 | aiModel | imageSize | 기타 |
|---|---|---|---|
| ComfyUI-image | baseModel + formatString '{{##model##}}' | select | referenceImageMethod (select) |
| ComfyUI-video | baseModel + formatString '{{##model##}}' | select (프레임 크기) | referenceImageMethod (select) |
| Gemini-image | baseModel | select (이미지 비율) | resolution (select) |
| Gemini-text | baseModel | — | systemPrompt / temperature / maxTokens |
| OpenAI-image | baseModel | select | quality / background / output_compression |
| OpenAI-text | baseModel | — | systemPrompt / temperature / maxTokens |
| OpenAI Compatible-text | baseModel | — | systemPrompt / temperature / maxTokens |

\`baseInputFields\` 는 빈 객체 — 신규 작업판은 \`customField\` 단일 경로로 렌더.

## 호환성

- 기존 작업판: baseInputFields 데이터 보존, hardcoded UI 그대로 작동
- 사용자 입력값 — top-level / additionalParams 어디에 들어가든 service 코드가 추출
- ComfyUI workflow placeholder 매칭은 formatString 으로 명시
- Phase F2/F3/F4 후속: hardcoded UI / admin 폼 baseInputFields tab / 스키마 필드 cleanup

## Test plan

- [x] customFieldHelpers 20 assertions 통과 (additionalParams fallback + 우선순위 포함)
- [x] --no-cache backend + frontend 빌드 통과
- [ ] 기존 작업판 (Gemini/OpenAI/ComfyUI) 사용자 페이지 — 중복 렌더링 사라졌는지
- [ ] 기존 작업판 실제 생성 — 변화 없이 작동
- [ ] 신규 작업판 (각 템플릿) 생성 → baseInputFields 비어있음, customField 만 렌더
- [ ] 신규 ComfyUI 템플릿으로 작업 → workflow placeholder 정상 치환 (\`{{##model##}}\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)