### PR TITLE
feat: LLM 대화 멀티턴 이어가기 (#375)

### DIFF
--- a/frontend/src/components/common/ConversationChatPanel.js
+++ b/frontend/src/components/common/ConversationChatPanel.js
@@ -1,0 +1,179 @@
+import React, { useState, useRef, useEffect } from 'react';
+import {
+  Box,
+  Typography,
+  Paper,
+  TextField,
+  Button,
+  CircularProgress,
+  Alert,
+  Stack,
+  Chip,
+  Divider
+} from '@mui/material';
+import {
+  Send,
+  Person as PersonIcon,
+  SmartToy as AssistantIcon,
+  Settings as SystemIcon
+} from '@mui/icons-material';
+import { useQuery, useMutation, useQueryClient } from 'react-query';
+import toast from 'react-hot-toast';
+import { conversationAPI, jobAPI } from '../../services/api';
+
+// 멀티턴 대화 모드 패널 (#375).
+// `conversationId` 가 주어졌을 때 PromptGeneration 페이지에서 PromptGeneratorPanel 대신 렌더.
+// 이전 messages 를 상단에 누적 표시, 하단의 입력창으로 다음 메시지 append.
+function ConversationChatPanel({ workboard, conversationId }) {
+  const [newMessage, setNewMessage] = useState('');
+  const transcriptRef = useRef(null);
+  const queryClient = useQueryClient();
+
+  const { data, isLoading, error } = useQuery(
+    ['conversation', conversationId],
+    () => conversationAPI.getById(conversationId),
+    { enabled: !!conversationId }
+  );
+
+  const conversation = data?.data?.data;
+  const messages = conversation?.messages || [];
+
+  useEffect(() => {
+    if (transcriptRef.current) {
+      transcriptRef.current.scrollTop = transcriptRef.current.scrollHeight;
+    }
+  }, [messages.length]);
+
+  const sendMutation = useMutation(
+    async (text) => {
+      return jobAPI.createPromptJob({
+        workboardId: workboard._id,
+        conversationId,
+        inputData: { userPrompt: text },
+      });
+    },
+    {
+      onSuccess: () => {
+        setNewMessage('');
+        queryClient.invalidateQueries(['conversation', conversationId]);
+        queryClient.invalidateQueries('conversations');
+      },
+      onError: (err) => {
+        toast.error('전송 실패: ' + (err.response?.data?.message || err.message));
+        // 실패 시에도 서버 측 conversation 은 failed 상태로 마킹돼 있으므로 refetch
+        queryClient.invalidateQueries(['conversation', conversationId]);
+      },
+    }
+  );
+
+  const handleSend = (e) => {
+    e.preventDefault();
+    const trimmed = newMessage.trim();
+    if (!trimmed) return;
+    sendMutation.mutate(trimmed);
+  };
+
+  if (isLoading) {
+    return (
+      <Box display="flex" justifyContent="center" py={4}>
+        <CircularProgress color="secondary" />
+      </Box>
+    );
+  }
+  if (error) {
+    return <Alert severity="error">대화를 불러오지 못했습니다: {error.message}</Alert>;
+  }
+  if (!conversation) {
+    return <Alert severity="warning">대화를 찾을 수 없습니다.</Alert>;
+  }
+
+  const isSending = sendMutation.isLoading;
+
+  return (
+    <Paper elevation={1} sx={{ p: { xs: 2, md: 3 } }}>
+      <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 2, flexWrap: 'wrap' }}>
+        <Chip label="대화 이어가기" color="secondary" size="small" />
+        {conversation.model && <Chip label={conversation.model} size="small" variant="outlined" />}
+        {conversation.serverType && <Chip label={conversation.serverType} size="small" variant="outlined" />}
+        <Box sx={{ flexGrow: 1 }} />
+        <Typography variant="caption" color="text.secondary">
+          시작: {new Date(conversation.createdAt).toLocaleString('ko-KR')}
+        </Typography>
+      </Stack>
+
+      <Box
+        ref={transcriptRef}
+        sx={{
+          maxHeight: 500,
+          overflow: 'auto',
+          mb: 2,
+          p: 2,
+          bgcolor: 'grey.50',
+          borderRadius: 1,
+        }}
+      >
+        <Stack spacing={1.5} divider={<Divider flexItem />}>
+          {messages.map((msg, idx) => (
+            <Box key={idx} sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
+              <Box sx={{ pt: 0.5 }}>
+                {msg.role === 'user' && <PersonIcon fontSize="small" color="primary" />}
+                {msg.role === 'assistant' && <AssistantIcon fontSize="small" color="action" />}
+                {msg.role === 'system' && <SystemIcon fontSize="small" color="action" />}
+              </Box>
+              <Box sx={{ flex: '1 1 0', minWidth: 0 }}>
+                <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'uppercase', letterSpacing: 0.5 }}>
+                  {msg.role}
+                </Typography>
+                <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', mt: 0.25 }}>
+                  {msg.content}
+                </Typography>
+              </Box>
+            </Box>
+          ))}
+        </Stack>
+        {isSending && (
+          <Box display="flex" justifyContent="center" mt={2}>
+            <CircularProgress size={20} color="secondary" />
+          </Box>
+        )}
+        {conversation.status === 'failed' && conversation.error?.message && (
+          <Alert severity="error" sx={{ mt: 2 }}>
+            마지막 시도 실패: {conversation.error.message}
+          </Alert>
+        )}
+      </Box>
+
+      <form onSubmit={handleSend}>
+        <Stack direction="row" spacing={1} alignItems="flex-end">
+          <TextField
+            fullWidth
+            multiline
+            rows={2}
+            placeholder="이어서 질문하거나 지시를 입력하세요..."
+            value={newMessage}
+            onChange={(e) => setNewMessage(e.target.value)}
+            disabled={isSending}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                handleSend(e);
+              }
+            }}
+            helperText="⌘/Ctrl + Enter 로 전송"
+          />
+          <Button
+            type="submit"
+            variant="contained"
+            color="secondary"
+            disabled={isSending || !newMessage.trim()}
+            startIcon={isSending ? <CircularProgress size={18} color="inherit" /> : <Send />}
+            sx={{ minWidth: 100, height: 56 }}
+          >
+            전송
+          </Button>
+        </Stack>
+      </form>
+    </Paper>
+  );
+}
+
+export default ConversationChatPanel;

--- a/frontend/src/components/common/ConversationHistoryPanel.js
+++ b/frontend/src/components/common/ConversationHistoryPanel.js
@@ -26,7 +26,9 @@ import {
   Settings as SystemIcon
 } from '@mui/icons-material';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
+import { Chat as ChatIcon } from '@mui/icons-material';
 import { conversationAPI } from '../../services/api';
 import Pagination from './Pagination';
 
@@ -36,6 +38,7 @@ function ConversationHistoryPanel() {
   const [page, setPage] = useState(1);
   const [detailItem, setDetailItem] = useState(null);
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
 
   const { data, isLoading, error } = useQuery(
     ['conversations', page],
@@ -97,6 +100,13 @@ function ConversationHistoryPanel() {
                     color={conv.status === 'completed' ? 'success' : conv.status === 'failed' ? 'error' : 'default'}
                     variant="outlined"
                   />
+                  {(conv.messages?.filter((m) => m.role !== 'system').length || 0) > 2 && (
+                    <Chip
+                      label={`${conv.messages.filter((m) => m.role !== 'system').length}턴`}
+                      size="small"
+                      variant="outlined"
+                    />
+                  )}
                   <Box sx={{ flexGrow: 1 }} />
                   <Typography variant="caption" color="text.secondary">
                     {new Date(conv.createdAt).toLocaleString('ko-KR')}
@@ -215,6 +225,18 @@ function ConversationHistoryPanel() {
           )}
         </DialogContent>
         <DialogActions>
+          {detailItem?.workboardId?._id && (
+            <Button
+              variant="contained"
+              color="secondary"
+              startIcon={<ChatIcon />}
+              onClick={() => {
+                navigate(`/prompt-generate/${detailItem.workboardId._id}?conversationId=${detailItem._id}`);
+              }}
+            >
+              이 대화 이어가기
+            </Button>
+          )}
           <Button onClick={() => setDetailItem(null)}>닫기</Button>
         </DialogActions>
       </Dialog>

--- a/frontend/src/pages/PromptGeneration.js
+++ b/frontend/src/pages/PromptGeneration.js
@@ -14,15 +14,18 @@ import {
   Chat,
   ContentCopy
 } from '@mui/icons-material';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { useQuery } from 'react-query';
 import { workboardAPI } from '../services/api';
 import PromptGeneratorPanel from '../components/PromptGeneratorPanel';
+import ConversationChatPanel from '../components/common/ConversationChatPanel';
 import toast from 'react-hot-toast';
 
 function PromptGeneration() {
   const { workboardId } = useParams();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const conversationId = searchParams.get('conversationId');
 
   const { data: workboardData, isLoading: workboardLoading, error: workboardError } = useQuery(
     ['workboard', workboardId],
@@ -75,15 +78,15 @@ function PromptGeneration() {
       <Box display="flex" alignItems="center" gap={2} mb={3}>
         <Button
           startIcon={<ArrowBack />}
-          onClick={() => navigate('/prompt-workboards')}
+          onClick={() => navigate(conversationId ? '/jobs' : '/prompt-workboards')}
         >
-          작업판 선택
+          {conversationId ? '히스토리로' : '작업판 선택'}
         </Button>
         <Box display="flex" alignItems="center" gap={1}>
           <Chat color="secondary" />
           <Typography variant="h5">{workboard.name}</Typography>
         </Box>
-        <Chip label="프롬프트 생성" color="secondary" size="small" />
+        <Chip label={conversationId ? '대화 이어가기' : '프롬프트 생성'} color="secondary" size="small" />
       </Box>
 
       <Box display="flex" alignItems="center" gap={0.5} mb={2}>
@@ -95,18 +98,25 @@ function PromptGeneration() {
         </IconButton>
       </Box>
 
-      {workboard.description && (
+      {workboard.description && !conversationId && (
         <Alert severity="info" sx={{ mb: 3 }}>
           {workboard.description}
         </Alert>
       )}
 
-      <PromptGeneratorPanel
-        workboard={workboard}
-        showHeader={false}
-        showSystemPrompt={false}
-        compact={false}
-      />
+      {conversationId ? (
+        <ConversationChatPanel
+          workboard={workboard}
+          conversationId={conversationId}
+        />
+      ) : (
+        <PromptGeneratorPanel
+          workboard={workboard}
+          showHeader={false}
+          showSystemPrompt={false}
+          compact={false}
+        />
+      )}
     </Container>
   );
 }

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -390,14 +390,14 @@ router.post('/:id/cancel', requireAuth, async (req, res) => {
 
 router.post('/generate-prompt', requireAuth, async (req, res) => {
   try {
-    const { workboardId, inputData } = req.body;
-    
+    const { workboardId, inputData, conversationId } = req.body;
+
     if (!workboardId || !inputData?.userPrompt) {
       return res.status(400).json({
         message: 'Missing required fields: workboardId, inputData.userPrompt'
       });
     }
-    
+
     const workboard = await Workboard.findById(workboardId).populate('serverId');
     if (!workboard) {
       return res.status(404).json({ message: 'Workboard not found' });
@@ -411,41 +411,67 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
     if (workboard.outputFormat !== 'text' && workboard.workboardType !== 'prompt') {
       return res.status(400).json({ message: 'This workboard is not a prompt workboard' });
     }
-    
+
     const server = workboard.serverId;
     if (!server || !server.isActive) {
       return res.status(400).json({ message: 'Server is not available' });
     }
-    
+
     const systemPrompt = workboard.baseInputFields?.systemPrompt || '';
     const model = inputData.model || workboard.baseInputFields?.aiModel?.[0]?.value || 'gpt-4';
     const temperature = workboard.baseInputFields?.temperature ?? 0.7;
     const maxTokens = workboard.baseInputFields?.maxTokens ?? 2000;
-    
+
     console.log('Prompt generation request:', {
       workboardId,
       model,
       temperature,
       maxTokens,
       serverUrl: server.serverUrl,
-      hasApiKey: !!server.configuration?.apiKey
+      hasApiKey: !!server.configuration?.apiKey,
+      isContinuation: !!conversationId,
     });
-    
-    const messages = [];
-    if (systemPrompt) {
-      messages.push({ role: 'system', content: systemPrompt });
-    }
-    messages.push({ role: 'user', content: inputData.userPrompt });
 
-    // ConversationJob pending 생성 (#373) — 호출 실패해도 히스토리에 흔적이 남도록.
-    const conversation = await ConversationJob.create({
-      userId: req.user._id,
-      workboardId: workboard._id,
-      serverType: server.serverType,
-      model,
-      messages: messages.map((m) => ({ ...m, createdAt: new Date() })),
-      status: 'processing',
-    });
+    // 멀티턴 (#375): conversationId 가 있으면 기존 대화 로드 후 append.
+    // 없으면 신규 대화 생성 (#373 Phase 1 동일 흐름).
+    let conversation;
+    let messages;
+    if (conversationId) {
+      conversation = await ConversationJob.findById(conversationId);
+      if (!conversation) {
+        return res.status(404).json({ message: '대화를 찾을 수 없습니다.' });
+      }
+      if (String(conversation.userId) !== String(req.user._id) && !req.user.isAdmin) {
+        return res.status(403).json({ message: '이 대화에 접근할 권한이 없습니다.' });
+      }
+      if (String(conversation.workboardId) !== String(workboard._id)) {
+        return res.status(400).json({ message: '대화가 다른 작업판에 속해 있습니다.' });
+      }
+      conversation.messages.push({
+        role: 'user',
+        content: inputData.userPrompt,
+        createdAt: new Date(),
+      });
+      conversation.status = 'processing';
+      conversation.error = undefined;
+      await conversation.save();
+      // LLM 에는 전체 시퀀스 전달
+      messages = conversation.messages.map((m) => ({ role: m.role, content: m.content }));
+    } else {
+      messages = [];
+      if (systemPrompt) {
+        messages.push({ role: 'system', content: systemPrompt });
+      }
+      messages.push({ role: 'user', content: inputData.userPrompt });
+      conversation = await ConversationJob.create({
+        userId: req.user._id,
+        workboardId: workboard._id,
+        serverType: server.serverType,
+        model,
+        messages: messages.map((m) => ({ ...m, createdAt: new Date() })),
+        status: 'processing',
+      });
+    }
 
     // server.serverType 기반 chat 서비스 분기. Gemini 는 generateContent (텍스트 모드),
     // 그 외 (OpenAI / OpenAI Compatible) 는 /v1/chat/completions.
@@ -469,7 +495,7 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
       throw chatError;
     }
 
-    // assistant 응답 messages 에 append + 비용 (Phase 3 에서 채움)
+    // assistant 응답 messages 에 append + usage (Phase 3 에서 비용 추정 채움)
     conversation.messages.push({
       role: 'assistant',
       content: result,


### PR DESCRIPTION
## Summary
- prompt-generate 가 `conversationId` 옵션 받으면 기존 `ConversationJob` 에 user/assistant 메시지를 append 하고 LLM 에 전체 messages 시퀀스를 전달.
- 작업판 페이지가 `?conversationId=` 쿼리 감지 시 `PromptGeneratorPanel` 대신 `ConversationChatPanel` 로 전환 — 이전 messages 누적 표시 + 다음 메시지 입력.
- 히스토리 상세 다이얼로그에 "이 대화 이어가기" 버튼, 카드에 `N턴` 칩 추가.

## Test plan
- [x] 백엔드 / 프론트엔드 빌드 (--no-cache) 성공
- [x] 로컬 검증: 신규 작업판 1회성 생성 → 히스토리 → 이어가기 → 추가 메시지 전송 → transcript 갱신
- [ ] dev 머지 후 alpha 환경 추가 검증

closes #375