### PR TITLE
refactor: 작업판 admin '기초 입력값' 탭 제거 (#199 Phase F3)

### DIFF
--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -470,11 +470,6 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
       loraExposurePolicy: 'full',
       loraWhitelist: [],
       isActive: true,
-      aiModels: [],
-      imageSizes: [],
-      referenceImageMethods: [],
-      systemPrompt: '',
-      referenceImages: [],
       negativePromptField: { enabled: false, required: false },
       upscaleMethodField: { enabled: false, required: false, options: [] },
       baseStyleField: { enabled: false, required: false, options: [], formatString: '{{##base_style##}}' },
@@ -488,8 +483,6 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
   const isComfyUI = serverType === 'ComfyUI';
   const isGemini = serverType === 'Gemini';
   const isOpenAIImage = (serverType === 'OpenAI' || serverType === 'OpenAI Compatible') && outputFormat === 'image';
-  const isPromptFormat = outputFormat === 'text';
-  const isImageFormat = outputFormat === 'image';
 
   // ComfyUI 서버의 availableBaseModels (#252) — allowedModelTypes 옵션 풀.
   // ServerModelCache 의 detailed endpoint 에서 derived (limit 1 로 가벼운 호출).
@@ -583,11 +576,7 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
             loraExposurePolicy: fullData.loraExposurePolicy || 'full',
             loraWhitelist: fullData.loraWhitelist || [],
             isActive: fullData.isActive ?? true,
-            aiModels: fullData.baseInputFields?.aiModel?.map(m => ({ key: m.key || '', value: m.value || '' })) || [],
-            imageSizes: fullData.baseInputFields?.imageSizes?.map(s => ({ key: s.key || '', value: s.value || '' })) || [],
-            referenceImageMethods: fullData.baseInputFields?.referenceImageMethods?.map(r => ({ key: r.key || '', value: r.value || '' })) || [],
-            systemPrompt: fullData.baseInputFields?.systemPrompt || '',
-            referenceImages: fullData.baseInputFields?.referenceImages?.map(r => ({ key: r.key || '', value: r.value || '' })) || [],
+            // F3: baseInputFields → form fields 매핑 제거 — customField 만 편집
             // 커스텀 필드
             negativePromptField: {
               enabled: fullData.additionalInputFields?.some(f => f.name === 'negativePrompt') || false,
@@ -708,8 +697,6 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
 
     const isComfyUIServer = data.serverType === 'ComfyUI';
     const normalizedOutputFormat = data.outputFormat || 'image';
-    const isPromptOutputFormat = normalizedOutputFormat === 'text';
-    const isImageOutputFormat = normalizedOutputFormat === 'image';
     const updateData = {
       name: data.name?.trim(),
       description: data.description?.trim(),
@@ -724,12 +711,15 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
       loraExposurePolicy: isComfyUIServer && data.loraExposurePolicy === 'whitelist' ? 'whitelist' : 'full',
       loraWhitelist: isComfyUIServer && Array.isArray(data.loraWhitelist) ? data.loraWhitelist : [],
       isActive: Boolean(data.isActive),
+      // F3: baseInputFields 편집 제거 — 신규/기존 모두 빈 상태로 저장.
+      // 스키마의 required: true (aiModel) 통과 위해 빈 배열 명시.
+      // F4 에서 baseInputFields 스키마 자체 drop 예정.
       baseInputFields: {
-        aiModel: (data.aiModels || []).filter(m => m.key && m.value),
-        imageSizes: isImageOutputFormat ? (data.imageSizes || []).filter(s => s.key && s.value) : [],
-        referenceImageMethods: isComfyUIServer ? (data.referenceImageMethods || []).filter(r => r.key && r.value) : [],
-        systemPrompt: isPromptOutputFormat ? (data.systemPrompt || '') : '',
-        referenceImages: isPromptOutputFormat ? (data.referenceImages || []).filter(r => r.key && r.value) : []
+        aiModel: [],
+        imageSizes: [],
+        referenceImageMethods: [],
+        systemPrompt: '',
+        referenceImages: []
       },
       additionalInputFields
     };
@@ -771,7 +761,6 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
           </Box>
           <Tabs value={tabValue} onChange={(e, newValue) => setTabValue(newValue)} sx={{ mb: 3 }}>
             <Tab label="기본 정보" />
-            <Tab label="기초 입력값" />
             <Tab label="커스텀 필드" />
             <Tab label="권한 / 노출" />
             {isComfyUI && <Tab label="워크플로우" />}
@@ -789,320 +778,9 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
             />
           )}
 
-          {/* 기초 입력값 탭 */}
-          {tabValue === 1 && (
-            <Box>
-              {/* AI 모델 설정 - 공통 */}
-              <Accordion defaultExpanded>
-                <AccordionSummary expandIcon={<ExpandMore />}>
-                  <Typography variant="h6">AI 모델 설정</Typography>
-                </AccordionSummary>
-                <AccordionDetails>
-                  <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
-                    <Box>
-                      <Typography variant="body2" color="textSecondary">
-                        사용자가 선택할 수 있는 AI 모델들을 설정합니다.
-                      </Typography>
-                      {isComfyUI && (
-                        <Typography variant="caption" color="primary" sx={{ fontFamily: 'monospace', mt: 1, display: 'block' }}>
-                          Workflow JSON 형식: <code>{'{{##model##}}'}</code>
-                        </Typography>
-                      )}
-                    </Box>
-                    <Button
-                      startIcon={<Add />}
-                      onClick={() => addArrayItem('aiModels')}
-                      size="small"
-                    >
-                      모델 추가
-                    </Button>
-                  </Box>
-                  <DragDropContext onDragEnd={onDragEnd}>
-                    <Droppable droppableId="aiModels" type="aiModels">
-                      {(provided) => (
-                        <Box ref={provided.innerRef} {...provided.droppableProps}>
-                          {watch('aiModels')?.map((model, index) => (
-                            <Draggable key={index} draggableId={`aiModel-${index}`} index={index}>
-                              {(provided) => (
-                                <Box
-                                  ref={provided.innerRef}
-                                  {...provided.draggableProps}
-                                  display="flex" gap={2} mb={2} alignItems="center"
-                                >
-                                  <Controller
-                                    name={`aiModels.${index}.key`}
-                                    control={control}
-                                    render={({ field }) => (
-                                      <TextField
-                                        {...field}
-                                        label="모델 표시명"
-                                        size="small"
-                                        sx={{ flex: 1 }}
-                                      />
-                                    )}
-                                  />
-                                  <Controller
-                                    name={`aiModels.${index}.value`}
-                                    control={control}
-                                    render={({ field }) => (
-                                      <TextField
-                                        {...field}
-                                        label={
-                                          serverType === 'OpenAI Compatible'
-                                            ? '모델 ID (예: gpt-4)'
-                                            : serverType === 'Gemini'
-                                              ? '모델 ID (예: gemini-2.5-flash-image)'
-                                              : serverType === 'OpenAI'
-                                                ? '모델 ID (예: gpt-image-1.5)'
-                                              : '모델 파일 경로'
-                                        }
-                                        size="small"
-                                        sx={{ flex: 2 }}
-                                      />
-                                    )}
-                                  />
-                                  <IconButton
-                                    onClick={() => removeArrayItem('aiModels', index)}
-                                    color="error"
-                                    size="small"
-                                  >
-                                    <Delete />
-                                  </IconButton>
-                                  <Box {...provided.dragHandleProps} sx={{ display: 'flex', alignItems: 'center', cursor: 'grab', color: 'text.secondary' }}>
-                                    <DragIndicator />
-                                  </Box>
-                                </Box>
-                              )}
-                            </Draggable>
-                          ))}
-                          {provided.placeholder}
-                        </Box>
-                      )}
-                    </Droppable>
-                  </DragDropContext>
-                </AccordionDetails>
-              </Accordion>
-
-              {/* 프롬프트 작업판 전용 설정 */}
-              {isPromptFormat && (
-                <>
-                  <Accordion defaultExpanded>
-                    <AccordionSummary expandIcon={<ExpandMore />}>
-                      <Typography variant="h6">시스템 프롬프트</Typography>
-                    </AccordionSummary>
-                    <AccordionDetails>
-                      <Typography variant="body2" color="textSecondary" mb={2}>
-                        AI에게 전달할 시스템 프롬프트를 설정합니다. 사용자 입력 앞에 이 내용이 추가됩니다.
-                      </Typography>
-                      <Controller
-                        name="systemPrompt"
-                        control={control}
-                        render={({ field }) => (
-                          <TextField
-                            {...field}
-                            fullWidth
-                            multiline
-                            rows={6}
-                            label="시스템 프롬프트"
-                            placeholder="예: 당신은 창의적인 프롬프트 작성 전문가입니다..."
-                          />
-                        )}
-                      />
-                    </AccordionDetails>
-                  </Accordion>
-
-                  <Accordion>
-                    <AccordionSummary expandIcon={<ExpandMore />}>
-                      <Typography variant="h6">참고 이미지 설정</Typography>
-                    </AccordionSummary>
-                    <AccordionDetails>
-                      <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
-                        <Typography variant="body2" color="textSecondary">
-                          프롬프트 생성 시 참고할 이미지 타입을 설정합니다.
-                        </Typography>
-                        <Button
-                          startIcon={<Add />}
-                          onClick={() => addArrayItem('referenceImages')}
-                          size="small"
-                        >
-                          이미지 타입 추가
-                        </Button>
-                      </Box>
-                      {watch('referenceImages')?.map((ref, index) => (
-                        <Box key={index} display="flex" gap={2} mb={2} alignItems="center">
-                          <Controller
-                            name={`referenceImages.${index}.key`}
-                            control={control}
-                            render={({ field }) => (
-                              <TextField
-                                {...field}
-                                label="이미지 타입명"
-                                placeholder="예: 캐릭터 참고"
-                                size="small"
-                                sx={{ flex: 1 }}
-                              />
-                            )}
-                          />
-                          <Controller
-                            name={`referenceImages.${index}.value`}
-                            control={control}
-                            render={({ field }) => (
-                              <TextField
-                                {...field}
-                                label="설명"
-                                placeholder="예: 캐릭터 외형 참고 이미지"
-                                size="small"
-                                sx={{ flex: 2 }}
-                              />
-                            )}
-                          />
-                          <IconButton
-                            onClick={() => removeArrayItem('referenceImages', index)}
-                            color="error"
-                            size="small"
-                          >
-                            <Delete />
-                          </IconButton>
-                        </Box>
-                      ))}
-                    </AccordionDetails>
-                  </Accordion>
-                </>
-              )}
-
-              {/* 이미지 작업판 전용 설정 */}
-              {isImageFormat && (
-                <>
-                  <Accordion>
-                    <AccordionSummary expandIcon={<ExpandMore />}>
-                      <Typography variant="h6">이미지 크기 설정</Typography>
-                    </AccordionSummary>
-                    <AccordionDetails>
-                      <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
-                        <Box>
-                          <Typography variant="body2" color="textSecondary">
-                            이미지 생성 크기 옵션들을 설정합니다.
-                          </Typography>
-                          {isComfyUI && (
-                            <Typography variant="caption" color="primary" sx={{ fontFamily: 'monospace', mt: 1, display: 'block' }}>
-                              Workflow JSON 형식: <code>{'{{##width##}}'}</code>, <code>{'{{##height##}}'}</code>
-                            </Typography>
-                          )}
-                        </Box>
-                        <Button
-                          startIcon={<Add />}
-                          onClick={() => addArrayItem('imageSizes')}
-                          size="small"
-                        >
-                          크기 추가
-                        </Button>
-                      </Box>
-                      {watch('imageSizes')?.map((size, index) => (
-                        <Box key={index} display="flex" gap={2} mb={2} alignItems="center">
-                          <Controller
-                            name={`imageSizes.${index}.key`}
-                            control={control}
-                            render={({ field }) => (
-                              <TextField
-                                {...field}
-                                label="크기 표시명 (예: 512x512)"
-                                size="small"
-                                sx={{ flex: 1 }}
-                              />
-                            )}
-                          />
-                          <Controller
-                            name={`imageSizes.${index}.value`}
-                            control={control}
-                            render={({ field }) => (
-                              <TextField
-                                {...field}
-                                label="실제 크기 값"
-                                size="small"
-                                sx={{ flex: 1 }}
-                              />
-                            )}
-                          />
-                          <IconButton
-                            onClick={() => removeArrayItem('imageSizes', index)}
-                            color="error"
-                            size="small"
-                          >
-                            <Delete />
-                          </IconButton>
-                        </Box>
-                      ))}
-                    </AccordionDetails>
-                  </Accordion>
-
-                  {isComfyUI && (
-                    <Accordion>
-                    <AccordionSummary expandIcon={<ExpandMore />}>
-                      <Typography variant="h6">참고 이미지 사용방식</Typography>
-                    </AccordionSummary>
-                    <AccordionDetails>
-                      <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
-                        <Box>
-                          <Typography variant="body2" color="textSecondary">
-                            참고 이미지를 어떻게 활용할지 옵션들을 설정합니다.
-                          </Typography>
-                          <Typography variant="caption" color="primary" sx={{ fontFamily: 'monospace', mt: 1, display: 'block' }}>
-                            Workflow JSON 형식: <code>{'{{##reference_method##}}'}</code>
-                          </Typography>
-                        </Box>
-                        <Button
-                          startIcon={<Add />}
-                          onClick={() => addArrayItem('referenceImageMethods')}
-                          size="small"
-                        >
-                          방식 추가
-                        </Button>
-                      </Box>
-                      {watch('referenceImageMethods')?.map((method, index) => (
-                        <Box key={index} display="flex" gap={2} mb={2} alignItems="center">
-                          <Controller
-                            name={`referenceImageMethods.${index}.key`}
-                            control={control}
-                            render={({ field }) => (
-                              <TextField
-                                {...field}
-                                label="방식 표시명"
-                                size="small"
-                                sx={{ flex: 1 }}
-                              />
-                            )}
-                          />
-                          <Controller
-                            name={`referenceImageMethods.${index}.value`}
-                            control={control}
-                            render={({ field }) => (
-                              <TextField
-                                {...field}
-                                label="실제 처리 방식"
-                                size="small"
-                                sx={{ flex: 1 }}
-                              />
-                            )}
-                          />
-                          <IconButton
-                            onClick={() => removeArrayItem('referenceImageMethods', index)}
-                            color="error"
-                            size="small"
-                          >
-                            <Delete />
-                          </IconButton>
-                        </Box>
-                      ))}
-                    </AccordionDetails>
-                    </Accordion>
-                  )}
-                </>
-              )}
-            </Box>
-          )}
 
           {/* 커스텀 필드 탭 */}
-          {tabValue === 2 && (
+          {tabValue === 1 && (
             <Box>
               <Alert severity="info" sx={{ mb: 3 }}>
                 커스텀 필드는 관리자가 선택적으로 활성화할 수 있는 입력 필드들입니다.
@@ -1635,7 +1313,7 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
           )}
 
           {/* 권한 / 노출 탭 (#198) */}
-          {tabValue === 3 && (
+          {tabValue === 2 && (
             <PermissionsAndExposurePanel
               control={control}
               isComfyUI={isComfyUI}
@@ -1647,7 +1325,7 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
           )}
 
           {/* 워크플로우 탭 - 이미지 타입만 */}
-          {isComfyUI && tabValue === 4 && (
+          {isComfyUI && tabValue === 3 && (
             <Box>
               {/* 사용 가능한 변수 목록 */}
               <Accordion defaultExpanded={false} sx={{ mb: 2 }}>


### PR DESCRIPTION
## Summary

#199 Phase F3 — 작업판 admin 의 \"기초 입력값\" 탭을 제거. baseInputFields 편집 UI 가 \"커스텀 필드\" 탭과 중복이어서 통일.

**WorkboardManagement.js: -334 lines / +12 lines.**

## 제거된 것

- \`<Tab label=\"기초 입력값\" />\` + 전체 tab 컨텐츠 (305 lines):
  - AI 모델 설정 (DnD)
  - 시스템 프롬프트
  - 참고 이미지 타입
  - 이미지 크기 설정 (DnD)
  - 참고 이미지 사용방식 설정 (DnD)
- form defaultValues 의 \`aiModels\` / \`imageSizes\` / \`referenceImageMethods\` / \`systemPrompt\` / \`referenceImages\`
- 작업판 fetch 시 baseInputFields → form 필드 매핑
- onSubmit 시 baseInputFields 데이터 구성 — 빈 객체로 덮어쓰기 (스키마 required 제약 위해 key 만 유지)
- 미사용 변수 (isPromptFormat / isImageFormat / isPromptOutputFormat / isImageOutputFormat)

## 탭 재인덱싱

| 이전 | 신규 | 라벨 |
|---|---|---|
| 0 | 0 | 기본 정보 |
| ~~1~~ | — | ~~기초 입력값~~ (제거) |
| 2 | 1 | 커스텀 필드 |
| 3 | 2 | 권한 / 노출 |
| 4 (ComfyUI) | 3 (ComfyUI) | 워크플로우 |

## 호환성

기존 작업판의 baseInputFields 데이터는 Phase B 가 이미 additionalInputFields 로 이전 완료. 이번 변경 후 작업판 저장 시 baseInputFields 는 빈 값으로 overwrite — 사용자 페이지는 F2 이후 baseInputFields 를 보지 않으므로 영향 없음. **Phase F4 에서 baseInputFields 스키마 필드 자체 drop**.

## Test plan

- [x] --no-cache frontend 빌드 통과
- [ ] admin 으로 작업판 편집 — \"기초 입력값\" 탭 없음, 4개 탭만 (또는 ComfyUI 시 5개)
- [ ] \"커스텀 필드\" 탭에서 aiModel/imageSize/systemPrompt/temperature/maxTokens 모두 편집 가능 (\"추가 커스톰 필드\" 섹션)
- [ ] 작업판 저장 후 재진입 — customField 데이터 유지
- [ ] 작업판 실행 — 정상 작동 (F2 사용자 페이지 customField 렌더 + Phase C 서비스 코드 헬퍼 경유)

🤖 Generated with [Claude Code](https://claude.com/claude-code)