### PR TITLE
feat: OpenAI/Gemini outputFormat 추론 + picker 필터 + whitelist picker (#354)

### DIFF
--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -235,7 +235,7 @@ function WorkboardCard({ workboard, onEdit, onDelete, onDuplicate, onExport, onV
 
 // 화이트리스트 필드 — Autocomplete (수동 입력) + picker 모달 (서버 모델/LoRA 선택).
 // ComfyUI 서버에서만 picker 표시. picker 는 multi-add 모드 — 카드 클릭마다 한 건씩 추가됨.
-function WhitelistField({ name, control, kind, serverId, placeholder, showPicker }) {
+function WhitelistField({ name, control, kind, serverId, outputFormat, placeholder, showPicker = true }) {
   const [pickerOpen, setPickerOpen] = useState(false);
   return (
     <Controller
@@ -293,6 +293,7 @@ function WhitelistField({ name, control, kind, serverId, placeholder, showPicker
                 open={pickerOpen}
                 onClose={() => setPickerOpen(false)}
                 serverId={serverId}
+                outputFormat={outputFormat}
                 isAdmin
                 mode="multi-add"
                 onPrimary={handleAdd}
@@ -306,7 +307,7 @@ function WhitelistField({ name, control, kind, serverId, placeholder, showPicker
 }
 
 // 권한 / 노출 정책 panel (#198) — 작업판 admin 폼의 한 탭으로 사용.
-function PermissionsAndExposurePanel({ control, isComfyUI, serverId, groups, modelExposurePolicyValue, loraExposurePolicyValue }) {
+function PermissionsAndExposurePanel({ control, isComfyUI, serverId, outputFormat, groups, modelExposurePolicyValue, loraExposurePolicyValue }) {
   return (
     <Box>
       {/* 접근 그룹 */}
@@ -384,16 +385,16 @@ function PermissionsAndExposurePanel({ control, isComfyUI, serverId, groups, mod
           {modelExposurePolicyValue === 'whitelist' && (
             <Box sx={{ mt: 2 }}>
               <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
-                노출할 모델 식별자 (ComfyUI=파일 경로, OpenAI/Gemini=모델 ID)
-                {isComfyUI && ' · "선택" 으로 서버에서 직접 추가'}
+                노출할 모델 식별자 (ComfyUI=파일 경로, OpenAI/Gemini=모델 ID) · "선택" 으로 서버에서 직접 추가
               </Typography>
               <WhitelistField
                 name="modelWhitelist"
                 control={control}
                 kind="model"
                 serverId={serverId}
+                outputFormat={outputFormat}
                 placeholder="예: SDXL/illustrious_v6.safetensors"
-                showPicker={isComfyUI}
+                showPicker
               />
             </Box>
           )}
@@ -1005,6 +1006,7 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
               control={control}
               isComfyUI={isComfyUI}
               serverId={watchedServerId}
+              outputFormat={watch('outputFormat')}
               groups={availableGroups}
               modelExposurePolicyValue={watch('modelExposurePolicy')}
               loraExposurePolicyValue={watch('loraExposurePolicy')}

--- a/frontend/src/components/common/MetadataPickerModal.js
+++ b/frontend/src/components/common/MetadataPickerModal.js
@@ -85,13 +85,16 @@ const KIND_ADAPTERS = {
     nsfwItemLabel: 'NSFW 모델 숨기기',
   },
   model: {
-    fetch: ({ serverId, workboardId, search, baseModel, allowedBaseModels, page, limit }) => {
+    fetch: ({ serverId, workboardId, search, baseModel, allowedBaseModels, outputFormat, page, limit }) => {
       const params = { search, baseModel, page, limit };
       if (allowedBaseModels && allowedBaseModels.length > 0) {
         params.allowedBaseModels = allowedBaseModels;
       }
       // workboardId 전달 시 backend 가 작업판의 modelExposurePolicy / modelWhitelist 적용 (#198 Phase D)
+      // 추가로 workboard.outputFormat 으로 provider outputFormats 자동 필터 (#354)
       if (workboardId) params.workboardId = workboardId;
+      // outputFormat 명시 전달 — workboardId 없이 admin 페이지에서 작업판 폼의 값으로 호출하는 경우 (#354)
+      if (outputFormat) params.outputFormat = outputFormat;
       return serverAPI.getDetailedModels(serverId, params);
     },
     extractList: (responseData) => responseData?.models || [],
@@ -132,6 +135,7 @@ function MetadataPickerModal({
   onClose,
   serverId,
   workboardId,
+  outputFormat,
   isAdmin = false,
   mode = 'select-single',
   selectedItem,
@@ -202,6 +206,7 @@ function MetadataPickerModal({
           search: searchQuery,
           baseModel: baseModelFilter,
           allowedBaseModels: allowedModelTypes,
+          outputFormat,
           page,
           limit: 20
         });
@@ -220,7 +225,7 @@ function MetadataPickerModal({
         setLoading(false);
       }
     },
-    [serverId, workboardId, searchQuery, baseModelFilter, allowedModelTypes, kind, adapter]
+    [serverId, workboardId, searchQuery, baseModelFilter, allowedModelTypes, outputFormat, kind, adapter]
   );
 
   // sync 폴링

--- a/src/models/ServerModelCache.js
+++ b/src/models/ServerModelCache.js
@@ -54,6 +54,9 @@ const modelItemSchema = new mongoose.Schema({
     name: String,
     description: String,
     capabilities: [String],
+    // 모델이 지원하는 outputFormat (#354). image / text / video / embedding / audio
+    // 추론 실패 시 빈 배열 — 필터에서 fallback 으로 노출
+    outputFormats: [String],
     contextWindow: Number,
     fetchedAt: Date,
     error: String

--- a/src/routes/servers.js
+++ b/src/routes/servers.js
@@ -325,7 +325,7 @@ router.get('/:id/models', verifyJWT, async (req, res) => {
         });
       }
 
-      const { search, hasMetadata, baseModel, workboardId, page = 1, limit = 50 } = req.query;
+      const { search, hasMetadata, baseModel, workboardId, outputFormat: outputFormatQuery, page = 1, limit = 50 } = req.query;
       // allowedBaseModels: query string 으로 array 또는 single 둘 다 받기.
       let allowedBaseModels = req.query.allowedBaseModels;
       if (typeof allowedBaseModels === 'string') {
@@ -334,8 +334,9 @@ router.get('/:id/models', verifyJWT, async (req, res) => {
         allowedBaseModels = undefined;
       }
 
-      // 작업판 컨텍스트의 모델 노출 정책 적용 (#198 Phase D)
+      // 작업판 컨텍스트의 모델 노출 정책 적용 (#198 Phase D) + outputFormat 자동 유추 (#354)
       let whitelist = undefined;
+      let outputFormat = outputFormatQuery || undefined;
       if (workboardId) {
         const wb = await Workboard.findById(workboardId);
         if (!wb) {
@@ -349,6 +350,10 @@ router.get('/:id/models', verifyJWT, async (req, res) => {
           // 빈 whitelist 면 정책상 0개 노출 — sentinel 로 빈 배열 대신 '__none__' 매칭 안 됨
           if (whitelist.length === 0) whitelist = ['__no_models_in_whitelist__'];
         }
+        // 명시적 outputFormat 쿼리가 없으면 workboard 의 것으로 자동 적용
+        if (!outputFormat && wb.outputFormat) {
+          outputFormat = wb.outputFormat;
+        }
       }
 
       const result = await modelMetadataService.searchServerModels(server._id, {
@@ -357,6 +362,7 @@ router.get('/:id/models', verifyJWT, async (req, res) => {
         baseModel,
         allowedBaseModels,
         whitelist,
+        outputFormat,
         page: parseInt(page),
         limit: parseInt(limit)
       });

--- a/src/services/modelMetadataService.js
+++ b/src/services/modelMetadataService.js
@@ -181,6 +181,49 @@ const fetchCivitaiMetadataByHash = async (hash, apiKey = null, retryCount = 0) =
 };
 
 /**
+ * OpenAI 모델 id 로부터 outputFormat 추론 (#354).
+ * `/v1/models` 응답에 타입 필드가 없어 id 패턴으로 분류.
+ * 매칭 실패 시 빈 배열 → 필터에서 fallback (안전: 미분류 모델은 노출됨)
+ */
+const inferOpenAIOutputFormats = (modelId) => {
+  if (!modelId || typeof modelId !== 'string') return [];
+  const id = modelId.toLowerCase();
+  // image 생성 (DALL-E, GPT-Image, sora 등)
+  if (id.startsWith('dall-e') || id.includes('gpt-image') || id.startsWith('sora')) {
+    return ['image'];
+  }
+  // text/chat 모델
+  if (
+    id.startsWith('gpt-') || id.startsWith('chatgpt-') ||
+    id.startsWith('o1-') || id.startsWith('o1') ||
+    id.startsWith('o3-') || id.startsWith('o3') ||
+    id.startsWith('o4-') || id.startsWith('o4')
+  ) {
+    return ['text'];
+  }
+  // 그 외 (whisper / tts / embedding / moderation 등) — 현재 워크플로 미지원이라
+  // 빈 배열 반환하여 어느 outputFormat 의 picker 에도 안 보이게.
+  return [];
+};
+
+/**
+ * Gemini 모델 정보로부터 outputFormat 추론 (#354).
+ * 이름에 'image-generation' 포함 시 image, 그 외 generateContent 지원 시 text.
+ */
+const inferGeminiOutputFormats = ({ name = '', displayName = '', supportedGenerationMethods = [] }) => {
+  const fullName = `${name} ${displayName}`.toLowerCase();
+  const methods = Array.isArray(supportedGenerationMethods) ? supportedGenerationMethods : [];
+  const formats = [];
+  if (fullName.includes('image-generation') || fullName.includes('imagen')) {
+    formats.push('image');
+  }
+  if (methods.includes('generateContent') && formats.length === 0) {
+    formats.push('text');
+  }
+  return formats;
+};
+
+/**
  * OpenAI / OpenAI Compatible 서버의 모델 목록 조회 (`GET /v1/models`).
  * 응답 스펙: { data: [{ id, object, created, owned_by, ... }] }
  */
@@ -200,6 +243,7 @@ const getOpenAIProviderModels = async (serverUrl, apiKey) => {
       name: m.id,
       description: m.description || '',
       capabilities: [],
+      outputFormats: inferOpenAIOutputFormats(m.id),
       contextWindow: m.context_window || null,
       ownedBy: m.owned_by || null
     }));
@@ -225,6 +269,7 @@ const getGeminiProviderModels = async (serverUrl, apiKey) => {
       name: m.displayName || m.name,
       description: m.description || '',
       capabilities: m.supportedGenerationMethods || [],
+      outputFormats: inferGeminiOutputFormats(m),
       contextWindow: m.inputTokenLimit || null
     }));
   } catch (error) {
@@ -527,7 +572,7 @@ const resetSyncStatus = async (serverId) => {
  * @param {string[]} opts.allowedBaseModels — civitai.baseModel 다중 매칭
  *   (작업판의 allowedModelTypes 와 매핑 — 필터 활성 시 Civitai 미등록 모델은 제외, #320)
  */
-const searchServerModels = async (serverId, { search, hasMetadata, baseModel, allowedBaseModels, whitelist, page = 1, limit = 50 } = {}) => {
+const searchServerModels = async (serverId, { search, hasMetadata, baseModel, allowedBaseModels, whitelist, outputFormat, page = 1, limit = 50 } = {}) => {
   const cache = await ServerModelCache.findOne({ serverId });
 
   if (!cache) {
@@ -580,6 +625,17 @@ const searchServerModels = async (serverId, { search, hasMetadata, baseModel, al
   // 필터 활성 시 civitai 미등록 (baseModel 미상) 모델도 제외 (#320).
   if (Array.isArray(allowedBaseModels) && allowedBaseModels.length > 0) {
     filtered = filtered.filter(m => allowedBaseModels.includes(m.civitai?.baseModel));
+  }
+
+  // outputFormat: provider.outputFormats 기반 필터 (#354).
+  // SaaS provider 모델 한정. ComfyUI checkpoint 는 provider.outputFormats 가 없으므로 영향 없음.
+  // outputFormats 미설정 (구 캐시) 항목은 fallback 으로 통과 — 다음 sync 후 정상 분류.
+  if (outputFormat) {
+    filtered = filtered.filter(m => {
+      const formats = m.provider?.outputFormats;
+      if (!Array.isArray(formats) || formats.length === 0) return true;  // fallback
+      return formats.includes(outputFormat);
+    });
   }
 
   // whitelist: 작업판의 modelExposurePolicy='whitelist' + modelWhitelist 적용 (#198 Phase D).


### PR DESCRIPTION
## Summary

### backend
- `ServerModelCache.provider.outputFormats: [String]` 신설
- `modelMetadataService`:
  - `inferOpenAIOutputFormats(modelId)` — id 패턴 (gpt-image / dall-e / sora → image, gpt/chatgpt/o1/o3/o4 → text)
  - `inferGeminiOutputFormats(modelData)` — name + supportedGenerationMethods 추론
  - provider getter 응답에 outputFormats 포함
- `searchServerModels` 가 `outputFormat` 파라미터로 필터. 미설정 항목은 fallback 통과.
- `/servers/:id/models` 라우트가 `outputFormat` 쿼리 + `workboardId` 기반 자동 유추.

### frontend
- `WorkboardManagement.WhitelistField`: `showPicker` 를 모든 server type 에 대해 `true`. picker 가 workboard `outputFormat` 으로 자동 필터.
- `MetadataPickerModal`: `outputFormat` prop 받아 fetch params 에 추가.

## Test plan

- [ ] 관리자 → 모델 관리 → OpenAI 서버 동기화 → image / text 모델이 분리되어 캐시됨
- [ ] 작업판 admin → 모델 관리 → 화이트리스트 → OpenAI 서버 선택 → "선택" 버튼이 보이고 picker 가 workboard outputFormat 에 맞는 모델만 표시
- [ ] outputFormat=image 작업판: gpt-image-* / dall-e-* 만 picker 노출
- [ ] outputFormat=text 작업판: gpt-* (chat) 만 노출
- [ ] Gemini 도 동일 동작 (image-generation / 일반 generateContent)
- [ ] 구 캐시 (outputFormats 미설정) 는 fallback 으로 모두 노출 — 다음 sync 후 정상 필터

closes #354