### PR TITLE
fix: form-data 누락 회귀 + {{##model##}} → {{##base_model##}} 일관성 (v2.0.6)

### DIFF
--- a/frontend/src/templates/ComfyUI-image.json
+++ b/frontend/src/templates/ComfyUI-image.json
@@ -6,7 +6,7 @@
       "label": "베이스 모델",
       "type": "baseModel",
       "required": true,
-      "formatString": "{{##model##}}",
+      "formatString": "{{##base_model##}}",
       "description": "서버의 모델 목록에서 선택. 작업판의 모델 노출 정책이 적용됩니다."
     },
     {
@@ -36,5 +36,5 @@
       ]
     }
   ],
-  "workflowData": "{\n  \"prompt\": \"{{##prompt##}}\",\n  \"negative_prompt\": \"{{##negative_prompt##}}\",\n  \"model\": \"{{##model##}}\",\n  \"width\": \"{{##width##}}\",\n  \"height\": \"{{##height##}}\"\n}"
+  "workflowData": "{\n  \"prompt\": \"{{##prompt##}}\",\n  \"negative_prompt\": \"{{##negative_prompt##}}\",\n  \"model\": \"{{##base_model##}}\",\n  \"width\": \"{{##width##}}\",\n  \"height\": \"{{##height##}}\"\n}"
 }

--- a/frontend/src/templates/ComfyUI-video.json
+++ b/frontend/src/templates/ComfyUI-video.json
@@ -6,7 +6,7 @@
       "label": "베이스 모델",
       "type": "baseModel",
       "required": true,
-      "formatString": "{{##model##}}",
+      "formatString": "{{##base_model##}}",
       "description": "서버의 모델 목록에서 선택. 작업판의 모델 노출 정책이 적용됩니다."
     },
     {
@@ -36,5 +36,5 @@
       ]
     }
   ],
-  "workflowData": "{\n  \"prompt\": \"{{##prompt##}}\",\n  \"negative_prompt\": \"{{##negative_prompt##}}\",\n  \"model\": \"{{##model##}}\",\n  \"width\": \"{{##width##}}\",\n  \"height\": \"{{##height##}}\"\n}"
+  "workflowData": "{\n  \"prompt\": \"{{##prompt##}}\",\n  \"negative_prompt\": \"{{##negative_prompt##}}\",\n  \"model\": \"{{##base_model##}}\",\n  \"width\": \"{{##width##}}\",\n  \"height\": \"{{##height##}}\"\n}"
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-rate-limit": "^7.1.5",
+    "form-data": "^4.0.0",
     "helmet": "^7.1.0",
     "joi": "^17.11.0",
     "jsonwebtoken": "^9.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       express-rate-limit:
         specifier: ^7.1.5
         version: 7.5.1(express@4.22.1)
+      form-data:
+        specifier: ^4.0.0
+        version: 4.0.5
       helmet:
         specifier: ^7.1.0
         version: 7.2.0

--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -595,7 +595,8 @@ const injectInputsIntoWorkflow = async (workflowTemplate, inputData, workboard =
   const replacements = {
     '{{##prompt##}}': { value: promptValue, type: 'string' },
     '{{##negative_prompt##}}': { value: negativePromptValue, type: 'string' },
-    '{{##model##}}': { value: extractValue(modelValue), type: 'string' },
+    '{{##model##}}': { value: extractValue(modelValue), type: 'string' },          // legacy alias
+    '{{##base_model##}}': { value: extractValue(modelValue), type: 'string' },     // snake_case canonical (v2.0.6+)
     '{{##width##}}': { value: width, type: 'number' },
     '{{##height##}}': { value: height, type: 'number' },
     '{{##seed##}}': { value: seedValue, type: 'number' },


### PR DESCRIPTION
## v2.0.6 patch

### 수정 (회귀 — 이미지 업로드 실패)
- fix: \`form-data\` 의존성 누락 — ComfyUI 이미지 업로드 시 \"Cannot find module 'form-data'\" 발생해 uploadedImageMap 비어있어 workflow 의 image filename 이 빈 문자열로 치환 → ComfyUI 가 \`input/\` 디렉토리 자체 열려고 시도해 실패. npm 의 transitive hoisting 으로 우연히 작동하던 것이 pnpm 의 strict resolution 에서 누락. package.json 에 명시.

### 일관성
- chore: \`{{##model##}}\` → \`{{##base_model##}}\`
  - ComfyUI 템플릿의 customField formatString + workflowData placeholder 모두 snake_case 통일
  - \`{{##model##}}\` 은 backend 의 legacy alias 로 유지 — 기존 작업판 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)