### PR TITLE
docs: v2.0 updatelog + version major 1 → 2

### DIFF
--- a/docs/updatelogs/v2.md
+++ b/docs/updatelogs/v2.md
@@ -1,0 +1,97 @@
+# v2 업데이트 내역
+
+## v2.0.0
+
+v2.0 메이저 릴리스. 작업판 권한 / 모델·LoRA 노출 정책 / 작업판 풀 커스텀화 / 모델 선택 UI 통합 / supply chain 보안 강화. v1.x 의 hardcoded 입력 정의가 모두 customField 단일 경로로 통일됨.
+
+### 권한 / 노출 정책 (#198)
+- feat: `Group` 모델 신설 — `name`, `description`, `permissions[]`, `isDefault` (#270, #271)
+  - 신규 가입자가 자동으로 들어가는 \"기본 그룹\" 1개 자동 생성·유지. 멱등 마이그레이션
+  - admin 은 implicit all-access — 그룹과 무관하게 모든 작업판 접근 가능
+- feat: 작업판 단위 접근 권한 — `Workboard.allowedGroupIds[]` (#272, #273)
+  - 사용자 ↔ 작업판 관계는 UNION 규칙: `workboard.allowedGroupIds ∩ user.groupIds ≠ ∅` 이면 접근 허용
+  - 백엔드 미들웨어 (`requireWorkboardAccess`) + GET 필터 빌더 (`buildWorkboardAccessFilter`) 신설. 기존 라우트가 자동 필터링
+- feat: 작업판의 모델·LoRA 노출 정책 — `modelExposurePolicy` / `loraExposurePolicy` (`full` / `whitelist`) + 화이트리스트 배열 (#274)
+  - 사용자 페이지의 model/LoRA picker 가 작업판 컨텍스트에서 backend 의 정책을 받아 자동 필터링
+  - `__no_models_in_whitelist__` sentinel 로 빈 화이트리스트 = \"0개 노출\" 정책 명시
+- feat: admin 그룹 관리 페이지 (`/admin/groups`) (#275)
+  - 그룹 CRUD + 멤버 관리 다이얼로그. admin 은 implicit all-access 라 멤버 목록에서 제외 표시
+- feat: 작업판 admin 에 화이트리스트 picker (#276)
+  - 직접 텍스트 입력 + \"선택\" 버튼으로 `MetadataPickerModal` (multi-add 모드) 호출. ComfyUI 서버 only
+
+### 작업판 풀 커스텀화 (#199)
+- feat: customField 헬퍼 + 스키마 — \`additionalInputFields\` 의 \`role\` 필드 (#278)
+  - 13개 role enum (model, prompt, negativePrompt, systemPrompt, imageSize, seed, temperature, maxTokens, lora, referenceImage, referenceImageMethod, stylePreset, upscaleMethod)
+  - `getFieldByRole` / `getFieldValueByRole` / `indexFieldsByRole` 헬퍼 — 서비스 코드가 필드 이름 대신 의미로 lookup
+- feat: 자동 마이그레이션 (#279, #280)
+  - 기존 `baseInputFields` 의 well-known 키 9개 → `additionalInputFields` role-부여 항목으로 자동 변환 (멱등)
+  - `WELL_KNOWN_FIELD_NAME_TO_ROLE` 매핑으로 v1.x 데이터 호환 (`prompt` / `negativePrompt` / `seed` 등 inputData 직접 키 fallback)
+- refactor: 서비스 코드 role 기반 lookup (#280)
+  - `queueService` 의 9개 위치를 `getFieldValueByRole` 헬퍼로 마이그레이션. `inputData.aiModel` 같은 직접 access 제거
+  - `inputData.additionalParams[fieldName]` fallback 으로 사용자 페이지 dynamic loop 의 nested 입력값도 인식
+- feat: 입력 타입 baseModel / lora 신설 (#281)
+  - role UI 대신 입력 타입으로 의미 부여. \"베이스 모델\" / \"LoRA\" 타입 선택 시 자동으로 `type → role` 매핑되어 서비스 코드 인식
+  - 사용자가 비표준 이름을 써도 의미 추론 가능
+- feat: 사용자 페이지 baseModel/lora picker 렌더 (#282)
+  - 신규 컴포넌트 `MetadataFieldInput` — TextField + 선택/해제 + `MetadataPickerModal` (select-single)
+  - `workboardId` 전달로 작업판 노출 정책 (#198) 자동 적용
+- feat: 템플릿 customField 화 + workflow 무결성 fix (#283)
+  - 5개 템플릿 (ComfyUI image/video, OpenAI image/text, OpenAI Compatible text, Gemini image/text) 의 `baseInputFields` 비우고 `additionalInputFields` 에 baseModel/lora/select/string/number 정의
+  - ComfyUI 의 aiModel customField 에 `formatString='{{##model##}}'` 명시 — workflow placeholder 매칭
+  - 종전 회귀 fix: `getFieldValueByRole` 가 nested `additionalParams` 도 fallback 조회 (ComfyUI workflow placeholder 가 dynamic loop 입력으로도 정상 치환)
+- refactor: 사용자 페이지 hardcoded UI 제거 (#284)
+  - `ImageGeneration.js` 의 aiModel select / 이미지 크기 select / \"모델 목록\" 버튼 + MetadataPickerModal 제거. baseInputFields 기반 기본값 / {key,value} 매핑 wrap 제거
+  - `PromptGeneratorPanel.js` 의 aiModel select / referenceImages / systemPrompt hardcoded UI 제거
+  - 전체 코드 -498 / +43 lines
+- refactor: 작업판 admin \"기초 입력값\" 탭 제거 (#286)
+  - 305 lines 의 baseInputFields 편집 UI 제거. 모든 입력 정의를 \"커스텀 필드\" 탭으로 일원화
+  - 탭 재인덱싱: 0=기본 정보 / 1=커스텀 필드 / 2=권한 노출 / 3=ComfyUI 워크플로우
+- refactor: baseInputFields 스키마 + role 필드 drop (#287)
+  - `Workboard.baseInputFields` subschema 제거 (9개 키)
+  - `inputFieldSchema.role` 필드 제거 — type=baseModel/lora 추론으로 대체
+  - 마이그레이션 `dropBaseInputFieldsSchema` 가 DB 잔존 데이터 `$unset`
+
+### 모델 선택 UI 통합 (#200, #260)
+- feat: 모델 메타데이터 + 동적 조회 — ModelCache 확장 + provider 별 동기화 (#245, #246, #247, #248, #249)
+  - Civitai 메타데이터 (description, baseModel, trigger words, 섬네일) 자동 fetch
+  - OpenAI/Gemini provider 의 동적 모델 목록 조회 (`/v1/models` 등)
+  - `routes/servers.js` 의 detailed endpoint — 4종 server type 통일 응답 구조 (LoRA 패턴과 동일)
+- feat: 모델 picker 그리드 + 통합 위계 (#250, #251, #261, #262, #263, #264, #265, #267, #268, #269)
+  - `MetadataPickerModal` — kind=lora|model 공통 picker. select-single / multi-add / prompt-insert 3개 모드
+  - `MetadataItemCard` — 메타데이터 / 섬네일 / trigger words / 상세 expand 통합 카드
+  - `MetadataItemGrid` — 반응형 그리드
+  - 인라인 LoRA 프롬프트 insert 모드 — 사용자가 LoRA 카드 클릭으로 프롬프트에 `<lora:...>` 자동 삽입
+  - Civitai 섬네일 URL 변환 (\`/original=true/\` → `/width=N/`) 으로 로딩 속도 개선 (#267)
+  - 빈 배열 reference 안정화로 무한 fetch loop 회귀 차단 (#266)
+
+### 작업판 모델 타입 제약 (#252)
+- feat: `Workboard.allowedModelTypes[]` (#253, #254, #255)
+  - civitai.baseModel 기반 작업판 별 base 모델 타입 화이트리스트 (SDXL / Flux / 등)
+  - 모델 picker 의 baseModel 필터 옵션이 작업판 제약과 교집합으로 노출
+  - 메타데이터 없는 모델 (Civitai 미등록 / hash 없음) 은 노출 — custom merge 등 일상적 케이스 대응
+
+### Phase 6: apiFormat 필드 완전 제거 (#181 마지막)
+- refactor: Workboard.apiFormat 필드 + dispatcher fallback 제거 (#244)
+  - v1.8.0 의 capability 조합 기반 라우팅으로 완전 전환 완료. ~130 lines cleanup
+
+### 운영 / 안정성
+- fix: stuck sync cleanup 마이그레이션 (#256, #257)
+- perf: 섬네일 공유 메모리 최적화 (#258, #259)
+- fix: model picker 의 빈 배열 reference 무한 fetch loop 회귀 (#266)
+- chore: 작업판 admin \"커스텀 필드\" 탭 평탄화 — hardcoded 3개 필드 + 외부 accordion 제거 (#288)
+- chore: \"입력 양식\" 으로 라벨 변경 (사용자 피드백: \"필드\" 가 프로그래머 용어) + 오타 수정 (#289)
+
+### Supply Chain 보안 강화
+- chore: npm → pnpm 마이그레이션 + Node 22 + `minimumReleaseAge: 1440` (#290)
+  - Mini Shai-Hulud (TanStack/SAP/Mistral/UiPath npm worm, 2026-04~05) 대응
+  - pnpm v11+ 기본 24시간 release cooldown 으로 신규 published 패키지 자동 차단
+  - `strict-dep-builds` 로 침해 dep 의 lifecycle script 자동 봉쇄
+  - `--frozen-lockfile` 로 lockfile mutation 차단
+  - 3개 package-lock.json → 3개 pnpm-lock.yaml, 3개 Dockerfile 갱신
+  - sharp 0.32 → 0.34 (Node 22 호환 + lifecycle script 불필요)
+
+### Breaking changes / 마이그레이션
+- `Workboard.baseInputFields` 스키마 제거 — 데이터는 자동 마이그레이션 (`backfillCustomFieldRoles`) 으로 `additionalInputFields` 로 이전됨
+- `inputFieldSchema.role` 필드 제거 — type=baseModel/lora 로 의미 추론 (사용자 admin UI 변경 없음)
+- v1.x 백업 파일 복원 시 baseInputFields 데이터 손실 (mongoose strict mode). v2.0 으로 운영 마이그레이션 완료 후의 백업은 영향 없음
+- npm → pnpm 전환 — 로컬 개발자 워크플로우 변경 필요. `corepack enable && pnpm install` 사용

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,7 +1,7 @@
 const config = {
   version: {
-    major: 1,
-    minor: 8
+    major: 2,
+    minor: 0
   },
   monitoring: {
     // 작업 목록 모니터링 주기 (3초)


### PR DESCRIPTION
## Summary

v2.0 출시 준비 — updatelog 작성 + frontend version major 1 → 2.

## Updatelog 주요 섹션

- **권한 / 노출 정책** (#198) — Group 모델 / 작업판 단위 접근 권한 / 모델·LoRA 노출 정책 (PR #270-275, #276)
- **작업판 풀 커스텀화** (#199) — Phase A~F4. baseInputFields 스키마 제거 + customField 단일 경로 (PR #278-287)
- **모델 선택 UI 통합** (#200, #260) — MetadataPickerModal + Card + Grid (PR #245-251, #261-269)
- **작업판 모델 타입 제약** (#252) (PR #253-255)
- **Phase 6: apiFormat 제거** (#181) (PR #244)
- **Supply chain 보안 강화** — npm → pnpm + minimumReleaseAge:1440 (#290) — Mini Shai-Hulud 대응
- **운영 / 안정성 fix** + admin UI 정리 (PR #256-259, #266, #288, #289)

## Breaking changes

- `Workboard.baseInputFields` 스키마 제거 — 자동 마이그레이션으로 데이터 보존
- `inputFieldSchema.role` 필드 제거 — type 추론으로 대체
- v1.x 백업 복원 시 baseInputFields 데이터 손실 (mongoose strict). v2.0 운영 마이그레이션 완료 후 백업은 영향 없음
- npm → pnpm 전환 (로컬 개발자: `corepack enable && pnpm install`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)