### PR TITLE
chore: release skill 에 delete_branch_on_merge off 안내 추가 (#329)

### DIFF
--- a/claude/skills/vcc-release-patch/SKILL.md
+++ b/claude/skills/vcc-release-patch/SKILL.md
@@ -81,6 +81,8 @@ gh pr create --base main --head dev --title "release: v{version}" --body "## v{v
 gh pr merge {PR번호} --merge
 \`\`\`
 
+> 리포지토리 설정 \`delete_branch_on_merge\` 는 **off** (#329). 릴리스 PR 머지 후 dev 브랜치는 자동 삭제되지 않음. 만에 하나 누군가 수동으로 dev 를 지운 경우 아래 \`주의사항 4\` 의 복구 절차 사용.
+
 ### 6단계: main 동기화 + 태그 + Release 생성
 
 \`\`\`bash

--- a/frontend/src/components/Sidebar.js
+++ b/frontend/src/components/Sidebar.js
@@ -271,12 +271,13 @@ function Sidebar({ mobileOpen, onMobileToggle }) {
           '& .MuiDrawer-paper': {
             boxSizing: 'border-box',
             width: DRAWER_WIDTH,
+            backgroundColor: '#2c3e50',  // 컨텐츠가 Paper 높이를 초과할 때 (관리자 메뉴) 하단 흰색 노출 방지 (#327)
           },
         }}
       >
         {drawer}
       </Drawer>
-      
+
       {/* 데스크탑용 permanent drawer */}
       <Drawer
         variant="permanent"
@@ -286,7 +287,8 @@ function Sidebar({ mobileOpen, onMobileToggle }) {
             boxSizing: 'border-box',
             width: DRAWER_WIDTH,
             position: 'relative',
-            height: '100%'
+            height: '100%',
+            backgroundColor: '#2c3e50',  // 컨텐츠가 Paper 높이를 초과할 때 하단 흰색 노출 방지 (#327)
           },
         }}
         open


### PR DESCRIPTION
## Summary

- 리포지토리 설정 `delete_branch_on_merge: false` 로 변경 완료
- `vcc-release-patch` skill 의 5단계 (PR 머지) 부분에 설정 off 사실 명시
- 기존 `주의사항 4` 의 `git push origin main:dev` 복구 가이드는 fallback 으로 유지

closes #329