### PR TITLE
fix: 모델/LoRA picker 열 때 그리드 깜박임 제거 (#324)

### DIFF
--- a/frontend/src/components/common/MetadataPickerModal.js
+++ b/frontend/src/components/common/MetadataPickerModal.js
@@ -247,13 +247,15 @@ function MetadataPickerModal({
     }
   }, [open, serverId, workboardId, fetchItems, adapter]);
 
-  // search/filter 변경 debounce
+  // search / baseModel 변경 시 debounce fetch. `open` 은 의존성에서 제외 —
+  // 모달 open 시 최초 fetch 는 위 useEffect 가 담당하며, 여기 포함하면 중복 fetch 로
+  // 카드 그리드가 잠깐 깜박임 (#324).
   useEffect(() => {
-    const timer = setTimeout(() => {
-      if (open) fetchItems(1);
-    }, 300);
+    if (!open) return undefined;
+    const timer = setTimeout(() => fetchItems(1), 300);
     return () => clearTimeout(timer);
-  }, [searchQuery, baseModelFilter, open, fetchItems]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchQuery, baseModelFilter, fetchItems]);
 
   const handleSync = async () => {
     if (!serverId) return;


### PR DESCRIPTION
## Summary

- `MetadataPickerModal` 의 debounce useEffect deps 에서 `open` 제거
- 모달 open 시 즉시 fetch (다른 useEffect) + 300ms debounced fetch (이 useEffect) 가 동시에 일어나면서 발생하던 그리드 깜박임 제거
- search / baseModel 변경 debounce 동작은 그대로 유지

## Test plan

- [ ] 작업판 사용자 페이지 → 베이스 모델 선택 모달 열기 시 그리드 깜박임 없음
- [ ] 모달 안에서 검색어 입력 시 300ms 후 결과 갱신 (debounce 동작 유지)
- [ ] 베이스 모델 dropdown 선택 시도 debounce 동작
- [ ] LoRA picker 도 동일하게 깜박임 없음
- [ ] 관리자 화이트리스트 picker 도 동일

closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)