### PR TITLE
fix: Civitai API 키 스키마 settings.external 이전 + 마이그레이션 (#293 Phase B)

### DIFF
--- a/src/migrations/relocateCivitaiApiKey.js
+++ b/src/migrations/relocateCivitaiApiKey.js
@@ -1,0 +1,32 @@
+const SystemSettings = require('../models/SystemSettings');
+
+// #293 Phase B: settings.lora.civitaiApiKey → settings.external.civitaiApiKey 이전.
+// 멱등 — external.civitaiApiKey 가 비어있고 lora.civitaiApiKey 가 설정돼 있을 때만 복사.
+// 이후엔 lora 위치는 fallback 으로만 읽힘 (SystemSettings.getCivitaiApiKey 참고).
+async function relocateCivitaiApiKey() {
+  try {
+    const settings = await SystemSettings.findOne({ key: 'global' });
+    if (!settings) {
+      console.log('[Migration] SystemSettings 없음 — Civitai API 키 이전 불필요');
+      return;
+    }
+    const legacy = settings.lora?.civitaiApiKey;
+    const current = settings.external?.civitaiApiKey;
+    if (!legacy) {
+      console.log('[Migration] Civitai API 키 이전 불필요 (legacy 없음)');
+      return;
+    }
+    if (current) {
+      console.log('[Migration] Civitai API 키 이전 불필요 (external 이미 설정됨)');
+      return;
+    }
+    if (!settings.external) settings.external = {};
+    settings.external.civitaiApiKey = legacy;
+    await settings.save();
+    console.log('[Migration] Civitai API 키 이전 완료 (lora → external)');
+  } catch (error) {
+    console.error('[Migration] Civitai API 키 이전 실패:', error.message);
+  }
+}
+
+module.exports = relocateCivitaiApiKey;

--- a/src/models/SystemSettings.js
+++ b/src/models/SystemSettings.js
@@ -28,7 +28,16 @@ const systemSettingsSchema = new mongoose.Schema({
       type: Boolean,
       default: true
     },
-    // Civitai API 키 (암호화 저장 권장)
+    // legacy field — #293 Phase B 에서 settings.external.civitaiApiKey 로 이전.
+    // 마이그레이션 후에도 fallback 으로 유지하다가 후속 cleanup 에서 제거.
+    civitaiApiKey: {
+      type: String,
+      default: null
+    }
+  },
+  // 외부 서비스 통합 설정 (#293 Phase B) — Civitai 등 외부 API.
+  // 베이스 모델 / LoRA 양쪽 서비스가 공유 사용.
+  external: {
     civitaiApiKey: {
       type: String,
       default: null
@@ -68,7 +77,10 @@ systemSettingsSchema.statics.updateLoraSettings = async function(updates) {
     settings.lora.nsfwLoraFilter = updates.nsfwLoraFilter;
   }
   if (updates.civitaiApiKey !== undefined) {
-    settings.lora.civitaiApiKey = updates.civitaiApiKey || null;
+    // #293 Phase B — 새 위치 우선, legacy 도 동기 갱신 (다른 코드 fallback 대비)
+    const v = updates.civitaiApiKey || null;
+    settings.external.civitaiApiKey = v;
+    settings.lora.civitaiApiKey = v;
   }
 
   await settings.save();
@@ -76,11 +88,17 @@ systemSettingsSchema.statics.updateLoraSettings = async function(updates) {
 };
 
 /**
- * Civitai API 키 조회
+ * Civitai API 키 조회 — settings.external.civitaiApiKey 우선, legacy settings.lora.civitaiApiKey
+ * fallback, 마지막으로 환경변수 (#293 Phase B)
  */
 systemSettingsSchema.statics.getCivitaiApiKey = async function() {
   const settings = await this.getGlobal();
-  return settings.lora.civitaiApiKey || process.env.CIVITAI_API_KEY || null;
+  return (
+    settings.external?.civitaiApiKey ||
+    settings.lora?.civitaiApiKey ||
+    process.env.CIVITAI_API_KEY ||
+    null
+  );
 };
 
 /**

--- a/src/server.js
+++ b/src/server.js
@@ -37,6 +37,7 @@ const initializeDefaultGroup = require('./migrations/initializeDefaultGroup');
 const assignDefaultGroupToWorkboards = require('./migrations/assignDefaultGroupToWorkboards');
 const backfillCustomFieldRoles = require('./migrations/backfillCustomFieldRoles');
 const dropBaseInputFieldsSchema = require('./migrations/dropBaseInputFieldsSchema');
+const relocateCivitaiApiKey = require('./migrations/relocateCivitaiApiKey');
 
 dotenv.config();
 
@@ -198,6 +199,7 @@ const startServer = async () => {
     await assignDefaultGroupToWorkboards();
     await backfillCustomFieldRoles();
     await dropBaseInputFieldsSchema();
+    await relocateCivitaiApiKey();
 
     // Initialize job queues after database connection
     console.log('Initializing job queues...');


### PR DESCRIPTION
## Summary

#293 의 Phase A (UI 공통 영역 분리) 는 #344 (PR #345) 로 이미 완료. 이번 PR 은 **Phase B (스키마 위치 정리)** 만 처리.

### 변경
- `SystemSettings` 에 `external.civitaiApiKey` 신설
- legacy `lora.civitaiApiKey` 는 fallback 으로 유지
- `updateLoraSettings({ civitaiApiKey })` 가 두 위치 모두 갱신 (전환 호환)
- `getCivitaiApiKey()` 는 `external` → `lora` → `env` 순으로 fallback
- 신규 마이그레이션 `relocateCivitaiApiKey` — server 부팅 시 자동 실행. external 비어있고 legacy 설정 시 복사 (멱등)

### 효과
- backend 코드 (modelMetadataService / loraMetadataService) 가 `getCivitaiApiKey()` 만 사용하므로 자동 적용
- frontend API 는 그대로 (`adminAPI.updateLoraSettings`) — backend 가 두 위치 동기 처리

## Test plan

- [ ] 부팅 시 마이그레이션 로그 `[Migration] Civitai API 키 이전 완료 (lora → external)` 1회 표시
- [ ] 마이그레이션 후 admin → 모델 관리 헤더의 API 키 "등록됨" 상태 유지
- [ ] OpenAI / Gemini sync 시 rate limit 로그 `API key: present` 정상 출력
- [ ] 키 변경/삭제도 정상 동작 (헤더 UI)

closes #293