### PR TITLE
feat: 텍스트 작업판 멀티턴 모드 + customField 기본값 편집 (#391)

### DIFF
--- a/frontend/src/components/PromptGeneratorPanel.js
+++ b/frontend/src/components/PromptGeneratorPanel.js
@@ -271,8 +271,9 @@ function PromptGeneratorPanel({
                 </Typography>
               )}
 
-              {/* F2: baseInputFields.aiModel / referenceImages hardcoded UI 제거 — customField 가 통합 처리 */}
-              {workboard.additionalInputFields?.map((field) => (
+              {/* F2: baseInputFields.aiModel / referenceImages hardcoded UI 제거 — customField 가 통합 처리.
+                  #391: conversation_mode 는 admin 전용 설정이라 사용자 폼에선 숨김 */}
+              {workboard.additionalInputFields?.filter((f) => f.name !== 'conversation_mode').map((field) => (
                 <Box key={field.name} sx={{ mb: 2 }}>
                   {field.type === 'string' && (
                     <Controller

--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -65,6 +65,60 @@ import {
   getServerTypeColor,
 } from '../../templates/capabilities';
 
+// admin 의 customField 기본값 입력기 — type=baseModel/lora 일 때 서버 모델 목록 Autocomplete (#391)
+function ServerMetadataDefaultValueInput({ serverId, type, value, onChange, label }) {
+  const fetcher = type === 'baseModel' ? serverAPI.getDetailedModels : serverAPI.getLoras;
+  const { data, isLoading } = useQuery(
+    ['adminDefaultValueMetadata', type, serverId],
+    () => fetcher(serverId, { limit: 200, detailed: true }),
+    { enabled: !!serverId, staleTime: 60_000 }
+  );
+  const items = data?.data?.data?.items
+    || data?.data?.data?.models
+    || data?.data?.data?.loras
+    || data?.data?.models
+    || data?.data?.loras
+    || [];
+
+  return (
+    <Autocomplete
+      options={items}
+      getOptionLabel={(opt) => {
+        if (!opt) return '';
+        if (typeof opt === 'string') return opt;
+        return opt.civitai?.model?.name
+          ? `${opt.civitai.model.name} (${opt.filename || opt.fileName})`
+          : (opt.filename || opt.fileName || opt.name || '');
+      }}
+      isOptionEqualToValue={(opt, val) => {
+        const optKey = typeof opt === 'string' ? opt : (opt.filename || opt.fileName || opt.name);
+        const valKey = typeof val === 'string' ? val : (val?.filename || val?.fileName || val?.name);
+        return optKey === valKey;
+      }}
+      value={typeof value === 'string'
+        ? (items.find((m) => (m.filename || m.fileName) === value) || (value ? value : null))
+        : (value || null)}
+      onChange={(_, picked) => {
+        if (!picked) return onChange('');
+        const key = typeof picked === 'string' ? picked : (picked.filename || picked.fileName || picked.name || '');
+        onChange(key);
+      }}
+      loading={isLoading}
+      disabled={!serverId}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          size="small"
+          fullWidth
+          label={label}
+          helperText={!serverId ? '서버 선택 후 사용 가능' : (isLoading ? '모델 목록 로딩 중...' : `${items.length}개 중 선택`)}
+        />
+      )}
+      size="small"
+    />
+  );
+}
+
 function WorkboardCard({ workboard, onEdit, onDelete, onDuplicate, onExport, onView, onToggleActive }) {
   const [anchorEl, setAnchorEl] = useState(null);
   const menuOpen = Boolean(anchorEl);
@@ -580,9 +634,13 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
             loraExposurePolicy: fullData.loraExposurePolicy || 'full',
             loraWhitelist: fullData.loraWhitelist || [],
             isActive: fullData.isActive ?? true,
-            // 커스텀 필드 — 모든 additionalInputFields 를 단일 generic 편집기에 노출
+            // 커스텀 필드 — 모든 additionalInputFields 를 단일 generic 편집기에 노출.
+            // defaultValue / description / placeholder 도 form 에 같이 싣어 admin 이 편집 가능 (#391)
             additionalCustomFields: (fullData.additionalInputFields || []).map(f => ({
               ...f,
+              defaultValue: f.defaultValue,
+              description: f.description || '',
+              placeholder: f.placeholder || '',
               imageConfig: f.imageConfig || { maxImages: 1 }
             }))
           };
@@ -634,17 +692,35 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
             required: Boolean(field.required),
             formatString: field.formatString || `{{##${field.name}##}}`
           };
-          
+
+          // defaultValue / description / placeholder 보존 (#391).
+          // boolean 은 false 도 의미 있으니 undefined 만 제외.
+          if (field.defaultValue !== undefined && field.defaultValue !== '') {
+            // number 타입은 숫자로 변환
+            if (field.type === 'number') {
+              const n = Number(field.defaultValue);
+              if (!Number.isNaN(n)) fieldData.defaultValue = n;
+            } else if (field.type === 'boolean') {
+              fieldData.defaultValue = Boolean(field.defaultValue);
+            } else {
+              fieldData.defaultValue = field.defaultValue;
+            }
+          } else if (field.type === 'boolean' && field.defaultValue === false) {
+            fieldData.defaultValue = false;
+          }
+          if (field.description) fieldData.description = field.description;
+          if (field.placeholder) fieldData.placeholder = field.placeholder;
+
           if (field.type === 'select') {
             fieldData.options = field.options || [];
           }
-          
+
           if (field.type === 'image') {
             fieldData.imageConfig = {
               maxImages: field.imageConfig?.maxImages || 1
             };
           }
-          
+
           additionalInputFields.push(fieldData);
         }
       });
@@ -859,6 +935,100 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
                                 <FormControlLabel
                                   control={<Switch {...fieldProps} checked={fieldProps.value} />}
                                   label="필수 입력"
+                                />
+                              )}
+                            />
+                          </Grid>
+                          {/* 사전정의값 (defaultValue) — type 별 입력 (#391) */}
+                          <Grid item xs={12}>
+                            <Controller
+                              name={`additionalCustomFields.${index}.defaultValue`}
+                              control={control}
+                              render={({ field: fieldProps }) => {
+                                if (field.type === 'boolean') {
+                                  return (
+                                    <FormControlLabel
+                                      control={<Switch checked={!!fieldProps.value} onChange={(e) => fieldProps.onChange(e.target.checked)} />}
+                                      label="기본값 (ON / OFF)"
+                                    />
+                                  );
+                                }
+                                if (field.type === 'select') {
+                                  const options = watch(`additionalCustomFields.${index}.options`) || [];
+                                  return (
+                                    <TextField
+                                      {...fieldProps}
+                                      value={fieldProps.value || ''}
+                                      fullWidth
+                                      select
+                                      label="기본값 (선택)"
+                                      size="small"
+                                      SelectProps={{ displayEmpty: true }}
+                                    >
+                                      <MenuItem value="">선택 없음</MenuItem>
+                                      {options.map((opt, i) => (
+                                        <MenuItem key={i} value={opt.value || ''}>{opt.key || opt.value}</MenuItem>
+                                      ))}
+                                    </TextField>
+                                  );
+                                }
+                                if (field.type === 'baseModel' || field.type === 'lora') {
+                                  return (
+                                    <ServerMetadataDefaultValueInput
+                                      serverId={watch('serverId')}
+                                      type={field.type}
+                                      value={fieldProps.value || ''}
+                                      onChange={fieldProps.onChange}
+                                      label={field.type === 'baseModel' ? '기본값 (베이스 모델)' : '기본값 (LoRA)'}
+                                    />
+                                  );
+                                }
+                                if (field.type === 'image') {
+                                  return null; // 이미지 기본값은 의미 없음
+                                }
+                                return (
+                                  <TextField
+                                    {...fieldProps}
+                                    value={fieldProps.value ?? ''}
+                                    fullWidth
+                                    type={field.type === 'number' ? 'number' : 'text'}
+                                    label="기본값"
+                                    placeholder="비워두면 기본값 없음"
+                                    size="small"
+                                  />
+                                );
+                              }}
+                            />
+                          </Grid>
+                          <Grid item xs={12} sm={6}>
+                            <Controller
+                              name={`additionalCustomFields.${index}.placeholder`}
+                              control={control}
+                              render={({ field: fieldProps }) => (
+                                <TextField
+                                  {...fieldProps}
+                                  value={fieldProps.value || ''}
+                                  fullWidth
+                                  label="플레이스홀더"
+                                  placeholder="입력창 안내 문구"
+                                  size="small"
+                                  disabled={['boolean', 'image', 'baseModel', 'lora'].includes(field.type)}
+                                />
+                              )}
+                            />
+                          </Grid>
+                          <Grid item xs={12} sm={6}>
+                            <Controller
+                              name={`additionalCustomFields.${index}.description`}
+                              control={control}
+                              render={({ field: fieldProps }) => (
+                                <TextField
+                                  {...fieldProps}
+                                  value={fieldProps.value || ''}
+                                  fullWidth
+                                  label="설명"
+                                  placeholder="필드 아래에 표시될 설명"
+                                  size="small"
                                 />
                               )}
                             />

--- a/frontend/src/components/common/WorkboardChatPanel.js
+++ b/frontend/src/components/common/WorkboardChatPanel.js
@@ -1,0 +1,352 @@
+import React, { useState, useRef, useEffect, useMemo } from 'react';
+import {
+  Box,
+  Typography,
+  Paper,
+  TextField,
+  Button,
+  CircularProgress,
+  Alert,
+  Stack,
+  Chip,
+  Divider,
+  Tooltip,
+  IconButton,
+  Collapse,
+  FormControlLabel,
+  Switch,
+} from '@mui/material';
+import {
+  Send,
+  Person as PersonIcon,
+  SmartToy as AssistantIcon,
+  Settings as SystemIcon,
+  BookmarkAdd as BookmarkAddIcon,
+  Tune as TuneIcon,
+  ExpandLess,
+  ExpandMore,
+  LockOutlined as LockIcon,
+} from '@mui/icons-material';
+import { useMutation, useQuery, useQueryClient } from 'react-query';
+import { Controller, useForm } from 'react-hook-form';
+import toast from 'react-hot-toast';
+import { jobAPI, conversationAPI, textAPI } from '../../services/api';
+import MetadataFieldInput from './MetadataFieldInput';
+
+// 텍스트 작업판의 멀티턴 대화 모드 패널 (#391).
+// PromptGeneration 페이지에서 workboard.conversation_mode = true 일 때 PromptGeneratorPanel 대신 렌더.
+// 매번 새 대화로 시작. 첫 메시지 전송 전엔 설정 (model / temperature / system_prompt 등) 편집 가능,
+// 전송 후엔 lock + collapse.
+function WorkboardChatPanel({ workboard }) {
+  const [conversationId, setConversationId] = useState(null);
+  const [settingsOpen, setSettingsOpen] = useState(true);
+  const [newMessage, setNewMessage] = useState('');
+  const transcriptRef = useRef(null);
+  const queryClient = useQueryClient();
+
+  // admin 이 설정하는 conversation_mode 외 customField 를 settings 폼으로 노출
+  const settingsFields = useMemo(
+    () => (workboard.additionalInputFields || []).filter((f) => f.name !== 'conversation_mode'),
+    [workboard]
+  );
+
+  // 폼 — defaultValues 는 customField defaultValue 사용
+  const formDefaults = useMemo(() => {
+    const d = {};
+    settingsFields.forEach((f) => { d[f.name] = f.defaultValue ?? ''; });
+    return d;
+  }, [settingsFields]);
+
+  const { control, getValues, reset } = useForm({ defaultValues: formDefaults });
+
+  useEffect(() => { reset(formDefaults); }, [formDefaults, reset]);
+
+  // 대화 시작 후 messages 동기화용 — 시작 전엔 비활성
+  const { data: convData } = useQuery(
+    ['conversation', conversationId],
+    () => conversationAPI.getById(conversationId),
+    { enabled: !!conversationId }
+  );
+  const conversation = convData?.data?.data;
+  const messages = conversation?.messages || [];
+
+  useEffect(() => {
+    if (transcriptRef.current) {
+      transcriptRef.current.scrollTop = transcriptRef.current.scrollHeight;
+    }
+  }, [messages.length]);
+
+  const sendMutation = useMutation(
+    ({ text, settings, cid }) => jobAPI.createPromptJob({
+      workboardId: workboard._id,
+      conversationId: cid || undefined,
+      inputData: { ...settings, userPrompt: text },
+    }),
+    {
+      onSuccess: (response) => {
+        const cid = response.data?.conversationId;
+        if (cid && !conversationId) {
+          setConversationId(cid);
+          setSettingsOpen(false);
+        }
+        setNewMessage('');
+        queryClient.invalidateQueries(['conversation', cid || conversationId]);
+        queryClient.invalidateQueries('conversations');
+      },
+      onError: (err) => {
+        toast.error('전송 실패: ' + (err.response?.data?.message || err.message));
+        if (conversationId) {
+          queryClient.invalidateQueries(['conversation', conversationId]);
+        }
+      },
+    }
+  );
+
+  const saveMessageMutation = useMutation(
+    ({ conversationJobId, messageIndex }) => textAPI.createGenerated({ conversationJobId, messageIndex }),
+    {
+      onSuccess: () => {
+        toast.success('생성된 텍스트로 저장되었습니다.');
+        queryClient.invalidateQueries('generatedTexts');
+      },
+      onError: (err) => toast.error(err.response?.data?.message || '저장 실패'),
+    }
+  );
+
+  const handleSend = (e) => {
+    e?.preventDefault?.();
+    const trimmed = newMessage.trim();
+    if (!trimmed) return;
+    sendMutation.mutate({ text: trimmed, settings: getValues(), cid: conversationId });
+  };
+
+  const isSending = sendMutation.isLoading;
+  const isLocked = !!conversationId; // 첫 전송 후 lock
+
+  const renderSettingField = (field) => {
+    const locked = isLocked;
+    if (field.type === 'string') {
+      return (
+        <Controller
+          name={field.name}
+          control={control}
+          render={({ field: formField }) => (
+            <TextField
+              {...formField}
+              fullWidth
+              size="small"
+              label={field.label}
+              placeholder={field.placeholder}
+              multiline={field.name.includes('prompt')}
+              rows={field.name.includes('prompt') ? 2 : 1}
+              disabled={locked}
+              helperText={field.description}
+            />
+          )}
+        />
+      );
+    }
+    if (field.type === 'number') {
+      return (
+        <Controller
+          name={field.name}
+          control={control}
+          render={({ field: formField }) => (
+            <TextField
+              {...formField}
+              fullWidth
+              size="small"
+              type="number"
+              label={field.label}
+              disabled={locked}
+              helperText={field.description}
+            />
+          )}
+        />
+      );
+    }
+    if (field.type === 'boolean') {
+      return (
+        <Controller
+          name={field.name}
+          control={control}
+          render={({ field: formField }) => (
+            <FormControlLabel
+              control={<Switch checked={!!formField.value} onChange={(e) => formField.onChange(e.target.checked)} disabled={locked} />}
+              label={field.label}
+            />
+          )}
+        />
+      );
+    }
+    if (field.type === 'baseModel' || field.type === 'lora') {
+      return (
+        <Controller
+          name={field.name}
+          control={control}
+          render={({ field: formField }) => (
+            <MetadataFieldInput
+              kind={field.type === 'baseModel' ? 'model' : 'lora'}
+              field={field}
+              value={formField.value || ''}
+              onChange={formField.onChange}
+              workboardId={workboard._id}
+              serverId={workboard?.serverId?._id || workboard?.serverId}
+              disabled={locked}
+            />
+          )}
+        />
+      );
+    }
+    return null;
+  };
+
+  return (
+    <Paper elevation={1} sx={{ p: { xs: 2, md: 3 } }}>
+      {/* 헤더 */}
+      <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 2, flexWrap: 'wrap' }}>
+        <Chip label="대화 모드" color="secondary" size="small" />
+        {conversation?.model && <Chip label={conversation.model} size="small" variant="outlined" />}
+        {conversation?.serverType && <Chip label={conversation.serverType} size="small" variant="outlined" />}
+        {conversation?.costEstimate?.amount != null && (
+          <Chip
+            label={`누적 $${conversation.costEstimate.amount.toFixed(6)}`}
+            size="small"
+            variant="outlined"
+            color="info"
+          />
+        )}
+        <Box sx={{ flexGrow: 1 }} />
+        {conversation?.createdAt && (
+          <Typography variant="caption" color="text.secondary">
+            시작: {new Date(conversation.createdAt).toLocaleString('ko-KR')}
+          </Typography>
+        )}
+      </Stack>
+
+      {/* 설정 패널 — 첫 전송 후 lock */}
+      {settingsFields.length > 0 && (
+        <Paper variant="outlined" sx={{ mb: 2 }}>
+          <Box
+            sx={{ display: 'flex', alignItems: 'center', gap: 1, p: 1.5, cursor: 'pointer' }}
+            onClick={() => setSettingsOpen((v) => !v)}
+          >
+            <TuneIcon fontSize="small" color="action" />
+            <Typography variant="subtitle2" sx={{ flexGrow: 1 }}>
+              설정 {isLocked && '(고정됨)'}
+            </Typography>
+            {isLocked && <LockIcon fontSize="small" color="action" />}
+            {settingsOpen ? <ExpandLess /> : <ExpandMore />}
+          </Box>
+          <Collapse in={settingsOpen}>
+            <Box sx={{ p: 2, pt: 0 }}>
+              <Stack spacing={2}>
+                {settingsFields.map((field) => (
+                  <Box key={field.name}>{renderSettingField(field)}</Box>
+                ))}
+              </Stack>
+              {isLocked && (
+                <Alert severity="info" sx={{ mt: 2 }}>
+                  대화가 시작되어 설정은 더 이상 변경할 수 없습니다. 새 설정으로 시작하려면 작업판을 다시 여세요.
+                </Alert>
+              )}
+            </Box>
+          </Collapse>
+        </Paper>
+      )}
+
+      {/* 대화 transcript */}
+      <Box
+        ref={transcriptRef}
+        sx={{
+          minHeight: 200,
+          maxHeight: 500,
+          overflow: 'auto',
+          mb: 2,
+          p: 2,
+          bgcolor: 'grey.50',
+          borderRadius: 1,
+        }}
+      >
+        {messages.length === 0 ? (
+          <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center', py: 4 }}>
+            아래 입력창에 메시지를 입력해 대화를 시작하세요.
+          </Typography>
+        ) : (
+          <Stack spacing={1.5} divider={<Divider flexItem />}>
+            {messages.map((msg, idx) => (
+              <Box key={idx} sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
+                <Box sx={{ pt: 0.5 }}>
+                  {msg.role === 'user' && <PersonIcon fontSize="small" color="primary" />}
+                  {msg.role === 'assistant' && <AssistantIcon fontSize="small" color="action" />}
+                  {msg.role === 'system' && <SystemIcon fontSize="small" color="action" />}
+                </Box>
+                <Box sx={{ flex: '1 1 0', minWidth: 0 }}>
+                  <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'uppercase', letterSpacing: 0.5 }}>
+                    {msg.role}
+                  </Typography>
+                  <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', mt: 0.25 }}>
+                    {msg.content}
+                  </Typography>
+                </Box>
+                {msg.role === 'assistant' && (
+                  <Tooltip title="이 응답을 텍스트 컨텐츠로 저장">
+                    <IconButton
+                      size="small"
+                      onClick={() => saveMessageMutation.mutate({ conversationJobId: conversationId, messageIndex: idx })}
+                      disabled={saveMessageMutation.isLoading}
+                    >
+                      <BookmarkAddIcon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                )}
+              </Box>
+            ))}
+          </Stack>
+        )}
+        {isSending && (
+          <Box display="flex" justifyContent="center" mt={2}>
+            <CircularProgress size={20} color="secondary" />
+          </Box>
+        )}
+        {conversation?.status === 'failed' && conversation?.error?.message && (
+          <Alert severity="error" sx={{ mt: 2 }}>
+            마지막 시도 실패: {conversation.error.message}
+          </Alert>
+        )}
+      </Box>
+
+      <form onSubmit={handleSend}>
+        <Stack direction="row" spacing={1} alignItems="flex-end">
+          <TextField
+            fullWidth
+            multiline
+            rows={2}
+            placeholder="메시지를 입력하세요..."
+            value={newMessage}
+            onChange={(e) => setNewMessage(e.target.value)}
+            disabled={isSending}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                handleSend(e);
+              }
+            }}
+            helperText="⌘/Ctrl + Enter 로 전송"
+          />
+          <Button
+            type="submit"
+            variant="contained"
+            color="secondary"
+            disabled={isSending || !newMessage.trim()}
+            startIcon={isSending ? <CircularProgress size={18} color="inherit" /> : <Send />}
+            sx={{ minWidth: 100, height: 56 }}
+          >
+            전송
+          </Button>
+        </Stack>
+      </form>
+    </Paper>
+  );
+}
+
+export default WorkboardChatPanel;

--- a/frontend/src/pages/PromptGeneration.js
+++ b/frontend/src/pages/PromptGeneration.js
@@ -19,6 +19,7 @@ import { useQuery } from 'react-query';
 import { workboardAPI } from '../services/api';
 import PromptGeneratorPanel from '../components/PromptGeneratorPanel';
 import ConversationChatPanel from '../components/common/ConversationChatPanel';
+import WorkboardChatPanel from '../components/common/WorkboardChatPanel';
 import toast from 'react-hot-toast';
 
 function PromptGeneration() {
@@ -104,19 +105,25 @@ function PromptGeneration() {
         </Alert>
       )}
 
-      {conversationId ? (
-        <ConversationChatPanel
-          workboard={workboard}
-          conversationId={conversationId}
-        />
-      ) : (
-        <PromptGeneratorPanel
-          workboard={workboard}
-          showHeader={false}
-          showSystemPrompt={false}
-          compact={false}
-        />
-      )}
+      {(() => {
+        if (conversationId) {
+          return <ConversationChatPanel workboard={workboard} conversationId={conversationId} />;
+        }
+        // #391: workboard.conversation_mode customField default 가 true 면 채팅 모드
+        const conversationMode = !!(workboard.additionalInputFields || [])
+          .find((f) => f.name === 'conversation_mode')?.defaultValue;
+        if (conversationMode) {
+          return <WorkboardChatPanel workboard={workboard} />;
+        }
+        return (
+          <PromptGeneratorPanel
+            workboard={workboard}
+            showHeader={false}
+            showSystemPrompt={false}
+            compact={false}
+          />
+        );
+      })()}
     </Container>
   );
 }

--- a/frontend/src/templates/Gemini-text.json
+++ b/frontend/src/templates/Gemini-text.json
@@ -24,11 +24,12 @@
       "description": "0.0 ~ 1.0. 높을수록 창의적, 낮을수록 일관적."
     },
     {
-      "name": "max_tokens",
-      "label": "Max Tokens",
-      "type": "number",
+      "name": "conversation_mode",
+      "label": "멀티턴 대화 모드",
+      "type": "boolean",
       "required": false,
-      "defaultValue": 2000
+      "defaultValue": false,
+      "description": "켜면 작업판이 단일 샷 프롬프트 생성기 대신 채팅 UI 로 동작합니다. 사용자에겐 노출되지 않는 관리자 설정입니다."
     }
   ],
   "workflowData": ""

--- a/frontend/src/templates/OpenAI Compatible-text.json
+++ b/frontend/src/templates/OpenAI Compatible-text.json
@@ -23,11 +23,12 @@
       "defaultValue": 0.7
     },
     {
-      "name": "max_tokens",
-      "label": "Max Tokens",
-      "type": "number",
+      "name": "conversation_mode",
+      "label": "멀티턴 대화 모드",
+      "type": "boolean",
       "required": false,
-      "defaultValue": 2000
+      "defaultValue": false,
+      "description": "켜면 작업판이 단일 샷 프롬프트 생성기 대신 채팅 UI 로 동작합니다. 사용자에겐 노출되지 않는 관리자 설정입니다."
     }
   ],
   "workflowData": ""

--- a/frontend/src/templates/OpenAI-text.json
+++ b/frontend/src/templates/OpenAI-text.json
@@ -24,11 +24,12 @@
       "description": "0.0 ~ 1.0. 높을수록 창의적, 낮을수록 일관적."
     },
     {
-      "name": "max_tokens",
-      "label": "Max Tokens",
-      "type": "number",
+      "name": "conversation_mode",
+      "label": "멀티턴 대화 모드",
+      "type": "boolean",
       "required": false,
-      "defaultValue": 2000
+      "defaultValue": false,
+      "description": "켜면 작업판이 단일 샷 프롬프트 생성기 대신 채팅 UI 로 동작합니다. 사용자에겐 노출되지 않는 관리자 설정입니다."
     }
   ],
   "workflowData": ""

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -429,8 +429,7 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
     }
     const temperatureValue = extractOpt(getFieldValueByRole(workboard, inputData, FIELD_ROLES.TEMPERATURE));
     const temperature = temperatureValue != null ? Number(temperatureValue) : 0.7;
-    const maxTokensValue = extractOpt(getFieldValueByRole(workboard, inputData, FIELD_ROLES.MAX_TOKENS));
-    const maxTokens = maxTokensValue != null ? Number(maxTokensValue) : 2000;
+    // maxTokens 는 두 chat 서비스 모두 모델 기본값을 사용하도록 단순화됨 (#391 후속) — 입력 받지 않음.
     // 멀티턴 시 model 은 기존 대화에 저장된 값을 우선 (작업판 변경에도 일관성 유지)
     let model = resolvedModel;
 
@@ -438,7 +437,6 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
       workboardId,
       model,
       temperature,
-      maxTokens,
       serverUrl: server.serverUrl,
       hasApiKey: !!server.configuration?.apiKey,
       isContinuation: !!conversationId,
@@ -501,7 +499,7 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
         server.serverUrl,
         server.configuration?.apiKey,
         messages,
-        { model, temperature, maxTokens, timeout: server.configuration?.timeout || 60000 }
+        { model, temperature, timeout: server.configuration?.timeout || 60000 }
       ));
     } catch (chatError) {
       conversation.status = 'failed';


### PR DESCRIPTION
## Summary
- **멀티턴 대화 모드** — 텍스트 작업판 customField 의 `conversation_mode` 토글로 채팅 UI 활성화. 매번 새 대화로 시작, 첫 전송 후 설정 lock.
- **max_tokens 제거** — 텍스트 출력 타입 전체. 두 chat 서비스가 이미 모델 기본값 사용 중이라 안전 정리.
- **customField 기본값 / 설명 / 플레이스홀더 편집** — 기존 admin 편집기가 이 셋을 드롭하던 문제 수정 + type-aware 입력기 (boolean 토글, select 옵션 드롭다운, baseModel/lora 서버 메타데이터 Autocomplete).

## 변경 파일
- 템플릿 3종 (`OpenAI-text.json`, `Gemini-text.json`, `OpenAI Compatible-text.json`)
- 백엔드 `src/routes/jobs.js`
- 프론트 `frontend/src/pages/PromptGeneration.js`
- 프론트 `frontend/src/components/PromptGeneratorPanel.js`
- 프론트 `frontend/src/components/common/WorkboardChatPanel.js` (신규)
- 프론트 `frontend/src/components/admin/WorkboardManagement.js`

## Test plan
- [x] 빌드 (--no-cache) 성공
- [x] 사용자 검증: 멀티턴 채팅 동작, 설정 lock, defaultValue / baseModel Autocomplete 모두 확인
- [ ] dev 머지 후 alpha 추가 검증

## Notes / 후속
- 기존 텍스트 작업판은 conversation_mode 필드 자동 마이그레이션 안 됨. 채팅 모드 쓰려면 admin 이 customField 수동 추가하거나 작업판 새로 생성.
- max_tokens 제거 — 기존 워크보드에 잔존하는 max_tokens customField 는 서버 측에선 무시됨. 깔끔히 하려면 admin 이 수동 삭제 권장.

closes #391