### PR TITLE
fix: schema-aware lookup + 템플릿 snake_case 통일 (v2.0.2)

### DIFF
--- a/frontend/src/templates/ComfyUI-image.json
+++ b/frontend/src/templates/ComfyUI-image.json
@@ -2,7 +2,7 @@
   "baseInputFields": {},
   "additionalInputFields": [
     {
-      "name": "aiModel",
+      "name": "base_model",
       "label": "베이스 모델",
       "type": "baseModel",
       "required": true,
@@ -10,7 +10,7 @@
       "description": "서버의 모델 목록에서 선택. 작업판의 모델 노출 정책이 적용됩니다."
     },
     {
-      "name": "imageSize",
+      "name": "image_size",
       "label": "이미지 크기",
       "type": "select",
       "required": true,
@@ -26,7 +26,7 @@
       ]
     },
     {
-      "name": "referenceImageMethod",
+      "name": "reference_image_method",
       "label": "참조 이미지 처리",
       "type": "select",
       "required": false,

--- a/frontend/src/templates/ComfyUI-video.json
+++ b/frontend/src/templates/ComfyUI-video.json
@@ -2,7 +2,7 @@
   "baseInputFields": {},
   "additionalInputFields": [
     {
-      "name": "aiModel",
+      "name": "base_model",
       "label": "베이스 모델",
       "type": "baseModel",
       "required": true,
@@ -10,7 +10,7 @@
       "description": "서버의 모델 목록에서 선택. 작업판의 모델 노출 정책이 적용됩니다."
     },
     {
-      "name": "imageSize",
+      "name": "image_size",
       "label": "프레임 크기",
       "type": "select",
       "required": true,
@@ -26,7 +26,7 @@
       ]
     },
     {
-      "name": "referenceImageMethod",
+      "name": "reference_image_method",
       "label": "참조 이미지 처리",
       "type": "select",
       "required": false,

--- a/frontend/src/templates/Gemini-image.json
+++ b/frontend/src/templates/Gemini-image.json
@@ -2,14 +2,14 @@
   "baseInputFields": {},
   "additionalInputFields": [
     {
-      "name": "aiModel",
+      "name": "base_model",
       "label": "베이스 모델",
       "type": "baseModel",
       "required": true,
       "description": "서버의 모델 목록에서 선택. 작업판의 모델 노출 정책이 적용됩니다."
     },
     {
-      "name": "imageSize",
+      "name": "image_size",
       "label": "이미지 비율",
       "type": "select",
       "required": true,

--- a/frontend/src/templates/Gemini-text.json
+++ b/frontend/src/templates/Gemini-text.json
@@ -2,14 +2,14 @@
   "baseInputFields": {},
   "additionalInputFields": [
     {
-      "name": "aiModel",
+      "name": "base_model",
       "label": "베이스 모델",
       "type": "baseModel",
       "required": true,
       "description": "서버의 모델 목록에서 선택. 작업판의 모델 노출 정책이 적용됩니다."
     },
     {
-      "name": "systemPrompt",
+      "name": "system_prompt",
       "label": "시스템 프롬프트",
       "type": "string",
       "required": false,
@@ -24,7 +24,7 @@
       "description": "0.0 ~ 1.0. 높을수록 창의적, 낮을수록 일관적."
     },
     {
-      "name": "maxTokens",
+      "name": "max_tokens",
       "label": "Max Tokens",
       "type": "number",
       "required": false,

--- a/frontend/src/templates/OpenAI Compatible-text.json
+++ b/frontend/src/templates/OpenAI Compatible-text.json
@@ -2,14 +2,14 @@
   "baseInputFields": {},
   "additionalInputFields": [
     {
-      "name": "aiModel",
+      "name": "base_model",
       "label": "베이스 모델",
       "type": "baseModel",
       "required": true,
       "description": "서버의 모델 목록에서 선택. 작업판의 모델 노출 정책이 적용됩니다."
     },
     {
-      "name": "systemPrompt",
+      "name": "system_prompt",
       "label": "시스템 프롬프트",
       "type": "string",
       "required": false,
@@ -23,7 +23,7 @@
       "defaultValue": 0.7
     },
     {
-      "name": "maxTokens",
+      "name": "max_tokens",
       "label": "Max Tokens",
       "type": "number",
       "required": false,

--- a/frontend/src/templates/OpenAI-image.json
+++ b/frontend/src/templates/OpenAI-image.json
@@ -2,14 +2,14 @@
   "baseInputFields": {},
   "additionalInputFields": [
     {
-      "name": "aiModel",
+      "name": "base_model",
       "label": "베이스 모델",
       "type": "baseModel",
       "required": true,
       "description": "서버의 모델 목록에서 선택. 작업판의 모델 노출 정책이 적용됩니다."
     },
     {
-      "name": "imageSize",
+      "name": "image_size",
       "label": "이미지 크기",
       "type": "select",
       "required": true,

--- a/frontend/src/templates/OpenAI-text.json
+++ b/frontend/src/templates/OpenAI-text.json
@@ -2,14 +2,14 @@
   "baseInputFields": {},
   "additionalInputFields": [
     {
-      "name": "aiModel",
+      "name": "base_model",
       "label": "베이스 모델",
       "type": "baseModel",
       "required": true,
       "description": "서버의 모델 목록에서 선택. 작업판의 모델 노출 정책이 적용됩니다."
     },
     {
-      "name": "systemPrompt",
+      "name": "system_prompt",
       "label": "시스템 프롬프트",
       "type": "string",
       "required": false,
@@ -24,7 +24,7 @@
       "description": "0.0 ~ 1.0. 높을수록 창의적, 낮을수록 일관적."
     },
     {
-      "name": "maxTokens",
+      "name": "max_tokens",
       "label": "Max Tokens",
       "type": "number",
       "required": false,

--- a/src/constants/fieldRoles.js
+++ b/src/constants/fieldRoles.js
@@ -60,15 +60,25 @@ const LEGACY_BASE_FIELD_TO_ROLE = Object.freeze({
 // 서비스 코드 fallback 및 Phase C 의 additionalInputFields role 자동 부여 마이그레이션에서 사용.
 const WELL_KNOWN_FIELD_NAME_TO_ROLE = Object.freeze({
   ...LEGACY_BASE_FIELD_TO_ROLE,
+  // camelCase (v1.x ~ v2.0.0)
   prompt: FIELD_ROLES.PROMPT,
   negativePrompt: FIELD_ROLES.NEGATIVE_PROMPT,
   seed: FIELD_ROLES.SEED,
-  // 신규 템플릿 (Phase F1) 는 단수형 이름 사용 — legacy plural 과 동등.
   imageSize: FIELD_ROLES.IMAGE_SIZE,
   referenceImageMethod: FIELD_ROLES.REFERENCE_IMAGE_METHOD,
   stylePreset: FIELD_ROLES.STYLE_PRESET,
   upscaleMethod: FIELD_ROLES.UPSCALE_METHOD,
-  referenceImage: FIELD_ROLES.REFERENCE_IMAGE
+  referenceImage: FIELD_ROLES.REFERENCE_IMAGE,
+  // snake_case (v2.0.2+ 컨벤션 — ComfyUI workflow placeholder 와 일관)
+  base_model: FIELD_ROLES.MODEL,
+  negative_prompt: FIELD_ROLES.NEGATIVE_PROMPT,
+  system_prompt: FIELD_ROLES.SYSTEM_PROMPT,
+  image_size: FIELD_ROLES.IMAGE_SIZE,
+  reference_image: FIELD_ROLES.REFERENCE_IMAGE,
+  reference_image_method: FIELD_ROLES.REFERENCE_IMAGE_METHOD,
+  style_preset: FIELD_ROLES.STYLE_PRESET,
+  upscale_method: FIELD_ROLES.UPSCALE_METHOD,
+  max_tokens: FIELD_ROLES.MAX_TOKENS
 });
 
 module.exports = {

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -11,6 +11,8 @@ const GeneratedVideo = require('../models/GeneratedVideo');
 const Workboard = require('../models/Workboard');
 const { escapeRegex } = require('../utils/escapeRegex');
 const Server = require('../models/Server');
+const { getFieldValueByRole } = require('../utils/customFieldHelpers');
+const { FIELD_ROLES } = require('../constants/fieldRoles');
 const router = express.Router();
 
 router.post('/generate', requireAuth, async (req, res) => {
@@ -32,11 +34,26 @@ router.post('/generate', requireAuth, async (req, res) => {
       tags
     } = req.body;
 
-    // #199 F2 이후 사용자 페이지는 aiModel / imageSize 등을 additionalParams 네임스페이스로 전송.
-    // legacy top-level 도 backward-compat 으로 받아 hoist.
+    if (!workboardId || !prompt) {
+      return res.status(400).json({ message: 'Missing required fields: workboardId, prompt' });
+    }
+
+    // 작업판 접근 권한 검사 (#198)
+    const wb = await Workboard.findById(workboardId);
+    if (!wb) {
+      return res.status(404).json({ message: 'Workboard not found' });
+    }
+    if (!userHasWorkboardAccess(req.user, wb)) {
+      return res.status(403).json({ message: '이 작업판에 접근할 권한이 없습니다.' });
+    }
+
+    // 모델 / 이미지 크기 추출 — customField 이름이 임의일 수 있어 schema-aware lookup.
+    // 작업판의 additionalInputFields 에서 type='baseModel' 인 필드 (없으면 well-known name fallback) 의
+    // name 으로 inputData (top-level 또는 additionalParams) 에서 값 조회.
     const ap = additionalParams || {};
-    const aiModel = req.body.aiModel || ap.aiModel;
-    const imageSize = req.body.imageSize || ap.imageSize;
+    const lookupInput = { ...req.body, additionalParams: ap };
+    const aiModel = req.body.aiModel || getFieldValueByRole(wb, lookupInput, FIELD_ROLES.MODEL);
+    const imageSize = req.body.imageSize || getFieldValueByRole(wb, lookupInput, FIELD_ROLES.IMAGE_SIZE);
 
     console.log('🔍 Extracted fields:', {
       workboardId,
@@ -48,20 +65,11 @@ router.post('/generate', requireAuth, async (req, res) => {
       additionalParamsKeys: Object.keys(ap)
     });
 
-    if (!workboardId || !prompt || !aiModel) {
-      console.error('❌ Missing required fields:', { workboardId: !!workboardId, prompt: !!prompt, aiModel: !!aiModel });
+    if (!aiModel) {
+      console.error('❌ aiModel 추출 실패 — workboard customField (type=baseModel) 또는 inputData 확인 필요');
       return res.status(400).json({
-        message: 'Missing required fields: workboardId, prompt, aiModel'
+        message: '베이스 모델이 지정되지 않았습니다. 작업판 \"입력 양식\" 에 베이스 모델 타입 필드가 있는지, 사용자 페이지에서 모델을 선택했는지 확인하세요.'
       });
-    }
-
-    // 작업판 접근 권한 검사 (#198)
-    const wb = await Workboard.findById(workboardId);
-    if (!wb) {
-      return res.status(404).json({ message: 'Workboard not found' });
-    }
-    if (!userHasWorkboardAccess(req.user, wb)) {
-      return res.status(403).json({ message: '이 작업판에 접근할 권한이 없습니다.' });
     }
 
     if (referenceImages && referenceImages.length > 0) {


### PR DESCRIPTION
## Summary

v2.0.1 의 hoist 만으로는 customField name 이 비표준이면 매칭 실패. schema-aware lookup + 템플릿 snake_case 통일.

## Changes

**Backend:**
- POST /jobs/generate 가 \`getFieldValueByRole\` 헬퍼 사용 — workboard.additionalInputFields 에서 type=baseModel 인 필드를 찾아 그 필드 이름으로 inputData 조회. customField name 이 임의여도 작동.
- \`WELL_KNOWN_FIELD_NAME_TO_ROLE\` 에 snake_case alias 추가 (base_model, image_size, system_prompt, max_tokens, negative_prompt, reference_image, reference_image_method, style_preset, upscale_method)

**Templates (5종 모두 snake_case 로 통일):**
- aiModel → base_model
- imageSize → image_size
- referenceImageMethod → reference_image_method
- systemPrompt → system_prompt
- maxTokens → max_tokens

ComfyUI workflow placeholder (\`{{##negative_prompt##}}\` 등) 와 일관된 컨벤션.

## Skip

v2.0.0 으로 생성된 작업판 없으므로 마이그레이션 없음 (사용자 결정).

## 검증

dev DB 의 실제 작업판 (customField name='base_model') 시뮬레이션 → 정상 추출.

🤖 Generated with [Claude Code](https://claude.com/claude-code)