### PR TITLE
chore: '사용 가능한 워크플로우 변수' 정리 (#312, #315)

### DIFF
--- a/frontend/src/constants/workflowVariables.js
+++ b/frontend/src/constants/workflowVariables.js
@@ -3,24 +3,17 @@
 // 양쪽 파일 + src/services/queueService.js 의 replacements 빌드 부분 모두 갱신.
 
 export const BUILTIN_WORKFLOW_VARIABLES = Object.freeze([
-  // 기본
   { key: '{{##prompt##}}', label: '프롬프트', valueType: 'string', category: 'basic' },
   { key: '{{##negative_prompt##}}', label: '네거티브 프롬프트', valueType: 'string', category: 'basic' },
   { key: '{{##base_model##}}', label: '베이스 모델 (filename / model id)', valueType: 'string', category: 'basic' },
   { key: '{{##width##}}', label: '이미지 너비', valueType: 'number', category: 'basic', note: 'image_size 의 \"WxH\" 값에서 자동 추출 (기본 512)' },
   { key: '{{##height##}}', label: '이미지 높이', valueType: 'number', category: 'basic', note: 'image_size 의 \"WxH\" 값에서 자동 추출 (기본 512)' },
   { key: '{{##seed##}}', label: '시드값 (64비트 UInt)', valueType: 'number', category: 'basic' },
-
-  // 추가
-  { key: '{{##reference_method##}}', label: '참조 이미지 방식', valueType: 'string', category: 'extra' },
-  { key: '{{##upscale_method##}}', label: '업스케일 방식', valueType: 'string', category: 'extra' },
-  { key: '{{##base_style##}}', label: '기본 스타일', valueType: 'string', category: 'extra' },
-  { key: '{{##user_id##}}', label: '사용자 ID 해시 (8자리)', valueType: 'string', category: 'extra' }
+  { key: '{{##user_id##}}', label: '사용자 ID 해시 (8자리)', valueType: 'string', category: 'basic', note: '시스템 제공 — 사용자 _id 의 SHA-256 8자리' }
 ]);
 
 export const WORKFLOW_VARIABLE_CATEGORIES = Object.freeze({
-  basic: '기본 변수',
-  extra: '추가 기능'
+  basic: '기본 변수'
 });
 
 const VALUE_TYPE_LABELS = {

--- a/src/constants/workflowVariables.js
+++ b/src/constants/workflowVariables.js
@@ -5,26 +5,19 @@
 // (frontend/src/constants/workflowVariables.js) 모두 갱신.
 
 const BUILTIN_WORKFLOW_VARIABLES = Object.freeze([
-  // 기본
   { key: '{{##prompt##}}', label: '프롬프트', valueType: 'string', category: 'basic' },
   { key: '{{##negative_prompt##}}', label: '네거티브 프롬프트', valueType: 'string', category: 'basic' },
   { key: '{{##base_model##}}', label: '베이스 모델 (filename / model id)', valueType: 'string', category: 'basic' },
   { key: '{{##width##}}', label: '이미지 너비', valueType: 'number', category: 'basic', note: 'image_size 의 \"WxH\" 값에서 자동 추출 (기본 512)' },
   { key: '{{##height##}}', label: '이미지 높이', valueType: 'number', category: 'basic', note: 'image_size 의 \"WxH\" 값에서 자동 추출 (기본 512)' },
   { key: '{{##seed##}}', label: '시드값 (64비트 UInt)', valueType: 'number', category: 'basic' },
-
-  // 추가
-  { key: '{{##reference_method##}}', label: '참조 이미지 방식', valueType: 'string', category: 'extra' },
-  { key: '{{##upscale_method##}}', label: '업스케일 방식', valueType: 'string', category: 'extra' },
-  { key: '{{##base_style##}}', label: '기본 스타일', valueType: 'string', category: 'extra' },
-  { key: '{{##user_id##}}', label: '사용자 ID 해시 (8자리)', valueType: 'string', category: 'extra' }
+  { key: '{{##user_id##}}', label: '사용자 ID 해시 (8자리)', valueType: 'string', category: 'basic', note: '시스템 제공 — 사용자 _id 의 SHA-256 8자리' }
 ]);
 
 const WORKFLOW_VARIABLE_KEYS = Object.freeze(BUILTIN_WORKFLOW_VARIABLES.map((v) => v.key));
 
 const WORKFLOW_VARIABLE_CATEGORIES = Object.freeze({
-  basic: '기본 변수',
-  extra: '추가 기능'
+  basic: '기본 변수'
 });
 
 module.exports = {

--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -565,32 +565,12 @@ const injectInputsIntoWorkflow = async (workflowTemplate, inputData, workboard =
   }
   console.log('📏 Parsed dimensions:', { width, height });
   
-  // 기본 고정 형식 문자열들과 타입 정보
-  // 업스케일 메서드 값 추출 (role 기반 + additionalParams fallback)
-  let upscaleMethodValue = '';
-  const upscaleFromRole = getFieldValueByRole(workboard, inputData, FIELD_ROLES.UPSCALE_METHOD);
-  if (upscaleFromRole) {
-    upscaleMethodValue = extractValue(upscaleFromRole);
-  } else if (inputData.additionalParams?.upscaleMethod) {
-    upscaleMethodValue = extractValue(inputData.additionalParams.upscaleMethod);
-  } else if (inputData.additionalParams?.upscale) {
-    upscaleMethodValue = extractValue(inputData.additionalParams.upscale);
-  }
-  
-  console.log('📈 Upscale method detection:', {
-    'inputData.upscaleMethod': inputData.upscaleMethod,
-    'inputData.additionalParams?.upscaleMethod': inputData.additionalParams?.upscaleMethod,
-    'inputData.additionalParams?.upscale': inputData.additionalParams?.upscale,
-    'final_value': upscaleMethodValue
-  });
-
   // 유저 ID 해시 생성
   const hashedUserId = hashUserId(inputData.userId);
 
   const promptValue = getFieldValueByRole(workboard, inputData, FIELD_ROLES.PROMPT) || '';
   const negativePromptValue = getFieldValueByRole(workboard, inputData, FIELD_ROLES.NEGATIVE_PROMPT) || '';
   const modelValue = getFieldValueByRole(workboard, inputData, FIELD_ROLES.MODEL);
-  const referenceMethodValue = getFieldValueByRole(workboard, inputData, FIELD_ROLES.REFERENCE_IMAGE_METHOD);
 
   // placeholder 키 정의는 src/constants/workflowVariables.js 와 frontend mirror 에 등록.
   // 신규 placeholder 추가 시 세 곳 모두 갱신 필요.
@@ -601,9 +581,6 @@ const injectInputsIntoWorkflow = async (workflowTemplate, inputData, workboard =
     '{{##width##}}': { value: width, type: 'number' },
     '{{##height##}}': { value: height, type: 'number' },
     '{{##seed##}}': { value: seedValue, type: 'number' },
-    '{{##reference_method##}}': { value: extractValue(referenceMethodValue), type: 'string' },
-    '{{##upscale_method##}}': { value: upscaleMethodValue, type: 'string' },
-    '{{##base_style##}}': { value: extractValue(inputData.baseStyle), type: 'string' },
     '{{##user_id##}}': { value: hashedUserId, type: 'string' }
   };
   


### PR DESCRIPTION
## #312 — 중복 표시 제거
- customField formatString 과 매칭되는 built-in 은 "기본 변수" 섹션에서 hide
- "사용자 정의 변수" 가 더 풍부한 메타데이터 (이름/타입/옵션) 를 갖고 있어 우선

## #315 — built-in 정리
- 제거: `{{##reference_method##}}` (`{{##reference_image_method##}}` 로 대체)
- 제거: `{{##upscale_method##}}` / `{{##base_style##}}` (admin 이 customField 로 직접 정의)
- 이동: `{{##user_id##}}` 를 "기본 변수" 카테고리 (시스템 제공 값)
- "추가 기능" 카테고리 자체 제거 (basic 만 남음)

queueService 의 해당 hardcoded replacements + 미사용 변수 제거.

closes #312, closes #315