### PR TITLE
fix: 모바일 모델 관리 정렬 미세 조정 (#383 후속)

### DIFF
--- a/frontend/src/components/admin/CivitaiAdminHeader.js
+++ b/frontend/src/components/admin/CivitaiAdminHeader.js
@@ -136,14 +136,15 @@ function CivitaiAdminHeader({
         </Box>
       </Stack>
 
-      {/* 2행: NSFW 토글들 */}
+      {/* 2행: NSFW 토글들. 모바일은 명시적 column 으로 X 정렬 흔들림 방지 (#383 후속) */}
       <Stack
-        direction="row"
-        spacing={2}
-        alignItems="center"
-        sx={{ mt: 1, flexWrap: 'wrap' }}
+        direction={{ xs: 'column', sm: 'row' }}
+        spacing={{ xs: 0.5, sm: 2 }}
+        alignItems={{ xs: 'flex-start', sm: 'center' }}
+        sx={{ mt: 1 }}
       >
         <FormControlLabel
+          sx={{ ml: 0, mr: 0 }}
           control={
             <Switch
               checked={nsfwFilter}
@@ -160,6 +161,7 @@ function CivitaiAdminHeader({
         />
 
         <FormControlLabel
+          sx={{ ml: 0, mr: 0 }}
           control={
             <Switch
               checked={!!nsfwModelFilter}

--- a/frontend/src/components/admin/MetadataManagementBody.js
+++ b/frontend/src/components/admin/MetadataManagementBody.js
@@ -14,6 +14,7 @@ import {
   Alert,
   Tooltip,
   Stack,
+  Grid,
   Paper,
   ToggleButton,
   ToggleButtonGroup,
@@ -372,27 +373,27 @@ function MetadataManagementBody({ kind, selectedServerId, selectedServer, nsfwMo
         </Tooltip>
       </Stack>
 
-      {/* 캐시 info 패널 */}
+      {/* 캐시 info 패널 — 모바일은 2×2, 데스크탑은 1×4 로 정렬 (#383 후속) */}
       {cacheInfo && (
         <Paper variant="outlined" sx={{ p: 1.5, mb: 2 }}>
-          <Stack direction="row" spacing={3} flexWrap="wrap">
-            <Box>
+          <Grid container spacing={2}>
+            <Grid item xs={6} sm={3}>
               <Typography variant="caption" color="text.secondary" display="block">서버</Typography>
-              <Typography variant="body2">{selectedServer?.name || '—'}</Typography>
-            </Box>
-            <Box>
+              <Typography variant="body2" noWrap title={selectedServer?.name || ''}>{selectedServer?.name || '—'}</Typography>
+            </Grid>
+            <Grid item xs={6} sm={3}>
               <Typography variant="caption" color="text.secondary" display="block">총 {adapter.label}</Typography>
               <Typography variant="body2">{adapter.extractTotal(syncStatus, pagination)}개</Typography>
-            </Box>
-            <Box>
+            </Grid>
+            <Grid item xs={6} sm={3}>
               <Typography variant="caption" color="text.secondary" display="block">메타데이터 있음</Typography>
               <Typography variant="body2">{adapter.extractMetaCount(syncStatus) ?? '-'}개</Typography>
-            </Box>
-            <Box>
+            </Grid>
+            <Grid item xs={6} sm={3}>
               <Typography variant="caption" color="text.secondary" display="block">마지막 메타 동기화</Typography>
               <Typography variant="body2">{formatDate(adapter.extractLastSync(cacheInfo, syncStatus))}</Typography>
-            </Box>
-          </Stack>
+            </Grid>
+          </Grid>
           {cacheInfo?.hashNodeAvailable === false && selectedServer?.serverType === 'ComfyUI' && (
             <Alert severity="info" sx={{ mt: 1 }}>
               ComfyUI 의 vcc-file-hash 노드가 설치되지 않아 해시 기반 메타데이터를 가져올 수 없습니다.


### PR DESCRIPTION
## Summary
#383 후속. 모바일에서 모델 관리 페이지의 두 가지 정렬 어긋남 처리.

1. **NSFW 토글** — `Stack direction="row" + flexWrap` 로 두 줄로 떨어지면서 FormControlLabel 의 기본 음수 marginLeft (-11px) 가 행마다 미묘하게 적용되어 두 토글의 좌측 정렬이 흔들림.
   - 모바일은 명시적 `direction: 'column'`
   - `FormControlLabel` 의 `ml/mr: 0` 명시
2. **캐시 정보 카드** — 4번째 컬럼 (`마지막 메타 동기화`) 이 wrap 으로 다음 줄로 떨어지면서 첫 번째 컬럼 (`서버`) 바로 아래에 붙어 한 컬럼처럼 보임.
   - `Stack(flexWrap)` → `Grid container`
   - xs 2×2, sm+ 1×4

## Test plan
- [x] iPhone 에서 새로고침 후 NSFW 토글 좌측 정렬 일치 (사용자: "잘 정렬됐습니다")
- [x] 캐시 정보 카드 2×2 정렬 확인 (사용자: "깔끔합니다 잘 됐네요")