### PR TITLE
fix: TEST_AUTO_ADMIN_DOMAIN 백도어 완전 제거 (#379)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,10 +63,10 @@ services:
       SMTP_FROM_NAME: ${SMTP_FROM_NAME:-VCC Manager}
       SIGNED_URL_EXPIRY: ${SIGNED_URL_EXPIRY:-3600}
       SIGNED_URL_ROUND_SECONDS: ${SIGNED_URL_ROUND_SECONDS:-1440}
-      # dev / e2e 환경 — signup rate limit 완화 (#359). 프로덕션은 기본값 3 유지.
-      SIGNUP_RATE_LIMIT_MAX: ${SIGNUP_RATE_LIMIT_MAX:-100}
-      # E2E 백도어 (#359) — 해당 도메인 이메일은 자동 admin 승격. 프로덕션 미사용.
-      TEST_AUTO_ADMIN_DOMAIN: ${TEST_AUTO_ADMIN_DOMAIN:-example.com}
+      # dev / e2e 환경 — signup rate limit 완화 (#359). 명시 설정 시만 적용 (#379).
+      SIGNUP_RATE_LIMIT_MAX: ${SIGNUP_RATE_LIMIT_MAX:-}
+      # NOTE: TEST_AUTO_ADMIN_DOMAIN 백도어는 #379 에서 완전 제거. E2E 테스트는 후속 작업에서
+      # 안전한 admin 부여 방식 (시크릿 헤더 / DB seed 등) 으로 재설계 필요.
     ports:
       - "${BACKEND_PORT:-3136}:3000"
     volumes:

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -143,13 +143,8 @@ userSchema.pre('save', async function(next) {
 userSchema.methods.updateAdminStatus = function() {
   const adminEmails = (process.env.ADMIN_EMAILS || '').split(',').map(email => email.trim());
   this.isAdmin = adminEmails.includes(this.email);
-  // E2E 백도어 (#359) — TEST_AUTO_ADMIN_DOMAIN 환경변수 (예: 'example.com') 설정 시
-  // 해당 도메인 이메일의 신규 가입자를 자동 admin 으로 승격. dev / e2e 환경 전용,
-  // 프로덕션에서는 절대 설정하지 말 것.
-  const testDomain = (process.env.TEST_AUTO_ADMIN_DOMAIN || '').trim();
-  if (testDomain && this.email.endsWith(`@${testDomain}`)) {
-    this.isAdmin = true;
-  }
+  // TEST_AUTO_ADMIN_DOMAIN 백도어 제거됨 (#379). dev 환경도 alpha 도메인으로 외부 노출되는 구조라
+  // 도메인 기반 자동 admin 승격은 공격 표면이 됨. E2E 테스트는 후속 작업에서 별도 안전 경로로 재설계 필요.
   // 관리자는 자동으로 승인됨
   if (this.isAdmin && this.approvalStatus === 'pending') {
     this.approvalStatus = 'approved';


### PR DESCRIPTION
## Summary
dev 환경이 alpha 도메인으로 외부 노출되어 있어 `@example.com` 자동 admin 백도어 (`TEST_AUTO_ADMIN_DOMAIN`) 가 공격 표면이 됨. docker-compose.yml 기본값 + User.updateAdminStatus 코드 경로 모두 제거.

검증:
- 백엔드 재빌드 후 `POST /api/auth/signup` 으로 `@example.com` 이메일 가입 → 응답에서 `isAdmin: false`, `approvalStatus: "pending"` 확인.

## Operations (이미 처리됨)
- 로컬 DB 에서 잔존 28명 (@example.com) + 그 중 자동 admin 승격된 1명 정리 완료.
- 남은 admin 은 iceemperor 본인 1명만.

## Follow-up
- E2E 테스트는 signup 으로 만든 사용자가 pending 상태로 남아 깨짐. 별도 이슈에서 안전한 admin 부여 방식 (시크릿 헤더 / DB seed 등) 으로 재설계 예정.

closes #379