### PR TITLE
feat: 입력 양식 customField DnD 순서 변경 (v2.1.0 minor)

### DIFF
--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -753,13 +753,25 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
                       필드 추가
                     </Button>
                   </Box>
+                  <DragDropContext onDragEnd={onDragEnd}>
+                    <Droppable droppableId="additionalCustomFields" type="additionalCustomFields">
+                      {(droppableProvided) => (
+                        <Box ref={droppableProvided.innerRef} {...droppableProvided.droppableProps}>
                   {watch('additionalCustomFields')?.map((field, index) => (
-                    <Accordion key={index} sx={{ mb: 2 }}>
-                      <AccordionSummary expandIcon={<ExpandMore />}>
-                        <Typography>
-                          {field.label || `커스텀 필드 ${index + 1}`}
-                        </Typography>
-                      </AccordionSummary>
+                    <Draggable key={index} draggableId={`customField-${index}`} index={index}>
+                      {(draggableProvided) => (
+                        <Box ref={draggableProvided.innerRef} {...draggableProvided.draggableProps}>
+                          <Accordion sx={{ mb: 2 }}>
+                            <AccordionSummary expandIcon={<ExpandMore />}>
+                              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%' }}>
+                                <Box {...draggableProvided.dragHandleProps} sx={{ display: 'flex', alignItems: 'center', cursor: 'grab', color: 'text.secondary' }} onClick={(e) => e.stopPropagation()}>
+                                  <DragIndicator />
+                                </Box>
+                                <Typography>
+                                  {field.label || `커스텀 필드 ${index + 1}`}
+                                </Typography>
+                              </Box>
+                            </AccordionSummary>
                       <AccordionDetails>
                         <Grid container spacing={2}>
                           <Grid item xs={6}>
@@ -973,8 +985,16 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
                           </Grid>
                         </Grid>
                       </AccordionDetails>
-                    </Accordion>
+                          </Accordion>
+                        </Box>
+                      )}
+                    </Draggable>
                   ))}
+                          {droppableProvided.placeholder}
+                        </Box>
+                      )}
+                    </Droppable>
+                  </DragDropContext>
             </Box>
           )}
 


### PR DESCRIPTION
작업판 admin 의 "입력 양식" 탭에서 customField 들을 드래그 앤 드롭으로 재정렬 가능. 순서는 사용자 페이지에서 그대로 반영됨.

- accordion 헤더에 드래그 핸들 (DragIndicator) 추가
- 기존 DnD 헬퍼 (onDragEnd / reorderArrayItem) 재사용