### PR TITLE
fix: POST /jobs/generate 가 additionalParams.aiModel/imageSize hoist (v2.0 회귀)

### DIFF
--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -22,8 +22,6 @@ router.post('/generate', requireAuth, async (req, res) => {
       workboardId,
       prompt,
       negativePrompt,
-      aiModel,
-      imageSize,
       referenceImages,
       referenceImageMethod,
       stylePreset,
@@ -33,7 +31,13 @@ router.post('/generate', requireAuth, async (req, res) => {
       randomSeed,
       tags
     } = req.body;
-    
+
+    // #199 F2 이후 사용자 페이지는 aiModel / imageSize 등을 additionalParams 네임스페이스로 전송.
+    // legacy top-level 도 backward-compat 으로 받아 hoist.
+    const ap = additionalParams || {};
+    const aiModel = req.body.aiModel || ap.aiModel;
+    const imageSize = req.body.imageSize || ap.imageSize;
+
     console.log('🔍 Extracted fields:', {
       workboardId,
       prompt: prompt?.substring(0, 50) + '...',
@@ -41,9 +45,9 @@ router.post('/generate', requireAuth, async (req, res) => {
       imageSize,
       seed,
       randomSeed,
-      additionalParamsKeys: additionalParams ? Object.keys(additionalParams) : []
+      additionalParamsKeys: Object.keys(ap)
     });
-    
+
     if (!workboardId || !prompt || !aiModel) {
       console.error('❌ Missing required fields:', { workboardId: !!workboardId, prompt: !!prompt, aiModel: !!aiModel });
       return res.status(400).json({


### PR DESCRIPTION
## Summary

v2.0 출시 직후 발견된 회귀 fix.

## 문제

\`POST /api/jobs/generate\` 라우트가 \`req.body.aiModel\` / \`req.body.imageSize\` 만 보고 있었음. #199 F2 이후 사용자 페이지는 이 값들을 \`req.body.additionalParams\` 네임스페이스에 담아 전송 (\`additionalParams.\${field.name}\` 형태의 dynamic loop 입력).

→ 작업 실행 시 \"Missing required fields: workboardId, prompt, aiModel\" 오류 발생.

## Fix

\`req.body.aiModel || additionalParams.aiModel\` 패턴으로 hoist. top-level 우선, additionalParams fallback. v1.x backward-compat 유지. \`imageSize\` 도 동일.

## 출시 권장

v2.0.1 patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)