### PR TITLE
feat: 프로젝트 세계관 + 워크보드 소속 (#396 Phase 1.A)

### DIFF
--- a/frontend/src/components/PromptGeneratorPanel.js
+++ b/frontend/src/components/PromptGeneratorPanel.js
@@ -131,13 +131,15 @@ function ImageUploadField({ label, description, images, onImagesChange, maxImage
   );
 }
 
-function PromptGeneratorPanel({ 
-  workboardId, 
+function PromptGeneratorPanel({
+  workboardId,
   workboard: externalWorkboard,
   onResultChange,
   showHeader = true,
   showSystemPrompt = true,
-  compact = false
+  compact = false,
+  projectId,
+  useWorldview
 }) {
   const [isGenerating, setIsGenerating] = useState(false);
   const [generatedResult, setGeneratedResult] = useState(null);
@@ -190,18 +192,21 @@ function PromptGeneratorPanel({
       
       const jobData = {
         workboardId: workboard._id,
+        // #396: 프로젝트 컨텍스트 / 세계관 적용 (단일 샷 모드)
+        projectId: projectId || undefined,
+        useWorldview: !!useWorldview,
         inputData: {
           model: formData.model,
           userPrompt: formData.userPrompt,
           ...uploadedImages,
           ...Object.fromEntries(
-            Object.entries(formData).filter(([key]) => 
+            Object.entries(formData).filter(([key]) =>
               !['model', 'userPrompt'].includes(key)
             )
           )
         }
       };
-      
+
       return jobAPI.createPromptJob(jobData);
     },
     {

--- a/frontend/src/components/common/ConversationHistoryPanel.js
+++ b/frontend/src/components/common/ConversationHistoryPanel.js
@@ -24,26 +24,32 @@ import {
   Delete as DeleteIcon,
   Person as PersonIcon,
   SmartToy as AssistantIcon,
-  Settings as SystemIcon
+  Settings as SystemIcon,
+  Public as PublicIcon,
+  Article as ArticleIcon,
+  ExpandLess,
+  ExpandMore
 } from '@mui/icons-material';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import { Chat as ChatIcon, BookmarkAdd as BookmarkAddIcon } from '@mui/icons-material';
+import { Collapse, Paper } from '@mui/material';
 import { conversationAPI, textAPI } from '../../services/api';
 import Pagination from './Pagination';
 
 // LLM 대화 히스토리 패널 (#373).
 // JobHistory 페이지의 \"텍스트\" 탭에서 사용. 카드 리스트 + 상세 다이얼로그.
-function ConversationHistoryPanel() {
+function ConversationHistoryPanel({ fetchFn, queryKey = 'conversations' }) {
   const [page, setPage] = useState(1);
   const [detailItem, setDetailItem] = useState(null);
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const effectiveFetch = fetchFn || ((params) => conversationAPI.getMy(params));
 
   const { data, isLoading, error } = useQuery(
-    ['conversations', page],
-    () => conversationAPI.getMy({ page, limit: 20 }),
+    [queryKey, page],
+    () => effectiveFetch({ page, limit: 20 }),
     { keepPreviousData: true }
   );
 
@@ -232,7 +238,40 @@ function ConversationHistoryPanel() {
                 </Typography>
               </Stack>
               <Divider />
-              {(detailItem.messages || []).map((msg, idx) => (
+              {/* 작업 지침 / 사전 컨텍스트 분리 표시 (#396) */}
+              {(detailItem.workboardSystemPrompt || detailItem.worldviewContext) && (
+                <Stack spacing={1}>
+                  {detailItem.workboardSystemPrompt && (
+                    <Paper variant="outlined" sx={{ p: 1.5, bgcolor: 'grey.50' }}>
+                      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 0.5 }}>
+                        <SystemIcon fontSize="small" color="action" />
+                        <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>작업 지침</Typography>
+                      </Stack>
+                      <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                        {detailItem.workboardSystemPrompt}
+                      </Typography>
+                    </Paper>
+                  )}
+                  {detailItem.worldviewContext && (
+                    <Paper variant="outlined" sx={{ p: 1.5, bgcolor: 'rgba(156, 39, 176, 0.04)' }}>
+                      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 0.5 }}>
+                        <PublicIcon fontSize="small" sx={{ color: '#9c27b0' }} />
+                        <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>사전 컨텍스트 (세계관)</Typography>
+                      </Stack>
+                      <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                        {detailItem.worldviewContext}
+                      </Typography>
+                    </Paper>
+                  )}
+                </Stack>
+              )}
+              <Divider><Chip label="대화" size="small" icon={<ArticleIcon fontSize="small" />} /></Divider>
+              {(detailItem.messages || []).map((msg, idx) => {
+                // workboardSystemPrompt / worldviewContext 가 별도 섹션으로 표시되면 system 메시지는 중복이라 숨김
+                if (msg.role === 'system' && (detailItem.workboardSystemPrompt || detailItem.worldviewContext)) {
+                  return null;
+                }
+                return (
                 <Box key={idx} sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
                   <Box sx={{ pt: 0.5 }}>
                     {msg.role === 'user' && <PersonIcon fontSize="small" color="primary" />}
@@ -259,7 +298,8 @@ function ConversationHistoryPanel() {
                     </Tooltip>
                   )}
                 </Box>
-              ))}
+                );
+              })}
               {detailItem.error?.message && (
                 <Alert severity="error">{detailItem.error.message}</Alert>
               )}

--- a/frontend/src/components/common/ProjectContextSelector.js
+++ b/frontend/src/components/common/ProjectContextSelector.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import {
+  Box,
+  Paper,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  FormControlLabel,
+  Switch,
+  Typography,
+  Stack,
+  Tooltip,
+} from '@mui/material';
+import { Public as PublicIcon } from '@mui/icons-material';
+import { useQuery } from 'react-query';
+import { projectAPI } from '../../services/api';
+
+// 작업판 실행 시 프로젝트 컨텍스트 / 세계관 사용 토글 (#396).
+// 프로젝트 선택 시 백엔드가 그 프로젝트의 세계관 텍스트들을 system 메시지의
+// [배경 / 사전 컨텍스트] 섹션으로 주입한다.
+function ProjectContextSelector({
+  projectId,
+  useWorldview,
+  onProjectChange,
+  onUseWorldviewChange,
+  disabled = false,
+}) {
+  const { data: projectsData } = useQuery('projects', () => projectAPI.getAll({ limit: 200 }));
+  const projects = projectsData?.data?.data?.projects || projectsData?.data?.projects || [];
+
+  return (
+    <Paper variant="outlined" sx={{ p: 1.5, mb: 2 }}>
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} alignItems={{ sm: 'center' }}>
+        <Stack direction="row" alignItems="center" spacing={1} sx={{ minWidth: { sm: 140 } }}>
+          <PublicIcon fontSize="small" color="action" />
+          <Typography variant="body2" sx={{ fontWeight: 500 }}>
+            프로젝트 컨텍스트
+          </Typography>
+        </Stack>
+        <FormControl size="small" sx={{ minWidth: 200, flexGrow: 1 }}>
+          <InputLabel>프로젝트 선택</InputLabel>
+          <Select
+            value={projectId || ''}
+            label="프로젝트 선택"
+            onChange={(e) => onProjectChange(e.target.value || '')}
+            disabled={disabled}
+          >
+            <MenuItem value=""><em>없음</em></MenuItem>
+            {projects.map((p) => (
+              <MenuItem key={p._id} value={p._id}>{p.name}</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <Tooltip title="ON 이면 선택한 프로젝트의 세계관 텍스트를 LLM 에 사전 컨텍스트로 주입">
+          <FormControlLabel
+            control={
+              <Switch
+                checked={!!useWorldview && !!projectId}
+                onChange={(e) => onUseWorldviewChange(e.target.checked)}
+                disabled={disabled || !projectId}
+              />
+            }
+            label="세계관 사용"
+          />
+        </Tooltip>
+      </Stack>
+    </Paper>
+  );
+}
+
+export default ProjectContextSelector;

--- a/frontend/src/components/common/TextContentPanel.js
+++ b/frontend/src/components/common/TextContentPanel.js
@@ -47,7 +47,7 @@ function stripExtension(filename) {
 // 텍스트 컨텐츠 패널 (#387).
 // kind: 'uploaded' (직접 작성, 편집/생성 가능) | 'generated' (대화에서 저장, 태그/삭제만 가능).
 // defaultTags: 새 항목 생성 시 기본 태그 (프로젝트 맥락에서 프로젝트 태그 자동 추가용).
-function TextContentPanel({ kind = 'uploaded', defaultTags = [] }) {
+function TextContentPanel({ kind = 'uploaded', defaultTags = [], filterTags = [], title }) {
   const isUploaded = kind === 'uploaded';
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState('');
@@ -63,9 +63,14 @@ function TextContentPanel({ kind = 'uploaded', defaultTags = [] }) {
   const deleteFn = isUploaded ? textAPI.deleteUploaded : textAPI.deleteGenerated;
   const createFn = textAPI.createUploaded;
 
+  const tagIds = (filterTags || []).map((t) => t._id || t).filter(Boolean);
   const { data, isLoading, error } = useQuery(
-    [queryKey, page, search],
-    () => listFn({ page, limit: 20, search }),
+    [queryKey, page, search, tagIds.join(',')],
+    () => {
+      const params = { page, limit: 20, search };
+      if (tagIds.length > 0) params.tags = tagIds.join(',');
+      return listFn(params);
+    },
     { keepPreviousData: true }
   );
 

--- a/frontend/src/components/common/WorkboardChatPanel.js
+++ b/frontend/src/components/common/WorkboardChatPanel.js
@@ -37,7 +37,7 @@ import MetadataFieldInput from './MetadataFieldInput';
 // PromptGeneration 페이지에서 workboard.conversation_mode = true 일 때 PromptGeneratorPanel 대신 렌더.
 // 매번 새 대화로 시작. 첫 메시지 전송 전엔 설정 (model / temperature / system_prompt 등) 편집 가능,
 // 전송 후엔 lock + collapse.
-function WorkboardChatPanel({ workboard }) {
+function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
   const [conversationId, setConversationId] = useState(null);
   const [settingsOpen, setSettingsOpen] = useState(true);
   const [newMessage, setNewMessage] = useState('');
@@ -80,6 +80,10 @@ function WorkboardChatPanel({ workboard }) {
     ({ text, settings, cid }) => jobAPI.createPromptJob({
       workboardId: workboard._id,
       conversationId: cid || undefined,
+      // 첫 메시지 (cid 없음) 일 때만 프로젝트 컨텍스트 / 세계관 적용 (#396).
+      // 이어가는 메시지엔 이미 첫 턴의 system 메시지가 보존되어 있음.
+      projectId: cid ? undefined : (projectId || undefined),
+      useWorldview: cid ? undefined : !!useWorldview,
       inputData: { ...settings, userPrompt: text },
     }),
     {

--- a/frontend/src/pages/ProjectDetail.js
+++ b/frontend/src/pages/ProjectDetail.js
@@ -16,7 +16,9 @@ import {
   DialogActions,
   Tooltip,
   FormControlLabel,
-  Checkbox
+  Checkbox,
+  Stack,
+  TextField
 } from '@mui/material';
 import {
   ArrowBack,
@@ -24,6 +26,8 @@ import {
   StarBorder,
   Edit,
   Delete,
+  Delete as DeleteIcon,
+  PlayArrow,
   Image as ImageIcon,
   TextSnippet,
   History,
@@ -37,7 +41,9 @@ import {
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import toast from 'react-hot-toast';
-import { projectAPI, imageAPI, userAPI, promptDataAPI } from '../services/api';
+import { projectAPI, imageAPI, userAPI, promptDataAPI, tagAPI, workboardAPI } from '../services/api';
+import TextContentPanel from '../components/common/TextContentPanel';
+import ConversationHistoryPanel from '../components/common/ConversationHistoryPanel';
 import MediaGrid from '../components/common/MediaGrid';
 import PromptDataPanel from '../components/common/PromptDataPanel';
 import PromptDataFormDialog from '../components/common/PromptDataFormDialog';
@@ -532,12 +538,198 @@ function PromptDataTab({ projectId }) {
   );
 }
 
-// 텍스트 탭 (placeholder)
-function TextTab() {
+// 세계관 (사전 컨텍스트) 탭 (#396).
+// UploadedText 중 [projectTag, worldviewTag] 모두 포함하는 항목만 노출.
+// 새 항목 생성 시 두 태그 자동 부여 (TextContentPanel 의 defaultTags).
+function WorldviewTab({ projectTag }) {
+  const { data: wvTagData, isLoading } = useQuery('worldviewTag', () => tagAPI.getWorldview(), { staleTime: 60_000 });
+  const worldviewTag = wvTagData?.data?.tag;
+  if (isLoading) return <Box display="flex" justifyContent="center" py={4}><CircularProgress /></Box>;
+  if (!worldviewTag || !projectTag) {
+    return <Alert severity="warning" sx={{ mt: 2 }}>세계관 태그 / 프로젝트 태그를 불러오지 못했습니다.</Alert>;
+  }
   return (
-    <Alert severity="info" sx={{ mt: 2 }}>
-      준비 중인 기능입니다.
-    </Alert>
+    <Box sx={{ mt: 2 }}>
+      <Alert severity="info" sx={{ mb: 2 }}>
+        여기에 작성한 텍스트는 작업판 실행 시 <strong>[배경 / 사전 컨텍스트]</strong> 로 LLM 에 주입됩니다.
+        등장인물 / 배경 / 톤 등 작업판이 알아야 할 사실을 단편으로 나눠 보관하세요.
+      </Alert>
+      <TextContentPanel
+        kind="uploaded"
+        defaultTags={[projectTag, worldviewTag]}
+        filterTags={[projectTag, worldviewTag]}
+      />
+    </Box>
+  );
+}
+
+// 작업판 멤버십 탭 (#396).
+function WorkboardsTab({ projectId }) {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const { data, isLoading } = useQuery(
+    ['projectWorkboards', projectId],
+    () => projectAPI.getWorkboards(projectId),
+  );
+  const workboards = data?.data?.data?.workboards || [];
+
+  const addMutation = useMutation(
+    (workboardId) => projectAPI.addWorkboard(projectId, workboardId),
+    {
+      onSuccess: () => {
+        toast.success('작업판이 추가되었습니다.');
+        queryClient.invalidateQueries(['projectWorkboards', projectId]);
+        setPickerOpen(false);
+      },
+      onError: (err) => toast.error(err.response?.data?.message || '추가 실패'),
+    }
+  );
+
+  const removeMutation = useMutation(
+    (workboardId) => projectAPI.removeWorkboard(projectId, workboardId),
+    {
+      onSuccess: () => {
+        toast.success('작업판이 제거되었습니다.');
+        queryClient.invalidateQueries(['projectWorkboards', projectId]);
+      },
+      onError: (err) => toast.error(err.response?.data?.message || '제거 실패'),
+    }
+  );
+
+  if (isLoading) return <Box display="flex" justifyContent="center" py={4}><CircularProgress /></Box>;
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 2 }}>
+        <Button variant="outlined" startIcon={<TextSnippet />} onClick={() => setPickerOpen(true)}>
+          작업판 추가
+        </Button>
+      </Box>
+      {workboards.length === 0 ? (
+        <Box textAlign="center" py={4}>
+          <Typography variant="body2" color="text.secondary">
+            소속 작업판이 없습니다. 우상단 "작업판 추가" 로 등록하세요.
+          </Typography>
+        </Box>
+      ) : (
+        <Stack spacing={1.5}>
+          {workboards.map((wb) => (
+            <Box
+              key={wb._id}
+              sx={{
+                display: 'flex', alignItems: 'center', gap: 1,
+                p: 1.5, border: 1, borderColor: 'divider', borderRadius: 1,
+                '&:hover': { borderColor: 'primary.main' }
+              }}
+            >
+              <Box sx={{ flex: '1 1 0', minWidth: 0 }}>
+                <Typography variant="subtitle2" noWrap>{wb.name}</Typography>
+                {wb.description && (
+                  <Typography variant="caption" color="text.secondary" noWrap display="block">{wb.description}</Typography>
+                )}
+                <Stack direction="row" spacing={0.5} sx={{ mt: 0.5 }}>
+                  {wb.outputFormat && <Chip label={wb.outputFormat} size="small" variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />}
+                  {wb.serverId?.name && <Chip label={wb.serverId.name} size="small" variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />}
+                  {!wb.isActive && <Chip label="비활성" size="small" color="warning" variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />}
+                </Stack>
+              </Box>
+              <Button
+                size="small"
+                variant="contained"
+                color="success"
+                startIcon={<PlayArrow />}
+                onClick={() => navigate(`${wb.outputFormat === 'text' ? '/prompt-generate' : '/generate'}/${wb._id}?projectId=${projectId}`)}
+              >
+                실행
+              </Button>
+              <IconButton
+                size="small"
+                color="error"
+                onClick={() => {
+                  if (window.confirm('작업판을 프로젝트에서 제거하시겠습니까? (작업판 자체는 삭제되지 않습니다)')) {
+                    removeMutation.mutate(wb._id);
+                  }
+                }}
+              >
+                <DeleteIcon fontSize="small" />
+              </IconButton>
+            </Box>
+          ))}
+        </Stack>
+      )}
+
+      <WorkboardPickerDialog
+        open={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        existingIds={workboards.map((w) => w._id)}
+        onPick={(wbId) => addMutation.mutate(wbId)}
+      />
+    </Box>
+  );
+}
+
+// 모든 작업판 중 골라 프로젝트에 추가하는 다이얼로그 (#396).
+function WorkboardPickerDialog({ open, onClose, existingIds = [], onPick }) {
+  const [search, setSearch] = useState('');
+  const { data, isLoading } = useQuery(
+    ['allWorkboardsForPicker'],
+    () => workboardAPI.getAll(),
+    { enabled: open }
+  );
+  const all = data?.data?.workboards || data?.data?.data?.workboards || [];
+  const filtered = all.filter((wb) => {
+    if (existingIds.includes(wb._id)) return false;
+    if (!search) return true;
+    return wb.name?.toLowerCase().includes(search.toLowerCase());
+  });
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>작업판 추가</DialogTitle>
+      <DialogContent dividers>
+        <TextField
+          size="small"
+          fullWidth
+          placeholder="작업판 검색..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          sx={{ mb: 2 }}
+        />
+        {isLoading ? (
+          <Box display="flex" justifyContent="center" py={2}><CircularProgress size={20} /></Box>
+        ) : filtered.length === 0 ? (
+          <Typography variant="body2" color="text.secondary" textAlign="center" py={2}>
+            추가할 수 있는 작업판이 없습니다.
+          </Typography>
+        ) : (
+          <Stack spacing={1}>
+            {filtered.map((wb) => (
+              <Box
+                key={wb._id}
+                onClick={() => onPick(wb._id)}
+                sx={{
+                  display: 'flex', alignItems: 'center', gap: 1,
+                  p: 1.5, border: 1, borderColor: 'divider', borderRadius: 1,
+                  cursor: 'pointer',
+                  '&:hover': { bgcolor: 'action.hover', borderColor: 'primary.main' }
+                }}
+              >
+                <Box sx={{ flex: '1 1 0', minWidth: 0 }}>
+                  <Typography variant="subtitle2" noWrap>{wb.name}</Typography>
+                  <Stack direction="row" spacing={0.5} sx={{ mt: 0.5 }}>
+                    {wb.outputFormat && <Chip label={wb.outputFormat} size="small" variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />}
+                  </Stack>
+                </Box>
+              </Box>
+            ))}
+          </Stack>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>닫기</Button>
+      </DialogActions>
+    </Dialog>
   );
 }
 
@@ -623,11 +815,12 @@ function ProjectDetail() {
   }
 
   return (
-    <Container maxWidth="xl" sx={{ mt: 4, mb: 4 }}>
+    <Container maxWidth="xl" sx={{ mt: { xs: 2, md: 4 }, mb: { xs: 2, md: 4 }, px: { xs: 1.5, sm: 3 } }}>
       <Button
         startIcon={<ArrowBack />}
         onClick={() => navigate('/projects')}
-        sx={{ mb: 2 }}
+        size="small"
+        sx={{ mb: 1 }}
       >
         프로젝트 목록
       </Button>
@@ -638,9 +831,10 @@ function ProjectDetail() {
           display: 'flex',
           justifyContent: 'space-between',
           alignItems: 'flex-start',
-          mb: 3,
+          gap: 1,
+          mb: { xs: 1.5, md: 3 },
           borderRadius: 2,
-          p: 3,
+          p: { xs: 1.5, md: 3 },
           position: 'relative',
           ...(project.coverImage?.url && {
             backgroundImage: `url(${project.coverImage.url})`,
@@ -657,11 +851,14 @@ function ProjectDetail() {
           })
         }}
       >
-        <Box>
-          <Box display="flex" alignItems="center" gap={1} mb={1}>
-            <Typography variant="h4">{project.name}</Typography>
+        <Box sx={{ minWidth: 0, flex: '1 1 0' }}>
+          <Box display="flex" alignItems="center" gap={0.5} mb={0.5} sx={{ flexWrap: 'wrap' }}>
+            <Typography variant="h5" sx={{ fontSize: { xs: '1.25rem', md: '2rem' }, fontWeight: 600, wordBreak: 'break-word' }}>
+              {project.name}
+            </Typography>
             <Tooltip title={project.isFavorite ? '즐겨찾기 해제' : '즐겨찾기 추가'}>
               <IconButton
+                size="small"
                 onClick={() => favoriteMutation.mutate()}
                 color={project.isFavorite ? 'warning' : 'default'}
               >
@@ -670,12 +867,13 @@ function ProjectDetail() {
             </Tooltip>
           </Box>
           {project.description && (
-            <Typography variant="body1" color="textSecondary" sx={{ mb: 1 }}>
+            <Typography variant="body2" color="textSecondary" sx={{ mb: 1, wordBreak: 'break-word' }}>
               {project.description}
             </Typography>
           )}
-          <Box display="flex" gap={1} alignItems="center">
+          <Box display="flex" gap={0.75} alignItems="center" sx={{ flexWrap: 'wrap' }}>
             <Chip
+              size="small"
               label={project.tagId?.name}
               sx={{ bgcolor: project.tagId?.color || '#7c4dff', color: 'white' }}
             />
@@ -700,15 +898,23 @@ function ProjectDetail() {
           </Box>
         </Box>
 
-        <Box display="flex" gap={1}>
-          <Button
-            variant="contained"
-            startIcon={<ViewModule />}
-            onClick={() => navigate(`/workboards?projectId=${id}`)}
-            size="small"
-          >
-            이미지 생성하기
-          </Button>
+        <Box display="flex" gap={1} sx={{ flexShrink: 0 }}>
+          <Tooltip title="작업판 목록으로 이동">
+            <Button
+              variant="contained"
+              startIcon={<ViewModule />}
+              onClick={() => navigate(`/workboards?projectId=${id}`)}
+              size="small"
+              sx={{
+                whiteSpace: 'nowrap',
+                flexShrink: 0,
+                minWidth: 'auto',
+                '& .MuiButton-startIcon': { mx: { xs: 0, sm: '-4px' }, mr: { xs: 0, sm: 1 } }
+              }}
+            >
+              <Box component="span" sx={{ display: { xs: 'none', sm: 'inline' } }}>작업판 보기</Box>
+            </Button>
+          </Tooltip>
           <IconButton onClick={() => setEditOpen(true)}>
             <Edit />
           </IconButton>
@@ -718,22 +924,55 @@ function ProjectDetail() {
         </Box>
       </Box>
 
-      {/* 탭 */}
-      <Tabs
-        value={tabValue}
-        onChange={(e, v) => setTabValue(v)}
-        sx={{ mb: 1, borderBottom: 1, borderColor: 'divider' }}
+      {/* 탭 — 모바일에서 붕 뜨지 않도록 bgcolor 로 묶고, 컴팩트하게 (#396 후속) */}
+      <Box
+        sx={{
+          borderBottom: 1,
+          borderColor: 'divider',
+          bgcolor: 'background.paper',
+          borderRadius: 1,
+          mb: 0,
+        }}
       >
-        <Tab icon={<TextSnippet />} label="프롬프트 데이터" iconPosition="start" />
-        <Tab icon={<ImageIcon />} label="이미지" iconPosition="start" />
-        <Tab label="텍스트" />
-        <Tab icon={<History />} label="작업 히스토리" iconPosition="start" />
-      </Tabs>
+        <Tabs
+          value={tabValue}
+          onChange={(e, v) => setTabValue(v)}
+          variant="scrollable"
+          scrollButtons={false}
+          sx={{
+            minHeight: { xs: 40, md: 48 },
+            '& .MuiTab-root': {
+              minHeight: { xs: 40, md: 48 },
+              py: { xs: 0.5, md: 1 },
+              px: { xs: 1.5, md: 2 },
+              fontSize: { xs: '0.8125rem', md: '0.875rem' },
+              minWidth: 'auto',
+            },
+            '& .MuiTab-iconWrapper': { mr: 0.5 },
+          }}
+        >
+          <Tab label="작업판" />
+          <Tab label="세계관" />
+          <Tab icon={<TextSnippet fontSize="small" />} label="프롬프트 데이터" iconPosition="start" />
+          <Tab icon={<ImageIcon fontSize="small" />} label="이미지" iconPosition="start" />
+          <Tab icon={<History fontSize="small" />} label="작업 히스토리" iconPosition="start" />
+          <Tab label="대화 히스토리" />
+        </Tabs>
+      </Box>
 
-      {tabValue === 0 && <PromptDataTab projectId={id} />}
-      {tabValue === 1 && <ImagesTab projectId={id} />}
-      {tabValue === 2 && <TextTab />}
-      {tabValue === 3 && <JobsTab projectId={id} />}
+      {tabValue === 0 && <WorkboardsTab projectId={id} />}
+      {tabValue === 1 && <WorldviewTab projectTag={project?.tagId} />}
+      {tabValue === 2 && <PromptDataTab projectId={id} />}
+      {tabValue === 3 && <ImagesTab projectId={id} />}
+      {tabValue === 4 && <JobsTab projectId={id} />}
+      {tabValue === 5 && (
+        <Box sx={{ mt: 2 }}>
+          <ConversationHistoryPanel
+            fetchFn={(params) => projectAPI.getConversations(id, params)}
+            queryKey={`projectConversations-${id}`}
+          />
+        </Box>
+      )}
 
       {/* 편집 다이얼로그 */}
       <ProjectEditDialog

--- a/frontend/src/pages/PromptGeneration.js
+++ b/frontend/src/pages/PromptGeneration.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Container,
   Typography,
@@ -20,6 +20,7 @@ import { workboardAPI } from '../services/api';
 import PromptGeneratorPanel from '../components/PromptGeneratorPanel';
 import ConversationChatPanel from '../components/common/ConversationChatPanel';
 import WorkboardChatPanel from '../components/common/WorkboardChatPanel';
+import ProjectContextSelector from '../components/common/ProjectContextSelector';
 import toast from 'react-hot-toast';
 
 function PromptGeneration() {
@@ -27,6 +28,17 @@ function PromptGeneration() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const conversationId = searchParams.get('conversationId');
+  const initialProjectId = searchParams.get('projectId') || '';
+
+  // 프로젝트 컨텍스트 / 세계관 토글 (#396)
+  const [projectId, setProjectId] = useState(initialProjectId);
+  const [useWorldview, setUseWorldview] = useState(!!initialProjectId);
+
+  // initialProjectId 가 바뀌면 (다른 작업판으로 이동 시) 동기화
+  useEffect(() => {
+    setProjectId(initialProjectId);
+    setUseWorldview(!!initialProjectId);
+  }, [initialProjectId, workboardId]);
 
   const { data: workboardData, isLoading: workboardLoading, error: workboardError } = useQuery(
     ['workboard', workboardId],
@@ -105,6 +117,16 @@ function PromptGeneration() {
         </Alert>
       )}
 
+      {/* 프로젝트 컨텍스트 / 세계관 토글 (#396). 멀티턴 이어가기 (conversationId 진입) 시엔 숨김 — 이미 첫 턴에 주입됨. */}
+      {!conversationId && (
+        <ProjectContextSelector
+          projectId={projectId}
+          useWorldview={useWorldview}
+          onProjectChange={(v) => { setProjectId(v); if (!v) setUseWorldview(false); else setUseWorldview(true); }}
+          onUseWorldviewChange={setUseWorldview}
+        />
+      )}
+
       {(() => {
         if (conversationId) {
           return <ConversationChatPanel workboard={workboard} conversationId={conversationId} />;
@@ -113,7 +135,13 @@ function PromptGeneration() {
         const conversationMode = !!(workboard.additionalInputFields || [])
           .find((f) => f.name === 'conversation_mode')?.defaultValue;
         if (conversationMode) {
-          return <WorkboardChatPanel workboard={workboard} />;
+          return (
+            <WorkboardChatPanel
+              workboard={workboard}
+              projectId={projectId}
+              useWorldview={useWorldview}
+            />
+          );
         }
         return (
           <PromptGeneratorPanel
@@ -121,6 +149,8 @@ function PromptGeneration() {
             showHeader={false}
             showSystemPrompt={false}
             compact={false}
+            projectId={projectId}
+            useWorldview={useWorldview}
           />
         );
       })()}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -261,6 +261,12 @@ export const projectAPI = {
   getPromptData: (id, params) => api.get(`/projects/${id}/prompt-data`, { params }),
   getJobs: (id, params) => api.get(`/projects/${id}/jobs`, { params }),
   getFavorites: () => api.get('/projects/favorites'),
+  // 작업판 멤버십 (#396)
+  getWorkboards: (id) => api.get(`/projects/${id}/workboards`),
+  addWorkboard: (id, workboardId) => api.post(`/projects/${id}/workboards/${workboardId}`),
+  removeWorkboard: (id, workboardId) => api.delete(`/projects/${id}/workboards/${workboardId}`),
+  // 프로젝트 컨텍스트로 실행된 LLM 대화 (#396)
+  getConversations: (id, params) => api.get(`/projects/${id}/conversations`, { params }),
 };
 
 export const apiKeyAPI = {
@@ -276,6 +282,8 @@ export const tagAPI = {
   delete: (id) => api.delete(`/tags/${id}`),
   search: (params) => api.get('/tags/search', { params }),
   getMy: () => api.get('/tags/my'),
+  // 세계관 역할 태그 — 없으면 자동 생성 (#396)
+  getWorldview: () => api.get('/tags/worldview'),
 };
 
 export default api;

--- a/src/migrations/ensureWorldviewTag.js
+++ b/src/migrations/ensureWorldviewTag.js
@@ -1,0 +1,37 @@
+const Tag = require('../models/Tag');
+const User = require('../models/User');
+
+// 세계관 (사전 컨텍스트) 역할 태그 자동 시드 (#396).
+// 각 사용자에게 isWorldviewTag=true 인 단일 태그 ("세계관") 가 없으면 생성.
+// idempotent — 이미 있으면 skip.
+async function ensureWorldviewTag() {
+  const users = await User.find({}, { _id: 1 }).lean();
+  let created = 0;
+  for (const user of users) {
+    const existing = await Tag.findOne({ userId: user._id, isWorldviewTag: true });
+    if (existing) continue;
+    // 같은 이름의 일반 태그가 이미 있다면 그것을 isWorldviewTag 로 승격
+    const sameName = await Tag.findOne({ userId: user._id, name: '세계관' });
+    if (sameName) {
+      sameName.isWorldviewTag = true;
+      await sameName.save();
+      created += 1;
+      continue;
+    }
+    await Tag.create({
+      userId: user._id,
+      createdBy: user._id,
+      name: '세계관',
+      color: '#9c27b0',
+      isWorldviewTag: true,
+    });
+    created += 1;
+  }
+  if (created > 0) {
+    console.log(`[Migration] 세계관 태그 시드: ${created}명 처리`);
+  } else {
+    console.log('[Migration] 세계관 태그 시드 불필요 (모두 보유)');
+  }
+}
+
+module.exports = ensureWorldviewTag;

--- a/src/models/ConversationJob.js
+++ b/src/models/ConversationJob.js
@@ -32,6 +32,16 @@ const conversationJobSchema = new mongoose.Schema({
   },
   serverType: String,
   model: String,
+  // 프로젝트 컨텍스트 (#396). 실행 시 사용자가 지정한 프로젝트 ID. null 가능.
+  // 프로젝트 작업 히스토리 / 사전 컨텍스트 표시에 사용.
+  projectId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Project',
+  },
+  // 합성 전 원본을 분리 저장해 display / audit 용도로 사용 (#396).
+  // 실제 LLM 호출엔 둘을 합쳐 system 메시지 1개로 전송하지만, 보존은 분리.
+  workboardSystemPrompt: String,
+  worldviewContext: String,
   messages: [conversationMessageSchema],
   status: {
     type: String,
@@ -58,5 +68,6 @@ const conversationJobSchema = new mongoose.Schema({
 
 conversationJobSchema.index({ userId: 1, createdAt: -1 });
 conversationJobSchema.index({ workboardId: 1, createdAt: -1 });
+conversationJobSchema.index({ projectId: 1, createdAt: -1 });
 
 module.exports = mongoose.model('ConversationJob', conversationJobSchema);

--- a/src/models/Project.js
+++ b/src/models/Project.js
@@ -27,7 +27,13 @@ const projectSchema = new mongoose.Schema({
     url: String,
     imageId: mongoose.Schema.Types.ObjectId,
     imageType: { type: String, enum: ['uploaded', 'generated'] }
-  }
+  },
+  // 프로젝트에 속한 작업판 목록 (#396).
+  // 단방향 참조 — 작업판은 자기가 어떤 프로젝트에 속하는지 모름. 한 작업판이 여러 프로젝트에 들어갈 수 있음.
+  workboardIds: [{
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Workboard'
+  }]
 }, {
   timestamps: true
 });

--- a/src/models/Tag.js
+++ b/src/models/Tag.js
@@ -24,6 +24,14 @@ const tagSchema = new mongoose.Schema({
     type: Boolean,
     default: false
   },
+  // 세계관 (사전 컨텍스트) 역할 태그 (#396).
+  // 사용자별 1개 — UploadedText.tags 가 [projectTag, worldviewTag] 두 개를 모두 포함하면
+  // 해당 프로젝트의 세계관 항목으로 인식해 LLM 호출 시 system 메시지의 [배경 / 사전 컨텍스트]
+  // 섹션으로 주입됨.
+  isWorldviewTag: {
+    type: Boolean,
+    default: false
+  },
   createdBy: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'User',

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -15,6 +15,41 @@ const Server = require('../models/Server');
 const { getFieldValueByRole } = require('../utils/customFieldHelpers');
 const { FIELD_ROLES } = require('../constants/fieldRoles');
 const { computeOpenAITextCost, computeGeminiTextCost } = require('../utils/pricing');
+const Project = require('../models/Project');
+const Tag = require('../models/Tag');
+const UploadedText = require('../models/UploadedText');
+
+// 세계관 (사전 컨텍스트) + 작업 지침 → 단일 system 메시지로 합성 (#396).
+// system prompt = LLM 의 역할 / 작업 방침 (작업판 admin 정의)
+// worldview = 프로젝트의 사실 / 컨텍스트 (사용자가 보유)
+function composeSystemPrompt(systemPrompt, worldviewTexts) {
+  const parts = [];
+  if (systemPrompt) {
+    parts.push('[작업 지침]\n' + systemPrompt);
+  }
+  if (worldviewTexts && worldviewTexts.length > 0) {
+    const ctx = worldviewTexts.map((t) => {
+      const head = t.title ? `## ${t.title}\n` : '';
+      return head + (t.content || '');
+    }).join('\n\n---\n\n');
+    parts.push('[배경 / 사전 컨텍스트]\n' + ctx);
+  }
+  return parts.join('\n\n');
+}
+
+// 프로젝트의 세계관 UploadedText 들 로드 (#396).
+async function getProjectWorldview(userId, projectId) {
+  if (!projectId) return [];
+  const project = await Project.findOne({ _id: projectId, userId }).lean();
+  if (!project || !project.tagId) return [];
+  const worldviewTag = await Tag.findOne({ userId, isWorldviewTag: true }).lean();
+  if (!worldviewTag) return [];
+  const texts = await UploadedText.find({
+    userId,
+    tags: { $all: [project.tagId, worldviewTag._id] },
+  }).sort({ createdAt: 1 }).lean();
+  return texts;
+}
 const router = express.Router();
 
 router.post('/generate', requireAuth, async (req, res) => {
@@ -391,7 +426,7 @@ router.post('/:id/cancel', requireAuth, async (req, res) => {
 
 router.post('/generate-prompt', requireAuth, async (req, res) => {
   try {
-    const { workboardId, inputData, conversationId } = req.body;
+    const { workboardId, inputData, conversationId, projectId, useWorldview } = req.body;
 
     if (!workboardId || !inputData?.userPrompt) {
       return res.status(400).json({
@@ -472,16 +507,26 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
       // LLM 에는 전체 시퀀스 전달
       messages = conversation.messages.map((m) => ({ role: m.role, content: m.content }));
     } else {
+      // 신규 대화 — 세계관 (#396) 주입 합성. 멀티턴 이어가기 시엔 기존 system 메시지 보존되므로
+      // 여기서만 합성.
+      const worldviewTexts = useWorldview ? await getProjectWorldview(req.user._id, projectId) : [];
+      const worldviewContext = worldviewTexts.length > 0
+        ? worldviewTexts.map((t) => (t.title ? `## ${t.title}\n` : '') + (t.content || '')).join('\n\n---\n\n')
+        : '';
+      const composedSystem = composeSystemPrompt(systemPrompt, worldviewTexts);
       messages = [];
-      if (systemPrompt) {
-        messages.push({ role: 'system', content: systemPrompt });
+      if (composedSystem) {
+        messages.push({ role: 'system', content: composedSystem });
       }
       messages.push({ role: 'user', content: inputData.userPrompt });
       conversation = await ConversationJob.create({
         userId: req.user._id,
         workboardId: workboard._id,
+        projectId: projectId || undefined,
         serverType: server.serverType,
         model,
+        workboardSystemPrompt: systemPrompt || undefined,
+        worldviewContext: worldviewContext || undefined,
         messages: messages.map((m) => ({ ...m, createdAt: new Date() })),
         status: 'processing',
       });

--- a/src/routes/projects.js
+++ b/src/routes/projects.js
@@ -239,6 +239,55 @@ router.put('/:id', requireAuth, async (req, res) => {
   }
 });
 
+// POST /:id/workboards/:workboardId - 작업판을 프로젝트에 추가 (#396)
+router.post('/:id/workboards/:workboardId', requireAuth, async (req, res) => {
+  try {
+    const project = await Project.findOne({ _id: req.params.id, userId: req.user._id });
+    if (!project) return res.status(404).json({ success: false, message: '프로젝트를 찾을 수 없습니다' });
+    const wbId = req.params.workboardId;
+    if (!project.workboardIds.some((id) => id.toString() === wbId)) {
+      project.workboardIds.push(wbId);
+      await project.save();
+    }
+    res.json({ success: true, data: { workboardIds: project.workboardIds } });
+  } catch (error) {
+    console.error('Add workboard to project error:', error);
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
+// DELETE /:id/workboards/:workboardId - 작업판을 프로젝트에서 제거
+router.delete('/:id/workboards/:workboardId', requireAuth, async (req, res) => {
+  try {
+    const project = await Project.findOne({ _id: req.params.id, userId: req.user._id });
+    if (!project) return res.status(404).json({ success: false, message: '프로젝트를 찾을 수 없습니다' });
+    const wbId = req.params.workboardId;
+    project.workboardIds = project.workboardIds.filter((id) => id.toString() !== wbId);
+    await project.save();
+    res.json({ success: true, data: { workboardIds: project.workboardIds } });
+  } catch (error) {
+    console.error('Remove workboard from project error:', error);
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
+// GET /:id/workboards - 프로젝트의 작업판 목록 (populate)
+router.get('/:id/workboards', requireAuth, async (req, res) => {
+  try {
+    const project = await Project.findOne({ _id: req.params.id, userId: req.user._id })
+      .populate({
+        path: 'workboardIds',
+        select: 'name description workboardType outputFormat isActive serverId',
+        populate: { path: 'serverId', select: 'name serverType' }
+      });
+    if (!project) return res.status(404).json({ success: false, message: '프로젝트를 찾을 수 없습니다' });
+    res.json({ success: true, data: { workboards: project.workboardIds || [] } });
+  } catch (error) {
+    console.error('Project workboards fetch error:', error);
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
 // DELETE /:id - 프로젝트 삭제 (전용 태그 + 관련 아이템 태그 해제)
 router.delete('/:id', requireAuth, async (req, res) => {
   try {
@@ -475,6 +524,43 @@ router.get('/:id/jobs', requireAuth, async (req, res) => {
   } catch (error) {
     console.error('Get project jobs error:', error);
     res.status(500).json({ success: false, message: '프로젝트 작업 히스토리 조회 실패' });
+  }
+});
+
+// GET /:id/conversations - 프로젝트 컨텍스트로 실행된 LLM 대화 히스토리 (#396)
+router.get('/:id/conversations', requireAuth, async (req, res) => {
+  try {
+    const { page = 1, limit = 20 } = req.query;
+    const project = await Project.findOne({ _id: req.params.id, userId: req.user._id });
+    if (!project) {
+      return res.status(404).json({ success: false, message: '프로젝트를 찾을 수 없습니다' });
+    }
+    const ConversationJob = require('../models/ConversationJob');
+    const filter = { userId: req.user._id, projectId: project._id };
+    const skip = (parseInt(page) - 1) * parseInt(limit);
+    const [items, total] = await Promise.all([
+      ConversationJob.find(filter)
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(parseInt(limit))
+        .populate('workboardId', 'name workboardType outputFormat')
+        .lean(),
+      ConversationJob.countDocuments(filter),
+    ]);
+    res.json({
+      success: true,
+      data: {
+        conversations: items,
+        pagination: {
+          current: parseInt(page),
+          pages: Math.ceil(total / parseInt(limit)),
+          total,
+        },
+      },
+    });
+  } catch (error) {
+    console.error('Get project conversations error:', error);
+    res.status(500).json({ success: false, message: error.message });
   }
 });
 

--- a/src/routes/tags.js
+++ b/src/routes/tags.js
@@ -7,6 +7,33 @@ const PromptData = require('../models/PromptData');
 const { escapeRegex } = require('../utils/escapeRegex');
 const router = express.Router();
 
+// 세계관 역할 태그 조회 — 없으면 자동 생성 (#396). 신규 사용자 대응.
+router.get('/worldview', requireAuth, async (req, res) => {
+  try {
+    let tag = await Tag.findOne({ userId: req.user._id, isWorldviewTag: true });
+    if (!tag) {
+      const sameName = await Tag.findOne({ userId: req.user._id, name: '세계관' });
+      if (sameName) {
+        sameName.isWorldviewTag = true;
+        await sameName.save();
+        tag = sameName;
+      } else {
+        tag = await Tag.create({
+          userId: req.user._id,
+          createdBy: req.user._id,
+          name: '세계관',
+          color: '#9c27b0',
+          isWorldviewTag: true,
+        });
+      }
+    }
+    res.json({ tag });
+  } catch (error) {
+    console.error('Worldview tag fetch error:', error);
+    res.status(500).json({ message: error.message });
+  }
+});
+
 router.get('/', requireAuth, async (req, res) => {
   try {
     const { search, limit = 50 } = req.query;

--- a/src/routes/texts.js
+++ b/src/routes/texts.js
@@ -13,8 +13,19 @@ const router = express.Router();
 
 function buildListFilter(req) {
   const filter = { userId: req.user._id };
-  const { tag, search } = req.query;
-  if (tag) filter.tags = tag;
+  const { tag, tags, search } = req.query;
+  // 다중 태그 — AND 조건 (모두 포함). 콤마 분리 또는 배열.
+  // 세계관 조회처럼 [projectTag, worldviewTag] 모두 포함하는 항목을 찾을 때 사용 (#396).
+  let tagList = [];
+  if (tags) {
+    tagList = Array.isArray(tags) ? tags : String(tags).split(',').filter(Boolean);
+  }
+  if (tag) tagList.push(tag);
+  if (tagList.length === 1) {
+    filter.tags = tagList[0];
+  } else if (tagList.length > 1) {
+    filter.tags = { $all: tagList };
+  }
   if (search) {
     const re = new RegExp(search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
     filter.$or = [{ title: re }, { content: re }];

--- a/src/server.js
+++ b/src/server.js
@@ -40,6 +40,7 @@ const assignDefaultGroupToWorkboards = require('./migrations/assignDefaultGroupT
 const backfillCustomFieldRoles = require('./migrations/backfillCustomFieldRoles');
 const dropBaseInputFieldsSchema = require('./migrations/dropBaseInputFieldsSchema');
 const relocateCivitaiApiKey = require('./migrations/relocateCivitaiApiKey');
+const ensureWorldviewTag = require('./migrations/ensureWorldviewTag');
 
 dotenv.config();
 
@@ -204,6 +205,7 @@ const startServer = async () => {
     await backfillCustomFieldRoles();
     await dropBaseInputFieldsSchema();
     await relocateCivitaiApiKey();
+    await ensureWorldviewTag();
 
     // Initialize job queues after database connection
     console.log('Initializing job queues...');


### PR DESCRIPTION
## Summary
[#395 epic](https://github.com/iceemperor-gcempire/vcc-manager/issues/395) 의 축 1 첫 슬라이스. 새 모델 / 컬렉션 없이 기존 텍스트 컨텐츠 (#387) 위에 **`[프로젝트 태그, 세계관 역할 태그]`** 조합으로 세계관을 표현. 프로젝트는 워크보드 목록을 보유 (단방향 참조).

### 데이터 모델
- `Tag.isWorldviewTag: Boolean` 추가 + migration 으로 사용자별 단일 \"세계관\" 태그 시드 (idempotent). 신규 사용자는 `GET /api/tags/worldview` 가 lazy 생성.
- `Project.workboardIds: [ObjectId]` — 단방향 참조. 한 워크보드가 여러 프로젝트에 들어갈 수 있음.
- `ConversationJob`: `projectId` / `workboardSystemPrompt` / `worldviewContext` 분리 저장. 실제 LLM 호출은 합쳐 system 메시지 1개로 전송하나 보존은 분리.

### 라우트
- `GET /api/tags/worldview` — 세계관 역할 태그 조회 / 자동 생성
- `GET/POST/DELETE /api/projects/:id/workboards[/:wbId]` — 워크보드 멤버십 관리
- `GET /api/projects/:id/conversations` — 프로젝트 컨텍스트 LLM 대화
- `GET /api/texts/uploaded?tags=a,b` — 다중 태그 AND 필터
- `POST /api/jobs/generate-prompt` 에 `projectId` + `useWorldview` 옵션. 세계관 텍스트들 로드 → system 메시지 `[작업 지침]` / `[배경 / 사전 컨텍스트]` 두 섹션으로 합성.

### UI
- **ProjectDetail**: 작업판 / 세계관 / 대화 히스토리 3개 탭 추가. 세계관 탭은 `TextContentPanel(defaultTags=[projectTag, worldviewTag])` 임베드, 작업판 탭은 멤버십 관리 + 카드별 \"실행\" (프로젝트 컨텍스트 자동 전달), 대화 히스토리는 `ConversationHistoryPanel(fetchFn)`.
- **ConversationHistoryPanel**: `fetchFn` / `queryKey` prop 으로 외부 fetch 주입 가능. 상세 다이얼로그에 \"작업 지침\" / \"사전 컨텍스트 (세계관)\" 별도 카드 노출.
- **PromptGeneration**: `ProjectContextSelector` (프로젝트 드롭다운 + 세계관 사용 토글). URL `?projectId=` 진입 시 자동 채움. 멀티턴 이어가기 시엔 숨김.
- **TextContentPanel**: `filterTags` prop 추가.
- **모바일 UI 정리**: 우측 상단 \"이미지 생성하기 → 작업판 보기\" 라벨 반응형 / 아이콘만, 프로젝트 헤더 padding 압축, 탭 영역 시각적으로 묶고 scroll button 제거.

## Test plan
- [x] 빌드 (--no-cache) 성공, 세계관 태그 시드 마이그레이션 정상 (`1명 처리`)
- [x] 프로젝트 세계관 탭에서 텍스트 작성 / 작업판 추가 / 실행 → ConversationJob 에 projectId/worldview 저장 확인
- [x] 모바일 UI 1차 정리 사용자 확인 완료

## Follow-up
- Phase 1.B 카테고리 카드 (#395 epic 본문)
- 파이프라인 (#397)
- 모바일 디자인 더 정밀하게 — 별도 이슈로 분리 가능

closes #396