### PR TITLE
fix: 대화 카드 액션 버튼을 이미지 카드와 통일 (#391 후속)

### DIFF
--- a/frontend/src/components/common/ConversationHistoryPanel.js
+++ b/frontend/src/components/common/ConversationHistoryPanel.js
@@ -19,7 +19,8 @@ import {
   Divider
 } from '@mui/material';
 import {
-  Visibility as VisibilityIcon,
+  Info as InfoIcon,
+  PlayArrow as PlayArrowIcon,
   Delete as DeleteIcon,
   Person as PersonIcon,
   SmartToy as AssistantIcon,
@@ -154,12 +155,38 @@ function ConversationHistoryPanel() {
                   </Typography>
                 )}
               </CardContent>
-              <CardActions sx={{ pt: 0, justifyContent: 'flex-end' }}>
-                <Tooltip title="상세">
-                  <IconButton size="small" onClick={() => setDetailItem(conv)}>
-                    <VisibilityIcon fontSize="small" />
-                  </IconButton>
-                </Tooltip>
+              <CardActions
+                sx={{
+                  pt: 0,
+                  justifyContent: 'flex-end',
+                  flexWrap: 'wrap',
+                  gap: 0.5,
+                  '& .MuiButton-root': { fontSize: { xs: '0.75rem', sm: '0.875rem' }, px: { xs: 1, sm: 1.5 }, minWidth: 'auto' }
+                }}
+              >
+                <Button
+                  size="small"
+                  onClick={() => setDetailItem(conv)}
+                  startIcon={<InfoIcon />}
+                  sx={{ '& .MuiButton-startIcon': { mx: { xs: 0, sm: '-4px' }, mr: { xs: 0.5, sm: 1 } } }}
+                >
+                  상세
+                </Button>
+                {conv.workboardId?._id && (
+                  <Button
+                    size="small"
+                    color="success"
+                    variant="contained"
+                    onClick={() =>
+                      navigate(`/prompt-generate/${conv.workboardId._id}?conversationId=${conv._id}`)
+                    }
+                    startIcon={<PlayArrowIcon />}
+                    sx={{ '& .MuiButton-startIcon': { mx: { xs: 0, sm: '-4px' }, mr: { xs: 0.5, sm: 1 } } }}
+                  >
+                    <Box component="span" sx={{ display: { xs: 'none', sm: 'inline' } }}>계속하기</Box>
+                    <Box component="span" sx={{ display: { xs: 'inline', sm: 'none' } }}>계속</Box>
+                  </Button>
+                )}
                 <Tooltip title="삭제">
                   <IconButton
                     size="small"


### PR DESCRIPTION
## Summary
텍스트 대화 카드의 눈동자 IconButton (상세) 만 노출되어 '계속하기' 가 상세 다이얼로그 안에 숨어 있었음. 이미지 카드 패턴 (상세 Button + 계속하기 success contained) 으로 통일해 직관성 확보.

## Test plan
- [x] 빌드 + 재기동 후 사용자 확인 완료