### PR TITLE
feat: vcc-manager 프로젝트 한정 skill 4종 추가 (#318)

### DIFF
--- a/claude/skills/vcc-recover-from-backup/SKILL.md
+++ b/claude/skills/vcc-recover-from-backup/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: vcc-recover-from-backup
+description: VCC 백업 ZIP 의 Workboard.json 에서 baseInputFields / customField 등 손실된 작업판 정의를 복구
+argument-hint: <백업 파일 경로 또는 backupJobId>
+---
+
+# vcc-recover-from-backup 스킬
+
+데이터베이스 마이그레이션 사고 / 운영자 실수로 작업판 정의 (특히 baseInputFields 의 options) 가 손실됐을 때 백업 ZIP 에서 복구.
+
+v2.0.5 의 \`scripts/recover-workboard-base-input-fields.js\` 활용.
+
+---
+
+## 전제 조건
+
+1. **백업 ZIP 보유** — v2.0 deploy 이전 또는 손실 시점 이전의 백업
+2. **백업 파일 위치 확인 가능**:
+   - admin UI \`/admin/backup\` 에서 fileName 확인
+   - 또는 \`docker compose exec backend ls /app/backups\`
+   - 또는 \`BackupJob\` 컬렉션 query
+3. **v2.0.5 이상의 backend 코드** — recovery script 가 포함된 버전
+4. **admin 권한** — DB write 권한 가진 사용자
+
+---
+
+## 동작 원리
+
+1. 백업 ZIP 의 \`database/Workboard.json\` 에서 워크보드 entries 추출
+2. 각 워크보드의 \`baseInputFields\` 에서 well-known 키 (aiModel / imageSizes / referenceImageMethods / stylePresets / upscaleMethods / systemPrompt / referenceImages / temperature / maxTokens) 검사
+3. 현재 DB 의 동일 \`_id\` 워크보드 의 \`additionalInputFields\` 에 누락된 customField 만 append (멱등)
+4. raw collection 사용 — mongoose strict 우회
+
+---
+
+## 실행 단계
+
+### 1단계: 백업 파일 위치 확인
+
+**A. admin UI**: \`/admin/backup\` 페이지에서 파일명 (예: \`vcc-backup-2026-05-13T...zip\`) 확인.
+
+**B. 컨테이너 ls**:
+\`\`\`bash
+docker compose -f docker-compose.prod.yml --env-file .env.production exec backend ls -la /app/backups
+\`\`\`
+
+**C. DB 조회**:
+\`\`\`bash
+docker compose -f docker-compose.prod.yml --env-file .env.production exec mongodb mongosh \\
+  -u admin -p <MONGO_ROOT_PASSWORD> --authenticationDatabase admin --quiet --eval \\
+  'use(\"vcc-manager\"); db.backupjobs.find({status:\"completed\"}, {fileName:1, filePath:1, createdAt:1}).sort({createdAt:-1}).limit(5).toArray()'
+\`\`\`
+
+### 2단계: 복구 script 실행
+
+\`\`\`bash
+docker compose -f docker-compose.prod.yml --env-file .env.production exec backend \\
+  node /app/scripts/recover-workboard-base-input-fields.js /app/backups/<filename>.zip
+\`\`\`
+
+**중요:** \`exec\` 사용 (이미 실행 중인 backend 컨테이너에서). \`run --rm\` 도 가능하지만 mongo 연결 위한 환경변수 셋업이 컨테이너 image 의 \`ENV\` + .env.production 둘 다 필요.
+
+호스트의 백업 파일을 컨테이너 안으로 마운트해서 사용하려면:
+\`\`\`bash
+docker compose -f docker-compose.prod.yml --env-file .env.production run --rm \\
+  -v /host/path/to/backup.zip:/tmp/backup.zip \\
+  backend node /app/scripts/recover-workboard-base-input-fields.js /tmp/backup.zip
+\`\`\`
+
+### 3단계: 결과 로그 분석
+
+script 가 작업판 별 어떤 customField 가 복구됐는지 출력:
+\`\`\`
+[Recover] Reading backup ZIP: /app/backups/vcc-backup-...zip
+[Recover] Found N workboards in backup
+  ✓ {workboard name}: +K field(s) — aiModel(select), imageSizes(select), ...
+[Recover] Summary: scanned=N, recovered=M, fields appended=K, ...
+\`\`\`
+
+- \`recovered\` = 복구된 워크보드 수
+- \`appended\` = 추가된 customField 총 개수
+- \`skipped (no match)\` = 백업에는 있는데 현재 DB 에 \_id 매치 안 되는 워크보드 (삭제된 경우)
+- \`skipped (no data)\` = baseInputFields 가 의미있는 데이터 없는 케이스
+
+### 4단계: admin UI 에서 검증
+
+복구된 작업판의 \"입력 양식\" 탭에서 새로 추가된 customField 들 확인:
+- 이름 (camelCase plural 형태로 들어감 — e.g. \`aiModel\`, \`imageSizes\`)
+- 사용자 페이지에서 동작 확인 위해 \`formatString\` 을 workflow placeholder 와 매칭되도록 admin 이 직접 수정 필요할 수 있음 (예: \`aiModel\` → formatString \`{{##base_model##}}\`)
+
+---
+
+## 주의사항
+
+1. **멱등** — 이미 같은 role 의 customField 가 있으면 skip. 여러 번 실행해도 중복 추가 안 됨
+2. **백업 ZIP 의 baseInputFields 가 비어있는 워크보드** — script 가 skip
+3. **\_id 매칭 안 되는 경우** (워크보드 삭제 후 백업 사용) — script 가 skip. 워크보드 자체를 복구하려면 별도 절차 (DB 전체 restore)
+4. **버전 호환성** — v1.x ~ v2.0.0 백업 모두 지원. v2.0.5+ 의 백업은 이미 customField 가 있어 거의 no-op
+5. **백업 파일 보안** — production 환경에서 백업에 사용자 데이터 포함. 호스트로 다운로드 시 주의
+
+---
+
+## 사용자 요청
+
+$ARGUMENTS

--- a/claude/skills/vcc-release-patch/SKILL.md
+++ b/claude/skills/vcc-release-patch/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: vcc-release-patch
+description: vcc-manager 의 patch / minor 출시 흐름을 자동화 — PR 머지 → updatelog 추가 → dev→main PR → tag → GitHub Release 까지 단일 명령으로 진행
+argument-hint: <semver> (예: v2.1.3 또는 2.1.3)
+---
+
+# vcc-release-patch 스킬
+
+vcc-manager 의 표준 patch / minor 출시 절차. CLAUDE.md 의 \`버전 릴리스 시\` 항목 자동화.
+
+---
+
+## 전제 조건
+
+1. **모든 변경은 이미 \`dev\` 브랜치에 머지된 상태** — 출시 PR 생성 직전에 release-blocker 변경 머지 완료
+2. \`docs/updatelogs/v{major}.md\` 파일 존재 — 없으면 신규 생성
+3. \`frontend/src/config.js\` 의 \`version.major\` / \`version.minor\` 가 출시 버전과 일치 (minor 변경 시 수동 업데이트 후 진행)
+4. 사용자 권한 — git push, gh PR/release 권한
+
+---
+
+## 실행 단계
+
+### 1단계: 변경 사항 요약 (dev vs main)
+
+\`\`\`
+git fetch origin main dev
+git log --oneline origin/main..origin/dev
+\`\`\`
+
+이번 patch 에 포함된 commit / PR 들을 식별. updatelog 작성 재료.
+
+### 2단계: updatelog 추가 (\`docs/updatelogs/v{major}.md\`)
+
+파일 상단 (\`# v2 업데이트 내역\` 제목 바로 아래) 에 \`## v{version}\` 섹션 추가.
+구조 예시:
+
+\`\`\`markdown
+## v2.1.3
+
+### 수정
+- fix: 변경 내용 (#PR번호 — closes #이슈번호)
+  - 상세 설명
+
+### 신규 기능
+- feat: ...
+
+### Breaking
+- ... (있는 경우)
+\`\`\`
+
+각 항목은 PR 본문에서 발췌. 사용자가 admin 으로서 알아야 할 행동 (마이그레이션 / 설정 변경) 도 명시.
+
+### 3단계: updatelog 커밋 + dev 푸시
+
+\`\`\`bash
+git checkout dev && git pull origin dev
+git add docs/updatelogs/v{major}.md
+git commit -m "docs: v{version} updatelog 추가
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+git push origin dev
+\`\`\`
+
+### 4단계: dev → main PR 생성
+
+\`\`\`bash
+gh pr create --base main --head dev --title "release: v{version}" --body "## v{version} {patch|minor}
+
+- 항목 1 (#PR번호)
+- 항목 2 (#PR번호)
+
+상세: [docs/updatelogs/v2.md](docs/updatelogs/v2.md)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+\`\`\`
+
+### 5단계: PR 머지 (merge commit — squash 금지)
+
+\`\`\`bash
+gh pr merge {PR번호} --merge
+\`\`\`
+
+### 6단계: main 동기화 + 태그 + Release 생성
+
+\`\`\`bash
+git checkout main && git pull origin main
+git tag -a v{version} -m "v{version} — 한줄 요약"
+git push origin v{version}
+
+gh release create v{version} --target main --title "v{version}" --notes "{updatelog 본문 발췌}"
+\`\`\`
+
+### 7단계: 사용자 안내
+
+배포 안내:
+- production 에서 \`git pull origin main\` + \`./scripts/deploy-prod.sh\` 재배포 필요
+- breaking change 있다면 admin 의 작업판 / 설정 수정 안내 명시
+
+---
+
+## 주의사항
+
+1. **squash merge 금지** — main 의 머지 commit 은 항상 merge commit (이 프로젝트 정책)
+2. **\`--no-verify\` 사용 금지** — pre-commit hook 우회 안 함
+3. **\`force push\` 금지** (특히 main / dev) — 머지 후 원격 브랜치 자동 삭제됨
+4. **dev 브랜치가 머지로 사라지면 재생성**:
+   \`\`\`bash
+   git push origin main:dev
+   \`\`\`
+5. **minor 출시 시 \`frontend/src/config.js\` 의 minor 증가** 를 별도 PR 또는 updatelog PR 안에서 함께 처리
+6. **태그는 항상 \`v\` prefix 포함** (예: \`v2.1.3\`, \`v2.2.0\`)
+
+---
+
+## 출시 후 확인 사항
+
+1. GitHub Releases 페이지에 새 release 표시 확인
+2. \`git tag\` 로컬 / 원격 동기화 확인
+3. production 재배포 후 \`/health\` endpoint 정상 반환 확인
+4. (필요시) 사용자에게 breaking change 안내
+
+---
+
+## 사용자 요청
+
+$ARGUMENTS

--- a/claude/skills/vcc-template-update/SKILL.md
+++ b/claude/skills/vcc-template-update/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: vcc-template-update
+description: vcc-manager 의 작업판 템플릿 (serverType-outputFormat JSON 5종) 을 일괄 갱신할 때의 점검 / 작성 절차
+argument-hint: <변경 사항 요약>
+---
+
+# vcc-template-update 스킬
+
+\`frontend/src/templates/*.json\` 5종 (ComfyUI-image, ComfyUI-video, Gemini-image, Gemini-text, OpenAI-image, OpenAI-text, OpenAI Compatible-text) 를 갱신할 때 일관성 / placeholder / customField 컨벤션 점검.
+
+신규 작업판 admin 이 \"새 작업판\" 생성 시 \`getWorkboardTemplate(serverType, outputFormat)\` 으로 채워지는 기본값.
+
+---
+
+## 템플릿 구조
+
+각 JSON 파일:
+
+\`\`\`json
+{
+  \"baseInputFields\": {},
+  \"additionalInputFields\": [
+    {
+      \"name\": \"base_model\",
+      \"label\": \"베이스 모델\",
+      \"type\": \"baseModel\",
+      \"required\": true,
+      \"formatString\": \"{{##base_model##}}\",
+      \"description\": \"...\"
+    },
+    { \"name\": \"image_size\", \"label\": \"이미지 크기\", \"type\": \"select\", \"options\": [...] },
+    ...
+  ],
+  \"workflowData\": \"...JSON 문자열 또는 빈 string\"
+}
+\`\`\`
+
+---
+
+## 컨벤션 (v2.1+)
+
+1. **\`baseInputFields\` 는 항상 빈 객체** — v2.0 F4 에서 schema drop 됨. customField 단일 경로
+2. **customField name 은 snake_case** — \`base_model\` / \`image_size\` / \`reference_image_method\` / \`system_prompt\` / \`max_tokens\` 등
+3. **type=baseModel** 은 베이스 모델 select. options 정의 안 함 — 서버의 모델 목록 + 작업판 노출 정책 활용
+4. **type=lora** 도 동일 — 서버의 LoRA 목록
+5. **type=select** options 의 value 는 ComfyUI 노드 또는 provider API 의 valid value 와 정확히 매칭
+6. **formatString 명시** — workflow placeholder 와 1:1 일치. 생략 시 \`{{##\${name}##}}\` 자동 사용
+7. **ComfyUI 템플릿의 workflowData** — placeholder 는 snake_case (\`{{##prompt##}}\` / \`{{##base_model##}}\` 등)
+8. **Gemini/OpenAI 텍스트 / 이미지 템플릿의 workflowData** — 빈 string. ComfyUI 만 workflow JSON 사용
+9. **defaultValue** — 사용자가 미선택 시 사용. select 의 경우 options[0].value 자동 fallback. number 는 명시 권장
+
+---
+
+## 갱신 절차
+
+### 1단계: 영향 분석
+
+변경의 종류 식별:
+- A. **placeholder 이름 변경** (예: \`{{##model##}}\` → \`{{##base_model##}}\`)
+  - 5개 템플릿의 \`workflowData\` + \`formatString\` 양쪽 갱신
+  - backend \`src/constants/workflowVariables.js\` + \`src/services/queueService.js\` 의 replacements 갱신
+  - frontend \`frontend/src/constants/workflowVariables.js\` mirror 갱신
+  - legacy alias 유지 여부 결정 (#310 같은 점진적 제거)
+- B. **customField name 변경** (예: \`aiModel\` → \`base_model\`)
+  - 신규 템플릿만 영향. 기존 작업판은 admin 이 별도 수정 필요
+- C. **options 추가/제거**
+  - 신규 작업판만 영향. ComfyUI 노드의 valid list 와 매칭 점검
+- D. **새 type 추가** (예: \`baseModel\` / \`lora\` 같은 v2.0 D 의 type 추가)
+  - schema enum (\`src/models/Workboard.js\`) 갱신
+  - frontend WorkboardManagement.js 의 type dropdown 갱신
+  - 사용자 페이지 렌더링 분기 (MetadataFieldInput 등) 갱신
+
+### 2단계: 5개 템플릿 일괄 점검
+
+체크리스트 — 각 파일에 대해:
+
+| 항목 | 확인 |
+|---|---|
+| \`baseInputFields\` | \`{}\` 빈 객체 |
+| \`additionalInputFields[].name\` | snake_case |
+| \`additionalInputFields[].formatString\` | workflow placeholder 와 매칭 |
+| \`baseModel\` 필드 1개 | type=baseModel (ComfyUI / Gemini / OpenAI 모두) |
+| \`image_size\` (이미지 type) / \`temperature\` 등 (텍스트 type) | 적절히 정의 |
+| ComfyUI 템플릿: \`workflowData\` | placeholder 가 위 \`formatString\` 들과 매칭 |
+| Gemini / OpenAI 템플릿: \`workflowData\` | 빈 string \`\"\"\` |
+
+### 3단계: 빌드 + 동작 확인
+
+\`\`\`bash
+DOCKER_BUILDKIT=1 docker compose build --no-cache frontend
+\`\`\`
+
+CRA build 가 JSON parse 실패하면 (잘못된 JSON) 에러로 끊음. 통과 확인.
+
+신규 작업판 생성 테스트:
+1. admin → 작업판 관리 → 새 작업판 (해당 serverType-outputFormat 조합)
+2. \"입력 양식\" 탭에 정의한 customField 들 표시 확인
+3. 사용자 페이지 → 작업 실행 → 정상 동작 확인
+
+### 4단계: 기존 작업판 영향 안내
+
+기존 작업판은 자동 갱신되지 않음. updatelog 에 admin 이 수동으로 해야 하는 작업 명시:
+- 어떤 placeholder 가 deprecated 되었는지
+- 어떤 customField 이름을 바꿔야 하는지
+- formatString 변경 권장 사항
+
+---
+
+## 자주 발생하는 회귀
+
+1. **JSON syntax 오류** — JSON.parse 실패 → fallback path 사용 → 의도와 다른 string 치환 가능
+2. **placeholder 와 formatString 불일치** — workflow 에 \`{{##model##}}\` 인데 customField formatString 은 \`{{##base_model##}}\` → 치환 안 됨 → 빈 값으로 ComfyUI 가 reject
+3. **camelCase / snake_case 혼재** — v2.1+ 에서 snake_case 단일화 결정. 신규 추가 시 snake_case 만
+4. **type=baseModel / lora 에 options 정의** — 불필요. 서버 목록을 자동으로 사용. options 추가하면 무시되지만 혼동 유발
+
+---
+
+## 사용자 요청
+
+$ARGUMENTS

--- a/claude/skills/vcc-workflow-debug/SKILL.md
+++ b/claude/skills/vcc-workflow-debug/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: vcc-workflow-debug
+description: ComfyUI 작업판 작업이 실패했을 때 백엔드 로그 + ComfyUI 응답 본문을 분석해 root cause 진단
+argument-hint: <jobId> 또는 최근 실패한 작업 (생략 시 last failed)
+---
+
+# vcc-workflow-debug 스킬
+
+ComfyUI 작업 실패 (job status=failed) 의 원인을 단계별로 진단. v2.0.4 부터 \`comfyUIService\` 가 ComfyUI 응답 본문을 \`❌ ComfyUI 응답 본문\` 로그로 캡쳐 — 그 로그가 진단의 출발점.
+
+---
+
+## 진단 순서
+
+### 1단계: 작업 ID 확인
+
+\`\`\`
+list_jobs(status='failed', limit=5)
+\`\`\`
+
+또는 사용자가 jobId 직접 제공 (\`6a04d4140bdcbdccbdd01580\` 같은 24자 ObjectId).
+
+### 2단계: 백엔드 로그 추출
+
+\`\`\`bash
+docker compose logs backend 2>&1 | grep -A 80 "{jobId}"
+\`\`\`
+
+(production) — \`docker compose -f docker-compose.prod.yml --env-file .env.production logs backend\`
+
+핵심 로그 라인 (시간순):
+- \`🎯 Image generation request received\` — 요청 수신
+- \`📋 Request body: { ... }\` — 페이로드
+- \`🔍 Extracted fields: { ... }\` — workboardId / prompt / aiModel / imageSize 추출
+- \`📦 Prepared inputData for job creation\` — queueService 진입 직전
+- \`🔄 Injecting inputs into workflow\` — 워크플로우 치환 시작
+- \`🔧 Built replacements object: { ... }\` — placeholder → value 매핑
+- \`📝 Workflow JSON preview\` — ComfyUI 로 보낼 최종 워크플로우 (앞 200자)
+- \`📤 Submitting workflow to ComfyUI\` — 제출
+- \`✅ Workflow submitted successfully\` — ComfyUI 가 받음 (validation 실패는 그 후)
+- \`❌ ComfyUI 응답 본문: { ... }\` — ComfyUI 의 validation / runtime 에러 본문
+
+### 3단계: 에러 분류
+
+ComfyUI 응답 본문의 \`error.type\` 또는 \`node_errors[].errors[].type\` 으로 분기:
+
+| 에러 타입 | 원인 | 점검 항목 |
+|---|---|---|
+| \`prompt_outputs_failed_validation\` + \`value_not_in_list\` | 노드의 input value 가 ComfyUI 가 인식 못 함 | \`received_value\` 와 \`list of length N\` — workboard 의 customField options 가 ComfyUI 노드 valid list 와 일치하는지 |
+| \`No such file or directory\` | ComfyUI 가 파일 (모델/이미지/LoRA) 못 찾음 | filename 정확한지, path separator (\`\\\` vs \`/\`), 빈 문자열 치환 여부 |
+| \`prompt_outputs_failed_validation\` + \`Required input is missing\` | 노드 input 비어있음 | workflow placeholder 가 치환 안 됐는지 (customField formatString 누락 / 매핑 불일치) |
+| \`Module 'X' not found\` | ComfyUI 측 노드 미설치 | ComfyUI 서버에 해당 custom node 추가 필요 |
+
+### 4단계: placeholder 치환 추적
+
+\`🔧 Built replacements object\` 에 모든 placeholder → value 가 보임.
+빈 문자열 (\`\"value\": \"\"\`) 인 placeholder 는 source 누락:
+- built-in placeholder (\`{{##base_model##}}\` 등) — \`Extracted fields\` 의 해당 값 검사
+- customField placeholder (\`{{##<field_name>##}}\`) — workboard 의 customField 정의 + 사용자 입력값 검사
+
+\`📝 Workflow JSON preview\` 에 미치환된 \`{{##...##}}\` 가 보이면 — workflow 에는 있는데 replacements 에 없는 placeholder. customField 정의 누락이거나 built-in 에 없는 placeholder 사용.
+
+### 5단계: customField 정의 검사
+
+\`\`\`
+get_workboard({workboardId})
+\`\`\`
+
+응답의 \`additionalFields[]\` 확인:
+- \`name\` — placeholder 이름 (\`{{##\${name}##}}\` 로 기본 변환)
+- \`formatString\` — 커스텀 placeholder (정의되어 있으면 우선)
+- \`type\` — string / number / select / image / baseModel / lora
+- \`options\` (select 타입) — 사용자가 선택 가능한 값들. ComfyUI 노드의 valid list 와 일치해야 함
+- \`defaultValue\` — 미선택 시 기본값
+
+### 6단계: 사용자 페이로드 검사
+
+\`📋 Request body\` 의 \`additionalParams\` 안에 사용자가 선택한 값들이 들어있는지 확인.
+
+빈 string / undefined 면:
+- 사용자가 미입력 → defaultValue 가 없거나 form initialization 실패
+- 프론트 페이지 reload / 페이로드 직렬화 문제
+
+### 7단계: 결론 및 fix 제안
+
+원인에 따라:
+- workboard 설정 문제 → admin 페이지에서 customField options / formatString 수정
+- workflow JSON 문제 → admin 페이지의 workflow 탭에서 JSON 수정
+- ComfyUI 서버 문제 (모델 파일 없음, custom node 미설치) → ComfyUI 측 처리
+
+---
+
+## 자주 발생하는 케이스 (이 프로젝트)
+
+### A. 베이스 모델 백슬래시 경로
+\`received_value\` 가 \`IXL\\nova.safetensors\` 같은 Windows-style 경로. ComfyUI 가 reject 하면 path normalization 필요. v2.0.3 에서 fix 된 double-escape 회귀와는 다른 이슈 — ComfyUI 자체의 path 인식.
+
+### B. image_size 가 ComfyUI 노드 valid list 와 불일치
+\`CM_SDXLExtendedResolution\` 같은 노드는 40개 specific 해상도만 허용. customField options 의 \`value\` 가 그 list 와 정확히 매칭돼야 함.
+
+### C. customField name 이 비표준 (예: \`base_model\` vs \`aiModel\`)
+v2.0.2 이전: hardcoded \`{{##model##}}\` placeholder 만 지원. v2.1.0+ 부터 \`{{##base_model##}}\` 단일화. 기존 workflowData 가 \`{{##model##}}\` 사용 중이면 admin 수정 필요.
+
+### D. 이미지 customField 가 비어있음
+"No uploaded image found for field 'X'" 로그 → \`uploadImageFieldsToComfyUI\` 가 그 필드의 이미지 못 찾음. 사용자가 이미지 첨부 안 했고 customField 가 type=image — v1.8.4 부터 빈 image 필드에 1024x1024 흰색 PNG 자동 주입 (sharp 동적 생성).
+
+---
+
+## 사용자 요청
+
+$ARGUMENTS


### PR DESCRIPTION
4개 SKILL.md 신규 추가:

- vcc-release-patch — 출시 흐름 자동화
- vcc-workflow-debug — ComfyUI 작업 실패 디버깅
- vcc-recover-from-backup — 백업 기반 작업판 복구
- vcc-template-update — 템플릿 일괄 갱신

closes #318