### PR TITLE
fix: 모바일 모델 관리/picker 리스트 뷰 가로 오버플로우 (#383)

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -119,9 +119,11 @@ function MainLayout() {
       <Header onMobileToggle={handleMobileToggle} />
       <Box sx={{ display: 'flex', flex: 1 }}>
         <Sidebar mobileOpen={mobileOpen} onMobileToggle={handleMobileToggle} />
-        <Box component="main" sx={{ 
-          flexGrow: 1, 
-          p: 3, 
+        <Box component="main" sx={{
+          flexGrow: 1,
+          minWidth: 0, // flex item 이 content intrinsic width 로 늘어나 body 가로 스크롤 유발하는 것 방지 (#383)
+          overflowX: 'hidden',
+          p: 3,
           backgroundColor: '#f5f5f5',
           minHeight: 'calc(100vh - 64px)'
         }}>

--- a/frontend/src/components/admin/MetadataImageListItem.js
+++ b/frontend/src/components/admin/MetadataImageListItem.js
@@ -55,6 +55,9 @@ function MetadataImageListItem({
         display: 'flex',
         alignItems: 'stretch',
         gap: 1.5,
+        width: '100%',
+        minWidth: 0,
+        overflow: 'hidden',
         border: 1,
         borderColor: selected ? 'primary.main' : 'divider',
         borderWidth: selected ? 2 : 1,
@@ -79,7 +82,7 @@ function MetadataImageListItem({
       </Box>
 
       {/* 중앙: 정보 */}
-      <Box sx={{ flex: '1 1 0', minWidth: 0, display: 'flex', flexDirection: 'column', justifyContent: 'space-between', py: 0.25 }}>
+      <Box sx={{ flex: '1 1 0', minWidth: 0, overflow: 'hidden', display: 'flex', flexDirection: 'column', justifyContent: 'space-between', py: 0.25 }}>
         {/* 모델명 + 버전 */}
         <Box>
           <Stack direction="row" alignItems="center" spacing={0.5}>

--- a/frontend/src/components/admin/MetadataManagementBody.js
+++ b/frontend/src/components/admin/MetadataManagementBody.js
@@ -443,7 +443,7 @@ function MetadataManagementBody({ kind, selectedServerId, selectedServer, nsfwMo
           )}
 
           {viewMode === 'list' && (
-            <Box>
+            <Box sx={{ width: '100%', overflow: 'hidden' }}>
               {renderItems.map(({ raw, item }, idx) => (
                 <Box
                   key={raw?.filename || idx}
@@ -453,12 +453,15 @@ function MetadataManagementBody({ kind, selectedServerId, selectedServer, nsfwMo
                     gap: 1,
                     py: 1,
                     px: 1.5,
+                    width: '100%',
+                    minWidth: 0,
+                    overflow: 'hidden',
                     borderBottom: 1,
                     borderColor: 'divider',
                     '&:hover': { bgcolor: 'action.hover' }
                   }}
                 >
-                  <Box sx={{ flex: '1 1 0', minWidth: 0 }}>
+                  <Box sx={{ flex: '1 1 0', minWidth: 0, overflow: 'hidden' }}>
                     <Typography variant="body2" noWrap title={item.displayName} sx={{ fontWeight: 500 }}>
                       {item.displayName}
                       {item.versionName && (
@@ -467,21 +470,21 @@ function MetadataManagementBody({ kind, selectedServerId, selectedServer, nsfwMo
                         </Typography>
                       )}
                     </Typography>
-                    <Typography variant="caption" color="text.secondary" noWrap title={item.filename} sx={{ fontFamily: 'monospace' }}>
+                    <Typography variant="caption" color="text.secondary" noWrap title={item.filename} sx={{ fontFamily: 'monospace', display: 'block' }}>
                       {item.filename}
                     </Typography>
                   </Box>
                   {item.baseModel && (
-                    <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0 }}>
+                    <Typography variant="caption" color="text.secondary" noWrap sx={{ flexShrink: 1, minWidth: 0, maxWidth: { xs: 80, sm: 160 }, overflow: 'hidden', textOverflow: 'ellipsis' }}>
                       {item.baseModel}
                     </Typography>
                   )}
                   {!item.hasMetadata && (
-                    <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0, fontStyle: 'italic' }}>
+                    <Typography variant="caption" color="text.secondary" noWrap sx={{ flexShrink: 0, fontStyle: 'italic' }}>
                       {item.hash ? '미등록' : '메타 없음'}
                     </Typography>
                   )}
-                  <Button size="small" onClick={() => setDetailItem(item)}>상세</Button>
+                  <Button size="small" onClick={() => setDetailItem(item)} sx={{ flexShrink: 0, minWidth: 'auto' }}>상세</Button>
                 </Box>
               ))}
             </Box>

--- a/frontend/src/components/common/MetadataPickerModal.js
+++ b/frontend/src/components/common/MetadataPickerModal.js
@@ -533,7 +533,7 @@ function MetadataPickerModal({
             )}
 
             {viewMode === 'list' && (
-              <Box>
+              <Box sx={{ width: '100%', overflow: 'hidden' }}>
                 {filteredItems.map((rawItem, idx) => {
                   const item = adapter.normalize(rawItem);
                   if (!item) return null;
@@ -548,6 +548,9 @@ function MetadataPickerModal({
                         gap: 1,
                         py: 1,
                         px: 1.5,
+                        width: '100%',
+                        minWidth: 0,
+                        overflow: 'hidden',
                         borderBottom: 1,
                         borderColor: 'divider',
                         cursor: cardClickable ? 'pointer' : 'default',
@@ -555,7 +558,7 @@ function MetadataPickerModal({
                         '&:hover': { bgcolor: 'action.hover' }
                       }}
                     >
-                      <Box sx={{ flex: '1 1 0', minWidth: 0 }}>
+                      <Box sx={{ flex: '1 1 0', minWidth: 0, overflow: 'hidden' }}>
                         <Typography variant="body2" noWrap title={item.displayName} sx={{ fontWeight: isSelected ? 600 : 500 }}>
                           {item.displayName}
                           {item.versionName && (
@@ -564,18 +567,18 @@ function MetadataPickerModal({
                             </Typography>
                           )}
                         </Typography>
-                        <Typography variant="caption" color="text.secondary" noWrap title={item.filename} sx={{ fontFamily: 'monospace' }}>
+                        <Typography variant="caption" color="text.secondary" noWrap title={item.filename} sx={{ fontFamily: 'monospace', display: 'block' }}>
                           {item.filename}
                         </Typography>
                       </Box>
                       {item.baseModel && (
-                        <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0 }}>
+                        <Typography variant="caption" color="text.secondary" noWrap sx={{ flexShrink: 1, minWidth: 0, maxWidth: { xs: 80, sm: 160 }, overflow: 'hidden', textOverflow: 'ellipsis' }}>
                           {item.baseModel}
                         </Typography>
                       )}
-                      <Button size="small" onClick={(e) => { e.stopPropagation(); setDetailItem(item); }}>상세</Button>
+                      <Button size="small" onClick={(e) => { e.stopPropagation(); setDetailItem(item); }} sx={{ flexShrink: 0, minWidth: 'auto' }}>상세</Button>
                       {!cardClickable && (
-                        <Button size="small" variant={mode === 'prompt-insert' ? 'contained' : 'text'} onClick={(e) => { e.stopPropagation(); handlePrimary(rawItem); }}>
+                        <Button size="small" variant={mode === 'prompt-insert' ? 'contained' : 'text'} onClick={(e) => { e.stopPropagation(); handlePrimary(rawItem); }} sx={{ flexShrink: 0, minWidth: 'auto' }}>
                           {mode === 'prompt-insert' ? '추가' : mode === 'multi-add' ? (isSelected ? '제거' : '추가') : '선택'}
                         </Button>
                       )}


### PR DESCRIPTION
## Summary
모바일에서 모델 관리 / 모델 picker 의 두 리스트형 뷰 (이미지 리스트 / 텍스트 리스트) 가 가로로 늘어나 카드 프레임을 벗어나는 문제 수정. 실제 root cause 는 행이 아니라 `App.js` 의 메인 컨테이너.

## Root cause
`<Box component="main">` 이 flex item 인데 `minWidth: 0` 이 누락. flex 기본 `min-width: auto` 가 content intrinsic width 로 작동해서, 긴 모델명/파일명이 들어가면 main 박스 자체가 viewport 너비를 넘어가 body 가로 스크롤 발생. 헤더 / 액션 버튼 / 카드들이 다 viewport 밖으로 밀려남.

## Fix
- `App.js` main Box 에 `minWidth: 0` + `overflowX: hidden` (필수)
- 리스트 행 outer Box 에 `width:100%, minWidth:0, overflow:hidden` 보강 (defense in depth)
- baseModel 텍스트는 `flexShrink:1` + `maxWidth: xs 80 / sm 160` + ellipsis
- 액션 버튼은 `flexShrink:0, minWidth:'auto'` 로 잘림 방지

## Test plan
- [x] 프론트엔드 빌드 (--no-cache) 성공
- [x] iPhone 에서 새로고침 후 모델 관리 페이지의 image-list / list 뷰가 viewport 안에 들어가고 가로 스크롤 없음 확인 (사용자: "오 드디어 잘 됩니다")

closes #383