### PR TITLE
feat: 화이트리스트 picker — 이미 선택된 항목 시각화 + 토글 + 카운트 (#277)

### DIFF
--- a/frontend/src/components/admin/MetadataImageListItem.js
+++ b/frontend/src/components/admin/MetadataImageListItem.js
@@ -41,7 +41,12 @@ function MetadataImageListItem({
   const previewImage = filteredImages[0];
 
   const handleRowClick = cardClickable && onPrimary ? () => onPrimary(item) : undefined;
-  const resolvedPrimaryLabel = primaryLabel || (primaryVariant === 'insert' ? '프롬프트에 추가' : primaryVariant === 'add' ? '추가' : '선택');
+  // multi-add 모드에서 이미 선택된 항목은 토글로 \"제거\" 표시 (#277)
+  const resolvedPrimaryLabel = primaryLabel || (
+    primaryVariant === 'insert' ? '프롬프트에 추가'
+      : primaryVariant === 'add' ? (selected ? '제거' : '추가')
+      : '선택'
+  );
 
   return (
     <Box

--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -243,11 +243,15 @@ function WhitelistField({ name, control, kind, serverId, outputFormat, placehold
       control={control}
       render={({ field }) => {
         const value = field.value || [];
-        const handleAdd = (rawItem) => {
+        // picker 의 multi-add 모드에서 카드를 다시 클릭하면 토글 — 이미 포함된 항목은 제거 (#277)
+        const handleToggle = (rawItem) => {
           const id = rawItem?.filename;
           if (!id) return;
-          if (value.includes(id)) return;
-          field.onChange([...value, id]);
+          if (value.includes(id)) {
+            field.onChange(value.filter((v) => v !== id));
+          } else {
+            field.onChange([...value, id]);
+          }
         };
         return (
           <Box>
@@ -296,7 +300,8 @@ function WhitelistField({ name, control, kind, serverId, outputFormat, placehold
                 outputFormat={outputFormat}
                 isAdmin
                 mode="multi-add"
-                onPrimary={handleAdd}
+                selectedItems={value}
+                onPrimary={handleToggle}
               />
             )}
           </Box>

--- a/frontend/src/components/common/MetadataItemCard.js
+++ b/frontend/src/components/common/MetadataItemCard.js
@@ -71,7 +71,12 @@ const MetadataItemCard = React.memo(function MetadataItemCard({
 
   const handleCardClick = cardClickable && onPrimary ? () => onPrimary(item) : undefined;
 
-  const resolvedPrimaryLabel = primaryLabel || (primaryVariant === 'insert' ? '프롬프트에 추가' : primaryVariant === 'add' ? '추가' : '선택');
+  // multi-add 모드에서 이미 선택된 항목은 토글로 \"제거\" 표시 (#277)
+  const resolvedPrimaryLabel = primaryLabel || (
+    primaryVariant === 'insert' ? '프롬프트에 추가'
+      : primaryVariant === 'add' ? (selected ? '제거' : '추가')
+      : '선택'
+  );
 
   return (
     <Card

--- a/frontend/src/components/common/MetadataPickerModal.js
+++ b/frontend/src/components/common/MetadataPickerModal.js
@@ -139,6 +139,7 @@ function MetadataPickerModal({
   isAdmin = false,
   mode = 'select-single',
   selectedItem,
+  selectedItems = EMPTY_ALLOWED_MODEL_TYPES,  // multi-add 모드의 현재 선택 목록 (#277)
   onPrimary,
   onTrainedWordClick,
   allowedModelTypes = EMPTY_ALLOWED_MODEL_TYPES,
@@ -368,6 +369,18 @@ function MetadataPickerModal({
           </ToggleButtonGroup>
         </Stack>
 
+        {/* multi-add 모드 선택 카운트 안내 (#277) */}
+        {mode === 'multi-add' && (
+          <Box sx={{ mb: 1.5 }}>
+            <Chip
+              label={`${selectedItems.length}개 선택됨`}
+              size="small"
+              color={selectedItems.length > 0 ? 'primary' : 'default'}
+              variant="outlined"
+            />
+          </Box>
+        )}
+
         {!isAdmin && (
           <Stack direction="row" spacing={2} sx={{ mb: 1, flexWrap: 'wrap' }}>
             <FormControlLabel
@@ -482,7 +495,7 @@ function MetadataPickerModal({
                   return (
                     <MetadataItemCard
                       item={item}
-                      selected={selectedItem === item.filename}
+                      selected={mode === 'multi-add' ? selectedItems.includes(item.filename) : selectedItem === item.filename}
                       onDetailClick={() => setDetailItem(item)}
                       onPrimary={() => handlePrimary(rawItem)}
                       primaryVariant={cardPrimaryVariant}
@@ -505,7 +518,7 @@ function MetadataPickerModal({
                     <MetadataImageListItem
                       key={rawItem?.filename || idx}
                       item={item}
-                      selected={selectedItem === item.filename}
+                      selected={mode === 'multi-add' ? selectedItems.includes(item.filename) : selectedItem === item.filename}
                       onDetailClick={() => setDetailItem(item)}
                       onPrimary={() => handlePrimary(rawItem)}
                       primaryVariant={cardPrimaryVariant}
@@ -524,7 +537,7 @@ function MetadataPickerModal({
                 {filteredItems.map((rawItem, idx) => {
                   const item = adapter.normalize(rawItem);
                   if (!item) return null;
-                  const isSelected = selectedItem === item.filename;
+                  const isSelected = mode === 'multi-add' ? selectedItems.includes(item.filename) : selectedItem === item.filename;
                   return (
                     <Box
                       key={rawItem?.filename || idx}
@@ -563,7 +576,7 @@ function MetadataPickerModal({
                       <Button size="small" onClick={(e) => { e.stopPropagation(); setDetailItem(item); }}>상세</Button>
                       {!cardClickable && (
                         <Button size="small" variant={mode === 'prompt-insert' ? 'contained' : 'text'} onClick={(e) => { e.stopPropagation(); handlePrimary(rawItem); }}>
-                          {mode === 'prompt-insert' ? '추가' : mode === 'multi-add' ? '추가' : '선택'}
+                          {mode === 'prompt-insert' ? '추가' : mode === 'multi-add' ? (isSelected ? '제거' : '추가') : '선택'}
                         </Button>
                       )}
                     </Box>


### PR DESCRIPTION
## Summary

작업판 admin 의 화이트리스트 picker (multi-add 모드) UX 개선.

- `MetadataPickerModal` 에 `selectedItems: string[]` prop. multi-add 모드의 각 카드/리스트 항목 selected 여부 계산.
- 상단에 `N개 선택됨` chip 안내 (primary 색 강조).
- 카드 / image-list / list view 모두 selected 항목은 `제거` 버튼 라벨 + 기존 selected highlight (border / CheckCircle / 배경) 적용.
- `WhitelistField` 가 토글 동작: 이미 포함된 모델 다시 클릭 시 제거.

기존 single-select / prompt-insert / 사용자 picker 모드는 영향 없음.

## Test plan

- [ ] admin → 작업판 → 권한·노출 → 모델 화이트리스트 → "선택"
- [ ] 모달 안에서 카드 클릭 "추가" → 카드가 selected 상태로 표시, 버튼 "제거" 로 바뀜
- [ ] selected 카드의 "제거" 버튼 클릭 → 화이트리스트에서 빠지고 "추가" 로 돌아옴
- [ ] 상단 "N개 선택됨" 카운트 실시간 갱신
- [ ] LoRA 화이트리스트도 동일 동작
- [ ] grid / image-list / list 3종 view mode 모두 정상

closes #277