### PR TITLE
fix: 모델 선택 비디오 썸네일 백색 화면 (civitai anim=false poster) (#321)

### DIFF
--- a/frontend/src/components/common/MetadataMediaThumbnail.js
+++ b/frontend/src/components/common/MetadataMediaThumbnail.js
@@ -27,6 +27,22 @@ export function civitaiThumbnailUrl(url, width = 300) {
   return url.replace(/\/original=true\//, `/width=${width}/`);
 }
 
+// Civitai 비디오 URL → 첫 프레임 정지 이미지 (poster 용).
+// `/anim=false,width=N/` transform segment 로 치환. 비-Civitai URL 은 null 반환.
+// (#321) 비디오 썸네일 hover 전 백색 화면 방지.
+export function civitaiVideoPosterUrl(url, width = 300) {
+  if (!url || typeof url !== 'string') return null;
+  if (!url.includes('image.civitai.com')) return null;
+  if (/\/anim=false/.test(url)) return url;
+  if (/\/original=true\//.test(url)) {
+    return url.replace(/\/original=true\//, `/anim=false,width=${width}/`);
+  }
+  if (/\/width=\d+\//.test(url)) {
+    return url.replace(/\/width=\d+\//, `/anim=false,width=${width}/`);
+  }
+  return null;
+}
+
 function MetadataMediaThumbnail({ image, alt, height, width, sx }) {
   const videoRef = useRef(null);
 
@@ -38,11 +54,13 @@ function MetadataMediaThumbnail({ image, alt, height, width, sx }) {
   const optimizedUrl = isVideoMedia(image) ? image.url : civitaiThumbnailUrl(image.url, targetWidth);
 
   if (isVideoMedia(image)) {
+    const posterUrl = civitaiVideoPosterUrl(image.url, targetWidth);
     return (
       <Box
         component="video"
         ref={videoRef}
         src={optimizedUrl}
+        poster={posterUrl || undefined}
         muted
         loop
         playsInline


### PR DESCRIPTION
## Summary

- `MetadataMediaThumbnail` 에 `civitaiVideoPosterUrl()` 헬퍼 추가
- civitai CDN 비디오 URL 에 `anim=false,width=N` transform 을 적용해 첫 프레임 정지 이미지 URL 생성
- `<video>` 의 `poster` 속성으로 지정해 hover 전 백색 화면 제거
- 비-civitai URL 은 `poster` 미설정 (기존 동작 유지)

## Test plan

- [ ] 모델 선택 모달에서 비디오 썸네일을 가진 카드가 즉시 첫 프레임 표시 (백색 없음)
- [ ] hover 시 비디오 재생, mouse out 시 정지/0초 복귀 동작 유지
- [ ] LoRA 선택 모달에서도 동일하게 적용 확인
- [ ] 비-civitai 비디오 URL (있다면) 도 깨지지 않음

closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)