### PR TITLE
feat: 모델 / LoRA 캐시 완전 삭제 버튼 (admin) (#341)

### DIFF
--- a/frontend/src/pages/admin/LoraManagementPage.js
+++ b/frontend/src/pages/admin/LoraManagementPage.js
@@ -27,8 +27,16 @@ import {
   OpenInNew as OpenInNewIcon,
   ContentCopy as CopyIcon,
   ViewModule as GridViewIcon,
-  ViewList as ListViewIcon
+  ViewList as ListViewIcon,
+  DeleteSweep as DeleteSweepIcon
 } from '@mui/icons-material';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions
+} from '@mui/material';
 import toast from 'react-hot-toast';
 import { serverAPI } from '../../services/api';
 import Pagination from '../../components/common/Pagination';
@@ -203,6 +211,10 @@ function LoraManagementPage({ selectedServerId, servers = [], nsfwFilter = true,
   // 뷰 모드 상태
   const [viewMode, setViewMode] = useState('grid'); // 'grid' | 'list'
 
+  // 캐시 완전 삭제 (#341)
+  const [clearCacheConfirmOpen, setClearCacheConfirmOpen] = useState(false);
+  const [clearingCache, setClearingCache] = useState(false);
+
   const comfyUIServers = servers;
 
   // 동기화 상태 폴링
@@ -325,6 +337,26 @@ function LoraManagementPage({ selectedServerId, servers = [], nsfwFilter = true,
     toast.success(`"${word}" 복사됨`);
   };
 
+  const handleClearCache = async () => {
+    if (!selectedServerId) return;
+    setClearingCache(true);
+    try {
+      await serverAPI.clearLoraCache(selectedServerId);
+      toast.success('LoRA 캐시를 비웠습니다. 다음 동기화부터 hash 부터 재계산됩니다.');
+      setClearCacheConfirmOpen(false);
+      setLoraModels([]);
+      setCacheInfo(null);
+      setAvailableBaseModels([]);
+      setPagination({ current: 1, pages: 0, total: 0 });
+      const response = await serverAPI.getLorasSyncStatus(selectedServerId);
+      setSyncStatus(response.data.data);
+    } catch (err) {
+      toast.error(err.response?.data?.message || '캐시 삭제 실패');
+    } finally {
+      setClearingCache(false);
+    }
+  };
+
   const formatDate = (dateString) => {
     if (!dateString) return '없음';
     return new Date(dateString).toLocaleString('ko-KR');
@@ -442,6 +474,20 @@ function LoraManagementPage({ selectedServerId, servers = [], nsfwFilter = true,
                   </Button>
                 </Tooltip>
               )}
+              <Tooltip title="모든 hash + civitai 메타데이터 삭제 (다음 동기화는 시간이 오래 걸림)">
+                <span>
+                  <Button
+                    variant="outlined"
+                    color="error"
+                    onClick={() => setClearCacheConfirmOpen(true)}
+                    disabled={!selectedServerId || syncing || loading || clearingCache}
+                    startIcon={<DeleteSweepIcon />}
+                    size="small"
+                  >
+                    캐시 삭제
+                  </Button>
+                </span>
+              </Tooltip>
             </Box>
           </Box>
 
@@ -589,6 +635,26 @@ function LoraManagementPage({ selectedServerId, servers = [], nsfwFilter = true,
           })()}
         </>
       )}
+
+      <Dialog open={clearCacheConfirmOpen} onClose={() => setClearCacheConfirmOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>LoRA 캐시 완전 삭제</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            선택한 서버({selectedServer?.name || ''})의 LoRA 캐시를 모두 비웁니다.
+            <br /><br />
+            • 모든 LoRA 의 hash, civitai 메타데이터가 삭제됩니다.<br />
+            • 다음 동기화는 hash 부터 다시 계산하므로 시간이 오래 걸릴 수 있습니다.<br />
+            • 일반 \"동기화\" 는 hash 를 재사용하므로 빠릅니다 — 이 작업은 처음부터 다시 받아야 할 때만 사용하세요.<br /><br />
+            계속하시겠어요?
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setClearCacheConfirmOpen(false)} disabled={clearingCache}>취소</Button>
+          <Button onClick={handleClearCache} color="error" variant="contained" disabled={clearingCache} startIcon={clearingCache ? <CircularProgress size={16} /> : <DeleteSweepIcon />}>
+            캐시 삭제
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   );
 }

--- a/frontend/src/pages/admin/ModelManagementPage.js
+++ b/frontend/src/pages/admin/ModelManagementPage.js
@@ -20,8 +20,16 @@ import {
 import {
   Refresh as RefreshIcon,
   Search as SearchIcon,
-  RestartAlt as RestartAltIcon
+  RestartAlt as RestartAltIcon,
+  DeleteSweep as DeleteSweepIcon
 } from '@mui/icons-material';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions
+} from '@mui/material';
 import toast from 'react-hot-toast';
 import { serverAPI } from '../../services/api';
 import Pagination from '../../components/common/Pagination';
@@ -42,6 +50,8 @@ function ModelManagementPage({ selectedServerId, servers = [], nsfwModelFilter =
   const [syncing, setSyncing] = useState(false);
   const [syncStatus, setSyncStatus] = useState(null);
   const [expandedId, setExpandedId] = useState(null);
+  const [clearCacheConfirmOpen, setClearCacheConfirmOpen] = useState(false);
+  const [clearingCache, setClearingCache] = useState(false);
 
   const selectedServer = servers.find((s) => s._id === selectedServerId);
 
@@ -144,6 +154,26 @@ function ModelManagementPage({ selectedServerId, servers = [], nsfwModelFilter =
     }
   };
 
+  const handleClearCache = async () => {
+    if (!selectedServerId) return;
+    setClearingCache(true);
+    try {
+      await serverAPI.clearModelCache(selectedServerId);
+      toast.success('모델 캐시를 비웠습니다. 다음 동기화부터 hash 부터 재계산됩니다.');
+      setClearCacheConfirmOpen(false);
+      setModels([]);
+      setCacheInfo(null);
+      setAvailableBaseModels([]);
+      setPagination({ current: 1, pages: 0, total: 0 });
+      const response = await serverAPI.getModelsSyncStatus(selectedServerId);
+      setSyncStatus(response.data.data);
+    } catch (err) {
+      toast.error(err.response?.data?.message || '캐시 삭제 실패');
+    } finally {
+      setClearingCache(false);
+    }
+  };
+
   return (
     <Box>
       <Stack direction={{ xs: 'column', md: 'row' }} justifyContent="space-between" alignItems={{ md: 'center' }} spacing={2} mb={3}>
@@ -177,6 +207,19 @@ function ModelManagementPage({ selectedServerId, servers = [], nsfwModelFilter =
               </Button>
             </Tooltip>
           )}
+          <Tooltip title="모든 hash + civitai 메타데이터 삭제 (다음 동기화는 시간이 오래 걸림)">
+            <span>
+              <Button
+                variant="outlined"
+                color="error"
+                startIcon={<DeleteSweepIcon />}
+                onClick={() => setClearCacheConfirmOpen(true)}
+                disabled={!selectedServerId || syncing || clearingCache}
+              >
+                캐시 삭제
+              </Button>
+            </span>
+          </Tooltip>
         </Stack>
       </Stack>
 
@@ -317,6 +360,26 @@ function ModelManagementPage({ selectedServerId, servers = [], nsfwModelFilter =
           )}
         </>
       )}
+
+      <Dialog open={clearCacheConfirmOpen} onClose={() => setClearCacheConfirmOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>모델 캐시 완전 삭제</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            선택한 서버({selectedServer?.name || ''})의 모델 캐시를 모두 비웁니다.
+            <br /><br />
+            • 모든 모델의 hash, civitai 메타데이터가 삭제됩니다.<br />
+            • 다음 동기화는 hash 부터 다시 계산하므로 시간이 오래 걸릴 수 있습니다 (모델 수와 파일 크기에 따라 수 분 이상).<br />
+            • 일반 \"동기화\" 는 hash 를 재사용하므로 빠릅니다 — 이 작업은 처음부터 다시 받아야 할 때만 사용하세요.<br /><br />
+            계속하시겠어요?
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setClearCacheConfirmOpen(false)} disabled={clearingCache}>취소</Button>
+          <Button onClick={handleClearCache} color="error" variant="contained" disabled={clearingCache} startIcon={clearingCache ? <CircularProgress size={16} /> : <DeleteSweepIcon />}>
+            캐시 삭제
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   );
 }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -192,11 +192,13 @@ export const serverAPI = {
   syncModels: (id, options = {}) => api.post(`/servers/${id}/models/sync`, options),
   getModelsSyncStatus: (id) => api.get(`/servers/${id}/models/status`),
   resetModelsSync: (id) => api.post(`/servers/${id}/models/sync/reset`),
+  clearModelCache: (id) => api.delete(`/servers/${id}/models/cache`),
   // LoRA 메타데이터 API
   getLoras: (id, params) => api.get(`/servers/${id}/loras`, { params }),
   syncLoras: (id, options = {}) => api.post(`/servers/${id}/loras/sync`, options),
   getLorasSyncStatus: (id) => api.get(`/servers/${id}/loras/status`),
   resetLorasSync: (id) => api.post(`/servers/${id}/loras/sync/reset`),
+  clearLoraCache: (id) => api.delete(`/servers/${id}/loras/cache`),
 };
 
 // 사용자 그룹 (#198)

--- a/src/routes/servers.js
+++ b/src/routes/servers.js
@@ -557,6 +557,32 @@ router.get('/:id/models/status', verifyJWT, async (req, res) => {
   }
 });
 
+// Model 캐시 완전 삭제 - 관리자만 (#341)
+// 일반 동기화는 existing.hash 를 재사용하지만, 캐시 자체를 비우면 다음 sync 가 hash 부터 재계산.
+router.delete('/:id/models/cache', requireAdmin, async (req, res) => {
+  try {
+    const cache = await ServerModelCache.findOne({ serverId: req.params.id });
+    if (!cache) {
+      return res.json({ success: true, message: '캐시가 없습니다.' });
+    }
+    cache.models = [];
+    cache.lastFetched = null;
+    cache.lastMetadataSync = null;
+    cache.progress = { current: 0, total: 0, stage: 'idle' };
+    cache.status = 'idle';
+    cache.errorMessage = null;
+    await cache.save();
+    res.json({ success: true, message: '모델 캐시를 비웠습니다.' });
+  } catch (error) {
+    console.error('모델 캐시 삭제 오류:', error);
+    res.status(500).json({
+      success: false,
+      message: '모델 캐시 삭제에 실패했습니다.',
+      error: error.message
+    });
+  }
+});
+
 // LoRA 동기화 (메타데이터 포함) - 관리자만
 router.post('/:id/loras/sync', requireAdmin, async (req, res) => {
   try {
@@ -624,6 +650,31 @@ router.get('/:id/loras/status', verifyJWT, async (req, res) => {
     res.status(500).json({
       success: false,
       message: '동기화 상태를 조회하는데 실패했습니다.',
+      error: error.message
+    });
+  }
+});
+
+// LoRA 캐시 완전 삭제 - 관리자만 (#341)
+router.delete('/:id/loras/cache', requireAdmin, async (req, res) => {
+  try {
+    const cache = await ServerLoraCache.findOne({ serverId: req.params.id });
+    if (!cache) {
+      return res.json({ success: true, message: '캐시가 없습니다.' });
+    }
+    cache.loraModels = [];
+    cache.lastFetched = null;
+    cache.lastCivitaiSync = null;
+    cache.progress = { current: 0, total: 0, stage: 'idle' };
+    cache.status = 'idle';
+    cache.errorMessage = null;
+    await cache.save();
+    res.json({ success: true, message: 'LoRA 캐시를 비웠습니다.' });
+  } catch (error) {
+    console.error('LoRA 캐시 삭제 오류:', error);
+    res.status(500).json({
+      success: false,
+      message: 'LoRA 캐시 삭제에 실패했습니다.',
       error: error.message
     });
   }

--- a/src/services/loraMetadataService.js
+++ b/src/services/loraMetadataService.js
@@ -258,7 +258,10 @@ const syncServerLoras = async (serverId, serverUrl, { progressCallback = null, f
         continue;
       }
 
-      // 새 모델 데이터 구성
+      // hash 재사용 정책 (#341):
+      // existing.hash 가 있으면 재계산하지 않고 civitai 메타만 새로 받음. 파일 내용이 바뀌면
+      // 파일명도 같이 바뀌는 경우가 대부분이라 기존 hash 를 신뢰해도 충돌 가능성 낮음. hash 까지
+      // 다시 받고 싶으면 admin 의 \"캐시 완전 삭제\" 버튼 (DELETE /api/servers/:id/loras/cache) 사용.
       const loraModel = {
         filename,
         relativePath: filename,

--- a/src/services/modelMetadataService.js
+++ b/src/services/modelMetadataService.js
@@ -348,6 +348,11 @@ const syncServerCheckpoints = async (serverId, serverUrl, { progressCallback = n
         continue;
       }
 
+      // hash 재사용 정책 (#341):
+      // existing.hash 가 있으면 재계산하지 않고 civitai 메타만 새로 받음. 체크포인트 SHA256 은
+      // 파일당 수십 초~분 단위라 가장 큰 비용. 보통 파일 내용이 바뀌면 파일명도 같이 바뀌어 새 entry 로
+      // 처리되므로 기존 hash 를 신뢰해도 충돌 가능성 낮음. hash 자체를 다시 받고 싶으면 admin 의
+      // \"캐시 완전 삭제\" 버튼 (DELETE /api/servers/:id/models/cache) 으로 cache.models 를 비운 뒤 동기화.
       const item = {
         filename,
         hash: existing?.hash || null,


### PR DESCRIPTION
## Summary

- backend: `DELETE /api/servers/:id/models/cache` / `DELETE /api/servers/:id/loras/cache` route 신설
- frontend: 관리자 모델 / LoRA 관리 페이지에 "캐시 삭제" 버튼 (error 색)
- 확인 다이얼로그 — 선택 서버 / 동작 결과 / hash 재계산 비용 안내
- service 코드에 hash 재사용 동작 코멘트 추가

## 의도된 흐름

- "동기화" (#335 적용 후): hash 는 재사용, civitai 메타만 새로 받음 (빠름)
- "캐시 삭제": hash 까지 모두 비움 → 다음 동기화는 SHA256 부터 재계산 (체크포인트는 분 단위 가능)

## Test plan

- [ ] 관리자 모델 관리 페이지에 "캐시 삭제" 버튼 보임 (error 색)
- [ ] 클릭 시 확인 다이얼로그 표시 (서버명 / 안내 / 취소·확인)
- [ ] 확인 후 modelCache 비워짐, 토스트 표시
- [ ] LoRA 관리 페이지도 동일
- [ ] 비관리자 / 다른 사용자 접근 차단

## 의존성

이 PR 은 #340 위에서 빌드됩니다. 머지 순서: #340 → #341.

closes #341