### PR TITLE
refactor: 워크플로우 변수 단일 진실 + legacy alias 제거 (v2.1)

### DIFF
--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -753,13 +753,25 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
                       필드 추가
                     </Button>
                   </Box>
+                  <DragDropContext onDragEnd={onDragEnd}>
+                    <Droppable droppableId="additionalCustomFields" type="additionalCustomFields">
+                      {(droppableProvided) => (
+                        <Box ref={droppableProvided.innerRef} {...droppableProvided.droppableProps}>
                   {watch('additionalCustomFields')?.map((field, index) => (
-                    <Accordion key={index} sx={{ mb: 2 }}>
-                      <AccordionSummary expandIcon={<ExpandMore />}>
-                        <Typography>
-                          {field.label || `커스텀 필드 ${index + 1}`}
-                        </Typography>
-                      </AccordionSummary>
+                    <Draggable key={index} draggableId={`customField-${index}`} index={index}>
+                      {(draggableProvided) => (
+                        <Box ref={draggableProvided.innerRef} {...draggableProvided.draggableProps}>
+                          <Accordion sx={{ mb: 2 }}>
+                            <AccordionSummary expandIcon={<ExpandMore />}>
+                              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%' }}>
+                                <Box {...draggableProvided.dragHandleProps} sx={{ display: 'flex', alignItems: 'center', cursor: 'grab', color: 'text.secondary' }} onClick={(e) => e.stopPropagation()}>
+                                  <DragIndicator />
+                                </Box>
+                                <Typography>
+                                  {field.label || `커스텀 필드 ${index + 1}`}
+                                </Typography>
+                              </Box>
+                            </AccordionSummary>
                       <AccordionDetails>
                         <Grid container spacing={2}>
                           <Grid item xs={6}>
@@ -973,8 +985,16 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
                           </Grid>
                         </Grid>
                       </AccordionDetails>
-                    </Accordion>
+                          </Accordion>
+                        </Box>
+                      )}
+                    </Draggable>
                   ))}
+                          {droppableProvided.placeholder}
+                        </Box>
+                      )}
+                    </Droppable>
+                  </DragDropContext>
             </Box>
           )}
 

--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -58,6 +58,7 @@ import { workboardAPI, serverAPI, groupAPI } from '../../services/api';
 import WorkboardBasicInfoForm from './WorkboardBasicInfoForm';
 import MetadataPickerModal from '../common/MetadataPickerModal';
 import { getWorkboardTemplate } from '../../templates';
+import { BUILTIN_WORKFLOW_VARIABLES, WORKFLOW_VARIABLE_CATEGORIES, formatValueType } from '../../constants/workflowVariables';
 import {
   getServerTypeLabel,
   getOutputFormatLabel,
@@ -1025,38 +1026,20 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
                     아래 변수들을 워크플로우 JSON에서 사용할 수 있습니다. 변수는 작업 실행 시 실제 값으로 치환됩니다.
                   </Typography>
 
-                  <Typography variant="subtitle2" fontWeight="bold" gutterBottom>기본 변수</Typography>
-                  <Box component="table" sx={{ width: '100%', mb: 2, '& td, & th': { p: 1, borderBottom: '1px solid #eee' } }}>
-                    <tbody>
-                      {renderVariableRow('{{##prompt##}}', '프롬프트 (문자열)')}
-                      {renderVariableRow('{{##negative_prompt##}}', '네거티브 프롬프트 (문자열)')}
-                      {renderVariableRow('{{##model##}}', 'AI 모델 (문자열)')}
-                      {renderVariableRow('{{##width##}}', '이미지 너비 (숫자)')}
-                      {renderVariableRow('{{##height##}}', '이미지 높이 (숫자)')}
-                      {renderVariableRow('{{##seed##}}', '시드값 (숫자, 64비트)')}
-                    </tbody>
-                  </Box>
-
-                  <Typography variant="subtitle2" fontWeight="bold" gutterBottom>샘플링 파라미터</Typography>
-                  <Box component="table" sx={{ width: '100%', mb: 2, '& td, & th': { p: 1, borderBottom: '1px solid #eee' } }}>
-                    <tbody>
-                      {renderVariableRow('{{##steps##}}', '스텝 수 (숫자, 기본값: 20)')}
-                      {renderVariableRow('{{##cfg##}}', 'CFG 스케일 (숫자, 기본값: 7)')}
-                      {renderVariableRow('{{##sampler##}}', '샘플러 (문자열, 기본값: euler)')}
-                      {renderVariableRow('{{##scheduler##}}', '스케줄러 (문자열, 기본값: normal)')}
-                    </tbody>
-                  </Box>
-
-                  <Typography variant="subtitle2" fontWeight="bold" gutterBottom>추가 기능</Typography>
-                  <Box component="table" sx={{ width: '100%', mb: 2, '& td, & th': { p: 1, borderBottom: '1px solid #eee' } }}>
-                    <tbody>
-                      {renderVariableRow('{{##reference_method##}}', '참조 이미지 방식 (문자열)')}
-                      {renderVariableRow('{{##upscale_method##}}', '업스케일 방식 (문자열)')}
-                      {renderVariableRow('{{##upscale##}}', '업스케일 방식 별칭 (문자열)')}
-                      {renderVariableRow('{{##base_style##}}', '기본 스타일 (문자열)')}
-                      {renderVariableRow('{{##user_id##}}', '사용자 ID 해시 (문자열, 8자리)')}
-                    </tbody>
-                  </Box>
+                  {Object.entries(WORKFLOW_VARIABLE_CATEGORIES).map(([catKey, catLabel]) => {
+                    const vars = BUILTIN_WORKFLOW_VARIABLES.filter((v) => v.category === catKey);
+                    if (vars.length === 0) return null;
+                    return (
+                      <React.Fragment key={catKey}>
+                        <Typography variant="subtitle2" fontWeight="bold" gutterBottom>{catLabel}</Typography>
+                        <Box component="table" sx={{ width: '100%', mb: 2, '& td, & th': { p: 1, borderBottom: '1px solid #eee' } }}>
+                          <tbody>
+                            {vars.map((v) => renderVariableRow(v.key, `${v.label} (${formatValueType(v.valueType, v.defaultValue)})`))}
+                          </tbody>
+                        </Box>
+                      </React.Fragment>
+                    );
+                  })}
 
                   <Typography variant="subtitle2" fontWeight="bold" gutterBottom>사용자 정의 변수</Typography>
                   {watch('additionalCustomFields')?.length > 0 ? (

--- a/frontend/src/constants/workflowVariables.js
+++ b/frontend/src/constants/workflowVariables.js
@@ -1,0 +1,46 @@
+// ComfyUI 워크플로우 placeholder 메타데이터 — backend (src/constants/workflowVariables.js) 의 mirror.
+// frontend 가 backend 디렉토리를 직접 import 못 해서 수동 동기화. 신규 placeholder 추가 시
+// 양쪽 파일 + src/services/queueService.js 의 replacements 빌드 부분 모두 갱신.
+
+export const BUILTIN_WORKFLOW_VARIABLES = Object.freeze([
+  // 기본
+  { key: '{{##prompt##}}', label: '프롬프트', valueType: 'string', category: 'basic' },
+  { key: '{{##negative_prompt##}}', label: '네거티브 프롬프트', valueType: 'string', category: 'basic' },
+  { key: '{{##base_model##}}', label: '베이스 모델 (filename / model id)', valueType: 'string', category: 'basic' },
+  { key: '{{##width##}}', label: '이미지 너비', valueType: 'number', category: 'basic' },
+  { key: '{{##height##}}', label: '이미지 높이', valueType: 'number', category: 'basic' },
+  { key: '{{##seed##}}', label: '시드값 (64비트 UInt)', valueType: 'number', category: 'basic' },
+
+  // 샘플링
+  { key: '{{##steps##}}', label: '스텝 수', valueType: 'number', category: 'sampling', defaultValue: 20 },
+  { key: '{{##cfg##}}', label: 'CFG 스케일', valueType: 'number', category: 'sampling', defaultValue: 7 },
+  { key: '{{##sampler##}}', label: '샘플러', valueType: 'string', category: 'sampling', defaultValue: 'euler' },
+  { key: '{{##scheduler##}}', label: '스케줄러', valueType: 'string', category: 'sampling', defaultValue: 'normal' },
+
+  // 추가
+  { key: '{{##reference_method##}}', label: '참조 이미지 방식', valueType: 'string', category: 'extra' },
+  { key: '{{##upscale_method##}}', label: '업스케일 방식', valueType: 'string', category: 'extra' },
+  { key: '{{##base_style##}}', label: '기본 스타일', valueType: 'string', category: 'extra' },
+  { key: '{{##user_id##}}', label: '사용자 ID 해시 (8자리)', valueType: 'string', category: 'extra' }
+]);
+
+export const WORKFLOW_VARIABLE_CATEGORIES = Object.freeze({
+  basic: '기본 변수',
+  sampling: '샘플링 파라미터',
+  extra: '추가 기능'
+});
+
+const VALUE_TYPE_LABELS = {
+  string: '문자열',
+  number: '숫자',
+  boolean: '체크박스',
+  select: '선택',
+  image: '이미지',
+  baseModel: '베이스 모델',
+  lora: 'LoRA'
+};
+
+export function formatValueType(valueType, defaultValue) {
+  const base = VALUE_TYPE_LABELS[valueType] || valueType;
+  return defaultValue !== undefined ? `${base}, 기본값: ${defaultValue}` : base;
+}

--- a/src/constants/workflowVariables.js
+++ b/src/constants/workflowVariables.js
@@ -1,0 +1,41 @@
+// ComfyUI 워크플로우 placeholder 메타데이터.
+//
+// queueService 가 빌드하는 \`replacements\` 맵의 키 (placeholder) 와 frontend 의 \"사용 가능한 워크플로우 변수\"
+// 표시 목록 단일 진실. 신규 placeholder 추가 시 여기 + queueService 의 replacements 빌드 + frontend mirror
+// (frontend/src/constants/workflowVariables.js) 모두 갱신.
+
+const BUILTIN_WORKFLOW_VARIABLES = Object.freeze([
+  // 기본
+  { key: '{{##prompt##}}', label: '프롬프트', valueType: 'string', category: 'basic' },
+  { key: '{{##negative_prompt##}}', label: '네거티브 프롬프트', valueType: 'string', category: 'basic' },
+  { key: '{{##base_model##}}', label: '베이스 모델 (filename / model id)', valueType: 'string', category: 'basic' },
+  { key: '{{##width##}}', label: '이미지 너비', valueType: 'number', category: 'basic' },
+  { key: '{{##height##}}', label: '이미지 높이', valueType: 'number', category: 'basic' },
+  { key: '{{##seed##}}', label: '시드값 (64비트 UInt)', valueType: 'number', category: 'basic' },
+
+  // 샘플링 (additionalParams 에서 가져옴, 기본값 있음)
+  { key: '{{##steps##}}', label: '스텝 수', valueType: 'number', category: 'sampling', defaultValue: 20 },
+  { key: '{{##cfg##}}', label: 'CFG 스케일', valueType: 'number', category: 'sampling', defaultValue: 7 },
+  { key: '{{##sampler##}}', label: '샘플러', valueType: 'string', category: 'sampling', defaultValue: 'euler' },
+  { key: '{{##scheduler##}}', label: '스케줄러', valueType: 'string', category: 'sampling', defaultValue: 'normal' },
+
+  // 추가
+  { key: '{{##reference_method##}}', label: '참조 이미지 방식', valueType: 'string', category: 'extra' },
+  { key: '{{##upscale_method##}}', label: '업스케일 방식', valueType: 'string', category: 'extra' },
+  { key: '{{##base_style##}}', label: '기본 스타일', valueType: 'string', category: 'extra' },
+  { key: '{{##user_id##}}', label: '사용자 ID 해시 (8자리)', valueType: 'string', category: 'extra' }
+]);
+
+const WORKFLOW_VARIABLE_KEYS = Object.freeze(BUILTIN_WORKFLOW_VARIABLES.map((v) => v.key));
+
+const WORKFLOW_VARIABLE_CATEGORIES = Object.freeze({
+  basic: '기본 변수',
+  sampling: '샘플링 파라미터',
+  extra: '추가 기능'
+});
+
+module.exports = {
+  BUILTIN_WORKFLOW_VARIABLES,
+  WORKFLOW_VARIABLE_KEYS,
+  WORKFLOW_VARIABLE_CATEGORIES
+};

--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -592,11 +592,12 @@ const injectInputsIntoWorkflow = async (workflowTemplate, inputData, workboard =
   const modelValue = getFieldValueByRole(workboard, inputData, FIELD_ROLES.MODEL);
   const referenceMethodValue = getFieldValueByRole(workboard, inputData, FIELD_ROLES.REFERENCE_IMAGE_METHOD);
 
+  // placeholder 키 정의는 src/constants/workflowVariables.js 와 frontend mirror 에 등록.
+  // 신규 placeholder 추가 시 세 곳 모두 갱신 필요.
   const replacements = {
     '{{##prompt##}}': { value: promptValue, type: 'string' },
     '{{##negative_prompt##}}': { value: negativePromptValue, type: 'string' },
-    '{{##model##}}': { value: extractValue(modelValue), type: 'string' },          // legacy alias
-    '{{##base_model##}}': { value: extractValue(modelValue), type: 'string' },     // snake_case canonical (v2.0.6+)
+    '{{##base_model##}}': { value: extractValue(modelValue), type: 'string' },
     '{{##width##}}': { value: width, type: 'number' },
     '{{##height##}}': { value: height, type: 'number' },
     '{{##seed##}}': { value: seedValue, type: 'number' },
@@ -606,7 +607,6 @@ const injectInputsIntoWorkflow = async (workflowTemplate, inputData, workboard =
     '{{##scheduler##}}': { value: inputData.additionalParams?.scheduler || 'normal', type: 'string' },
     '{{##reference_method##}}': { value: extractValue(referenceMethodValue), type: 'string' },
     '{{##upscale_method##}}': { value: upscaleMethodValue, type: 'string' },
-    '{{##upscale##}}': { value: upscaleMethodValue, type: 'string' },  // 별칭 추가
     '{{##base_style##}}': { value: extractValue(inputData.baseStyle), type: 'string' },
     '{{##user_id##}}': { value: hashedUserId, type: 'string' }
   };


### PR DESCRIPTION
**Changes:**
- src/constants/workflowVariables.js (신규) — backend canonical placeholder 목록
- frontend/src/constants/workflowVariables.js (신규) — frontend mirror (수동 sync 주석)
- queueService 의 replacements 에서 `{{##model##}}` / `{{##upscale##}}` 완전 제거
- 'WorkboardManagement.js "사용 가능한 워크플로우 변수"' 섹션이 constants 를 loop 으로 표시 — 하드코딩 13개 entry 제거

**Breaking:** 기존 workflowData 에 `{{##model##}}` 또는 `{{##upscale##}}` 사용 중인 작업판은 admin 이 workflow JSON 에서 `{{##base_model##}}` / `{{##upscale_method##}}` 로 변경 필요. v2.0.6 에서 deprecated 처리만 했던 alias 를 v2.1 에서 제거.