### PR TITLE
fix: 작업판 모델 타입 필터 시 civitai 미등록 모델 숨김 (#320)

### DIFF
--- a/frontend/src/components/common/MetadataFieldInput.js
+++ b/frontend/src/components/common/MetadataFieldInput.js
@@ -13,7 +13,7 @@ import MetadataPickerModal from './MetadataPickerModal';
 // 다른 customField (select / number / string) 와 동일하게 TextField 의 floating label 사용해 디자인 통일.
 // 표시는 Civitai 모델 이름 (있으면) 또는 파일 basename — 경로는 tooltip / helperText.
 // 내부 form value 는 그대로 filename (workflow injection 용).
-function MetadataFieldInput({ kind, field, value, onChange, workboardId, serverId }) {
+function MetadataFieldInput({ kind, field, value, onChange, workboardId, serverId, allowedModelTypes }) {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [displayName, setDisplayName] = useState('');
   const [displayValue, setDisplayValue] = useState('');
@@ -71,6 +71,7 @@ function MetadataFieldInput({ kind, field, value, onChange, workboardId, serverI
         onClose={() => setPickerOpen(false)}
         workboardId={workboardId}
         serverId={serverId}
+        allowedModelTypes={allowedModelTypes}
         mode="select-single"
         selectedItem={value}
         onPrimary={(rawItem) => {

--- a/frontend/src/components/common/MetadataPickerModal.js
+++ b/frontend/src/components/common/MetadataPickerModal.js
@@ -397,9 +397,6 @@ function MetadataPickerModal({
             {allowedModelTypes.map((t) => (
               <Chip key={t} label={t} size="small" color="primary" variant="outlined" />
             ))}
-            <Typography variant="caption" color="text.secondary">
-              + 메타데이터 없는 모델
-            </Typography>
           </Box>
         )}
 

--- a/frontend/src/pages/ImageGeneration.js
+++ b/frontend/src/pages/ImageGeneration.js
@@ -1034,6 +1034,7 @@ function ImageGeneration() {
                               onChange={formField.onChange}
                               workboardId={id}
                               serverId={workboardData?.serverId?._id || workboardData?.serverId}
+                              allowedModelTypes={field.type === 'baseModel' ? workboardData?.allowedModelTypes : undefined}
                             />
                           ) : (
                             <TextField

--- a/src/services/modelMetadataService.js
+++ b/src/services/modelMetadataService.js
@@ -489,8 +489,8 @@ const resetSyncStatus = async (serverId) => {
  * @param {string} opts.search — filename / civitai 메타 / provider 메타 통합 검색
  * @param {boolean} opts.hasMetadata — civitai 또는 provider 메타데이터 보유 여부
  * @param {string} opts.baseModel — civitai.baseModel 단일 매칭 (사용자 dropdown 필터용)
- * @param {string[]} opts.allowedBaseModels — civitai.baseModel 다중 매칭 + baseModel 미상 fallback
- *   (작업판의 allowedModelTypes 와 매핑 — Civitai 미등록 모델은 항상 통과)
+ * @param {string[]} opts.allowedBaseModels — civitai.baseModel 다중 매칭
+ *   (작업판의 allowedModelTypes 와 매핑 — 필터 활성 시 Civitai 미등록 모델은 제외, #320)
  */
 const searchServerModels = async (serverId, { search, hasMetadata, baseModel, allowedBaseModels, whitelist, page = 1, limit = 50 } = {}) => {
   const cache = await ServerModelCache.findOne({ serverId });
@@ -542,12 +542,9 @@ const searchServerModels = async (serverId, { search, hasMetadata, baseModel, al
   }
 
   // allowedBaseModels: 작업판의 allowedModelTypes 적용. 빈 배열/미설정은 제약 없음.
-  // baseModel 미상 모델 (Civitai 미등록 / hash 없음) 은 항상 통과 (custom merge 대응).
+  // 필터 활성 시 civitai 미등록 (baseModel 미상) 모델도 제외 (#320).
   if (Array.isArray(allowedBaseModels) && allowedBaseModels.length > 0) {
-    filtered = filtered.filter(m => {
-      if (!m.civitai?.baseModel) return true;
-      return allowedBaseModels.includes(m.civitai.baseModel);
-    });
+    filtered = filtered.filter(m => allowedBaseModels.includes(m.civitai?.baseModel));
   }
 
   // whitelist: 작업판의 modelExposurePolicy='whitelist' + modelWhitelist 적용 (#198 Phase D).


### PR DESCRIPTION
## Summary

- `searchServerModels()` 의 `allowedBaseModels` 필터 동작 변경
- 필터 활성 시 `civitai.baseModel` 이 없는 모델 (civitai 미등록) 도 제외
- 필터 미설정 시엔 기존대로 모두 노출 (변화 없음)

## Test plan

- [ ] `allowedModelTypes` 가 설정된 작업판: 베이스 모델 셀렉터에 civitai 매칭된 모델만 표시
- [ ] `allowedModelTypes` 비어있는 작업판: civitai 미등록 모델도 표시 (기존 동작 유지)
- [ ] 관리자 모델 관리 페이지 (필터 없이 호출) 영향 없음 확인

closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)