### PR TITLE
fix: 모바일 사이드바 하단 배경색 잘림 (#327)

### DIFF
--- a/frontend/src/components/Sidebar.js
+++ b/frontend/src/components/Sidebar.js
@@ -271,12 +271,13 @@ function Sidebar({ mobileOpen, onMobileToggle }) {
           '& .MuiDrawer-paper': {
             boxSizing: 'border-box',
             width: DRAWER_WIDTH,
+            backgroundColor: '#2c3e50',  // 컨텐츠가 Paper 높이를 초과할 때 (관리자 메뉴) 하단 흰색 노출 방지 (#327)
           },
         }}
       >
         {drawer}
       </Drawer>
-      
+
       {/* 데스크탑용 permanent drawer */}
       <Drawer
         variant="permanent"
@@ -286,7 +287,8 @@ function Sidebar({ mobileOpen, onMobileToggle }) {
             boxSizing: 'border-box',
             width: DRAWER_WIDTH,
             position: 'relative',
-            height: '100%'
+            height: '100%',
+            backgroundColor: '#2c3e50',  // 컨텐츠가 Paper 높이를 초과할 때 하단 흰색 노출 방지 (#327)
           },
         }}
         open


### PR DESCRIPTION
## Summary

- Drawer Paper 에 직접 `backgroundColor: '#2c3e50'` 지정
- 메뉴 + 관리자 메뉴 항목이 viewport 를 초과해 스크롤될 때 하단에 흰색이 노출되던 문제 해결
- 모바일(temporary) / 데스크탑(permanent) 양쪽 모두 적용

## Test plan

- [ ] 모바일에서 햄버거 메뉴 → 사이드바 끝까지 스크롤 시 배경이 끝까지 다크 (#2c3e50)
- [ ] 데스크탑 사이드바도 동일하게 통일된 배경
- [ ] 관리자 메뉴 항목들 본래 색상 유지

closes #327