### PR TITLE
chore: '커스톰 필드' → '커스텀 필드' 오타 수정

### DIFF
--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -757,7 +757,7 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
                     <Accordion key={index} sx={{ mb: 2 }}>
                       <AccordionSummary expandIcon={<ExpandMore />}>
                         <Typography>
-                          {field.label || `커스톰 필드 ${index + 1}`}
+                          {field.label || `커스텀 필드 ${index + 1}`}
                         </Typography>
                       </AccordionSummary>
                       <AccordionDetails>
@@ -787,7 +787,7 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
                                   {...fieldProps}
                                   fullWidth
                                   label="표시명"
-                                  placeholder="예: 커스톰 옵션"
+                                  placeholder="예: 커스텀 옵션"
                                   size="small"
                                 />
                               )}


### PR DESCRIPTION
WorkboardManagement.js 의 \"입력 양식\" 탭 내 필드 라벨 / placeholder 2개소.

- field accordion 헤더의 fallback 라벨
- 표시명 입력의 placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)