### PR TITLE
release: v2.0.1

### DIFF
--- a/docs/updatelogs/v2.md
+++ b/docs/updatelogs/v2.md
@@ -1,5 +1,14 @@
 # v2 업데이트 내역
 
+## v2.0.1
+
+### 수정
+- fix: 기존 작업판 실행 시 \"Missing required fields: workboardId, prompt, aiModel\" 회귀 (#295)
+  - v2.0 (#199 F2) 이후 사용자 페이지는 \`aiModel\` / \`imageSize\` 를 customField dynamic loop 의 \`additionalParams\` 네임스페이스로 전송
+  - `POST /api/jobs/generate` 라우트 validation 이 top-level 만 보고 있어 \"Missing required\" 오류 발생
+  - \`req.body.aiModel || additionalParams.aiModel\` 패턴으로 hoist. top-level 우선, additionalParams fallback (v1.x 페이로드 backward-compat)
+  - imageSize 도 동일 패턴 적용
+
 ## v2.0.0
 
 v2.0 메이저 릴리스. 작업판 권한 / 모델·LoRA 노출 정책 / 작업판 풀 커스텀화 / 모델 선택 UI 통합 / supply chain 보안 강화. v1.x 의 hardcoded 입력 정의가 모두 customField 단일 경로로 통일됨.

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -22,8 +22,6 @@ router.post('/generate', requireAuth, async (req, res) => {
       workboardId,
       prompt,
       negativePrompt,
-      aiModel,
-      imageSize,
       referenceImages,
       referenceImageMethod,
       stylePreset,
@@ -33,7 +31,13 @@ router.post('/generate', requireAuth, async (req, res) => {
       randomSeed,
       tags
     } = req.body;
-    
+
+    // #199 F2 이후 사용자 페이지는 aiModel / imageSize 등을 additionalParams 네임스페이스로 전송.
+    // legacy top-level 도 backward-compat 으로 받아 hoist.
+    const ap = additionalParams || {};
+    const aiModel = req.body.aiModel || ap.aiModel;
+    const imageSize = req.body.imageSize || ap.imageSize;
+
     console.log('🔍 Extracted fields:', {
       workboardId,
       prompt: prompt?.substring(0, 50) + '...',
@@ -41,9 +45,9 @@ router.post('/generate', requireAuth, async (req, res) => {
       imageSize,
       seed,
       randomSeed,
-      additionalParamsKeys: additionalParams ? Object.keys(additionalParams) : []
+      additionalParamsKeys: Object.keys(ap)
     });
-    
+
     if (!workboardId || !prompt || !aiModel) {
       console.error('❌ Missing required fields:', { workboardId: !!workboardId, prompt: !!prompt, aiModel: !!aiModel });
       return res.status(400).json({


### PR DESCRIPTION
## v2.0.1 patch

### 수정
- fix: 기존 작업판 실행 시 \"Missing required fields: workboardId, prompt, aiModel\" 회귀 (#295)
  - v2.0 (#199 F2) 이후 customField dynamic loop 가 \`additionalParams\` 네임스페이스로 보내는 \`aiModel\` / \`imageSize\` 를 라우트가 못 읽던 문제
  - top-level / additionalParams 양쪽 hoist 로 fix. v1.x backward-compat 유지

상세: [docs/updatelogs/v2.md](docs/updatelogs/v2.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)