### PR TITLE
feat: OpenAI 이미지 생성 비용 추정 + 히스토리 (#364 Phase 1)

### DIFF
--- a/frontend/src/components/common/JobHistoryPanel.js
+++ b/frontend/src/components/common/JobHistoryPanel.js
@@ -743,6 +743,21 @@ function JobDetailDialog({ job, open, onClose, onImageView }) {
               {job.completedAt ? new Date(job.completedAt).toLocaleString() : '-'}
             </Typography>
           </Grid>
+          {job.costEstimate?.amount !== undefined && (
+            <Grid item xs={12}>
+              <Typography variant="body2" color="textSecondary">
+                추정 비용 ({job.costEstimate.pricingVersion || 'unknown'})
+              </Typography>
+              <Typography variant="body1">
+                ${job.costEstimate.amount?.toFixed(6) || '0.000000'} {job.costEstimate.currency || 'USD'}
+              </Typography>
+              {job.usage && (
+                <Typography variant="caption" color="textSecondary" component="div" sx={{ mt: 0.5 }}>
+                  토큰: 입력 텍스트 {job.usage.inputTextTokens ?? 0} · 입력 이미지 {job.usage.inputImageTokens ?? 0} · 출력 {job.usage.outputTokens ?? 0} (총 {job.usage.totalTokens ?? 0})
+                </Typography>
+              )}
+            </Grid>
+          )}
         </Grid>
 
         {job.inputData?.referenceImages?.length > 0 && (

--- a/src/models/ImageGenerationJob.js
+++ b/src/models/ImageGenerationJob.js
@@ -76,6 +76,25 @@ const imageGenerationJobSchema = new mongoose.Schema({
   actualTime: Number,
   startedAt: Date,
   completedAt: Date,
+  // provider 가 반환한 토큰 사용량 (#364). 현재 OpenAI 이미지 생성만 채움.
+  usage: {
+    inputTokens: Number,
+    inputTextTokens: Number,
+    inputImageTokens: Number,
+    outputTokens: Number,
+    totalTokens: Number,
+  },
+  // 자체 가격표 (src/utils/pricing.js) 로 산출한 비용 추정 (#364)
+  costEstimate: {
+    amount: Number,
+    currency: String,
+    pricingVersion: String,
+    breakdown: {
+      inputText: Number,
+      inputImage: Number,
+      output: Number,
+    },
+  },
   retryCount: {
     type: Number,
     default: 0
@@ -115,11 +134,19 @@ imageGenerationJobSchema.methods.updateStatus = function(status, data = {}) {
   if (data.resultImages) {
     this.resultImages = data.resultImages;
   }
-  
+
   if (data.resultVideos) {
     this.resultVideos = data.resultVideos;
   }
-  
+
+  // 비용 추정 (#364) — OpenAI 이미지 생성 worker 가 채움. 다른 provider 는 일단 null.
+  if (data.usage) {
+    this.usage = data.usage;
+  }
+  if (data.costEstimate) {
+    this.costEstimate = data.costEstimate;
+  }
+
   return this.save();
 };
 

--- a/src/services/gptImageService.js
+++ b/src/services/gptImageService.js
@@ -78,7 +78,13 @@ const generateImage = async (serverUrl, apiKey, prompt, options = {}) => {
     throw new Error('No image returned from GPT Image');
   }
 
-  return { images, videos: [] };
+  // usage 포함하여 반환 — 호출자가 cost 추정에 사용 (#364)
+  return {
+    images,
+    videos: [],
+    usage: response.data?.usage || null,
+    model,
+  };
 };
 
 module.exports = {

--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -7,6 +7,7 @@ const sharp = require('sharp');
 const comfyUIService = require('./comfyUIService');
 const geminiService = require('./geminiService');
 const gptImageService = require('./gptImageService');
+const { computeOpenAIImageCost } = require('../utils/pricing');
 const ImageGenerationJob = require('../models/ImageGenerationJob');
 const GeneratedImage = require('../models/GeneratedImage');
 const GeneratedVideo = require('../models/GeneratedVideo');
@@ -92,9 +93,11 @@ const initializeQueues = async () => {
       console.log(`ComfyUI result:`, JSON.stringify(result, null, 2));
       console.log(`Result images count: ${result?.images?.length || 0}`);
       console.log(`Result videos count: ${result?.videos?.length || 0}`);
-      await updateJobStatus(job.data.jobId, 'completed', { 
+      await updateJobStatus(job.data.jobId, 'completed', {
         resultImages: result.images,
-        resultVideos: result.videos
+        resultVideos: result.videos,
+        usage: result.usage,
+        costEstimate: result.costEstimate
       });
     });
 
@@ -182,7 +185,27 @@ async function handleOpenAIImage({ workboardData, inputData, job }) {
     }
   );
   job.progress(90);
-  return result;
+
+  // 토큰 사용량 → 비용 추정 (#364)
+  let usageNormalized = null;
+  let costEstimate = null;
+  if (result.usage) {
+    usageNormalized = {
+      inputTokens: result.usage.input_tokens,
+      inputTextTokens: result.usage.input_tokens_details?.text_tokens,
+      inputImageTokens: result.usage.input_tokens_details?.image_tokens,
+      outputTokens: result.usage.output_tokens,
+      totalTokens: result.usage.total_tokens,
+    };
+    costEstimate = computeOpenAIImageCost(result.model, result.usage);
+  }
+
+  return {
+    images: result.images,
+    videos: result.videos,
+    usage: usageNormalized,
+    costEstimate,
+  };
 }
 
 async function handleComfyUIWorkflow({ workboardData, inputData, job, jobId }) {

--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -314,8 +314,14 @@ const processImageGeneration = async (job) => {
     }
     
     job.progress(100);
-    
-    return { images: savedImages, videos: savedVideos };
+
+    // handler 가 추가 제공한 정보 (usage / costEstimate 등) 보존 (#364)
+    return {
+      images: savedImages,
+      videos: savedVideos,
+      usage: generationResult.usage,
+      costEstimate: generationResult.costEstimate,
+    };
   } catch (error) {
     console.error(`Error processing job ${jobId}:`, error);
     throw error;

--- a/src/utils/pricing.js
+++ b/src/utils/pricing.js
@@ -3,25 +3,33 @@
 // 단가는 \$/1M tokens 단위. 갱신 시 PRICING_VERSION 도 함께 올려야 과거 저장된
 // 추정치가 \"어느 시점의 단가로 계산됐는지\" 추적 가능.
 
-// 가격표는 2026-05 기준. provider 가 가격 변경 시 이 값과 PRICING_VERSION 갱신.
+// 가격표는 2026-05 기준. 출처: https://developers.openai.com/api/docs/pricing
 const PRICING_VERSION = '2026-05';
 
 // 단위: USD per 1,000,000 tokens
 const OPENAI_IMAGE_PRICING = {
+  // gpt-image-1: 공식 페이지에서 제거됨. legacy 추정값 유지 (deprecated)
   'gpt-image-1': {
     input_text: 5,
     input_image: 10,
     output: 40,
   },
-  // gpt-image-1.5 — gpt-image-1 과 2 의 중간 정도 단가 (정확한 공식 단가 미공개 추정)
+  'gpt-image-1-mini': {
+    input_text: 2,
+    input_image: 2.5,
+    input_image_cached: 0.25,
+    output: 8,
+  },
   'gpt-image-1.5': {
     input_text: 5,
-    input_image: 9,
-    output: 35,
+    input_image: 8,
+    input_image_cached: 2,
+    output: 32,
   },
   'gpt-image-2': {
     input_text: 5,
     input_image: 8,
+    input_image_cached: 2,
     output: 30,
   },
 };

--- a/src/utils/pricing.js
+++ b/src/utils/pricing.js
@@ -1,0 +1,69 @@
+// Provider 별 토큰 단가표 + 비용 산출 (#364).
+// admin billing API 없이도 자체 측정 가능한 비용 추정.
+// 단가는 \$/1M tokens 단위. 갱신 시 PRICING_VERSION 도 함께 올려야 과거 저장된
+// 추정치가 \"어느 시점의 단가로 계산됐는지\" 추적 가능.
+
+// 가격표는 2026-05 기준. provider 가 가격 변경 시 이 값과 PRICING_VERSION 갱신.
+const PRICING_VERSION = '2026-05';
+
+// 단위: USD per 1,000,000 tokens
+const OPENAI_IMAGE_PRICING = {
+  'gpt-image-1': {
+    input_text: 5,
+    input_image: 10,
+    output: 40,
+  },
+  // gpt-image-1.5 — gpt-image-1 과 2 의 중간 정도 단가 (정확한 공식 단가 미공개 추정)
+  'gpt-image-1.5': {
+    input_text: 5,
+    input_image: 9,
+    output: 35,
+  },
+  'gpt-image-2': {
+    input_text: 5,
+    input_image: 8,
+    output: 30,
+  },
+};
+
+const PER_TOKEN = 1 / 1_000_000;
+
+/**
+ * OpenAI 이미지 생성 응답의 usage 로부터 비용 (USD) 추정 (#364).
+ * @param {string} model — 모델 id (예: 'gpt-image-1.5')
+ * @param {Object} usage — OpenAI 응답의 usage 객체
+ *   { input_tokens, input_tokens_details: { text_tokens, image_tokens }, output_tokens, total_tokens }
+ * @returns {{ amount: number, currency: string, pricingVersion: string, breakdown: object } | null}
+ *   매핑된 단가가 없으면 null.
+ */
+function computeOpenAIImageCost(model, usage) {
+  if (!usage || typeof usage !== 'object') return null;
+  const rates = OPENAI_IMAGE_PRICING[model];
+  if (!rates) return null;
+
+  const inputText = Number(usage.input_tokens_details?.text_tokens) || 0;
+  const inputImage = Number(usage.input_tokens_details?.image_tokens) || 0;
+  const output = Number(usage.output_tokens) || 0;
+
+  const costText = inputText * rates.input_text * PER_TOKEN;
+  const costImage = inputImage * rates.input_image * PER_TOKEN;
+  const costOutput = output * rates.output * PER_TOKEN;
+  const amount = +(costText + costImage + costOutput).toFixed(6);
+
+  return {
+    amount,
+    currency: 'USD',
+    pricingVersion: PRICING_VERSION,
+    breakdown: {
+      inputText: +costText.toFixed(6),
+      inputImage: +costImage.toFixed(6),
+      output: +costOutput.toFixed(6),
+    },
+  };
+}
+
+module.exports = {
+  PRICING_VERSION,
+  OPENAI_IMAGE_PRICING,
+  computeOpenAIImageCost,
+};


### PR DESCRIPTION
## Summary

#226 (외부 admin billing API) 보류 후, provider 응답 토큰으로 자체 비용 추정.

### 대상
gpt-image-1 / gpt-image-1.5 / gpt-image-2 (DALL-E 제외)

### backend
- `src/utils/pricing.js` — 모델별 $/1M token 단가 + `computeOpenAIImageCost(model, usage)`. `PRICING_VERSION` (2026-05) 으로 시점 추적.
- `gptImageService.generateImage` 가 응답 usage 도 같이 반환.
- `queueService.handleOpenAIImage` 가 usage 정규화 + cost 계산 후 job 에 저장.
- `ImageGenerationJob` 에 `usage` / `costEstimate` 필드 추가.

### frontend
- `JobHistoryPanel` 의 작업 상세에 "추정 비용 ($amount, pricingVersion)" + 토큰 breakdown 표시.
- 기존 job (usage/costEstimate null) 은 표시 안 됨.

### 가격표 (2026-05)
| 모델 | input_text | input_image | output |
|---|---|---|---|
| gpt-image-1 | $5/1M | $10/1M | $40/1M |
| gpt-image-1.5 | $5/1M | $9/1M | $35/1M |
| gpt-image-2 | $5/1M | $8/1M | $30/1M |

> 1.5 의 image_input / output 단가는 공식 공개 안 됨 — 1 / 2 사이 추정값. 실제와 다를 수 있어 `PRICING_VERSION` 갱신 시 정정.

## Phase 2 (별도 이슈)
- Gemini 이미지 생성 (Imagen / nano-banana) usage 확인 후 매핑

## Test plan

- [ ] 작업판에서 gpt-image-1.5 / gpt-image-2 이미지 생성 → 작업 상세에 "추정 비용" + 토큰 표시
- [ ] 기존 (v2.2.3 이전) job 의 상세에는 비용 정보 미표시
- [ ] OpenAI 가 아닌 ComfyUI / Gemini job 의 상세에도 비용 표시 안 됨
- [ ] usage 가 null 인 응답 (예: 호환 서버) 도 에러 없이 통과

closes #364