### PR TITLE
fix: Phase B 마이그레이션 raw collection + 데이터 복구 script (v2.0.5)

### DIFF
--- a/scripts/recover-workboard-base-input-fields.js
+++ b/scripts/recover-workboard-base-input-fields.js
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+// v2.0 마이그레이션 버그 (Phase B 가 mongoose strict 로 baseInputFields 를 못 읽어 customField 생성 실패) 의
+// 일회성 데이터 복구 스크립트. v2.0 배포 직전 백업 ZIP 의 Workboard.json 을 읽어 현재 DB 의 작업판에
+// 누락된 customField 를 추가한다.
+//
+// 사용법:
+//   docker compose exec backend node /app/scripts/recover-workboard-base-input-fields.js /path/to/backup.zip
+//
+// 또는 호스트에서:
+//   cd /Users/.../vcc-manager
+//   docker compose run --rm -v /path/to/backup.zip:/tmp/backup.zip backend node /app/scripts/recover-workboard-base-input-fields.js /tmp/backup.zip
+//
+// 동작:
+// - 백업의 Workboard.json 에서 각 작업판의 baseInputFields 추출
+// - 현재 DB 의 작업판 (_id 매치) 의 additionalInputFields 검사
+// - 누락된 well-known 필드 (aiModel/imageSizes 등) 를 buildEntryFromLegacy 로 변환해 추가
+// - raw collection 으로 update 해 mongoose strict 우회
+
+const fs = require('fs');
+const path = require('path');
+const unzipper = require('unzipper');
+const mongoose = require('mongoose');
+const { buildEntryFromLegacy } = require('../src/migrations/backfillCustomFieldRoles');
+const { LEGACY_BASE_FIELD_TO_ROLE, WELL_KNOWN_FIELD_NAME_TO_ROLE } = require('../src/constants/fieldRoles');
+
+const TYPE_TO_ROLE = { baseModel: 'model', lora: 'lora' };
+
+async function extractWorkboardJson(zipPath) {
+  return new Promise((resolve, reject) => {
+    let found = null;
+    fs.createReadStream(zipPath)
+      .pipe(unzipper.Parse())
+      .on('entry', (entry) => {
+        if (entry.path === 'database/Workboard.json') {
+          const chunks = [];
+          entry.on('data', (c) => chunks.push(c));
+          entry.on('end', () => {
+            try {
+              found = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+            } catch (e) {
+              reject(new Error(`Workboard.json parse failed: ${e.message}`));
+            }
+          });
+        } else {
+          entry.autodrain();
+        }
+      })
+      .on('close', () => {
+        if (!found) reject(new Error('database/Workboard.json not found in backup'));
+        else resolve(found);
+      })
+      .on('error', reject);
+  });
+}
+
+// 어떤 role 이 customField 에 이미 점유돼 있는지 — type 매핑까지 고려
+function occupiedRoles(currentCustomFields) {
+  const roles = new Set();
+  for (const f of currentCustomFields || []) {
+    if (!f) continue;
+    if (f.role) roles.add(f.role);
+    if (TYPE_TO_ROLE[f.type]) roles.add(TYPE_TO_ROLE[f.type]);
+    // well-known 이름도 점유로 간주
+    if (WELL_KNOWN_FIELD_NAME_TO_ROLE[f.name]) roles.add(WELL_KNOWN_FIELD_NAME_TO_ROLE[f.name]);
+  }
+  return roles;
+}
+
+async function run() {
+  const zipPath = process.argv[2];
+  if (!zipPath) {
+    console.error('Usage: recover-workboard-base-input-fields.js <backup.zip>');
+    process.exit(1);
+  }
+  if (!fs.existsSync(zipPath)) {
+    console.error(`File not found: ${zipPath}`);
+    process.exit(1);
+  }
+
+  console.log(`[Recover] Reading backup ZIP: ${zipPath}`);
+  const backupWorkboards = await extractWorkboardJson(zipPath);
+  console.log(`[Recover] Found ${backupWorkboards.length} workboards in backup`);
+
+  const uri = process.env.MONGODB_URI || 'mongodb://admin:password@mongodb:27017/vcc-manager?authSource=admin';
+  await mongoose.connect(uri);
+  const collection = mongoose.connection.collection('workboards');
+
+  let scanned = 0;
+  let recovered = 0;
+  let appendedFields = 0;
+  let skippedNoMatch = 0;
+  let skippedNoData = 0;
+
+  for (const bwb of backupWorkboards) {
+    scanned += 1;
+    const id = bwb._id?.$oid || bwb._id;
+    if (!id) continue;
+
+    const base = bwb.baseInputFields || {};
+    const hasMeaningful = Object.entries(LEGACY_BASE_FIELD_TO_ROLE).some(([k]) => {
+      const v = base[k];
+      if (v === undefined || v === null) return false;
+      if (Array.isArray(v)) return v.length > 0;
+      if (typeof v === 'string') return v.length > 0;
+      if (typeof v === 'number') return false;  // schema 기본값 (temperature 0.7 등) 은 의미 없음
+      return Boolean(v);
+    });
+    if (!hasMeaningful) {
+      skippedNoData += 1;
+      continue;
+    }
+
+    const cur = await collection.findOne({ _id: new mongoose.Types.ObjectId(id) });
+    if (!cur) {
+      skippedNoMatch += 1;
+      continue;
+    }
+
+    const currentFields = cur.additionalInputFields || [];
+    const occupied = occupiedRoles(currentFields);
+
+    const newEntries = [];
+    for (const [legacyKey, role] of Object.entries(LEGACY_BASE_FIELD_TO_ROLE)) {
+      if (occupied.has(role)) continue;  // 이미 의미적으로 점유 → skip (중복 회피)
+      const legacyValue = base[legacyKey];
+      if (legacyValue === undefined || legacyValue === null) continue;
+      const entry = buildEntryFromLegacy(legacyKey, legacyValue);
+      if (!entry) continue;
+      if (entry.type === 'select' && (!entry.options || entry.options.length === 0)) continue;
+      if (entry.type === 'string' && (entry.defaultValue === undefined || entry.defaultValue === '')) continue;
+      // F4 에서 role 필드 drop 됨 — entry 의 role 도 제거 (mongoose 가 어차피 strip 하지만 명시적으로)
+      delete entry.role;
+      newEntries.push(entry);
+    }
+
+    if (newEntries.length === 0) continue;
+
+    await collection.updateOne(
+      { _id: cur._id },
+      { $push: { additionalInputFields: { $each: newEntries } } }
+    );
+    recovered += 1;
+    appendedFields += newEntries.length;
+    console.log(`  ✓ ${cur.name}: +${newEntries.length} field(s) — ${newEntries.map(e => `${e.name}(${e.type})`).join(', ')}`);
+  }
+
+  console.log(`\n[Recover] Summary: scanned=${scanned}, recovered=${recovered}, fields appended=${appendedFields}, skipped (no match)=${skippedNoMatch}, skipped (no data)=${skippedNoData}`);
+  await mongoose.disconnect();
+}
+
+run().catch((e) => {
+  console.error('[Recover] Fatal:', e);
+  process.exit(1);
+});

--- a/src/migrations/backfillCustomFieldRoles.js
+++ b/src/migrations/backfillCustomFieldRoles.js
@@ -69,7 +69,11 @@ function buildEntryFromLegacy(legacyKey, legacyValue) {
 
 async function backfillCustomFieldRoles() {
   try {
-    const workboards = await Workboard.find({});
+    // raw collection 사용 — Workboard.find() 는 mongoose strict 로 schema 에서 제거된 baseInputFields 를
+    // strip 해버려 마이그레이션이 \"옮길 데이터 없음\" 으로 잘못 판단함 (v2.0.0 회귀, 데이터 손실 발생).
+    // raw collection 으로 읽으면 unknown 필드도 surface 됨.
+    const collection = Workboard.collection;
+    const workboards = await collection.find({}).toArray();
     let migratedCount = 0;
     let roleAssignedCount = 0;
     let appendedCount = 0;
@@ -80,14 +84,15 @@ async function backfillCustomFieldRoles() {
       const existingRoles = new Set(existing.filter((f) => f && f.role).map((f) => f.role));
       const existingByName = new Map(existing.filter((f) => f && f.name).map((f) => [f.name, f]));
       let dirty = false;
+      const pushList = [];
 
       for (const [legacyKey, role] of Object.entries(LEGACY_BASE_FIELD_TO_ROLE)) {
-        if (existingRoles.has(role)) continue;  // 이미 마이그레이션 됨
+        if (existingRoles.has(role)) continue;
         if (!Object.prototype.hasOwnProperty.call(base, legacyKey)) continue;
 
         const legacyValue = base[legacyKey];
 
-        // 같은 name 이 있지만 role 이 없는 경우 — role 만 부여
+        // 같은 name 이 있지만 role 이 없는 경우 — role 만 부여 (raw update 사용)
         if (existingByName.has(legacyKey)) {
           const target = existingByName.get(legacyKey);
           if (!target.role) {
@@ -99,23 +104,31 @@ async function backfillCustomFieldRoles() {
           continue;
         }
 
-        // 새 entry 생성
         const entry = buildEntryFromLegacy(legacyKey, legacyValue);
         if (!entry) continue;
-        // 빈 옵션 배열은 의미 없으므로 skip (select 타입 한정)
         if (entry.type === 'select' && (!entry.options || entry.options.length === 0)) continue;
-        // 빈 문자열 systemPrompt 도 skip (사용자가 채우지 않은 케이스)
         if (entry.type === 'string' && (entry.defaultValue === undefined || entry.defaultValue === '')) continue;
 
-        wb.additionalInputFields.push(entry);
+        pushList.push(entry);
         existingRoles.add(role);
         appendedCount += 1;
         dirty = true;
       }
 
       if (dirty) {
-        wb.markModified('additionalInputFields');
-        await wb.save();
+        // raw update — mongoose strict (스키마에 없는 role 필드) 우회
+        const updateOp = {};
+        if (pushList.length > 0) {
+          updateOp.$push = { additionalInputFields: { $each: pushList } };
+        }
+        // role 부여만 있는 경우 — 전체 additionalInputFields 를 set 으로 덮어쓰기
+        const hasOnlyRoleAssignment = pushList.length === 0;
+        if (hasOnlyRoleAssignment) {
+          updateOp.$set = { additionalInputFields: existing };
+        }
+        if (Object.keys(updateOp).length > 0) {
+          await collection.updateOne({ _id: wb._id }, updateOp);
+        }
         migratedCount += 1;
       }
     }


### PR DESCRIPTION
v2.0.0 회귀 — Phase B 가 mongoose strict 로 baseInputFields 못 읽어 데이터 손실. raw collection 사용으로 fix + 백업 ZIP 기반 일회성 복구 script 추가.