### PR TITLE
feat: 모델 관리 공용 헤더 (서버 / NSFW / API key 통합) (#337)

### DIFF
--- a/frontend/src/components/admin/CivitaiAdminHeader.js
+++ b/frontend/src/components/admin/CivitaiAdminHeader.js
@@ -1,0 +1,169 @@
+import React, { useState } from 'react';
+import {
+  Paper,
+  Box,
+  Stack,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  TextField,
+  Button,
+  Switch,
+  FormControlLabel,
+  Typography,
+  Chip,
+  CircularProgress
+} from '@mui/material';
+import {
+  Save as SaveIcon,
+  Visibility as VisibilityIcon,
+  VisibilityOff as VisibilityOffIcon,
+  Key as KeyIcon
+} from '@mui/icons-material';
+import toast from 'react-hot-toast';
+import { adminAPI } from '../../services/api';
+
+// 모델 관리 (베이스 모델 / LoRA 탭) 의 공용 헤더 (#337).
+// 서버 선택기 / NSFW 이미지 토글 / Civitai API key 를 한 곳에서 관리.
+// 동기화 버튼은 각 탭의 페이지에 남겨둠 (탭별로 캐시가 다르므로).
+//
+// props:
+//   selectedServerId, onServerChange — 부모 (MetadataManagementPage) 가 상위에서 보유
+//   eligibleServers                 — 현재 탭에 해당하는 서버 목록 (모델 탭: 4종, LoRA 탭: ComfyUI 만)
+//   nsfwFilter, onNsfwFilterChange   — global systemSettings 와 동기화
+//   hasCivitaiApiKey, onApiKeyChange — 저장 결과 콜백 (저장 후 has 갱신)
+function CivitaiAdminHeader({
+  selectedServerId,
+  onServerChange,
+  eligibleServers,
+  nsfwFilter,
+  onNsfwFilterChange,
+  hasCivitaiApiKey,
+  onApiKeySaved
+}) {
+  const [apiKeyInput, setApiKeyInput] = useState('');
+  const [showApiKeyInput, setShowApiKeyInput] = useState(false);
+  const [savingKey, setSavingKey] = useState(false);
+
+  const handleNsfwToggle = async () => {
+    const newValue = !nsfwFilter;
+    try {
+      await adminAPI.updateLoraSettings({ nsfwFilter: newValue });
+      onNsfwFilterChange(newValue);
+      toast.success(newValue ? 'NSFW 이미지가 숨겨집니다.' : 'NSFW 이미지가 표시됩니다.');
+    } catch (_e) {
+      toast.error('설정 저장에 실패했습니다.');
+    }
+  };
+
+  const handleSaveApiKey = async () => {
+    if (!apiKeyInput.trim() && !hasCivitaiApiKey) {
+      toast.error('API 키를 입력해주세요.');
+      return;
+    }
+    setSavingKey(true);
+    try {
+      await adminAPI.updateLoraSettings({ civitaiApiKey: apiKeyInput.trim() || null });
+      onApiKeySaved(!!apiKeyInput.trim());
+      setApiKeyInput('');
+      setShowApiKeyInput(false);
+      toast.success(apiKeyInput.trim() ? 'Civitai API 키가 저장되었습니다.' : 'API 키가 삭제되었습니다.');
+    } catch (_e) {
+      toast.error('API 키 저장에 실패했습니다.');
+    } finally {
+      setSavingKey(false);
+    }
+  };
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+      <Stack
+        direction={{ xs: 'column', md: 'row' }}
+        spacing={2}
+        alignItems={{ md: 'center' }}
+        sx={{ flexWrap: 'wrap' }}
+      >
+        {/* 서버 선택기 */}
+        <FormControl size="small" sx={{ minWidth: 220 }}>
+          <InputLabel>서버</InputLabel>
+          <Select
+            value={selectedServerId || ''}
+            label="서버"
+            onChange={(e) => onServerChange(e.target.value)}
+          >
+            {eligibleServers.length === 0 ? (
+              <MenuItem value="" disabled>
+                현재 탭에 호환되는 서버 없음
+              </MenuItem>
+            ) : (
+              eligibleServers.map((s) => (
+                <MenuItem key={s._id} value={s._id}>
+                  {s.name} ({s.serverType})
+                </MenuItem>
+              ))
+            )}
+          </Select>
+        </FormControl>
+
+        {/* NSFW 이미지 토글 */}
+        <FormControlLabel
+          control={
+            <Switch
+              checked={nsfwFilter}
+              onChange={handleNsfwToggle}
+              color="primary"
+            />
+          }
+          label={
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              {nsfwFilter ? <VisibilityOffIcon fontSize="small" /> : <VisibilityIcon fontSize="small" />}
+              <Typography variant="body2">NSFW 이미지 숨기기</Typography>
+            </Box>
+          }
+        />
+
+        {/* API 키 */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+          <KeyIcon color="action" fontSize="small" />
+          <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: 'nowrap' }}>
+            Civitai API 키:
+          </Typography>
+          {hasCivitaiApiKey ? (
+            <Chip label="등록됨" color="success" size="small" variant="outlined" />
+          ) : (
+            <Chip label="미등록" size="small" variant="outlined" />
+          )}
+          <Button size="small" onClick={() => setShowApiKeyInput(!showApiKeyInput)}>
+            {showApiKeyInput ? '취소' : hasCivitaiApiKey ? '변경' : '등록'}
+          </Button>
+        </Box>
+      </Stack>
+
+      {showApiKeyInput && (
+        <Box sx={{ display: 'flex', gap: 1, mt: 2, alignItems: 'center', flexWrap: 'wrap' }}>
+          <TextField
+            size="small"
+            type="password"
+            placeholder={hasCivitaiApiKey ? '새 API 키 (빈칸=삭제)' : 'API 키 입력'}
+            value={apiKeyInput}
+            onChange={(e) => setApiKeyInput(e.target.value)}
+            sx={{ flex: '1 1 200px', minWidth: 150, maxWidth: 400 }}
+            autoComplete="off"
+          />
+          <Button
+            variant="contained"
+            size="small"
+            onClick={handleSaveApiKey}
+            disabled={savingKey}
+            startIcon={savingKey ? <CircularProgress size={16} /> : <SaveIcon />}
+          >
+            저장
+          </Button>
+        </Box>
+      )}
+    </Paper>
+  );
+}
+
+export default CivitaiAdminHeader;

--- a/frontend/src/pages/admin/LoraManagementPage.js
+++ b/frontend/src/pages/admin/LoraManagementPage.js
@@ -9,14 +9,9 @@ import {
   TextField,
   InputAdornment,
   Button,
-  Card,
-  CardContent,
-  CardMedia,
-  CardActions,
   Grid,
   Chip,
   IconButton,
-  Collapse,
   CircularProgress,
   LinearProgress,
   Alert,
@@ -24,8 +19,6 @@ import {
   Stack,
   Switch,
   FormControlLabel,
-  Paper,
-  Divider,
   ToggleButton,
   ToggleButtonGroup,
   Avatar
@@ -33,25 +26,15 @@ import {
 import {
   Refresh as RefreshIcon,
   Search as SearchIcon,
-  ExpandMore as ExpandMoreIcon,
-  ExpandLess as ExpandLessIcon,
   OpenInNew as OpenInNewIcon,
-  Info as InfoIcon,
   ContentCopy as CopyIcon,
-  Settings as SettingsIcon,
-  Visibility as VisibilityIcon,
-  VisibilityOff as VisibilityOffIcon,
-  Save as SaveIcon,
-  Key as KeyIcon,
   ViewModule as GridViewIcon,
   ViewList as ListViewIcon,
   Block as BlockIcon
 } from '@mui/icons-material';
-import { useQuery, useQueryClient } from 'react-query';
 import toast from 'react-hot-toast';
 import { serverAPI, adminAPI } from '../../services/api';
 import Pagination from '../../components/common/Pagination';
-import { sanitizeHtml } from '../../utils/sanitizeHtml';
 import MetadataItemCard from '../../components/common/MetadataItemCard';
 import MetadataItemGrid from '../../components/common/MetadataItemGrid';
 import { normalizeLora } from '../../utils/metadataItem';
@@ -203,8 +186,8 @@ function LoraListItem({ lora, onCopyTriggerWord, getBaseModelColor, nsfwFilter }
   );
 }
 
-function LoraManagementPage() {
-  const [selectedServerId, setSelectedServerId] = useState('');
+// selectedServerId / servers / nsfwFilter 는 부모 (MetadataManagementPage) 에서 공용 헤더와 함께 보유 (#337)
+function LoraManagementPage({ selectedServerId, servers = [], nsfwFilter = true }) {
   const [loraModels, setLoraModels] = useState([]);
   const [loading, setLoading] = useState(false);
   const [syncing, setSyncing] = useState(false);
@@ -216,13 +199,8 @@ function LoraManagementPage() {
   const [pagination, setPagination] = useState({ current: 1, pages: 0, total: 0 });
   const [baseModelFilter, setBaseModelFilter] = useState('');
 
-  // 전역 설정 상태
-  const [nsfwFilter, setNsfwFilter] = useState(true);
+  // LoRA 한정 NSFW 필터 (NSFW 이미지 토글은 공용 헤더가 보유)
   const [nsfwLoraFilter, setNsfwLoraFilter] = useState(true);
-  const [hasCivitaiApiKey, setHasCivitaiApiKey] = useState(false);
-  const [apiKeyInput, setApiKeyInput] = useState('');
-  const [showApiKeyInput, setShowApiKeyInput] = useState(false);
-  const [savingSettings, setSavingSettings] = useState(false);
 
   // 서버 전체 기본 모델 목록 (API에서 가져옴)
   const [availableBaseModels, setAvailableBaseModels] = useState([]);
@@ -230,37 +208,18 @@ function LoraManagementPage() {
   // 뷰 모드 상태
   const [viewMode, setViewMode] = useState('grid'); // 'grid' | 'list'
 
-  const queryClient = useQueryClient();
+  const comfyUIServers = servers;
 
-  // 전역 설정 조회
+  // LoRA 한정 설정 조회 (nsfwLoraFilter)
   useEffect(() => {
-    const fetchSettings = async () => {
-      try {
-        const response = await adminAPI.getLoraSettings();
+    adminAPI.getLoraSettings()
+      .then((response) => {
         if (response.data.success) {
-          setNsfwFilter(response.data.data.nsfwFilter);
           setNsfwLoraFilter(response.data.data.nsfwLoraFilter ?? true);
-          setHasCivitaiApiKey(response.data.data.hasCivitaiApiKey);
         }
-      } catch (err) {
-        console.error('Failed to fetch LoRA settings:', err);
-      }
-    };
-    fetchSettings();
+      })
+      .catch((err) => console.error('Failed to fetch LoRA-specific settings:', err));
   }, []);
-
-  // NSFW 이미지 필터 토글
-  const handleNsfwFilterToggle = async () => {
-    const newValue = !nsfwFilter;
-    setNsfwFilter(newValue);
-    try {
-      await adminAPI.updateLoraSettings({ nsfwFilter: newValue });
-      toast.success(newValue ? 'NSFW 이미지가 숨겨집니다.' : 'NSFW 이미지가 표시됩니다.');
-    } catch (err) {
-      setNsfwFilter(!newValue); // 롤백
-      toast.error('설정 저장에 실패했습니다.');
-    }
-  };
 
   // NSFW LoRA 필터 토글
   const handleNsfwLoraFilterToggle = async () => {
@@ -274,48 +233,6 @@ function LoraManagementPage() {
       toast.error('설정 저장에 실패했습니다.');
     }
   };
-
-  // API 키 저장
-  const handleSaveApiKey = async () => {
-    if (!apiKeyInput.trim() && !hasCivitaiApiKey) {
-      toast.error('API 키를 입력해주세요.');
-      return;
-    }
-
-    setSavingSettings(true);
-    try {
-      await adminAPI.updateLoraSettings({
-        civitaiApiKey: apiKeyInput.trim() || null
-      });
-      setHasCivitaiApiKey(!!apiKeyInput.trim());
-      setApiKeyInput('');
-      setShowApiKeyInput(false);
-      toast.success(apiKeyInput.trim() ? 'Civitai API 키가 저장되었습니다.' : 'API 키가 삭제되었습니다.');
-    } catch (err) {
-      toast.error('API 키 저장에 실패했습니다.');
-    } finally {
-      setSavingSettings(false);
-    }
-  };
-
-  // ComfyUI 서버 목록 조회
-  const { data: serversData, isLoading: serversLoading } = useQuery(
-    ['servers', { includeInactive: false }],
-    () => serverAPI.getServers({ includeInactive: false }),
-    {
-      onSuccess: (data) => {
-        const servers = data?.data?.data?.servers || [];
-        const comfyUIServers = servers.filter(s => s.serverType === 'ComfyUI');
-        // 첫 번째 ComfyUI 서버 자동 선택
-        if (comfyUIServers.length > 0 && !selectedServerId) {
-          setSelectedServerId(comfyUIServers[0]._id);
-        }
-      }
-    }
-  );
-
-  const servers = serversData?.data?.data?.servers || [];
-  const comfyUIServers = servers.filter(s => s.serverType === 'ComfyUI');
 
   // 동기화 상태 폴링
   useEffect(() => {
@@ -455,134 +372,31 @@ function LoraManagementPage() {
 
   return (
     <Box sx={{ overflow: 'hidden' }}>
-      {/* 전역 설정 패널 */}
-      <Paper variant="outlined" sx={{ p: 2, mb: 3, overflow: 'hidden' }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
-          <SettingsIcon color="action" />
-          <Typography variant="subtitle1" fontWeight="medium">
-            전역 설정
-          </Typography>
-        </Box>
-
-        <Grid container spacing={3} alignItems="center">
-          {/* NSFW LoRA 필터 */}
-          <Grid item xs={12} sm={6} md={3}>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={nsfwLoraFilter}
-                  onChange={handleNsfwLoraFilterToggle}
-                  color="primary"
-                />
-              }
-              label={
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                  <BlockIcon fontSize="small" />
-                  <span>NSFW LoRA 숨기기</span>
-                </Box>
-              }
+      {/* LoRA 전용 설정 (NSFW LoRA 숨기기) — 공용 NSFW 이미지 / API key 는 공용 헤더 (#337) */}
+      <Box sx={{ mb: 2 }}>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={nsfwLoraFilter}
+              onChange={handleNsfwLoraFilterToggle}
+              color="primary"
+              size="small"
             />
-          </Grid>
-
-          {/* NSFW 이미지 필터 */}
-          <Grid item xs={12} sm={6} md={3}>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={nsfwFilter}
-                  onChange={handleNsfwFilterToggle}
-                  color="primary"
-                />
-              }
-              label={
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                  {nsfwFilter ? <VisibilityOffIcon fontSize="small" /> : <VisibilityIcon fontSize="small" />}
-                  <span>NSFW 이미지 숨기기</span>
-                </Box>
-              }
-            />
-          </Grid>
-
-          {/* Civitai API 키 */}
-          <Grid item xs={12} sm={12} md={6}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
-              <KeyIcon color="action" fontSize="small" />
-              <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: 'nowrap' }}>
-                Civitai API 키:
-              </Typography>
-              {hasCivitaiApiKey ? (
-                <Chip label="등록됨" color="success" size="small" variant="outlined" />
-              ) : (
-                <Chip label="미등록" size="small" variant="outlined" />
-              )}
-              <Button size="small" onClick={() => setShowApiKeyInput(!showApiKeyInput)}>
-                {showApiKeyInput ? '취소' : hasCivitaiApiKey ? '변경' : '등록'}
-              </Button>
+          }
+          label={
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <BlockIcon fontSize="small" />
+              <Typography variant="body2">NSFW LoRA 숨기기</Typography>
             </Box>
-
-            {showApiKeyInput && (
-              <Box sx={{ display: 'flex', gap: 1, mt: 2, alignItems: 'center', flexWrap: 'wrap' }}>
-                <TextField
-                  size="small"
-                  type="password"
-                  placeholder={hasCivitaiApiKey ? '새 API 키 (빈칸=삭제)' : 'API 키 입력'}
-                  value={apiKeyInput}
-                  onChange={(e) => setApiKeyInput(e.target.value)}
-                  sx={{ flex: '1 1 200px', minWidth: 150, maxWidth: 400 }}
-                  autoComplete="off"
-                />
-                <Button
-                  variant="contained"
-                  size="small"
-                  onClick={handleSaveApiKey}
-                  disabled={savingSettings}
-                  startIcon={savingSettings ? <CircularProgress size={16} /> : <SaveIcon />}
-                >
-                  저장
-                </Button>
-              </Box>
-            )}
-
-            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
-              API 키 등록 시 조회 속도 5배 향상 (1초→0.2초)
-            </Typography>
-          </Grid>
-        </Grid>
-      </Paper>
-
-      {/* 서버 선택 */}
-      <Box sx={{ mb: 3 }}>
-        <FormControl fullWidth>
-          <InputLabel>ComfyUI 서버 선택</InputLabel>
-          <Select
-            value={selectedServerId}
-            label="ComfyUI 서버 선택"
-            onChange={(e) => {
-              setSelectedServerId(e.target.value);
-              setLoraModels([]);
-              setCacheInfo(null);
-              setSyncStatus(null);
-              setSearchQuery('');
-              setBaseModelFilter('');
-              setAvailableBaseModels([]);
-            }}
-            disabled={serversLoading}
-          >
-            {comfyUIServers.map(server => (
-              <MenuItem key={server._id} value={server._id}>
-                <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                  {server.name}
-                </Box>
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-        {comfyUIServers.length === 0 && !serversLoading && (
-          <Alert severity="info" sx={{ mt: 2 }}>
-            등록된 ComfyUI 서버가 없습니다. 서버 관리에서 ComfyUI 서버를 추가해주세요.
-          </Alert>
-        )}
+          }
+        />
       </Box>
+
+      {comfyUIServers.length === 0 && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          등록된 ComfyUI 서버가 없습니다. 서버 관리에서 ComfyUI 서버를 추가해주세요.
+        </Alert>
+      )}
 
       {selectedServerId && (
         <>

--- a/frontend/src/pages/admin/MetadataManagementPage.js
+++ b/frontend/src/pages/admin/MetadataManagementPage.js
@@ -1,19 +1,80 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Container, Box, Typography, Tabs, Tab } from '@mui/material';
+import { useQuery } from 'react-query';
 import LoraManagementPage from './LoraManagementPage';
 import ModelManagementPage from './ModelManagementPage';
+import CivitaiAdminHeader from '../../components/admin/CivitaiAdminHeader';
+import { serverAPI, adminAPI } from '../../services/api';
 
-// 통합 모델 admin 페이지 (#260 Phase 7).
+const MODEL_SERVER_TYPES = ['ComfyUI', 'OpenAI', 'OpenAI Compatible', 'Gemini'];
+const LORA_SERVER_TYPES = ['ComfyUI'];
+
+const SELECTED_SERVER_KEY = 'vcc.metadataAdmin.selectedServerId';
+
+// 통합 모델 admin 페이지 (#260 Phase 7, #337).
 // LoRA 와 베이스 모델 (체크포인트) 을 단일 메뉴로 통합. 향후 Upscaler / VAE
 // 등이 추가되면 탭으로 확장.
+// 공용 헤더 (서버 선택기 / NSFW 이미지 토글 / Civitai API key) 를 두 탭이 공유 (#337).
 function MetadataManagementPage() {
   const [tab, setTab] = useState('checkpoint');
+  const [selectedServerId, setSelectedServerId] = useState(() => localStorage.getItem(SELECTED_SERVER_KEY) || '');
+  const [nsfwFilter, setNsfwFilter] = useState(true);
+  const [hasCivitaiApiKey, setHasCivitaiApiKey] = useState(false);
+
+  // 전체 서버 목록
+  const { data: serversData } = useQuery(
+    ['servers', { includeInactive: false }],
+    () => serverAPI.getServers({ includeInactive: false })
+  );
+  const allServers = serversData?.data?.data?.servers || [];
+
+  // 현재 탭에 호환되는 서버 목록
+  const eligibleTypes = tab === 'checkpoint' ? MODEL_SERVER_TYPES : LORA_SERVER_TYPES;
+  const eligibleServers = allServers.filter((s) => eligibleTypes.includes(s.serverType));
+
+  // 탭 / 서버 목록 변경 시 선택된 서버가 호환되는지 확인. 아니면 첫 호환 서버로 fallback.
+  useEffect(() => {
+    if (eligibleServers.length === 0) {
+      return;
+    }
+    const currentValid = eligibleServers.find((s) => s._id === selectedServerId);
+    if (!currentValid) {
+      setSelectedServerId(eligibleServers[0]._id);
+    }
+  }, [tab, eligibleServers, selectedServerId]);
+
+  // selectedServerId localStorage 영속화
+  useEffect(() => {
+    if (selectedServerId) localStorage.setItem(SELECTED_SERVER_KEY, selectedServerId);
+  }, [selectedServerId]);
+
+  // 글로벌 settings (nsfwFilter / hasCivitaiApiKey) 로드
+  useEffect(() => {
+    adminAPI.getLoraSettings()
+      .then((response) => {
+        if (response.data.success) {
+          setNsfwFilter(response.data.data.nsfwFilter ?? true);
+          setHasCivitaiApiKey(!!response.data.data.hasCivitaiApiKey);
+        }
+      })
+      .catch((err) => console.error('Failed to fetch admin settings:', err));
+  }, []);
 
   return (
     <Container maxWidth="xl" sx={{ py: 3, overflow: 'hidden' }}>
       <Typography variant="h5" gutterBottom>
         모델 관리
       </Typography>
+
+      <CivitaiAdminHeader
+        selectedServerId={selectedServerId}
+        onServerChange={setSelectedServerId}
+        eligibleServers={eligibleServers}
+        nsfwFilter={nsfwFilter}
+        onNsfwFilterChange={setNsfwFilter}
+        hasCivitaiApiKey={hasCivitaiApiKey}
+        onApiKeySaved={setHasCivitaiApiKey}
+      />
 
       <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 2 }}>
         <Tabs value={tab} onChange={(_, v) => setTab(v)}>
@@ -22,8 +83,19 @@ function MetadataManagementPage() {
         </Tabs>
       </Box>
 
-      {tab === 'checkpoint' && <ModelManagementPage />}
-      {tab === 'lora' && <LoraManagementPage />}
+      {tab === 'checkpoint' && (
+        <ModelManagementPage
+          selectedServerId={selectedServerId}
+          servers={eligibleServers}
+        />
+      )}
+      {tab === 'lora' && (
+        <LoraManagementPage
+          selectedServerId={selectedServerId}
+          servers={eligibleServers}
+          nsfwFilter={nsfwFilter}
+        />
+      )}
     </Container>
   );
 }

--- a/frontend/src/pages/admin/ModelManagementPage.js
+++ b/frontend/src/pages/admin/ModelManagementPage.js
@@ -9,8 +9,6 @@ import {
   TextField,
   InputAdornment,
   Button,
-  Grid,
-  Chip,
   CircularProgress,
   LinearProgress,
   Alert,
@@ -24,7 +22,6 @@ import {
   Search as SearchIcon,
   RestartAlt as RestartAltIcon
 } from '@mui/icons-material';
-import { useQuery } from 'react-query';
 import toast from 'react-hot-toast';
 import { serverAPI } from '../../services/api';
 import Pagination from '../../components/common/Pagination';
@@ -32,11 +29,8 @@ import MetadataItemCard from '../../components/common/MetadataItemCard';
 import MetadataItemGrid from '../../components/common/MetadataItemGrid';
 import { normalizeModel } from '../../utils/metadataItem';
 
-// 모델 동기화를 지원하는 serverType 목록 (#200 의 모든 4종)
-const SUPPORTED_SERVER_TYPES = ['ComfyUI', 'OpenAI', 'OpenAI Compatible', 'Gemini'];
-
-function ModelManagementPage() {
-  const [selectedServerId, setSelectedServerId] = useState('');
+// selectedServerId / servers 는 부모 (MetadataManagementPage) 에서 공용 헤더와 함께 보유 (#337)
+function ModelManagementPage({ selectedServerId, servers = [] }) {
   const [searchQuery, setSearchQuery] = useState('');
   const [baseModelFilter, setBaseModelFilter] = useState('');
   const [pagination, setPagination] = useState({ current: 1, pages: 0, total: 0 });
@@ -49,24 +43,7 @@ function ModelManagementPage() {
   const [syncStatus, setSyncStatus] = useState(null);
   const [expandedId, setExpandedId] = useState(null);
 
-  // 서버 목록 (4종 serverType) 조회
-  const { data: serversData } = useQuery(
-    ['servers', { includeInactive: false }],
-    () => serverAPI.getServers({ includeInactive: false }),
-    {
-      onSuccess: (data) => {
-        const all = data?.data?.data?.servers || [];
-        const supported = all.filter((s) => SUPPORTED_SERVER_TYPES.includes(s.serverType));
-        if (supported.length > 0 && !selectedServerId) {
-          setSelectedServerId(supported[0]._id);
-        }
-      }
-    }
-  );
-
-  const allServers = serversData?.data?.data?.servers || [];
-  const supportedServers = allServers.filter((s) => SUPPORTED_SERVER_TYPES.includes(s.serverType));
-  const selectedServer = supportedServers.find((s) => s._id === selectedServerId);
+  const selectedServer = servers.find((s) => s._id === selectedServerId);
 
   // 모델 목록 fetch
   const fetchModels = useCallback(
@@ -176,20 +153,6 @@ function ModelManagementPage() {
           </Typography>
         </Box>
         <Stack direction="row" spacing={1} alignItems="center">
-          <FormControl size="small" sx={{ minWidth: 200 }}>
-            <InputLabel>서버</InputLabel>
-            <Select
-              value={selectedServerId}
-              label="서버"
-              onChange={(e) => setSelectedServerId(e.target.value)}
-            >
-              {supportedServers.map((s) => (
-                <MenuItem key={s._id} value={s._id}>
-                  {s.name} ({s.serverType})
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
           <Tooltip title="모델 메타데이터 동기화">
             <span>
               <Button


### PR DESCRIPTION
## Summary

- 모델 관리 페이지 (`MetadataManagementPage`) 의 타이틀과 탭 사이에 공용 `CivitaiAdminHeader` 추가
- 서버 선택기 / NSFW 이미지 토글 / Civitai API key 입력을 한 곳에서 관리
- 베이스 모델 탭과 LoRA 탭이 동일한 서버 선택을 공유 (탭 전환 시 호환되면 유지, 아니면 첫 호환 서버로 fallback)
- 서버 선택은 `localStorage` 로 영속화

## Changes

- 신규 `frontend/src/components/admin/CivitaiAdminHeader.js` — 공용 헤더 컴포넌트
- `MetadataManagementPage` 가 selectedServerId / nsfwFilter / hasCivitaiApiKey 상태 보유, props 로 자식에 전달
- `ModelManagementPage` / `LoraManagementPage` 는 props 로 받음, 자체 서버 선택기 / NSFW 이미지 / API key 입력 UI 제거
- LoRA 의 "NSFW LoRA 숨김" 토글은 LoRA 한정이라 LoRA 페이지에 잔존

## Test plan

- [ ] 관리자 → 모델 관리 페이지 진입: 헤더에 서버 선택기 + NSFW 토글 + API key 입력 보임
- [ ] 탭 전환 (베이스 모델 ↔ LoRA) 시 서버 선택 유지 (둘 다 ComfyUI 인 경우)
- [ ] 베이스 모델 탭에서 OpenAI 서버 선택 후 LoRA 탭 전환 시 자동으로 첫 ComfyUI 서버 fallback
- [ ] NSFW 이미지 토글 ON/OFF 시 동기화 및 카드 미디어 필터 정상
- [ ] API key 등록/변경/삭제 정상
- [ ] 페이지 새로고침 후 서버 선택 유지

closes #337