### PR TITLE
feat: Gemini 이미지 생성 비용 추정 (#367, #364 Phase 2)

### DIFF
--- a/src/services/geminiService.js
+++ b/src/services/geminiService.js
@@ -107,7 +107,13 @@ const generateImage = async (serverUrl, apiKey, prompt, options = {}) => {
     throw new Error('No image returned from Gemini');
   }
 
-  return { images, videos: [] };
+  // usage 포함 반환 — 호출자가 cost 추정에 사용 (#367)
+  return {
+    images,
+    videos: [],
+    usage: response.data?.usageMetadata || null,
+    model,
+  };
 };
 
 // Gemini LLM (Chat) — generateContent 호출 후 첫 번째 candidate 의 텍스트 본문 반환.

--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -7,7 +7,7 @@ const sharp = require('sharp');
 const comfyUIService = require('./comfyUIService');
 const geminiService = require('./geminiService');
 const gptImageService = require('./gptImageService');
-const { computeOpenAIImageCost } = require('../utils/pricing');
+const { computeOpenAIImageCost, computeGeminiImageCost } = require('../utils/pricing');
 const ImageGenerationJob = require('../models/ImageGenerationJob');
 const GeneratedImage = require('../models/GeneratedImage');
 const GeneratedVideo = require('../models/GeneratedVideo');
@@ -159,7 +159,28 @@ async function handleGeminiImage({ workboardData, inputData, job }) {
     }
   );
   job.progress(90);
-  return result;
+
+  // 토큰 사용량 → 비용 추정 (#367)
+  let usageNormalized = null;
+  let costEstimate = null;
+  if (result.usage) {
+    usageNormalized = {
+      inputTokens: result.usage.promptTokenCount,
+      // Gemini 응답은 입력 텍스트/이미지 구분 없음 — input 전체를 inputImage 칸에 보관
+      inputTextTokens: 0,
+      inputImageTokens: result.usage.promptTokenCount,
+      outputTokens: result.usage.candidatesTokenCount,
+      totalTokens: result.usage.totalTokenCount,
+    };
+    costEstimate = computeGeminiImageCost(result.model, result.usage);
+  }
+
+  return {
+    images: result.images,
+    videos: result.videos,
+    usage: usageNormalized,
+    costEstimate,
+  };
 }
 
 async function handleOpenAIImage({ workboardData, inputData, job }) {

--- a/src/utils/pricing.js
+++ b/src/utils/pricing.js
@@ -70,8 +70,71 @@ function computeOpenAIImageCost(model, usage) {
   };
 }
 
+// Gemini 이미지 생성 모델 단가 (2026-05).
+// 출처: https://ai.google.dev/gemini-api/docs/pricing
+// 단위: USD per 1M tokens. output 은 per-image 가격을 모델별 평균 토큰량으로
+// 환산한 추정. \"candidatesTokenCount\" 가 실제 출력 토큰량이므로 그대로 곱하면 \$/image 와 거의 일치.
+// imagen-* 는 per-image 정액 — 토큰 기반 추정 대상 아님 (별도 처리 필요, Phase 2 외).
+const GEMINI_IMAGE_PRICING = {
+  'gemini-2.5-flash-image': {
+    input_text: 0.30,
+    input_image: 0.30,
+    output: 30,
+  },
+  'gemini-2.5-flash-image-preview': {
+    input_text: 0.30,
+    input_image: 0.30,
+    output: 30,
+  },
+  'gemini-3-pro-image-preview': {
+    input_text: 2.00,
+    input_image: 2.00,
+    output: 120,
+  },
+  'gemini-3.1-flash-image-preview': {
+    input_text: 0.50,
+    input_image: 0.50,
+    output: 40,
+  },
+};
+
+/**
+ * Gemini 이미지 생성 응답 usageMetadata → 비용 추정 (#367).
+ * @param {string} model — 모델 id (예: 'gemini-3-pro-image-preview')
+ * @param {Object} usage — \`response.usageMetadata\` 또는 정규화된 객체
+ *   { promptTokenCount, candidatesTokenCount, totalTokenCount, cachedContentTokenCount }
+ * @returns {{ amount, currency, pricingVersion, breakdown } | null}
+ */
+function computeGeminiImageCost(model, usage) {
+  if (!usage || typeof usage !== 'object') return null;
+  const rates = GEMINI_IMAGE_PRICING[model];
+  if (!rates) return null;
+
+  // Gemini 는 usageMetadata 가 prompt / candidates / total 만 노출. 입력 텍스트/이미지
+  // 구분은 응답에 없어 input 전부에 input_image 단가 적용 (text == image 단가라 동일).
+  const promptTokens = Number(usage.promptTokenCount ?? usage.promptTokens) || 0;
+  const outputTokens = Number(usage.candidatesTokenCount ?? usage.candidatesTokens) || 0;
+
+  const costInput = promptTokens * rates.input_image * PER_TOKEN;
+  const costOutput = outputTokens * rates.output * PER_TOKEN;
+  const amount = +(costInput + costOutput).toFixed(6);
+
+  return {
+    amount,
+    currency: 'USD',
+    pricingVersion: PRICING_VERSION,
+    breakdown: {
+      inputText: 0,  // Gemini 응답은 text/image 입력 구분 안 됨
+      inputImage: +costInput.toFixed(6),
+      output: +costOutput.toFixed(6),
+    },
+  };
+}
+
 module.exports = {
   PRICING_VERSION,
   OPENAI_IMAGE_PRICING,
+  GEMINI_IMAGE_PRICING,
   computeOpenAIImageCost,
+  computeGeminiImageCost,
 };


### PR DESCRIPTION
## Summary

#364 Phase 2 — OpenAI 와 동일 path 로 Gemini 이미지 생성 비용 추정.

### 대상
- `gemini-2.5-flash-image` (+ `-preview`)
- `gemini-3-pro-image-preview`
- `gemini-3.1-flash-image-preview`
- 제외: `imagen-*` (per-image 정액 — usage 토큰 없음. 별도 처리)

### backend
- `pricing.js`: `GEMINI_IMAGE_PRICING` + `computeGeminiImageCost(model, usage)`
- `geminiService.generateImage` 가 `{ images, videos, usage (usageMetadata), model }` 반환
- `queueService.handleGeminiImage` 가 usage 정규화 + cost 계산

### 가격표 (2026-05)
| 모델 | input | output |
|---|---|---|
| gemini-2.5-flash-image | $0.30/1M | $30/1M |
| gemini-3-pro-image-preview | $2.00/1M | $120/1M |
| gemini-3.1-flash-image-preview | $0.50/1M | $40/1M |

## Test plan

- [ ] Gemini 작업판에서 이미지 생성 → 작업 상세에 "추정 비용 ($amount)" + 토큰 breakdown 표시
- [ ] OpenAI / ComfyUI 작업은 영향 없음
- [ ] 가격표 미등록 모델 (imagen-*) 은 usage 만 저장, costEstimate 없음 — UI 가 표시 안 함

closes #367