### PR TITLE
release: v2.4.1 — 모바일 가로 오버플로우 + 정렬 fix

### DIFF
--- a/docs/updatelogs/v2.md
+++ b/docs/updatelogs/v2.md
@@ -1,5 +1,16 @@
 # v2 업데이트 내역
 
+## v2.4.1
+
+### 수정
+- fix: 모바일 가로 오버플로우 — 모델 관리 / 모델 picker 의 리스트 / 이미지 리스트 뷰에서 긴 모델명·파일명 때문에 행이 viewport 보다 넓어져 body 전체 가로 스크롤이 발생하던 문제 (#383, #384)
+  - 실제 root cause 는 `App.js` 의 `<Box component="main">` 이 flex item 인데 `minWidth: 0` 누락. flex 기본 `min-width: auto` 가 content intrinsic width 로 작동해 main 박스 자체가 viewport 를 넘김.
+  - main Box 에 `minWidth: 0` + `overflowX: hidden` 추가. 행 outer Box 도 `width: 100%`, `minWidth: 0`, `overflow: hidden` 보강 (defense in depth).
+  - baseModel 텍스트는 `flexShrink: 1` + `maxWidth: xs 80 / sm 160` + ellipsis. 액션 버튼은 `flexShrink: 0, minWidth: 'auto'`.
+- fix: 모바일 모델 관리 페이지 미세 정렬 (#383 후속, #385)
+  - CivitaiAdminHeader 의 NSFW 토글 두 개를 `Stack row + flexWrap` 에서 `direction={{ xs: 'column' }}` 로 변경. FormControlLabel 의 기본 음수 marginLeft (-11px) 도 0 으로 명시.
+  - 캐시 정보 카드: `Stack(flexWrap)` → `Grid container`. 모바일 2×2, 데스크탑 1×4. 이전엔 4번째 컬럼 (`마지막 메타 동기화`) 이 첫 번째 컬럼 (`서버`) 바로 아래에 wrap 되어 한 컬럼처럼 보이는 문제.
+
 ## v2.4.0
 
 ### 신규 기능

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -119,9 +119,11 @@ function MainLayout() {
       <Header onMobileToggle={handleMobileToggle} />
       <Box sx={{ display: 'flex', flex: 1 }}>
         <Sidebar mobileOpen={mobileOpen} onMobileToggle={handleMobileToggle} />
-        <Box component="main" sx={{ 
-          flexGrow: 1, 
-          p: 3, 
+        <Box component="main" sx={{
+          flexGrow: 1,
+          minWidth: 0, // flex item 이 content intrinsic width 로 늘어나 body 가로 스크롤 유발하는 것 방지 (#383)
+          overflowX: 'hidden',
+          p: 3,
           backgroundColor: '#f5f5f5',
           minHeight: 'calc(100vh - 64px)'
         }}>

--- a/frontend/src/components/admin/CivitaiAdminHeader.js
+++ b/frontend/src/components/admin/CivitaiAdminHeader.js
@@ -136,14 +136,15 @@ function CivitaiAdminHeader({
         </Box>
       </Stack>
 
-      {/* 2행: NSFW 토글들 */}
+      {/* 2행: NSFW 토글들. 모바일은 명시적 column 으로 X 정렬 흔들림 방지 (#383 후속) */}
       <Stack
-        direction="row"
-        spacing={2}
-        alignItems="center"
-        sx={{ mt: 1, flexWrap: 'wrap' }}
+        direction={{ xs: 'column', sm: 'row' }}
+        spacing={{ xs: 0.5, sm: 2 }}
+        alignItems={{ xs: 'flex-start', sm: 'center' }}
+        sx={{ mt: 1 }}
       >
         <FormControlLabel
+          sx={{ ml: 0, mr: 0 }}
           control={
             <Switch
               checked={nsfwFilter}
@@ -160,6 +161,7 @@ function CivitaiAdminHeader({
         />
 
         <FormControlLabel
+          sx={{ ml: 0, mr: 0 }}
           control={
             <Switch
               checked={!!nsfwModelFilter}

--- a/frontend/src/components/admin/MetadataImageListItem.js
+++ b/frontend/src/components/admin/MetadataImageListItem.js
@@ -55,6 +55,9 @@ function MetadataImageListItem({
         display: 'flex',
         alignItems: 'stretch',
         gap: 1.5,
+        width: '100%',
+        minWidth: 0,
+        overflow: 'hidden',
         border: 1,
         borderColor: selected ? 'primary.main' : 'divider',
         borderWidth: selected ? 2 : 1,
@@ -79,7 +82,7 @@ function MetadataImageListItem({
       </Box>
 
       {/* 중앙: 정보 */}
-      <Box sx={{ flex: '1 1 0', minWidth: 0, display: 'flex', flexDirection: 'column', justifyContent: 'space-between', py: 0.25 }}>
+      <Box sx={{ flex: '1 1 0', minWidth: 0, overflow: 'hidden', display: 'flex', flexDirection: 'column', justifyContent: 'space-between', py: 0.25 }}>
         {/* 모델명 + 버전 */}
         <Box>
           <Stack direction="row" alignItems="center" spacing={0.5}>

--- a/frontend/src/components/admin/MetadataManagementBody.js
+++ b/frontend/src/components/admin/MetadataManagementBody.js
@@ -14,6 +14,7 @@ import {
   Alert,
   Tooltip,
   Stack,
+  Grid,
   Paper,
   ToggleButton,
   ToggleButtonGroup,
@@ -372,27 +373,27 @@ function MetadataManagementBody({ kind, selectedServerId, selectedServer, nsfwMo
         </Tooltip>
       </Stack>
 
-      {/* 캐시 info 패널 */}
+      {/* 캐시 info 패널 — 모바일은 2×2, 데스크탑은 1×4 로 정렬 (#383 후속) */}
       {cacheInfo && (
         <Paper variant="outlined" sx={{ p: 1.5, mb: 2 }}>
-          <Stack direction="row" spacing={3} flexWrap="wrap">
-            <Box>
+          <Grid container spacing={2}>
+            <Grid item xs={6} sm={3}>
               <Typography variant="caption" color="text.secondary" display="block">서버</Typography>
-              <Typography variant="body2">{selectedServer?.name || '—'}</Typography>
-            </Box>
-            <Box>
+              <Typography variant="body2" noWrap title={selectedServer?.name || ''}>{selectedServer?.name || '—'}</Typography>
+            </Grid>
+            <Grid item xs={6} sm={3}>
               <Typography variant="caption" color="text.secondary" display="block">총 {adapter.label}</Typography>
               <Typography variant="body2">{adapter.extractTotal(syncStatus, pagination)}개</Typography>
-            </Box>
-            <Box>
+            </Grid>
+            <Grid item xs={6} sm={3}>
               <Typography variant="caption" color="text.secondary" display="block">메타데이터 있음</Typography>
               <Typography variant="body2">{adapter.extractMetaCount(syncStatus) ?? '-'}개</Typography>
-            </Box>
-            <Box>
+            </Grid>
+            <Grid item xs={6} sm={3}>
               <Typography variant="caption" color="text.secondary" display="block">마지막 메타 동기화</Typography>
               <Typography variant="body2">{formatDate(adapter.extractLastSync(cacheInfo, syncStatus))}</Typography>
-            </Box>
-          </Stack>
+            </Grid>
+          </Grid>
           {cacheInfo?.hashNodeAvailable === false && selectedServer?.serverType === 'ComfyUI' && (
             <Alert severity="info" sx={{ mt: 1 }}>
               ComfyUI 의 vcc-file-hash 노드가 설치되지 않아 해시 기반 메타데이터를 가져올 수 없습니다.

--- a/frontend/src/components/admin/MetadataManagementBody.js
+++ b/frontend/src/components/admin/MetadataManagementBody.js
@@ -443,7 +443,7 @@ function MetadataManagementBody({ kind, selectedServerId, selectedServer, nsfwMo
           )}
 
           {viewMode === 'list' && (
-            <Box>
+            <Box sx={{ width: '100%', overflow: 'hidden' }}>
               {renderItems.map(({ raw, item }, idx) => (
                 <Box
                   key={raw?.filename || idx}
@@ -453,12 +453,15 @@ function MetadataManagementBody({ kind, selectedServerId, selectedServer, nsfwMo
                     gap: 1,
                     py: 1,
                     px: 1.5,
+                    width: '100%',
+                    minWidth: 0,
+                    overflow: 'hidden',
                     borderBottom: 1,
                     borderColor: 'divider',
                     '&:hover': { bgcolor: 'action.hover' }
                   }}
                 >
-                  <Box sx={{ flex: '1 1 0', minWidth: 0 }}>
+                  <Box sx={{ flex: '1 1 0', minWidth: 0, overflow: 'hidden' }}>
                     <Typography variant="body2" noWrap title={item.displayName} sx={{ fontWeight: 500 }}>
                       {item.displayName}
                       {item.versionName && (
@@ -467,21 +470,21 @@ function MetadataManagementBody({ kind, selectedServerId, selectedServer, nsfwMo
                         </Typography>
                       )}
                     </Typography>
-                    <Typography variant="caption" color="text.secondary" noWrap title={item.filename} sx={{ fontFamily: 'monospace' }}>
+                    <Typography variant="caption" color="text.secondary" noWrap title={item.filename} sx={{ fontFamily: 'monospace', display: 'block' }}>
                       {item.filename}
                     </Typography>
                   </Box>
                   {item.baseModel && (
-                    <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0 }}>
+                    <Typography variant="caption" color="text.secondary" noWrap sx={{ flexShrink: 1, minWidth: 0, maxWidth: { xs: 80, sm: 160 }, overflow: 'hidden', textOverflow: 'ellipsis' }}>
                       {item.baseModel}
                     </Typography>
                   )}
                   {!item.hasMetadata && (
-                    <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0, fontStyle: 'italic' }}>
+                    <Typography variant="caption" color="text.secondary" noWrap sx={{ flexShrink: 0, fontStyle: 'italic' }}>
                       {item.hash ? '미등록' : '메타 없음'}
                     </Typography>
                   )}
-                  <Button size="small" onClick={() => setDetailItem(item)}>상세</Button>
+                  <Button size="small" onClick={() => setDetailItem(item)} sx={{ flexShrink: 0, minWidth: 'auto' }}>상세</Button>
                 </Box>
               ))}
             </Box>

--- a/frontend/src/components/common/MetadataPickerModal.js
+++ b/frontend/src/components/common/MetadataPickerModal.js
@@ -533,7 +533,7 @@ function MetadataPickerModal({
             )}
 
             {viewMode === 'list' && (
-              <Box>
+              <Box sx={{ width: '100%', overflow: 'hidden' }}>
                 {filteredItems.map((rawItem, idx) => {
                   const item = adapter.normalize(rawItem);
                   if (!item) return null;
@@ -548,6 +548,9 @@ function MetadataPickerModal({
                         gap: 1,
                         py: 1,
                         px: 1.5,
+                        width: '100%',
+                        minWidth: 0,
+                        overflow: 'hidden',
                         borderBottom: 1,
                         borderColor: 'divider',
                         cursor: cardClickable ? 'pointer' : 'default',
@@ -555,7 +558,7 @@ function MetadataPickerModal({
                         '&:hover': { bgcolor: 'action.hover' }
                       }}
                     >
-                      <Box sx={{ flex: '1 1 0', minWidth: 0 }}>
+                      <Box sx={{ flex: '1 1 0', minWidth: 0, overflow: 'hidden' }}>
                         <Typography variant="body2" noWrap title={item.displayName} sx={{ fontWeight: isSelected ? 600 : 500 }}>
                           {item.displayName}
                           {item.versionName && (
@@ -564,18 +567,18 @@ function MetadataPickerModal({
                             </Typography>
                           )}
                         </Typography>
-                        <Typography variant="caption" color="text.secondary" noWrap title={item.filename} sx={{ fontFamily: 'monospace' }}>
+                        <Typography variant="caption" color="text.secondary" noWrap title={item.filename} sx={{ fontFamily: 'monospace', display: 'block' }}>
                           {item.filename}
                         </Typography>
                       </Box>
                       {item.baseModel && (
-                        <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0 }}>
+                        <Typography variant="caption" color="text.secondary" noWrap sx={{ flexShrink: 1, minWidth: 0, maxWidth: { xs: 80, sm: 160 }, overflow: 'hidden', textOverflow: 'ellipsis' }}>
                           {item.baseModel}
                         </Typography>
                       )}
-                      <Button size="small" onClick={(e) => { e.stopPropagation(); setDetailItem(item); }}>상세</Button>
+                      <Button size="small" onClick={(e) => { e.stopPropagation(); setDetailItem(item); }} sx={{ flexShrink: 0, minWidth: 'auto' }}>상세</Button>
                       {!cardClickable && (
-                        <Button size="small" variant={mode === 'prompt-insert' ? 'contained' : 'text'} onClick={(e) => { e.stopPropagation(); handlePrimary(rawItem); }}>
+                        <Button size="small" variant={mode === 'prompt-insert' ? 'contained' : 'text'} onClick={(e) => { e.stopPropagation(); handlePrimary(rawItem); }} sx={{ flexShrink: 0, minWidth: 'auto' }}>
                           {mode === 'prompt-insert' ? '추가' : mode === 'multi-add' ? (isSelected ? '제거' : '추가') : '선택'}
                         </Button>
                       )}


### PR DESCRIPTION
## v2.4.1 Release

### 수정
- 모바일에서 모델 관리 / picker 리스트 뷰 가로 오버플로우 (#383, #384)
- 모바일 NSFW 토글 / 캐시 정보 카드 정렬 (#383 후속, #385)

자세한 내용: `docs/updatelogs/v2.md` v2.4.1 섹션.

## Post-merge
- main 에서 v2.4.1 태그 + GitHub Release
- alpha 는 dev 직결이라 추가 배포 불필요