### PR TITLE
fix: 동기화 버튼이 항상 forceRefresh 로 동작 (#335)

### DIFF
--- a/frontend/src/components/common/MetadataPickerModal.js
+++ b/frontend/src/components/common/MetadataPickerModal.js
@@ -67,7 +67,8 @@ const KIND_ADAPTERS = {
       return responseData?.cacheInfo || null;
     },
     extractAvailableBaseModels: (responseData) => responseData?.availableBaseModels || null,
-    sync: (serverId) => serverAPI.syncLoras(serverId),
+    // 동기화 버튼은 항상 forceRefresh — 기존 hash 는 재사용되고 civitai 메타만 새로 받음 (#335)
+    sync: (serverId) => serverAPI.syncLoras(serverId, { forceRefresh: true }),
     getStatus: (serverId) => serverAPI.getLorasSyncStatus(serverId),
     normalize: normalizeLora,
     label: 'LoRA',
@@ -88,7 +89,8 @@ const KIND_ADAPTERS = {
     extractPagination: (responseData) => responseData?.pagination || { current: 1, pages: 0, total: 0 },
     extractCacheInfo: (responseData) => responseData?.cacheInfo || null,
     extractAvailableBaseModels: (responseData) => responseData?.availableBaseModels || null,
-    sync: (serverId) => serverAPI.syncModels(serverId),
+    // 동기화 버튼은 항상 forceRefresh (#335)
+    sync: (serverId) => serverAPI.syncModels(serverId, { forceRefresh: true }),
     getStatus: (serverId) => serverAPI.getModelsSyncStatus(serverId),
     normalize: normalizeModel,
     label: '베이스 모델',

--- a/frontend/src/pages/admin/LoraManagementPage.js
+++ b/frontend/src/pages/admin/LoraManagementPage.js
@@ -411,7 +411,8 @@ function LoraManagementPage() {
     return () => clearTimeout(timer);
   }, [selectedServerId, searchQuery, baseModelFilter, fetchLoraModels]);
 
-  const handleSync = async (forceRefresh = false) => {
+  // 동기화 = 항상 강제 재동기화. hash 는 재사용되고 civitai 메타만 새로 받음 (#335)
+  const handleSync = async () => {
     if (!selectedServerId) {
       toast.error('서버를 선택해주세요.');
       return;
@@ -421,10 +422,8 @@ function LoraManagementPage() {
     setError(null);
 
     try {
-      await serverAPI.syncLoras(selectedServerId, { forceRefresh });
-      toast.success(forceRefresh
-        ? 'LoRA 강제 새로고침이 시작되었습니다. (모든 메타데이터를 다시 가져옵니다)'
-        : 'LoRA 동기화가 시작되었습니다.');
+      await serverAPI.syncLoras(selectedServerId, { forceRefresh: true });
+      toast.success('LoRA 동기화가 시작되었습니다.');
     } catch (err) {
       console.error('Failed to start sync:', err);
       setSyncing(false);
@@ -657,26 +656,13 @@ function LoraManagementPage() {
               <Box sx={{ flex: 1 }} /> {/* 스페이서 */}
               <Button
                 variant="contained"
-                onClick={() => handleSync(false)}
+                onClick={handleSync}
                 disabled={syncing || loading}
                 startIcon={syncing ? <CircularProgress size={16} /> : <RefreshIcon />}
                 size="small"
               >
-                {syncStatus?.totalLoras > 0 ? '동기화' : '동기화'}
+                동기화
               </Button>
-              {syncStatus?.totalLoras > 0 && (
-                <Tooltip title="모든 메타데이터를 Civitai에서 새로 가져옵니다">
-                  <Button
-                    variant="outlined"
-                    color="warning"
-                    onClick={() => handleSync(true)}
-                    disabled={syncing || loading}
-                    size="small"
-                  >
-                    강제
-                  </Button>
-                </Tooltip>
-              )}
             </Box>
           </Box>
 

--- a/frontend/src/pages/admin/ModelManagementPage.js
+++ b/frontend/src/pages/admin/ModelManagementPage.js
@@ -146,7 +146,8 @@ function ModelManagementPage() {
     if (!selectedServerId) return;
     try {
       setSyncing(true);
-      await serverAPI.syncModels(selectedServerId);
+      // 동기화 = 항상 강제 재동기화. hash 는 재사용되고 civitai 메타만 새로 받음 (#335)
+      await serverAPI.syncModels(selectedServerId, { forceRefresh: true });
       toast.success('모델 동기화를 시작했습니다.');
     } catch (err) {
       console.error('Sync failed:', err);


### PR DESCRIPTION
## Summary

- picker / 관리자 모델·LoRA 페이지의 "동기화" 가 `forceRefresh: true` 를 명시 전달
- 새 civitai 메타 필드 (`versionName` #333, `civitai.red` URL #331) 가 기존 캐시에도 즉시 반영
- hash 는 `existing?.hash` 가 있으면 재사용 (modelMetadataService.js:355) → 동기화 비용은 civitai API 호출 시간만 증가
- LoRA 관리 페이지의 별도 "강제" 버튼은 일반 "동기화" 와 동일해지므로 제거

## Test plan

- [ ] picker (사용자 페이지) "동기화" → versionName / civitai.red URL 이 기존 모델에도 반영
- [ ] 관리자 모델 관리 페이지 "동기화" 동일
- [ ] 관리자 LoRA 관리 페이지 "동기화" 동일, "강제" 버튼 사라짐
- [ ] hash 가 이미 있는 모델은 hash 재계산 없이 civitai 만 새로 호출 (백엔드 로그)

closes #335