### PR TITLE
fix: civitai NSFW 모델/LoRA 바로가기 링크를 civitai.red 로 (#331)

### DIFF
--- a/src/services/loraMetadataService.js
+++ b/src/services/loraMetadataService.js
@@ -157,7 +157,8 @@ const fetchCivitaiMetadataByHash = async (hash, apiKey = null, retryCount = 0) =
       trainedWords: data.trainedWords || [],
       images,
       nsfw: data.model?.nsfw || false,
-      modelUrl: `https://civitai.com/models/${data.modelId}?modelVersionId=${data.id}`,
+      // civitai 정책: NSFW 모델은 civitai.red 도메인으로만 접근 (#331)
+      modelUrl: `https://${data.model?.nsfw ? 'civitai.red' : 'civitai.com'}/models/${data.modelId}?modelVersionId=${data.id}`,
       fetchedAt: new Date()
     };
   } catch (error) {

--- a/src/services/modelMetadataService.js
+++ b/src/services/modelMetadataService.js
@@ -133,7 +133,8 @@ const fetchCivitaiMetadataByHash = async (hash, apiKey = null, retryCount = 0) =
       trainedWords: data.trainedWords || [],
       images,
       nsfw: data.model?.nsfw || false,
-      modelUrl: `https://civitai.com/models/${data.modelId}?modelVersionId=${data.id}`,
+      // civitai 정책: NSFW 모델은 civitai.red 도메인으로만 접근 (#331)
+      modelUrl: `https://${data.model?.nsfw ? 'civitai.red' : 'civitai.com'}/models/${data.modelId}?modelVersionId=${data.id}`,
       fetchedAt: new Date()
     };
   } catch (error) {


### PR DESCRIPTION
## Summary

- `fetchCivitaiMetadataByHash` (model / LoRA 양쪽) 의 `modelUrl` 생성 시 `nsfw` 플래그 기반으로 호스트 분기
- nsfw=true 면 `civitai.red`, false 면 기존대로 `civitai.com`
- civitai 정책 변경(NSFW 는 civitai.red 만 접근) 대응

## 적용 범위

- 신규 sync 부터 적용
- 기존 캐시에 저장된 `modelUrl` 은 그대로 유지. admin 이 해당 서버를 다시 "동기화" 누르면 교체됨

## Test plan

- [ ] NSFW 모델 sync 후 modelUrl 이 `civitai.red` 도메인인지 확인
- [ ] 일반 모델은 기존대로 `civitai.com`
- [ ] LoRA 도 동일 동작

closes #331