### PR TITLE
release: v2.0.3

### DIFF
--- a/docs/updatelogs/v2.md
+++ b/docs/updatelogs/v2.md
@@ -1,5 +1,13 @@
 # v2 업데이트 내역
 
+## v2.0.3
+
+### 수정
+- fix: ComfyUI workflow injection 의 partial-match 경로 double-escape 회귀 (#299)
+  - \`replaceInObject\` 의 부분 일치 분기가 \`escapeForJsonString\` 으로 backslash 를 \`\\\\\` 로 만든 후 JS object 에 저장. 이후 axios 가 JSON.stringify 로 한 번 더 escape — ComfyUI 가 double-escape 된 경로로 수신해 Windows 모델 경로 손상
+  - 수정: partial-match 도 full-match 와 동일하게 raw value 사용. JSON.stringify 의 자동 escape 만 적용
+  - fallback string-replacement (workflowString 직접 조작) 는 JSON 텍스트 컨텍스트라 escape 유지
+
 ## v2.0.2
 
 ### 수정

--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -686,24 +686,25 @@ const injectInputsIntoWorkflow = async (workflowTemplate, inputData, workboard =
 // JSON 객체 내에서 재귀적으로 값을 치환하는 함수
 const replaceInObject = (obj, replacements, seedValue = null) => {
   if (typeof obj === 'string') {
-    // 문자열이 완전히 플레이스홀더인 경우 (이스케이핑 없이 원본 값 반환)
+    // 문자열이 완전히 플레이스홀더인 경우 — raw value 반환.
+    // 이미 JSON.parse 된 object 의 string field 이므로 backslash 등은 literal 로 들어가야 함;
+    // 직렬화는 axios / JSON.stringify 에서 자동 escape.
     const replacement = replacements[obj];
     if (replacement) {
       return replacement.value;
     }
-    
-    // 부분 문자열 치환 (문자열 내 일부만 플레이스홀더인 경우 - 이스케이핑 적용)
+
+    // 부분 문자열 치환 — 마찬가지로 raw value 사용. escapeForJsonString 적용 시 axios 의 JSON.stringify 가
+    // 다시 escape 하여 double-escape 됨 (Windows 경로 `IXL\nova...` 가 ComfyUI 에 `IXL\\nova...` 로 전달).
     let result = obj;
     Object.keys(replacements).forEach(key => {
       if (result.includes(key)) {
         const value = replacements[key].value;
-        // 부분 치환의 경우에만 이스케이핑 적용 (JSON 문자열 안에서 안전하게 사용하기 위해)
-        const escapedValue = escapeForJsonString(value);
-        result = result.replace(new RegExp(key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'), escapedValue);
-        
-        if (value !== escapedValue) {
-          console.log(`🔧 Auto-escaped special characters in partial replacement "${key}": "${value}" → "${escapedValue}"`);
-        }
+        // String.replace 의 $ 패턴 충돌 방지 위해 replacement 함수 형태 사용 (raw literal substitute)
+        result = result.replace(
+          new RegExp(key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'),
+          () => String(value)
+        );
       }
     });
     return result;


### PR DESCRIPTION
## v2.0.3 patch

- fix: workflow injection partial-match double-escape — Windows 모델 경로 손상 회귀 (#299)

상세: [docs/updatelogs/v2.md](docs/updatelogs/v2.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)