### PR TITLE
release: v2.2.2

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -230,6 +230,56 @@ docker-compose up -d
 
 ---
 
+## 🧩 초기 모델 / LoRA 동기화 (관리자)
+
+설치 직후엔 시스템에 모델 / LoRA 가 비어있습니다. 아래 절차로 admin 이 한 번 등록·동기화하면 사용자가 작업판에서 베이스 모델 / LoRA picker 로 선택 가능합니다.
+
+### 1. 서버 등록
+**admin → 서버 관리** 에서 ComfyUI / OpenAI / OpenAI Compatible / Gemini 서버 추가.
+- ComfyUI: `serverUrl` (예: `http://localhost:8188`)
+- SaaS 계열: `serverUrl` + API key (서버 등록 시 입력)
+
+### 2. (ComfyUI 만) `vcc-file-hash` 커스텀 노드 설치
+체크포인트 / LoRA 의 SHA256 해시를 ComfyUI 가 제공하기 위해 필요합니다. Civitai 메타데이터 매칭의 전제.
+
+```bash
+# ComfyUI 의 custom_nodes 폴더에 복사 또는 심볼릭 링크
+cp -r /path/to/vcc-manager/tools/comfyui-vcc-file-hash ComfyUI/custom_nodes/
+# 또는
+ln -s /path/to/vcc-manager/tools/comfyui-vcc-file-hash ComfyUI/custom_nodes/comfyui-vcc-file-hash
+
+# ComfyUI 재시작
+```
+
+설치 확인:
+```bash
+curl "http://<comfyui-url>/api/vcc/file-hash/ping"
+# 응답에 "version": "3.1+" 가 보이면 정상
+```
+
+> v3.1+ 부터 vcc-manager 동기화 시작 시 자동으로 `POST /api/vcc/file-hash/refresh/{folder_type}` 호출 → ComfyUI 의 stale 파일 목록을 강제 갱신. 파일 삭제 등이 즉시 반영됩니다.
+
+### 3. (선택) Civitai API key 등록
+파일 SHA256 으로 Civitai 메타데이터 (모델 이름·버전·트리거 워드·미리보기 이미지 등) 를 받기 위한 단계. 키 없이도 동기화는 가능하지만 rate limit 이 5배 느림 (1초/요청 → 0.2초/요청).
+
+**admin → 모델 관리** 페이지 상단 공용 헤더의 **\"Civitai API 키\"** 항목에서 입력 → 저장.
+
+### 4. 모델 / LoRA 동기화
+**admin → 모델 관리** → 상단의 서버 선택기에서 대상 서버 선택 → **\"베이스 모델\"** 탭 → **\"동기화\"** 버튼 클릭.
+- 진행률 표시 (해시 계산 → Civitai 조회)
+- 완료 후 카드 그리드 / image-list / list 3종 view mode 로 결과 확인 가능
+- **\"LoRA\"** 탭에서도 동일 동작 (ComfyUI 서버만)
+
+NSFW 모델 / 이미지 숨김 토글도 공용 헤더에서 설정. 작업판 사용자 페이지 picker 에 동일 토글 (user preference) 도 제공.
+
+### 5. (선택) 캐시 완전 삭제 후 재동기화
+일반 \"동기화\" 는 기존 hash 를 재사용해 빠르지만, 드물게 hash 까지 다시 계산하고 싶을 때:
+**admin → 모델 관리** 페이지 상단의 **\"캐시 삭제\"** 버튼 → 확인 → 다시 \"동기화\".
+
+체크포인트는 파일당 SHA256 계산이 수십 초~분 단위라 시간이 오래 걸립니다.
+
+---
+
 ## 📚 다음 단계
 
 설치 완료 후 다음 문서들을 참조하세요:

--- a/docs/updatelogs/v2.md
+++ b/docs/updatelogs/v2.md
@@ -1,5 +1,31 @@
 # v2 업데이트 내역
 
+## v2.2.2
+
+### 신규 기능
+- feat: OpenAI / Gemini 모델의 outputFormat 추론 + workboard 기반 picker 필터 (#354, #355)
+  - OpenAI: id 패턴 (gpt-image / dall-e / sora → image, gpt / chatgpt / o1 / o3 / o4 → text). 그 외 (whisper / tts / embedding 등) 미지원으로 picker 미노출.
+  - Gemini: \`supportedGenerationMethods\` 우선 (predict → image, generateContent → name 패턴 추가 검사), name/displayName/description 통합 검사 (imagen / image-generation / image-preview / image-edit / nano-banana / -image-/-image\$ 모두 image 분류)
+  - \`provider.outputFormats: [String]\` 신규 schema 필드
+  - workboard 의 outputFormat 으로 picker 자동 필터. 사용자 / admin 화이트리스트 양쪽 적용.
+- feat: admin 작업판 화이트리스트 picker 활성화 (모든 server type) (#354)
+  - 기존 ComfyUI 만 가능했던 \"선택\" 버튼이 OpenAI / Gemini 등 모든 서버에서 활성. workboard outputFormat 으로 자동 필터.
+- feat: Civitai API 키 스키마를 \`settings.external.civitaiApiKey\` 로 이전 (#293 Phase B, #356)
+  - 기존 \`settings.lora.civitaiApiKey\` (LoRA namespace 라 \"베이스 모델은 별도 키?\" 오해 유발) → \`settings.external\` (외부 서비스 통합 namespace)
+  - 부팅 시 자동 마이그레이션 (멱등). legacy 위치도 fallback 으로 유지.
+
+### 수정
+- fix: API GET 응답에 \`Cache-Control: no-store\` 명시 (#354)
+  - admin 동기화 후 picker 가 같은 URL 캐시 재사용해 이전 모델 목록을 표시하던 문제. \`/api/*\` 미들웨어에서 모든 GET 응답에 cache 비활성 헤더 추가.
+- fix: picker 의 vcc-file-hash 미설치 안내 Alert 제거 (#354)
+  - SaaS provider (OpenAI / Gemini) 작업판에서도 잘못 노출되던 안내. admin 페이지에는 serverType 게이트와 함께 잔존.
+- fix: picker Dialog 의 height 를 \`85vh\` 고정 (#354)
+  - 검색 글자 입력 시 fetch loading / pagination 변화로 다이얼로그 전체가 덜컹거리던 문제.
+
+### 문서
+- docs: INSTALLATION.md 에 \"초기 모델 / LoRA 동기화\" 섹션 추가 (#352, #353)
+  - 신규 설치 admin 의 첫 작업 흐름 (서버 등록 → vcc-file-hash 노드 설치 → Civitai API 키 → 동기화 → 캐시 삭제) 단계별 안내. v2.2 의 공용 헤더 / 3종 view mode / NSFW 토글도 함께 설명.
+
 ## v2.2.1
 
 ### 신규 기능

--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -235,7 +235,7 @@ function WorkboardCard({ workboard, onEdit, onDelete, onDuplicate, onExport, onV
 
 // 화이트리스트 필드 — Autocomplete (수동 입력) + picker 모달 (서버 모델/LoRA 선택).
 // ComfyUI 서버에서만 picker 표시. picker 는 multi-add 모드 — 카드 클릭마다 한 건씩 추가됨.
-function WhitelistField({ name, control, kind, serverId, placeholder, showPicker }) {
+function WhitelistField({ name, control, kind, serverId, outputFormat, placeholder, showPicker = true }) {
   const [pickerOpen, setPickerOpen] = useState(false);
   return (
     <Controller
@@ -293,6 +293,7 @@ function WhitelistField({ name, control, kind, serverId, placeholder, showPicker
                 open={pickerOpen}
                 onClose={() => setPickerOpen(false)}
                 serverId={serverId}
+                outputFormat={outputFormat}
                 isAdmin
                 mode="multi-add"
                 onPrimary={handleAdd}
@@ -306,7 +307,7 @@ function WhitelistField({ name, control, kind, serverId, placeholder, showPicker
 }
 
 // 권한 / 노출 정책 panel (#198) — 작업판 admin 폼의 한 탭으로 사용.
-function PermissionsAndExposurePanel({ control, isComfyUI, serverId, groups, modelExposurePolicyValue, loraExposurePolicyValue }) {
+function PermissionsAndExposurePanel({ control, isComfyUI, serverId, outputFormat, groups, modelExposurePolicyValue, loraExposurePolicyValue }) {
   return (
     <Box>
       {/* 접근 그룹 */}
@@ -384,16 +385,16 @@ function PermissionsAndExposurePanel({ control, isComfyUI, serverId, groups, mod
           {modelExposurePolicyValue === 'whitelist' && (
             <Box sx={{ mt: 2 }}>
               <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
-                노출할 모델 식별자 (ComfyUI=파일 경로, OpenAI/Gemini=모델 ID)
-                {isComfyUI && ' · "선택" 으로 서버에서 직접 추가'}
+                노출할 모델 식별자 (ComfyUI=파일 경로, OpenAI/Gemini=모델 ID) · "선택" 으로 서버에서 직접 추가
               </Typography>
               <WhitelistField
                 name="modelWhitelist"
                 control={control}
                 kind="model"
                 serverId={serverId}
+                outputFormat={outputFormat}
                 placeholder="예: SDXL/illustrious_v6.safetensors"
-                showPicker={isComfyUI}
+                showPicker
               />
             </Box>
           )}
@@ -1005,6 +1006,7 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
               control={control}
               isComfyUI={isComfyUI}
               serverId={watchedServerId}
+              outputFormat={watch('outputFormat')}
               groups={availableGroups}
               modelExposurePolicyValue={watch('modelExposurePolicy')}
               loraExposurePolicyValue={watch('loraExposurePolicy')}

--- a/frontend/src/components/common/MetadataPickerModal.js
+++ b/frontend/src/components/common/MetadataPickerModal.js
@@ -301,7 +301,16 @@ function MetadataPickerModal({
   const resolvedTitle = title || `${adapter.label} 선택`;
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="lg"
+      fullWidth
+      PaperProps={{
+        // 검색 입력 시 결과 영역 height 변화로 다이얼로그 전체가 덜컹거리는 문제 방지 (#354)
+        sx: { height: '85vh' }
+      }}
+    >
       <DialogTitle sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
         <Typography variant="h6">{resolvedTitle}</Typography>
         <IconButton onClick={onClose} size="small">
@@ -388,17 +397,13 @@ function MetadataPickerModal({
           </Stack>
         )}
 
-        {cacheInfo && (
+        {cacheInfo && (cacheInfo.lastFetched || cacheInfo.lastMetadataSync || cacheInfo.lastCivitaiSync) && (
           <Box sx={{ mb: 2 }}>
             <Typography variant="caption" color="text.secondary">
               {cacheInfo.lastFetched && `마지막 조회: ${new Date(cacheInfo.lastFetched).toLocaleString('ko-KR')}`}
               {(cacheInfo.lastMetadataSync || cacheInfo.lastCivitaiSync) && ` · 메타 동기화: ${new Date(cacheInfo.lastMetadataSync || cacheInfo.lastCivitaiSync).toLocaleString('ko-KR')}`}
             </Typography>
-            {cacheInfo.hashNodeAvailable === false && (
-              <Alert severity="info" sx={{ mt: 1 }}>
-                ComfyUI 의 vcc-file-hash 노드가 설치되지 않아 해시 기반 메타데이터를 가져올 수 없습니다.
-              </Alert>
-            )}
+            {/* vcc-file-hash 미설치 안내는 admin 페이지에만 (#354) — picker 에선 ComfyUI 인지 즉시 알 수 없어 OpenAI 서버에도 잘못 노출되던 문제. */}
           </Box>
         )}
 

--- a/frontend/src/components/common/MetadataPickerModal.js
+++ b/frontend/src/components/common/MetadataPickerModal.js
@@ -85,13 +85,16 @@ const KIND_ADAPTERS = {
     nsfwItemLabel: 'NSFW 모델 숨기기',
   },
   model: {
-    fetch: ({ serverId, workboardId, search, baseModel, allowedBaseModels, page, limit }) => {
+    fetch: ({ serverId, workboardId, search, baseModel, allowedBaseModels, outputFormat, page, limit }) => {
       const params = { search, baseModel, page, limit };
       if (allowedBaseModels && allowedBaseModels.length > 0) {
         params.allowedBaseModels = allowedBaseModels;
       }
       // workboardId 전달 시 backend 가 작업판의 modelExposurePolicy / modelWhitelist 적용 (#198 Phase D)
+      // 추가로 workboard.outputFormat 으로 provider outputFormats 자동 필터 (#354)
       if (workboardId) params.workboardId = workboardId;
+      // outputFormat 명시 전달 — workboardId 없이 admin 페이지에서 작업판 폼의 값으로 호출하는 경우 (#354)
+      if (outputFormat) params.outputFormat = outputFormat;
       return serverAPI.getDetailedModels(serverId, params);
     },
     extractList: (responseData) => responseData?.models || [],
@@ -132,6 +135,7 @@ function MetadataPickerModal({
   onClose,
   serverId,
   workboardId,
+  outputFormat,
   isAdmin = false,
   mode = 'select-single',
   selectedItem,
@@ -202,6 +206,7 @@ function MetadataPickerModal({
           search: searchQuery,
           baseModel: baseModelFilter,
           allowedBaseModels: allowedModelTypes,
+          outputFormat,
           page,
           limit: 20
         });
@@ -220,7 +225,7 @@ function MetadataPickerModal({
         setLoading(false);
       }
     },
-    [serverId, workboardId, searchQuery, baseModelFilter, allowedModelTypes, kind, adapter]
+    [serverId, workboardId, searchQuery, baseModelFilter, allowedModelTypes, outputFormat, kind, adapter]
   );
 
   // sync 폴링

--- a/src/migrations/relocateCivitaiApiKey.js
+++ b/src/migrations/relocateCivitaiApiKey.js
@@ -1,0 +1,32 @@
+const SystemSettings = require('../models/SystemSettings');
+
+// #293 Phase B: settings.lora.civitaiApiKey → settings.external.civitaiApiKey 이전.
+// 멱등 — external.civitaiApiKey 가 비어있고 lora.civitaiApiKey 가 설정돼 있을 때만 복사.
+// 이후엔 lora 위치는 fallback 으로만 읽힘 (SystemSettings.getCivitaiApiKey 참고).
+async function relocateCivitaiApiKey() {
+  try {
+    const settings = await SystemSettings.findOne({ key: 'global' });
+    if (!settings) {
+      console.log('[Migration] SystemSettings 없음 — Civitai API 키 이전 불필요');
+      return;
+    }
+    const legacy = settings.lora?.civitaiApiKey;
+    const current = settings.external?.civitaiApiKey;
+    if (!legacy) {
+      console.log('[Migration] Civitai API 키 이전 불필요 (legacy 없음)');
+      return;
+    }
+    if (current) {
+      console.log('[Migration] Civitai API 키 이전 불필요 (external 이미 설정됨)');
+      return;
+    }
+    if (!settings.external) settings.external = {};
+    settings.external.civitaiApiKey = legacy;
+    await settings.save();
+    console.log('[Migration] Civitai API 키 이전 완료 (lora → external)');
+  } catch (error) {
+    console.error('[Migration] Civitai API 키 이전 실패:', error.message);
+  }
+}
+
+module.exports = relocateCivitaiApiKey;

--- a/src/models/ServerModelCache.js
+++ b/src/models/ServerModelCache.js
@@ -54,6 +54,9 @@ const modelItemSchema = new mongoose.Schema({
     name: String,
     description: String,
     capabilities: [String],
+    // 모델이 지원하는 outputFormat (#354). image / text / video / embedding / audio
+    // 추론 실패 시 빈 배열 — 필터에서 fallback 으로 노출
+    outputFormats: [String],
     contextWindow: Number,
     fetchedAt: Date,
     error: String

--- a/src/models/SystemSettings.js
+++ b/src/models/SystemSettings.js
@@ -28,7 +28,16 @@ const systemSettingsSchema = new mongoose.Schema({
       type: Boolean,
       default: true
     },
-    // Civitai API 키 (암호화 저장 권장)
+    // legacy field — #293 Phase B 에서 settings.external.civitaiApiKey 로 이전.
+    // 마이그레이션 후에도 fallback 으로 유지하다가 후속 cleanup 에서 제거.
+    civitaiApiKey: {
+      type: String,
+      default: null
+    }
+  },
+  // 외부 서비스 통합 설정 (#293 Phase B) — Civitai 등 외부 API.
+  // 베이스 모델 / LoRA 양쪽 서비스가 공유 사용.
+  external: {
     civitaiApiKey: {
       type: String,
       default: null
@@ -68,7 +77,10 @@ systemSettingsSchema.statics.updateLoraSettings = async function(updates) {
     settings.lora.nsfwLoraFilter = updates.nsfwLoraFilter;
   }
   if (updates.civitaiApiKey !== undefined) {
-    settings.lora.civitaiApiKey = updates.civitaiApiKey || null;
+    // #293 Phase B — 새 위치 우선, legacy 도 동기 갱신 (다른 코드 fallback 대비)
+    const v = updates.civitaiApiKey || null;
+    settings.external.civitaiApiKey = v;
+    settings.lora.civitaiApiKey = v;
   }
 
   await settings.save();
@@ -76,11 +88,17 @@ systemSettingsSchema.statics.updateLoraSettings = async function(updates) {
 };
 
 /**
- * Civitai API 키 조회
+ * Civitai API 키 조회 — settings.external.civitaiApiKey 우선, legacy settings.lora.civitaiApiKey
+ * fallback, 마지막으로 환경변수 (#293 Phase B)
  */
 systemSettingsSchema.statics.getCivitaiApiKey = async function() {
   const settings = await this.getGlobal();
-  return settings.lora.civitaiApiKey || process.env.CIVITAI_API_KEY || null;
+  return (
+    settings.external?.civitaiApiKey ||
+    settings.lora?.civitaiApiKey ||
+    process.env.CIVITAI_API_KEY ||
+    null
+  );
 };
 
 /**

--- a/src/routes/servers.js
+++ b/src/routes/servers.js
@@ -325,7 +325,7 @@ router.get('/:id/models', verifyJWT, async (req, res) => {
         });
       }
 
-      const { search, hasMetadata, baseModel, workboardId, page = 1, limit = 50 } = req.query;
+      const { search, hasMetadata, baseModel, workboardId, outputFormat: outputFormatQuery, page = 1, limit = 50 } = req.query;
       // allowedBaseModels: query string 으로 array 또는 single 둘 다 받기.
       let allowedBaseModels = req.query.allowedBaseModels;
       if (typeof allowedBaseModels === 'string') {
@@ -334,8 +334,9 @@ router.get('/:id/models', verifyJWT, async (req, res) => {
         allowedBaseModels = undefined;
       }
 
-      // 작업판 컨텍스트의 모델 노출 정책 적용 (#198 Phase D)
+      // 작업판 컨텍스트의 모델 노출 정책 적용 (#198 Phase D) + outputFormat 자동 유추 (#354)
       let whitelist = undefined;
+      let outputFormat = outputFormatQuery || undefined;
       if (workboardId) {
         const wb = await Workboard.findById(workboardId);
         if (!wb) {
@@ -349,6 +350,10 @@ router.get('/:id/models', verifyJWT, async (req, res) => {
           // 빈 whitelist 면 정책상 0개 노출 — sentinel 로 빈 배열 대신 '__none__' 매칭 안 됨
           if (whitelist.length === 0) whitelist = ['__no_models_in_whitelist__'];
         }
+        // 명시적 outputFormat 쿼리가 없으면 workboard 의 것으로 자동 적용
+        if (!outputFormat && wb.outputFormat) {
+          outputFormat = wb.outputFormat;
+        }
       }
 
       const result = await modelMetadataService.searchServerModels(server._id, {
@@ -357,6 +362,7 @@ router.get('/:id/models', verifyJWT, async (req, res) => {
         baseModel,
         allowedBaseModels,
         whitelist,
+        outputFormat,
         page: parseInt(page),
         limit: parseInt(limit)
       });

--- a/src/server.js
+++ b/src/server.js
@@ -63,6 +63,15 @@ app.use(cors({
 app.use(express.json({ limit: '50mb' }));
 app.use(express.urlencoded({ extended: true, limit: '50mb' }));
 
+// API GET 응답에 Cache-Control 명시 — 브라우저 heuristic 캐싱으로 인한 stale 응답 방지
+// (예: admin 모델 sync 후 picker 가 같은 URL 캐시를 재사용해 이전 목록을 보이는 문제)
+app.use('/api', (req, res, next) => {
+  if (req.method === 'GET') {
+    res.setHeader('Cache-Control', 'no-store, max-age=0');
+  }
+  next();
+});
+
 // Passport configuration
 require('./config/passport');
 app.use(passport.initialize());

--- a/src/server.js
+++ b/src/server.js
@@ -37,6 +37,7 @@ const initializeDefaultGroup = require('./migrations/initializeDefaultGroup');
 const assignDefaultGroupToWorkboards = require('./migrations/assignDefaultGroupToWorkboards');
 const backfillCustomFieldRoles = require('./migrations/backfillCustomFieldRoles');
 const dropBaseInputFieldsSchema = require('./migrations/dropBaseInputFieldsSchema');
+const relocateCivitaiApiKey = require('./migrations/relocateCivitaiApiKey');
 
 dotenv.config();
 
@@ -198,6 +199,7 @@ const startServer = async () => {
     await assignDefaultGroupToWorkboards();
     await backfillCustomFieldRoles();
     await dropBaseInputFieldsSchema();
+    await relocateCivitaiApiKey();
 
     // Initialize job queues after database connection
     console.log('Initializing job queues...');

--- a/src/services/modelMetadataService.js
+++ b/src/services/modelMetadataService.js
@@ -629,13 +629,14 @@ const searchServerModels = async (serverId, { search, hasMetadata, baseModel, al
   }
 
   // outputFormat: provider.outputFormats 기반 필터 (#354).
-  // SaaS provider 모델 한정. ComfyUI checkpoint 는 provider.outputFormats 가 없으므로 영향 없음.
-  // outputFormats 미설정 (구 캐시) 항목은 fallback 으로 통과 — 다음 sync 후 정상 분류.
+  // SaaS provider 모델 한정 — ComfyUI checkpoint 는 provider.found=false 라 영향 없음.
+  // 매칭 실패 / 미분류 (whisper / tts / embedding 등 현재 워크플로 미지원) 도 숨김 — 나중에
+  // 해당 타입 워크플로 도입 시 inferOpenAI/inferGemini 에 맞춰 노출 (#354 후속).
   if (outputFormat) {
     filtered = filtered.filter(m => {
-      const formats = m.provider?.outputFormats;
-      if (!Array.isArray(formats) || formats.length === 0) return true;  // fallback
-      return formats.includes(outputFormat);
+      if (!m.provider?.found) return true;  // ComfyUI checkpoint 등
+      const formats = m.provider.outputFormats;
+      return Array.isArray(formats) && formats.includes(outputFormat);
     });
   }
 

--- a/src/services/modelMetadataService.js
+++ b/src/services/modelMetadataService.js
@@ -324,6 +324,7 @@ const syncServerProviderModels = async (server, { progressCallback = null } = {}
         name: pm.name,
         description: pm.description,
         capabilities: pm.capabilities,
+        outputFormats: pm.outputFormats || [],
         contextWindow: pm.contextWindow,
         fetchedAt: new Date()
       }

--- a/src/services/modelMetadataService.js
+++ b/src/services/modelMetadataService.js
@@ -208,16 +208,31 @@ const inferOpenAIOutputFormats = (modelId) => {
 
 /**
  * Gemini 모델 정보로부터 outputFormat 추론 (#354).
- * 이름에 'image-generation' 포함 시 image, 그 외 generateContent 지원 시 text.
+ * Gemini 의 이미지 모델 명명 패턴이 다양해 (imagen, gemini-X-flash-image-*,
+ * gemini-X-pro-image-*, nano-banana 등) 포괄 매칭.
  */
 const inferGeminiOutputFormats = ({ name = '', displayName = '', supportedGenerationMethods = [] }) => {
   const fullName = `${name} ${displayName}`.toLowerCase();
   const methods = Array.isArray(supportedGenerationMethods) ? supportedGenerationMethods : [];
   const formats = [];
-  if (fullName.includes('image-generation') || fullName.includes('imagen')) {
+
+  // image 패턴: imagen / image-generation / image-preview / image-edit / nano-banana
+  // 또는 일반 -image- 중간 토큰 / -image 끝 토큰 (vision 입력 전용 모델 제외).
+  const isImage = (
+    /imagen/.test(fullName) ||
+    /image-generation/.test(fullName) ||
+    /image-preview/.test(fullName) ||
+    /image-edit/.test(fullName) ||
+    /nano-banana/.test(fullName) ||
+    /-image-/.test(fullName) ||
+    /-image$/.test(fullName)
+  ) && !/vision/.test(fullName);
+
+  if (isImage) {
     formats.push('image');
   }
-  if (methods.includes('generateContent') && formats.length === 0) {
+  // text 는 image 분류가 안 됐고 generateContent 지원하는 경우
+  if (formats.length === 0 && methods.includes('generateContent')) {
     formats.push('text');
   }
   return formats;

--- a/src/services/modelMetadataService.js
+++ b/src/services/modelMetadataService.js
@@ -181,6 +181,49 @@ const fetchCivitaiMetadataByHash = async (hash, apiKey = null, retryCount = 0) =
 };
 
 /**
+ * OpenAI 모델 id 로부터 outputFormat 추론 (#354).
+ * `/v1/models` 응답에 타입 필드가 없어 id 패턴으로 분류.
+ * 매칭 실패 시 빈 배열 → 필터에서 fallback (안전: 미분류 모델은 노출됨)
+ */
+const inferOpenAIOutputFormats = (modelId) => {
+  if (!modelId || typeof modelId !== 'string') return [];
+  const id = modelId.toLowerCase();
+  // image 생성 (DALL-E, GPT-Image, sora 등)
+  if (id.startsWith('dall-e') || id.includes('gpt-image') || id.startsWith('sora')) {
+    return ['image'];
+  }
+  // text/chat 모델
+  if (
+    id.startsWith('gpt-') || id.startsWith('chatgpt-') ||
+    id.startsWith('o1-') || id.startsWith('o1') ||
+    id.startsWith('o3-') || id.startsWith('o3') ||
+    id.startsWith('o4-') || id.startsWith('o4')
+  ) {
+    return ['text'];
+  }
+  // 그 외 (whisper / tts / embedding / moderation 등) — 현재 워크플로 미지원이라
+  // 빈 배열 반환하여 어느 outputFormat 의 picker 에도 안 보이게.
+  return [];
+};
+
+/**
+ * Gemini 모델 정보로부터 outputFormat 추론 (#354).
+ * 이름에 'image-generation' 포함 시 image, 그 외 generateContent 지원 시 text.
+ */
+const inferGeminiOutputFormats = ({ name = '', displayName = '', supportedGenerationMethods = [] }) => {
+  const fullName = `${name} ${displayName}`.toLowerCase();
+  const methods = Array.isArray(supportedGenerationMethods) ? supportedGenerationMethods : [];
+  const formats = [];
+  if (fullName.includes('image-generation') || fullName.includes('imagen')) {
+    formats.push('image');
+  }
+  if (methods.includes('generateContent') && formats.length === 0) {
+    formats.push('text');
+  }
+  return formats;
+};
+
+/**
  * OpenAI / OpenAI Compatible 서버의 모델 목록 조회 (`GET /v1/models`).
  * 응답 스펙: { data: [{ id, object, created, owned_by, ... }] }
  */
@@ -200,6 +243,7 @@ const getOpenAIProviderModels = async (serverUrl, apiKey) => {
       name: m.id,
       description: m.description || '',
       capabilities: [],
+      outputFormats: inferOpenAIOutputFormats(m.id),
       contextWindow: m.context_window || null,
       ownedBy: m.owned_by || null
     }));
@@ -225,6 +269,7 @@ const getGeminiProviderModels = async (serverUrl, apiKey) => {
       name: m.displayName || m.name,
       description: m.description || '',
       capabilities: m.supportedGenerationMethods || [],
+      outputFormats: inferGeminiOutputFormats(m),
       contextWindow: m.inputTokenLimit || null
     }));
   } catch (error) {
@@ -527,7 +572,7 @@ const resetSyncStatus = async (serverId) => {
  * @param {string[]} opts.allowedBaseModels — civitai.baseModel 다중 매칭
  *   (작업판의 allowedModelTypes 와 매핑 — 필터 활성 시 Civitai 미등록 모델은 제외, #320)
  */
-const searchServerModels = async (serverId, { search, hasMetadata, baseModel, allowedBaseModels, whitelist, page = 1, limit = 50 } = {}) => {
+const searchServerModels = async (serverId, { search, hasMetadata, baseModel, allowedBaseModels, whitelist, outputFormat, page = 1, limit = 50 } = {}) => {
   const cache = await ServerModelCache.findOne({ serverId });
 
   if (!cache) {
@@ -580,6 +625,17 @@ const searchServerModels = async (serverId, { search, hasMetadata, baseModel, al
   // 필터 활성 시 civitai 미등록 (baseModel 미상) 모델도 제외 (#320).
   if (Array.isArray(allowedBaseModels) && allowedBaseModels.length > 0) {
     filtered = filtered.filter(m => allowedBaseModels.includes(m.civitai?.baseModel));
+  }
+
+  // outputFormat: provider.outputFormats 기반 필터 (#354).
+  // SaaS provider 모델 한정. ComfyUI checkpoint 는 provider.outputFormats 가 없으므로 영향 없음.
+  // outputFormats 미설정 (구 캐시) 항목은 fallback 으로 통과 — 다음 sync 후 정상 분류.
+  if (outputFormat) {
+    filtered = filtered.filter(m => {
+      const formats = m.provider?.outputFormats;
+      if (!Array.isArray(formats) || formats.length === 0) return true;  // fallback
+      return formats.includes(outputFormat);
+    });
   }
 
   // whitelist: 작업판의 modelExposurePolicy='whitelist' + modelWhitelist 적용 (#198 Phase D).

--- a/src/services/modelMetadataService.js
+++ b/src/services/modelMetadataService.js
@@ -208,33 +208,37 @@ const inferOpenAIOutputFormats = (modelId) => {
 
 /**
  * Gemini 모델 정보로부터 outputFormat 추론 (#354).
- * Gemini 의 이미지 모델 명명 패턴이 다양해 (imagen, gemini-X-flash-image-*,
- * gemini-X-pro-image-*, nano-banana 등) 포괄 매칭.
+ * 신호 우선순위:
+ *   1. supportedGenerationMethods.predict / predictLongRunning → Imagen 류 image 생성
+ *   2. generateContent + 이름/설명에 image 키워드 → multimodal image (Nano Banana 등)
+ *   3. generateContent 단독 → text
  */
-const inferGeminiOutputFormats = ({ name = '', displayName = '', supportedGenerationMethods = [] }) => {
-  const fullName = `${name} ${displayName}`.toLowerCase();
-  const methods = Array.isArray(supportedGenerationMethods) ? supportedGenerationMethods : [];
+const inferGeminiOutputFormats = (modelData) => {
+  const name = (modelData.name || '').toLowerCase();
+  const displayName = (modelData.displayName || '').toLowerCase();
+  const description = (modelData.description || '').toLowerCase();
+  const fullText = `${name} ${displayName} ${description}`;
+  const methods = Array.isArray(modelData.supportedGenerationMethods) ? modelData.supportedGenerationMethods : [];
+
+  const hasPredict = methods.includes('predict') || methods.includes('predictLongRunning');
+  const hasGenerateContent = methods.includes('generateContent');
+  const hasEmbed = methods.includes('embedContent') || methods.includes('batchEmbedContents');
+
+  // image 키워드 — 이름 + displayName + description 통합 검사
+  const imagePattern = /imagen|image-generation|image-preview|image-edit|nano-banana|-image-|-image$|image\s*generation/;
+  const isImageByName = imagePattern.test(fullText);
+  // vision = image INPUT 전용 (gemini-pro-vision). image OUT 으로 분류하지 않음.
+  const isVision = /\bvision\b/.test(fullText) && !isImageByName;
+
   const formats = [];
-
-  // image 패턴: imagen / image-generation / image-preview / image-edit / nano-banana
-  // 또는 일반 -image- 중간 토큰 / -image 끝 토큰 (vision 입력 전용 모델 제외).
-  const isImage = (
-    /imagen/.test(fullName) ||
-    /image-generation/.test(fullName) ||
-    /image-preview/.test(fullName) ||
-    /image-edit/.test(fullName) ||
-    /nano-banana/.test(fullName) ||
-    /-image-/.test(fullName) ||
-    /-image$/.test(fullName)
-  ) && !/vision/.test(fullName);
-
-  if (isImage) {
+  if (!isVision && (hasPredict || (isImageByName && hasGenerateContent))) {
     formats.push('image');
   }
-  // text 는 image 분류가 안 됐고 generateContent 지원하는 경우
-  if (formats.length === 0 && methods.includes('generateContent')) {
+  if (formats.length === 0 && hasGenerateContent && !isImageByName) {
     formats.push('text');
   }
+  // embed 전용 모델은 현재 워크플로 미지원 → 빈 배열 반환하여 picker 미노출
+
   return formats;
 };
 


### PR DESCRIPTION
## v2.2.2 — Patch Release

### 신규 기능
- feat: OpenAI / Gemini 모델 outputFormat 추론 + workboard 기반 picker 필터 (#354, #355)
- feat: admin 작업판 화이트리스트 picker 활성화 (모든 server type) (#354)
- feat: Civitai API 키 스키마 \`settings.external\` 로 이전 + 자동 마이그레이션 (#293 Phase B, #356)

### 수정
- fix: API GET 응답에 \`Cache-Control: no-store\` (picker stale 데이터 방지) (#354)
- fix: picker 의 vcc-file-hash 미설치 안내 Alert 제거 (#354)
- fix: picker Dialog height 85vh 고정 (입력 시 덜컹거림) (#354)

### 문서
- docs: INSTALLATION.md 초기 모델/LoRA 동기화 가이드 (#352, #353)

자세한 내용은 [docs/updatelogs/v2.md](docs/updatelogs/v2.md) 참고.

🤖 Generated with [Claude Code](https://claude.com/claude-code)