### PR TITLE
release: v2.2.1

### DIFF
--- a/docs/updatelogs/v2.md
+++ b/docs/updatelogs/v2.md
@@ -1,5 +1,16 @@
 # v2 업데이트 내역
 
+## v2.2.1
+
+### 신규 기능
+- feat: ComfyUI \`folder_paths.cached_filename_list_\` 의 stale 자동 해결 (#349, #350)
+  - \`vcc-file-hash\` 커스텀 노드 v3.0 → v3.1: 신규 \`POST /api/vcc/file-hash/refresh/{folder_type}\` endpoint — folder 캐시 무효화 + 즉시 재스캔.
+  - vcc-manager 동기화 (모델 / LoRA) 시작 시 자동 호출 — best-effort, 구 노드(v3.0 이하) 환경에서는 404 silently fallback.
+  - 효과: 파일 시스템에서 모델 삭제 후 ComfyUI 재시작 없이도 vcc-manager \"동기화\" 1회로 삭제된 모델이 목록에서 자동 제거.
+
+### 사용자 작업
+- ComfyUI 의 \`custom_nodes/comfyui-vcc-file-hash/\` 를 v3.1 로 업데이트 + ComfyUI 재시작 1회. 이후엔 자동.
+
 ## v2.2.0
 
 ### 모델 관리 UI 통합 + 3종 view mode

--- a/src/services/loraMetadataService.js
+++ b/src/services/loraMetadataService.js
@@ -54,6 +54,29 @@ const getLoraFilenames = async (serverUrl) => {
 };
 
 /**
+ * ComfyUI folder_paths 의 loras 캐시 강제 갱신 (#349).
+ * vcc-file-hash 노드 v3.1+ 가 있어야 함. 구 노드면 404 fallback.
+ */
+const refreshFolderCache = async (serverUrl, folderType) => {
+  try {
+    const response = await axios.post(
+      `${serverUrl}/api/vcc/file-hash/refresh/${folderType}`,
+      null,
+      { timeout: 10000 }
+    );
+    if (response.data?.success) {
+      console.log(`[LoraSync] folder_paths cache refreshed for ${folderType} (${response.data.count} files)`);
+      return true;
+    }
+  } catch (error) {
+    if (error.response?.status !== 404) {
+      console.warn(`[LoraSync] folder refresh failed for ${folderType}: ${error.message}`);
+    }
+  }
+  return false;
+};
+
+/**
  * VCC File Hash 커스텀 노드 설치 여부 확인.
  * v2.0 의 신규 일반화 엔드포인트 우선, 구 LoRA 전용 엔드포인트 fallback.
  */
@@ -217,6 +240,9 @@ const syncServerLoras = async (serverId, serverUrl, { progressCallback = null, f
     // 2단계: ComfyUI에서 LoRA 파일명 목록 조회
     if (progressCallback) progressCallback('fetching_list', 0, 0);
     await cache.updateProgress(0, 0, 'fetching_list');
+
+    // ComfyUI folder_paths 캐시 강제 갱신 (#349)
+    await refreshFolderCache(serverUrl, 'loras');
 
     const filenames = await getLoraFilenames(serverUrl);
     console.log(`Got ${filenames.length} LoRA files from ComfyUI`);

--- a/src/services/modelMetadataService.js
+++ b/src/services/modelMetadataService.js
@@ -69,6 +69,31 @@ const checkVccFileHashNodeAvailable = async (serverUrl) => {
 };
 
 /**
+ * ComfyUI folder_paths 의 특정 folder_type 캐시 강제 갱신 요청.
+ * vcc-file-hash 노드 v3.1+ 의 \`POST /api/vcc/file-hash/refresh/{folder_type}\` 사용.
+ * 노드가 구 버전이면 endpoint 가 없어 404 — silently 무시 (#349).
+ */
+const refreshFolderCache = async (serverUrl, folderType) => {
+  try {
+    const response = await axios.post(
+      `${serverUrl}/api/vcc/file-hash/refresh/${folderType}`,
+      null,
+      { timeout: 10000 }
+    );
+    if (response.data?.success) {
+      console.log(`[ModelSync] folder_paths cache refreshed for ${folderType} (${response.data.count} files)`);
+      return true;
+    }
+  } catch (error) {
+    // 404 (endpoint 없음) 은 정상적인 fallback. 다른 에러는 로깅만.
+    if (error.response?.status !== 404) {
+      console.warn(`[ModelSync] folder refresh failed for ${folderType}: ${error.message}`);
+    }
+  }
+  return false;
+};
+
+/**
  * 단일 checkpoint 파일의 SHA256 해시 조회.
  * 신규 노드 (file-hash/checkpoints/{filename}) 사용. 구 노드는 checkpoint 미지원.
  */
@@ -313,6 +338,9 @@ const syncServerCheckpoints = async (serverId, serverUrl, { progressCallback = n
 
     if (progressCallback) progressCallback('fetching_list', 0, 0);
     await cache.updateProgress(0, 0, 'fetching_list');
+
+    // ComfyUI folder_paths 캐시 강제 갱신 (삭제된 파일 즉시 반영, #349)
+    await refreshFolderCache(serverUrl, 'checkpoints');
 
     const filenames = await getCheckpointFilenames(serverUrl);
     console.log(`[ModelSync] Got ${filenames.length} checkpoints from ComfyUI`);

--- a/tools/comfyui-vcc-file-hash/README.md
+++ b/tools/comfyui-vcc-file-hash/README.md
@@ -32,8 +32,22 @@ ComfyUI 를 재시작하면 자동 로드됨.
 {
   "success": true,
   "message": "VCC File Hash node is running",
-  "version": "3.0",
+  "version": "3.1",
   "supported_folder_types": ["checkpoints", "clip", "loras", "vae", ...]
+}
+```
+
+### POST /api/vcc/file-hash/refresh/{folder_type}
+
+ComfyUI `folder_paths.cached_filename_list_` 의 해당 folder 캐시 무효화 + 즉시 재스캔. 파일 추가/삭제가 mtime 변화로 즉시 반영되지 않을 때 사용. vcc-manager 동기화 시작 시 자동 호출 (v2.2+).
+
+**응답 예시:**
+```json
+{
+  "success": true,
+  "folder_type": "checkpoints",
+  "invalidated": true,
+  "count": 54
 }
 ```
 

--- a/tools/comfyui-vcc-file-hash/__init__.py
+++ b/tools/comfyui-vcc-file-hash/__init__.py
@@ -19,7 +19,7 @@ import folder_paths
 from aiohttp import web
 from server import PromptServer
 
-NODE_VERSION = "3.0"
+NODE_VERSION = "3.1"
 
 # ComfyUI folder_paths 가 인식하는 type 만 허용 (path traversal 방어)
 SUPPORTED_FOLDER_TYPES = {
@@ -136,6 +136,40 @@ async def get_file_hash(request):
     filename = request.match_info.get("filename", "")
     return build_hash_response(folder_type, filename)
 
+@PromptServer.instance.routes.post("/api/vcc/file-hash/refresh/{folder_type}")
+async def refresh_folder_cache(request):
+    """
+    ComfyUI folder_paths 의 특정 folder_type 캐시 무효화 + 즉시 재스캔.
+    파일 삭제·추가가 즉시 반영되지 않을 때 vcc-manager 동기화 직전 호출 (#349).
+    """
+    folder_type = request.match_info.get("folder_type", "")
+    if folder_type not in SUPPORTED_FOLDER_TYPES:
+        return web.json_response({
+            "success": False,
+            "error": f"Unsupported folder_type: {folder_type}"
+        }, status=400)
+
+    try:
+        invalidated = False
+        cache_dict = getattr(folder_paths, "cached_filename_list_", None)
+        if isinstance(cache_dict, dict) and folder_type in cache_dict:
+            del cache_dict[folder_type]
+            invalidated = True
+        # 즉시 재스캔
+        files = folder_paths.get_filename_list(folder_type)
+        return web.json_response({
+            "success": True,
+            "folder_type": folder_type,
+            "invalidated": invalidated,
+            "count": len(files) if files else 0,
+        })
+    except Exception as e:
+        print(f"[VCC File Hash] refresh error: {e}")
+        return web.json_response({
+            "success": False,
+            "error": str(e)
+        }, status=500)
+
 # ── Legacy API (backward compat for older vcc-manager versions) ─────
 
 @PromptServer.instance.routes.get("/api/vcc/lora-hash/ping")
@@ -156,7 +190,8 @@ NODE_CLASS_MAPPINGS = {}
 NODE_DISPLAY_NAME_MAPPINGS = {}
 
 print("[VCC File Hash] Loaded - API endpoints:")
-print("[VCC File Hash]   GET /api/vcc/file-hash/ping")
-print("[VCC File Hash]   GET /api/vcc/file-hash/{folder_type}/{filename}")
-print("[VCC File Hash]   GET /api/vcc/lora-hash/ping              (legacy alias)")
-print("[VCC File Hash]   GET /api/vcc/lora-hash/{filename}         (legacy alias for folder_type=loras)")
+print("[VCC File Hash]   GET  /api/vcc/file-hash/ping")
+print("[VCC File Hash]   GET  /api/vcc/file-hash/{folder_type}/{filename}")
+print("[VCC File Hash]   POST /api/vcc/file-hash/refresh/{folder_type}")
+print("[VCC File Hash]   GET  /api/vcc/lora-hash/ping              (legacy alias)")
+print("[VCC File Hash]   GET  /api/vcc/lora-hash/{filename}         (legacy alias for folder_type=loras)")


### PR DESCRIPTION
## v2.2.1 — Patch Release

### 신규 기능
- feat: ComfyUI folder_paths cached_filename_list_ stale 자동 해결 (#349, #350)
  - vcc-file-hash 커스텀 노드 v3.1: POST /api/vcc/file-hash/refresh/{folder_type}
  - vcc-manager 동기화 시작 시 자동 호출

### 사용자 작업
- ComfyUI 측 custom node 업데이트 (v3.0 → v3.1) + 재시작 1회

자세한 내용은 [docs/updatelogs/v2.md](docs/updatelogs/v2.md) 참고.

🤖 Generated with [Claude Code](https://claude.com/claude-code)