### PR TITLE
feat: LLM 텍스트 대화 비용 추정 + 모델 role 해결 (#377)

### DIFF
--- a/frontend/src/components/common/ConversationChatPanel.js
+++ b/frontend/src/components/common/ConversationChatPanel.js
@@ -95,6 +95,14 @@ function ConversationChatPanel({ workboard, conversationId }) {
         <Chip label="대화 이어가기" color="secondary" size="small" />
         {conversation.model && <Chip label={conversation.model} size="small" variant="outlined" />}
         {conversation.serverType && <Chip label={conversation.serverType} size="small" variant="outlined" />}
+        {conversation.costEstimate?.amount != null && (
+          <Chip
+            label={`누적 $${conversation.costEstimate.amount.toFixed(6)}`}
+            size="small"
+            variant="outlined"
+            color="info"
+          />
+        )}
         <Box sx={{ flexGrow: 1 }} />
         <Typography variant="caption" color="text.secondary">
           시작: {new Date(conversation.createdAt).toLocaleString('ko-KR')}

--- a/frontend/src/components/common/ConversationHistoryPanel.js
+++ b/frontend/src/components/common/ConversationHistoryPanel.js
@@ -219,6 +219,12 @@ function ConversationHistoryPanel() {
                   <Typography variant="caption" color="text.secondary" display="block">
                     토큰: 입력 {detailItem.usage.promptTokens ?? 0} · 출력 {detailItem.usage.completionTokens ?? 0} (총 {detailItem.usage.totalTokens ?? 0})
                   </Typography>
+                  {detailItem.costEstimate?.amount != null && (
+                    <Typography variant="caption" color="text.secondary" display="block">
+                      추정 비용: ${detailItem.costEstimate.amount.toFixed(6)} {detailItem.costEstimate.currency || 'USD'}
+                      {detailItem.costEstimate.pricingVersion && ` (${detailItem.costEstimate.pricingVersion})`}
+                    </Typography>
+                  )}
                 </Box>
               )}
             </Stack>

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -14,6 +14,7 @@ const { escapeRegex } = require('../utils/escapeRegex');
 const Server = require('../models/Server');
 const { getFieldValueByRole } = require('../utils/customFieldHelpers');
 const { FIELD_ROLES } = require('../constants/fieldRoles');
+const { computeOpenAITextCost, computeGeminiTextCost } = require('../utils/pricing');
 const router = express.Router();
 
 router.post('/generate', requireAuth, async (req, res) => {
@@ -417,10 +418,21 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
       return res.status(400).json({ message: 'Server is not available' });
     }
 
-    const systemPrompt = workboard.baseInputFields?.systemPrompt || '';
-    const model = inputData.model || workboard.baseInputFields?.aiModel?.[0]?.value || 'gpt-4';
-    const temperature = workboard.baseInputFields?.temperature ?? 0.7;
-    const maxTokens = workboard.baseInputFields?.maxTokens ?? 2000;
+    // role 기반 lookup (#377) — 작업판 customField (`base_model`, `system_prompt`, ...) 가 단일 진입점.
+    // legacy baseInputFields fallback 제거됨 — F2 / baseInputFields migration 완료 후 DB 에 잔존 없음.
+    const extractOpt = (v) => (v && typeof v === 'object' && v.value !== undefined ? v.value : v);
+    const systemPrompt = extractOpt(getFieldValueByRole(workboard, inputData, FIELD_ROLES.SYSTEM_PROMPT)) || '';
+    const resolvedModel = extractOpt(getFieldValueByRole(workboard, inputData, FIELD_ROLES.MODEL));
+    if (!resolvedModel && !conversationId) {
+      // 멀티턴(이어가기) 은 inputData 에 model 이 없어도 conversation 에 저장된 model 을 사용
+      return res.status(400).json({ message: '작업판에 모델이 선택되지 않았습니다.' });
+    }
+    const temperatureValue = extractOpt(getFieldValueByRole(workboard, inputData, FIELD_ROLES.TEMPERATURE));
+    const temperature = temperatureValue != null ? Number(temperatureValue) : 0.7;
+    const maxTokensValue = extractOpt(getFieldValueByRole(workboard, inputData, FIELD_ROLES.MAX_TOKENS));
+    const maxTokens = maxTokensValue != null ? Number(maxTokensValue) : 2000;
+    // 멀티턴 시 model 은 기존 대화에 저장된 값을 우선 (작업판 변경에도 일관성 유지)
+    let model = resolvedModel;
 
     console.log('Prompt generation request:', {
       workboardId,
@@ -446,6 +458,10 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
       }
       if (String(conversation.workboardId) !== String(workboard._id)) {
         return res.status(400).json({ message: '대화가 다른 작업판에 속해 있습니다.' });
+      }
+      // 멀티턴은 대화에 저장된 model 유지 (#377)
+      if (conversation.model) {
+        model = conversation.model;
       }
       conversation.messages.push({
         role: 'user',
@@ -495,13 +511,31 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
       throw chatError;
     }
 
-    // assistant 응답 messages 에 append + usage (Phase 3 에서 비용 추정 채움)
+    // assistant 응답 + usage + 비용 추정 (#377). usage 누적 (멀티턴 시 직전 턴 토큰 합산).
     conversation.messages.push({
       role: 'assistant',
       content: result,
       createdAt: new Date(),
     });
-    conversation.usage = usage;
+    const turnUsage = usage || { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+    const prevUsage = conversation.usage || {};
+    conversation.usage = {
+      promptTokens: (prevUsage.promptTokens || 0) + (turnUsage.promptTokens || 0),
+      completionTokens: (prevUsage.completionTokens || 0) + (turnUsage.completionTokens || 0),
+      totalTokens: (prevUsage.totalTokens || 0) + (turnUsage.totalTokens || 0),
+    };
+    const computeCost = server.serverType === 'Gemini'
+      ? computeGeminiTextCost
+      : computeOpenAITextCost;
+    const turnCost = computeCost(model, turnUsage);
+    if (turnCost) {
+      const prevAmount = conversation.costEstimate?.amount || 0;
+      conversation.costEstimate = {
+        amount: +(prevAmount + turnCost.amount).toFixed(6),
+        currency: turnCost.currency,
+        pricingVersion: turnCost.pricingVersion,
+      };
+    }
     conversation.status = 'completed';
     conversation.completedAt = new Date();
     await conversation.save();
@@ -512,7 +546,8 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
       success: true,
       conversationId: conversation._id,
       result,
-      usage,
+      usage: turnUsage,
+      costEstimate: conversation.costEstimate || null,
       model
     });
   } catch (error) {

--- a/src/utils/pricing.js
+++ b/src/utils/pricing.js
@@ -131,10 +131,131 @@ function computeGeminiImageCost(model, usage) {
   };
 }
 
+// 텍스트(chat) 모델 단가 (2026-05).
+// OpenAI: https://developers.openai.com/api/docs/pricing
+// 단위: USD per 1M tokens.
+const OPENAI_TEXT_PRICING = {
+  // gpt-5.5 family
+  'gpt-5.5': {
+    input: 5.00,
+    input_cached: 0.50,
+    output: 30.00,
+  },
+  'gpt-5.5-pro': {
+    input: 30.00,
+    output: 180.00,
+  },
+  // gpt-5.4 family
+  'gpt-5.4': {
+    input: 2.50,
+    input_cached: 0.25,
+    output: 15.00,
+  },
+  'gpt-5.4-mini': {
+    input: 0.75,
+    input_cached: 0.075,
+    output: 4.50,
+  },
+  'gpt-5.4-nano': {
+    input: 0.20,
+    input_cached: 0.02,
+    output: 1.25,
+  },
+  'gpt-5.4-pro': {
+    input: 30.00,
+    output: 180.00,
+  },
+};
+
+// Gemini: https://ai.google.dev/gemini-api/docs/pricing
+// gemini-3.1-pro-preview 는 context length tier 가 200k 기준으로 단가가 다름.
+const GEMINI_TEXT_PRICING = {
+  'gemini-3.1-flash-lite': {
+    input: 0.25,
+    output: 1.50,
+  },
+  'gemini-3.1-flash-lite-preview': {
+    input: 0.25,
+    output: 1.50,
+  },
+  'gemini-3.1-pro-preview': {
+    input: 2.00,
+    output: 12.00,
+    input_long: 4.00,
+    output_long: 18.00,
+    long_threshold: 200_000,
+  },
+};
+
+/**
+ * OpenAI 텍스트(chat) 응답 usage → 비용 추정 (#377).
+ * 현재 normalized usage shape 은 cached 구분이 없어 input 전체를 표준 input 단가로 계산.
+ * @param {string} model
+ * @param {{ promptTokens?: number, completionTokens?: number }} usage
+ */
+function computeOpenAITextCost(model, usage) {
+  if (!usage || typeof usage !== 'object') return null;
+  const rates = OPENAI_TEXT_PRICING[model];
+  if (!rates) return null;
+
+  const input = Number(usage.promptTokens) || 0;
+  const output = Number(usage.completionTokens) || 0;
+
+  const costInput = input * rates.input * PER_TOKEN;
+  const costOutput = output * rates.output * PER_TOKEN;
+  const amount = +(costInput + costOutput).toFixed(6);
+
+  return {
+    amount,
+    currency: 'USD',
+    pricingVersion: PRICING_VERSION,
+    breakdown: {
+      input: +costInput.toFixed(6),
+      output: +costOutput.toFixed(6),
+    },
+  };
+}
+
+/**
+ * Gemini 텍스트 응답 usage → 비용 추정 (#377).
+ * gemini-3.1-pro-preview 는 promptTokens > 200k 면 long_* 단가 적용.
+ */
+function computeGeminiTextCost(model, usage) {
+  if (!usage || typeof usage !== 'object') return null;
+  const rates = GEMINI_TEXT_PRICING[model];
+  if (!rates) return null;
+
+  const input = Number(usage.promptTokens) || 0;
+  const output = Number(usage.completionTokens) || 0;
+
+  const longTier = rates.long_threshold && input > rates.long_threshold;
+  const inputRate = longTier ? rates.input_long : rates.input;
+  const outputRate = longTier ? rates.output_long : rates.output;
+
+  const costInput = input * inputRate * PER_TOKEN;
+  const costOutput = output * outputRate * PER_TOKEN;
+  const amount = +(costInput + costOutput).toFixed(6);
+
+  return {
+    amount,
+    currency: 'USD',
+    pricingVersion: PRICING_VERSION,
+    breakdown: {
+      input: +costInput.toFixed(6),
+      output: +costOutput.toFixed(6),
+      tier: longTier ? 'long' : 'standard',
+    },
+  };
+}
+
 module.exports = {
   PRICING_VERSION,
   OPENAI_IMAGE_PRICING,
   GEMINI_IMAGE_PRICING,
+  OPENAI_TEXT_PRICING,
+  GEMINI_TEXT_PRICING,
   computeOpenAIImageCost,
   computeGeminiImageCost,
+  computeOpenAITextCost,
+  computeGeminiTextCost,
 };


### PR DESCRIPTION
## Summary
- `pricing.js` 에 텍스트 모델 가격표 추가 (USD per 1M tokens)
  - OpenAI: `gpt-5.5`, `gpt-5.5-pro`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.4-pro`
  - Gemini: `gemini-3.1-flash-lite`, `gemini-3.1-flash-lite-preview`, `gemini-3.1-pro-preview` (200K context tier)
- prompt-generate 가 chat 호출 성공 후 비용 산출해 `ConversationJob.costEstimate` 누적 저장 (멀티턴 시 턴별 비용 합산)
- model / systemPrompt / temperature / maxTokens 를 `getFieldValueByRole` 로 일원화. customField `base_model` 값이 인식되지 않아 항상 `gpt-4` fallback 으로 저장되던 버그 수정. legacy `baseInputFields` fallback chain 제거
- 멀티턴은 conversation 에 저장된 model 유지 (작업판 변경에도 일관성)
- 히스토리 상세 + 채팅 헤더에 누적 비용 노출

## Test plan
- [x] 백엔드 빌드 (--no-cache) 성공
- [x] 로컬: gpt-5.4-mini, gpt-5.5 등으로 신규 대화 → 비용 표시 확인 (`사용자 잘 됩니다 확인 완료`)
- [x] legacy fallback 제거 후 모델 선택 누락 시 400 가드 동작 확인
- [ ] dev 머지 후 alpha 환경 추가 검증

## Notes
- cached input 토큰 구분은 normalized usage 에 없어 일단 전체 input 에 표준 단가 적용. 정밀화는 후속 가능.

closes #377