### PR TITLE
feat: 베이스 모델/LoRA 카드 UI 개선 — 버전명/디테일 다이얼로그 (#333)

### DIFF
--- a/frontend/src/components/common/MetadataDetailDialog.js
+++ b/frontend/src/components/common/MetadataDetailDialog.js
@@ -1,0 +1,210 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  Box,
+  Chip,
+  Stack,
+  Divider,
+  IconButton,
+  Tooltip,
+  Link
+} from '@mui/material';
+import {
+  Close as CloseIcon,
+  OpenInNew as OpenInNewIcon,
+  ContentCopy as ContentCopyIcon
+} from '@mui/icons-material';
+import toast from 'react-hot-toast';
+import MetadataMediaThumbnail from './MetadataMediaThumbnail';
+import { sanitizeHtml } from '../../utils/sanitizeHtml';
+import { getKindLabel } from '../../utils/metadataItem';
+import { getBaseModelColor } from './MetadataItemCard';
+
+// 베이스 모델 / LoRA 카드의 상세 메타데이터 다이얼로그 (#333).
+// 카드에서 디테일 버튼 클릭 시 표시. 이름/버전, 미디어 그리드, 설명, trained words,
+// 파일 경로, hash, civitai 링크 등 카드에는 표시하지 않은 항목까지 모두 모아 보여줌.
+function MetadataDetailDialog({ open, onClose, item, nsfwImageFilter = true, baseModelColorFn = getBaseModelColor }) {
+  if (!item) return null;
+
+  const filteredImages = nsfwImageFilter
+    ? (item.images || []).filter((img) => !img.nsfw)
+    : (item.images || []);
+  const hasCivitai = item.metadataSource === 'civitai';
+  const hasProvider = item.metadataSource === 'provider';
+
+  const handleCopyFilename = () => {
+    navigator.clipboard.writeText(item.filename || '').then(
+      () => toast.success('파일 경로를 복사했습니다.'),
+      () => toast.error('복사 실패')
+    );
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle sx={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 2 }}>
+        <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+          <Typography variant="h6" sx={{ wordBreak: 'break-word' }}>
+            {item.displayName}
+          </Typography>
+          {item.versionName && (
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+              버전: {item.versionName}
+            </Typography>
+          )}
+        </Box>
+        <IconButton onClick={onClose} size="small">
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+
+      <DialogContent dividers>
+        {/* 배지 */}
+        <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', mb: 2 }}>
+          <Chip label={getKindLabel(item.kind)} size="small" variant="outlined" />
+          {item.baseModel && (
+            <Chip
+              label={item.baseModel}
+              size="small"
+              color={baseModelColorFn(item.baseModel)}
+              variant="outlined"
+            />
+          )}
+          {item.capabilities?.map((c) => (
+            <Chip key={c} label={c} size="small" variant="outlined" />
+          ))}
+        </Box>
+
+        {/* 미디어 그리드 */}
+        {filteredImages.length > 0 && (
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fill, minmax(150px, 1fr))',
+              gap: 1,
+              mb: 2
+            }}
+          >
+            {filteredImages.map((img, i) => (
+              <MetadataMediaThumbnail
+                key={i}
+                image={img}
+                alt={`Preview ${i + 1}`}
+                height={150}
+                sx={{ borderRadius: 1 }}
+              />
+            ))}
+          </Box>
+        )}
+
+        {/* 설명 */}
+        {item.description && (
+          <Box sx={{ mb: 2 }}>
+            <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
+              설명
+            </Typography>
+            {hasCivitai ? (
+              <Typography
+                variant="body2"
+                color="text.primary"
+                sx={{ '& p': { margin: 0 }, '& img': { maxWidth: '100%' } }}
+                dangerouslySetInnerHTML={{ __html: sanitizeHtml(item.description) }}
+              />
+            ) : (
+              <Typography variant="body2" color="text.primary" sx={{ whiteSpace: 'pre-wrap' }}>
+                {item.description}
+              </Typography>
+            )}
+          </Box>
+        )}
+
+        {/* 트리거 워드 */}
+        {item.trainedWords?.length > 0 && (
+          <Box sx={{ mb: 2 }}>
+            <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
+              트리거 워드
+            </Typography>
+            <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+              {item.trainedWords.map((word, i) => (
+                <Chip key={i} label={word} size="small" />
+              ))}
+            </Box>
+          </Box>
+        )}
+
+        {item.contextWindow && (
+          <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1 }}>
+            context: {item.contextWindow.toLocaleString()} tokens
+          </Typography>
+        )}
+
+        <Divider sx={{ my: 2 }} />
+
+        {/* 메타데이터 */}
+        <Stack spacing={1}>
+          <Box>
+            <Typography variant="caption" color="text.secondary" display="block">
+              파일 경로
+            </Typography>
+            <Stack direction="row" spacing={0.5} alignItems="center">
+              <Typography variant="body2" sx={{ wordBreak: 'break-all', flexGrow: 1, fontFamily: 'monospace' }}>
+                {item.filename || '—'}
+              </Typography>
+              {item.filename && (
+                <Tooltip title="복사">
+                  <IconButton size="small" onClick={handleCopyFilename}>
+                    <ContentCopyIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              )}
+            </Stack>
+          </Box>
+
+          {item.hash && (
+            <Box>
+              <Typography variant="caption" color="text.secondary" display="block">
+                SHA256
+              </Typography>
+              <Typography variant="body2" sx={{ wordBreak: 'break-all', fontFamily: 'monospace' }}>
+                {item.hash}
+              </Typography>
+            </Box>
+          )}
+
+          {item.modelUrl && (
+            <Box>
+              <Typography variant="caption" color="text.secondary" display="block">
+                Civitai
+              </Typography>
+              <Link href={item.modelUrl} target="_blank" rel="noopener noreferrer" variant="body2">
+                {item.modelUrl} <OpenInNewIcon fontSize="inherit" sx={{ verticalAlign: 'middle' }} />
+              </Link>
+            </Box>
+          )}
+
+          {!item.hasMetadata && (
+            <Typography variant="caption" color="text.secondary">
+              메타데이터 없음 — Civitai 미등록 또는 sync 대기 중
+            </Typography>
+          )}
+
+          {hasProvider && (
+            <Typography variant="caption" color="text.secondary">
+              메타데이터 출처: provider API
+            </Typography>
+          )}
+        </Stack>
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={onClose}>닫기</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export default MetadataDetailDialog;

--- a/frontend/src/components/common/MetadataItemCard.js
+++ b/frontend/src/components/common/MetadataItemCard.js
@@ -13,14 +13,12 @@ import {
 } from '@mui/material';
 import {
   Info as InfoIcon,
-  ExpandMore as ExpandMoreIcon,
-  ExpandLess as ExpandLessIcon,
+  InfoOutlined as InfoOutlinedIcon,
   OpenInNew as OpenInNewIcon,
   CheckCircle as CheckCircleIcon,
   Add as AddIcon
 } from '@mui/icons-material';
 import MetadataMediaThumbnail from './MetadataMediaThumbnail';
-import { sanitizeHtml } from '../../utils/sanitizeHtml';
 import { getKindLabel } from '../../utils/metadataItem';
 
 // baseModel → MUI color 매핑 — LoRA / Model 공용. 기존 LoraListModal 의 정책 그대로.
@@ -41,8 +39,7 @@ export function getBaseModelColor(baseModel) {
  * @param {Object} props
  * @param {import('../../utils/metadataItem').MetadataItem} props.item
  * @param {boolean} [props.selected] — 선택 표시 (단일 선택 picker)
- * @param {boolean} [props.expanded] — 확장 영역 (description + 추가 이미지) 표시
- * @param {() => void} [props.onToggleExpand]
+ * @param {(item) => void} [props.onDetailClick] — 디테일 버튼 클릭 콜백 (#333)
  * @param {(item) => void} [props.onPrimary] — 카드 전체 클릭 또는 primary 버튼 액션. 미지정 시 클릭 비활성
  * @param {string} [props.primaryLabel] — primary 버튼 라벨 (기본 '선택')
  * @param {'select'|'add'|'insert'} [props.primaryVariant] — 버튼 스타일 힌트
@@ -55,8 +52,7 @@ export function getBaseModelColor(baseModel) {
 const MetadataItemCard = React.memo(function MetadataItemCard({
   item,
   selected = false,
-  expanded = false,
-  onToggleExpand,
+  onDetailClick,
   onPrimary,
   primaryLabel,
   primaryVariant = 'select',
@@ -72,9 +68,6 @@ const MetadataItemCard = React.memo(function MetadataItemCard({
     ? (item.images || []).filter((img) => !img.nsfw)
     : (item.images || []);
   const previewImage = filteredImages[0];
-
-  const hasCivitai = item.metadataSource === 'civitai';
-  const hasProvider = item.metadataSource === 'provider';
 
   const handleCardClick = cardClickable && onPrimary ? () => onPrimary(item) : undefined;
 
@@ -124,10 +117,16 @@ const MetadataItemCard = React.memo(function MetadataItemCard({
           </Typography>
         </Stack>
 
-        {/* 파일명 (메타데이터 있을 때만 별도 표시) */}
-        {item.hasMetadata && item.filename !== item.displayName && (
-          <Typography variant="caption" color="text.secondary" noWrap display="block">
-            {item.filename}
+        {/* 버전명 (civitai 메타에 versionName 이 있을 때만) */}
+        {item.versionName && (
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            noWrap
+            display="block"
+            title={item.versionName}
+          >
+            버전: {item.versionName}
           </Typography>
         )}
 
@@ -164,14 +163,14 @@ const MetadataItemCard = React.memo(function MetadataItemCard({
           </Typography>
         )}
 
-        {/* 트리거 워드 (LoRA / civitai trainedWords) */}
+        {/* 트리거 워드 (LoRA / civitai trainedWords) — 최대 3개. 전체 목록은 디테일 다이얼로그에서 */}
         {item.trainedWords?.length > 0 && (
           <Box sx={{ mt: 1 }}>
             <Typography variant="caption" color="text.secondary">
               트리거 워드{onTrainedWordClick ? (trainedWordInsertMode ? ' (클릭시 프롬프트에 삽입)' : ' (클릭시 복사)') : ''}:
             </Typography>
             <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', mt: 0.5 }}>
-              {item.trainedWords.slice(0, expanded ? undefined : 3).map((word, i) => (
+              {item.trainedWords.slice(0, 3).map((word, i) => (
                 <Chip
                   key={i}
                   label={word}
@@ -185,7 +184,7 @@ const MetadataItemCard = React.memo(function MetadataItemCard({
                   variant={trainedWordInsertMode ? 'outlined' : 'filled'}
                 />
               ))}
-              {!expanded && item.trainedWords.length > 3 && (
+              {item.trainedWords.length > 3 && (
                 <Chip label={`+${item.trainedWords.length - 3}`} size="small" variant="outlined" />
               )}
             </Box>
@@ -193,62 +192,20 @@ const MetadataItemCard = React.memo(function MetadataItemCard({
         )}
       </CardContent>
 
-      {/* 확장 영역 (description + 추가 이미지) */}
-      {expanded && (
-        <CardContent sx={{ pt: 0 }}>
-          {item.description && hasCivitai && (
-            <Typography
-              variant="body2"
-              color="text.secondary"
-              sx={{
-                maxHeight: 100,
-                overflow: 'auto',
-                mb: 1,
-                '& p': { margin: 0 }
-              }}
-              dangerouslySetInnerHTML={{
-                __html: sanitizeHtml(item.description.substring(0, 500))
-              }}
-            />
-          )}
-          {item.description && hasProvider && (
-            <Typography
-              variant="body2"
-              color="text.secondary"
-              sx={{ maxHeight: 100, overflow: 'auto', mb: 1 }}
-            >
-              {item.description.substring(0, 500)}
-            </Typography>
-          )}
-          {filteredImages.length > 1 && (
-            <Box sx={{ display: 'flex', gap: 1, overflow: 'auto', mt: 1 }}>
-              {filteredImages.slice(1).map((img, i) => (
-                <MetadataMediaThumbnail
-                  key={i}
-                  image={img}
-                  alt={`Preview ${i + 2}`}
-                  width={60}
-                  height={60}
-                  sx={{ borderRadius: 1, flexShrink: 0 }}
-                />
-              ))}
-            </Box>
-          )}
-        </CardContent>
-      )}
-
       <CardActions sx={{ justifyContent: 'space-between', pt: 0 }}>
         <Stack direction="row" spacing={0.5}>
-          {(item.hasMetadata || item.description) && onToggleExpand && (
-            <IconButton
-              size="small"
-              onClick={(e) => {
-                e.stopPropagation();
-                onToggleExpand();
-              }}
-            >
-              {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-            </IconButton>
+          {onDetailClick && (
+            <Tooltip title="상세 정보">
+              <IconButton
+                size="small"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDetailClick(item);
+                }}
+              >
+                <InfoOutlinedIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
           )}
           {item.modelUrl && (
             <Tooltip title="Civitai 에서 보기">

--- a/frontend/src/components/common/MetadataPickerModal.js
+++ b/frontend/src/components/common/MetadataPickerModal.js
@@ -35,6 +35,7 @@ import { serverAPI, workboardAPI, userAPI } from '../../services/api';
 import Pagination from './Pagination';
 import MetadataItemCard from './MetadataItemCard';
 import MetadataItemGrid from './MetadataItemGrid';
+import MetadataDetailDialog from './MetadataDetailDialog';
 import { normalizeLora, normalizeModel } from '../../utils/metadataItem';
 
 // ─── Per-kind API adapters ────────────────────────────────────────
@@ -143,7 +144,7 @@ function MetadataPickerModal({
   const [baseModelFilter, setBaseModelFilter] = useState('');
   const [availableBaseModels, setAvailableBaseModels] = useState([]);
   const [pagination, setPagination] = useState({ current: 1, pages: 0, total: 0 });
-  const [expandedId, setExpandedId] = useState(null);
+  const [detailItem, setDetailItem] = useState(null);
 
   const queryClient = useQueryClient();
 
@@ -465,8 +466,7 @@ function MetadataPickerModal({
                   <MetadataItemCard
                     item={item}
                     selected={selectedItem === item.filename}
-                    expanded={expandedId === item.id}
-                    onToggleExpand={() => setExpandedId(expandedId === item.id ? null : item.id)}
+                    onDetailClick={() => setDetailItem(item)}
                     onPrimary={() => handlePrimary(rawItem)}
                     primaryVariant={cardPrimaryVariant}
                     cardClickable={cardClickable}
@@ -493,6 +493,12 @@ function MetadataPickerModal({
       <DialogActions>
         <Button onClick={onClose}>닫기</Button>
       </DialogActions>
+      <MetadataDetailDialog
+        open={!!detailItem}
+        item={detailItem}
+        onClose={() => setDetailItem(null)}
+        nsfwImageFilter={nsfwImageFilter}
+      />
     </Dialog>
   );
 }

--- a/frontend/src/pages/admin/LoraManagementPage.js
+++ b/frontend/src/pages/admin/LoraManagementPage.js
@@ -54,6 +54,7 @@ import Pagination from '../../components/common/Pagination';
 import { sanitizeHtml } from '../../utils/sanitizeHtml';
 import MetadataItemCard from '../../components/common/MetadataItemCard';
 import MetadataItemGrid from '../../components/common/MetadataItemGrid';
+import MetadataDetailDialog from '../../components/common/MetadataDetailDialog';
 import { normalizeLora } from '../../utils/metadataItem';
 
 // LoRA 리스트 아이템 컴포넌트
@@ -212,7 +213,7 @@ function LoraManagementPage() {
   const [cacheInfo, setCacheInfo] = useState(null);
   const [syncStatus, setSyncStatus] = useState(null);
   const [searchQuery, setSearchQuery] = useState('');
-  const [expandedLora, setExpandedLora] = useState(null);
+  const [detailItem, setDetailItem] = useState(null);
   const [pagination, setPagination] = useState({ current: 1, pages: 0, total: 0 });
   const [baseModelFilter, setBaseModelFilter] = useState('');
 
@@ -779,10 +780,7 @@ function LoraManagementPage() {
                       return (
                         <MetadataItemCard
                           item={item}
-                          expanded={expandedLora === item.filename}
-                          onToggleExpand={() => setExpandedLora(
-                            expandedLora === item.filename ? null : item.filename
-                          )}
+                          onDetailClick={() => setDetailItem(item)}
                           onTrainedWordClick={(word) => handleCopyTriggerWord(word)}
                           nsfwImageFilter={nsfwFilter}
                         />
@@ -824,6 +822,12 @@ function LoraManagementPage() {
           })()}
         </>
       )}
+      <MetadataDetailDialog
+        open={!!detailItem}
+        item={detailItem}
+        onClose={() => setDetailItem(null)}
+        nsfwImageFilter={nsfwFilter}
+      />
     </Box>
   );
 }

--- a/frontend/src/pages/admin/ModelManagementPage.js
+++ b/frontend/src/pages/admin/ModelManagementPage.js
@@ -30,6 +30,7 @@ import { serverAPI } from '../../services/api';
 import Pagination from '../../components/common/Pagination';
 import MetadataItemCard from '../../components/common/MetadataItemCard';
 import MetadataItemGrid from '../../components/common/MetadataItemGrid';
+import MetadataDetailDialog from '../../components/common/MetadataDetailDialog';
 import { normalizeModel } from '../../utils/metadataItem';
 
 // 모델 동기화를 지원하는 serverType 목록 (#200 의 모든 4종)
@@ -47,7 +48,7 @@ function ModelManagementPage() {
   const [error, setError] = useState(null);
   const [syncing, setSyncing] = useState(false);
   const [syncStatus, setSyncStatus] = useState(null);
-  const [expandedId, setExpandedId] = useState(null);
+  const [detailItem, setDetailItem] = useState(null);
 
   // 서버 목록 (4종 serverType) 조회
   const { data: serversData } = useQuery(
@@ -335,8 +336,7 @@ function ModelManagementPage() {
               return (
                 <MetadataItemCard
                   item={item}
-                  expanded={expandedId === item.id}
-                  onToggleExpand={() => setExpandedId(expandedId === item.id ? null : item.id)}
+                  onDetailClick={() => setDetailItem(item)}
                   nsfwImageFilter={false}
                 />
               );
@@ -354,6 +354,12 @@ function ModelManagementPage() {
           )}
         </>
       )}
+      <MetadataDetailDialog
+        open={!!detailItem}
+        item={detailItem}
+        onClose={() => setDetailItem(null)}
+        nsfwImageFilter={false}
+      />
     </Box>
   );
 }

--- a/frontend/src/utils/metadataItem.js
+++ b/frontend/src/utils/metadataItem.js
@@ -19,6 +19,7 @@
  * @property {string} filename        — 원본 식별자 (저장 시 사용)
  * @property {'lora'|'checkpoint'|'provider-model'} kind
  * @property {string} displayName     — UI 표시 이름 (civitai → provider → filename 우선순위)
+ * @property {string|null} versionName — civitai 모델 버전명 (예: "V2.0", "v20Bold"). 모델명과 별도 표시 (#333)
  * @property {string} description     — 설명 (HTML 가능)
  * @property {string|null} baseModel  — 베이스 모델 (Civitai)
  * @property {string[]} trainedWords  — 트리거 워드 (LoRA / Civitai)
@@ -65,6 +66,7 @@ export function normalizeLora(raw) {
     filename: raw.filename,
     kind: 'lora',
     displayName: pickDisplayName(raw),
+    versionName: civ.versionName || null,
     description: pickDescription(raw),
     baseModel: civ.baseModel || null,
     trainedWords: civ.trainedWords || [],
@@ -109,6 +111,7 @@ export function normalizeModel(raw, { serverType } = {}) {
     filename: raw.filename,
     kind,
     displayName: pickDisplayName(raw),
+    versionName: civ.versionName || null,
     description: pickDescription(raw),
     baseModel: civ.baseModel || null,
     trainedWords: civ.trainedWords || [],

--- a/src/models/ServerLoraCache.js
+++ b/src/models/ServerLoraCache.js
@@ -22,6 +22,7 @@ const loraModelItemSchema = new mongoose.Schema({
     modelId: Number,
     modelVersionId: Number,
     name: String,
+    versionName: String,
     description: String,
     baseModel: String,
     trainedWords: [String],

--- a/src/models/ServerModelCache.js
+++ b/src/models/ServerModelCache.js
@@ -24,6 +24,7 @@ const modelItemSchema = new mongoose.Schema({
     modelId: Number,
     modelVersionId: Number,
     name: String,
+    versionName: String,
     description: String,
     baseModel: String,
     trainedWords: [String],

--- a/src/services/loraMetadataService.js
+++ b/src/services/loraMetadataService.js
@@ -152,6 +152,7 @@ const fetchCivitaiMetadataByHash = async (hash, apiKey = null, retryCount = 0) =
       modelId: data.modelId,
       modelVersionId: data.id,
       name: data.model?.name || data.name,
+      versionName: data.name || null,
       description: data.description || data.model?.description,
       baseModel: data.baseModel,
       trainedWords: data.trainedWords || [],

--- a/src/services/modelMetadataService.js
+++ b/src/services/modelMetadataService.js
@@ -128,6 +128,7 @@ const fetchCivitaiMetadataByHash = async (hash, apiKey = null, retryCount = 0) =
       modelId: data.modelId,
       modelVersionId: data.id,
       name: data.model?.name || data.name,
+      versionName: data.name || null,
       description: data.description || data.model?.description,
       baseModel: data.baseModel,
       trainedWords: data.trainedWords || [],


### PR DESCRIPTION
## Summary

### 1. 버전명 표시
- backend: `fetchCivitaiMetadataByHash` 가 `versionName: data.name` 도 캐시. `ServerModelCache` / `ServerLoraCache` 의 `civitai` 서브스키마에 `versionName: String` 추가.
- 프론트 normalize: `MetadataItem.versionName` 노출.
- `MetadataItemCard` 가 모델명 아래에 `버전: <versionName>` 캡션 표시.

### 2. 파일 경로 제거
- 카드 본문의 filename 줄 제거.
- 디테일 다이얼로그에서만 표시 + 클립보드 복사 버튼 포함.

### 3. 디테일 다이얼로그
- 펼치기 버튼 / expanded 영역 로직 제거.
- `ℹ️ 상세 정보` 버튼 신설 (`onDetailClick` prop).
- 신규 `MetadataDetailDialog`: 모델명+버전, kind/baseModel/capabilities chip, preview 미디어 그리드, description, 전체 트리거 워드, 파일 경로, hash, civitai 링크.
- 적용 caller: `MetadataPickerModal` (베이스 모델/LoRA picker), `ModelManagementPage`, `LoraManagementPage` — 모두 `expandedId`/`expandedLora` state 를 `detailItem` state 로 교체.

## 적용 범위

기존 캐시는 `versionName` 없음 → 다음 sync (관리자 "동기화" 버튼) 까지 버전 캡션 표시 안 됨.

## Test plan

- [ ] 작업판에서 베이스 모델 선택 모달 → 카드에 모델명 + "버전: …" 캡션 표시 (sync 후)
- [ ] LoRA 픽커도 동일하게 버전명 표시
- [ ] 카드에서 파일 경로 보이지 않음
- [ ] ℹ️ 디테일 버튼 클릭 시 다이얼로그 — 모델명/버전/이미지/설명/트리거 워드/파일 경로(복사 버튼)/hash/civitai 링크 모두 정상
- [ ] 관리자 모델/LoRA 관리 페이지도 동일 동작
- [ ] picker dropdown / search / 페이지네이션 / 동기화 동작 영향 없음

closes #333