### PR TITLE
feat: 작업판 파이프라인 (#397 Phase 2.A) + 프로젝트 태그 통일

### DIFF
--- a/frontend/src/components/common/PipelinePanel.js
+++ b/frontend/src/components/common/PipelinePanel.js
@@ -1,0 +1,891 @@
+import React, { useState, useMemo } from 'react';
+import {
+  Box,
+  Stack,
+  Typography,
+  Button,
+  IconButton,
+  TextField,
+  Card,
+  CardContent,
+  CardActions,
+  Chip,
+  CircularProgress,
+  Alert,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  FormControlLabel,
+  Switch,
+  Stepper,
+  Step,
+  StepLabel,
+  StepContent,
+  Paper,
+} from '@mui/material';
+import {
+  Add as AddIcon,
+  Edit as EditIcon,
+  Delete as DeleteIcon,
+  PlayArrow as PlayArrowIcon,
+  Settings as SettingsIcon,
+  ArrowUpward,
+  ArrowDownward,
+  CheckCircle as CheckCircleIcon,
+  Error as ErrorIcon,
+  Stop as StopIcon,
+} from '@mui/icons-material';
+import MetadataFieldInput from './MetadataFieldInput';
+import { useQuery, useMutation, useQueryClient } from 'react-query';
+import toast from 'react-hot-toast';
+import { pipelineAPI, projectAPI, jobAPI } from '../../services/api';
+
+// 프로젝트 종속 작업판 파이프라인 (#397).
+// 단계: 목록 → 빌더 → 실행. 모두 한 패널에서.
+function PipelinePanel({ projectId }) {
+  const [view, setView] = useState('list'); // list | builder | runner
+  const [editingPipelineId, setEditingPipelineId] = useState(null);
+  const [runningPipelineId, setRunningPipelineId] = useState(null);
+  const queryClient = useQueryClient();
+
+  const { data, isLoading } = useQuery(
+    ['pipelines', projectId],
+    () => pipelineAPI.list(projectId),
+    { enabled: !!projectId }
+  );
+  const pipelines = data?.data?.data?.pipelines || [];
+
+  const deleteMutation = useMutation(
+    (pid) => pipelineAPI.delete(projectId, pid),
+    {
+      onSuccess: () => {
+        toast.success('파이프라인이 삭제되었습니다.');
+        queryClient.invalidateQueries(['pipelines', projectId]);
+      },
+      onError: (err) => toast.error(err.response?.data?.message || '삭제 실패'),
+    }
+  );
+
+  if (view === 'builder') {
+    return (
+      <PipelineBuilder
+        projectId={projectId}
+        pipelineId={editingPipelineId}
+        onClose={() => { setView('list'); setEditingPipelineId(null); }}
+      />
+    );
+  }
+  if (view === 'runner') {
+    return (
+      <PipelineRunner
+        projectId={projectId}
+        pipelineId={runningPipelineId}
+        onClose={() => { setView('list'); setRunningPipelineId(null); }}
+      />
+    );
+  }
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
+        <Typography variant="subtitle1" color="text.secondary">
+          작업판 A → B → C 직선 실행. 단계의 출력 타입이 다음 단계의 입력 타입과 일치하면 자동 주입됩니다.
+        </Typography>
+        <Button
+          variant="outlined"
+          startIcon={<AddIcon />}
+          onClick={() => { setEditingPipelineId(null); setView('builder'); }}
+        >
+          새 파이프라인
+        </Button>
+      </Box>
+
+      {isLoading ? (
+        <Box display="flex" justifyContent="center" py={4}><CircularProgress /></Box>
+      ) : pipelines.length === 0 ? (
+        <Box textAlign="center" py={4}>
+          <Typography variant="body2" color="text.secondary">
+            등록된 파이프라인이 없습니다. "새 파이프라인" 으로 작성하세요.
+          </Typography>
+        </Box>
+      ) : (
+        <Stack spacing={1.5}>
+          {pipelines.map((p) => (
+            <Card key={p._id} variant="outlined">
+              <CardContent sx={{ pb: 1 }}>
+                <Box display="flex" alignItems="center" gap={1} sx={{ mb: 0.5, flexWrap: 'wrap' }}>
+                  <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>{p.name}</Typography>
+                  <Chip label={`${p.steps?.length || 0}단계`} size="small" variant="outlined" />
+                  {p.useWorldview && <Chip label="세계관 ON" size="small" color="secondary" variant="outlined" />}
+                </Box>
+                {p.description && (
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                    {p.description}
+                  </Typography>
+                )}
+                {/* 단계 미리보기 — 작업판 이름 + description (작업판/단계). 모바일에선 description 숨김. */}
+                <Stack spacing={0.75} sx={{ mt: 0.5 }}>
+                  {(p.steps || []).map((s, idx) => (
+                    <Box key={idx} sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
+                      <Chip
+                        label={idx + 1}
+                        size="small"
+                        color={s.workboardId?.isActive === false ? 'warning' : 'primary'}
+                        sx={{ height: 22, minWidth: 22, '& .MuiChip-label': { px: 1 } }}
+                      />
+                      <Box sx={{ flex: '1 1 0', minWidth: 0 }}>
+                        <Typography variant="body2" sx={{ fontWeight: 500 }} noWrap>
+                          {s.workboardId?.name || '(삭제됨)'}
+                        </Typography>
+                        {s.workboardId?.description && (
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            sx={{
+                              display: { xs: 'none', sm: '-webkit-box' },
+                              WebkitLineClamp: 2,
+                              WebkitBoxOrient: 'vertical',
+                              overflow: 'hidden',
+                              whiteSpace: 'pre-wrap',
+                            }}
+                          >
+                            {s.workboardId.description}
+                          </Typography>
+                        )}
+                        {s.note && (
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            sx={{ display: 'block', fontStyle: 'italic', whiteSpace: 'pre-wrap' }}
+                          >
+                            {s.note}
+                          </Typography>
+                        )}
+                      </Box>
+                    </Box>
+                  ))}
+                </Stack>
+              </CardContent>
+              <CardActions sx={{ pt: 0, justifyContent: 'flex-end' }}>
+                <Button
+                  size="small"
+                  color="success"
+                  variant="contained"
+                  startIcon={<PlayArrowIcon />}
+                  onClick={() => { setRunningPipelineId(p._id); setView('runner'); }}
+                  disabled={(p.steps || []).length === 0}
+                >
+                  실행
+                </Button>
+                <Button
+                  size="small"
+                  startIcon={<EditIcon />}
+                  onClick={() => { setEditingPipelineId(p._id); setView('builder'); }}
+                >
+                  편집
+                </Button>
+                <IconButton
+                  size="small"
+                  color="error"
+                  onClick={() => {
+                    if (window.confirm(`"${p.name}" 파이프라인을 삭제하시겠습니까?`)) {
+                      deleteMutation.mutate(p._id);
+                    }
+                  }}
+                >
+                  <DeleteIcon fontSize="small" />
+                </IconButton>
+              </CardActions>
+            </Card>
+          ))}
+        </Stack>
+      )}
+    </Box>
+  );
+}
+
+// 파이프라인 빌더 — 단계 목록 편집 (#397)
+function PipelineBuilder({ projectId, pipelineId, onClose }) {
+  const isNew = !pipelineId;
+  const queryClient = useQueryClient();
+
+  const { data: pipelineData, isLoading } = useQuery(
+    ['pipeline', projectId, pipelineId],
+    () => pipelineAPI.get(projectId, pipelineId),
+    { enabled: !!pipelineId }
+  );
+  const loaded = pipelineData?.data?.data?.pipeline;
+
+  // 프로젝트의 작업판 목록 (단계 선택용)
+  const { data: wbData } = useQuery(
+    ['projectWorkboards', projectId],
+    () => projectAPI.getWorkboards(projectId),
+  );
+  const projectWorkboards = wbData?.data?.data?.workboards || [];
+
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [useWorldview, setUseWorldview] = useState(true);
+  const [steps, setSteps] = useState([]);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [inputsDialogStepIdx, setInputsDialogStepIdx] = useState(-1);
+
+  // 로드 시 폼 초기화
+  React.useEffect(() => {
+    if (loaded) {
+      setName(loaded.name || '');
+      setDescription(loaded.description || '');
+      setUseWorldview(loaded.useWorldview !== false);
+      setSteps((loaded.steps || []).map((s) => ({
+        workboardId: s.workboardId?._id || s.workboardId,
+        workboard: s.workboardId, // populated
+        autoInject: s.autoInject !== false,
+        inputs: s.inputs || {},
+        note: s.note || '',
+      })));
+    }
+  }, [loaded]);
+
+  const saveMutation = useMutation(
+    (payload) => isNew
+      ? pipelineAPI.create(projectId, payload)
+      : pipelineAPI.update(projectId, pipelineId, payload),
+    {
+      onSuccess: () => {
+        toast.success('저장되었습니다.');
+        // list + single 모두 invalidate — 재진입 시 stale cache 방지
+        queryClient.invalidateQueries(['pipelines', projectId]);
+        if (pipelineId) {
+          queryClient.invalidateQueries(['pipeline', projectId, pipelineId]);
+        }
+        onClose();
+      },
+      onError: (err) => toast.error(err.response?.data?.message || '저장 실패'),
+    }
+  );
+
+  const handleSave = () => {
+    if (!name.trim()) {
+      toast.error('이름을 입력해 주세요.');
+      return;
+    }
+    if (steps.length === 0) {
+      toast.error('최소 하나 이상의 단계가 필요합니다.');
+      return;
+    }
+    saveMutation.mutate({
+      name: name.trim(),
+      description: description.trim(),
+      useWorldview,
+      steps: steps.map((s) => ({
+        workboardId: s.workboardId,
+        autoInject: s.autoInject,
+        inputs: s.inputs || {},
+        note: s.note,
+      })),
+    });
+  };
+
+  const moveStep = (idx, delta) => {
+    const next = [...steps];
+    const to = idx + delta;
+    if (to < 0 || to >= next.length) return;
+    [next[idx], next[to]] = [next[to], next[idx]];
+    setSteps(next);
+  };
+
+  const removeStep = (idx) => {
+    setSteps(steps.filter((_, i) => i !== idx));
+  };
+
+  const addStep = (wb) => {
+    setSteps([...steps, { workboardId: wb._id, workboard: wb, autoInject: true, inputs: {}, note: '' }]);
+    setPickerOpen(false);
+  };
+
+  const updateStepInputs = (idx, inputs) => {
+    const next = [...steps];
+    next[idx] = { ...next[idx], inputs };
+    setSteps(next);
+  };
+
+  if (isLoading && pipelineId) {
+    return <Box display="flex" justifyContent="center" py={4}><CircularProgress /></Box>;
+  }
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      <Box display="flex" alignItems="center" gap={1} mb={2}>
+        <Typography variant="h6">{isNew ? '새 파이프라인' : '파이프라인 편집'}</Typography>
+        <Box sx={{ flexGrow: 1 }} />
+        <Button onClick={onClose}>취소</Button>
+        <Button variant="contained" onClick={handleSave} disabled={saveMutation.isLoading}>저장</Button>
+      </Box>
+
+      <Stack spacing={2}>
+        <TextField
+          size="small"
+          label="이름"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          inputProps={{ maxLength: 100 }}
+          fullWidth
+        />
+        <TextField
+          size="small"
+          label="설명 (선택)"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          inputProps={{ maxLength: 500 }}
+          multiline
+          minRows={2}
+          fullWidth
+        />
+        <FormControlLabel
+          control={<Switch checked={useWorldview} onChange={(e) => setUseWorldview(e.target.checked)} />}
+          label="LLM 단계에서 프로젝트 세계관 자동 주입"
+        />
+
+        <Box>
+          <Box display="flex" alignItems="center" mb={1}>
+            <Typography variant="subtitle2" sx={{ flexGrow: 1 }}>단계 ({steps.length})</Typography>
+            <Button
+              size="small"
+              startIcon={<AddIcon />}
+              variant="outlined"
+              onClick={() => setPickerOpen(true)}
+            >
+              단계 추가
+            </Button>
+          </Box>
+          {steps.length === 0 ? (
+            <Alert severity="info">
+              "단계 추가" 로 프로젝트 소속 작업판을 순서대로 등록하세요.
+              먼저 프로젝트의 "작업판" 탭에서 사용할 작업판들을 추가해 두어야 합니다.
+            </Alert>
+          ) : (
+            <Stack spacing={1}>
+              {steps.map((s, idx) => (
+                <Paper key={idx} variant="outlined" sx={{ p: 1.5 }}>
+                  <Box display="flex" alignItems="center" gap={1}>
+                    <Chip label={idx + 1} size="small" color="primary" />
+                    <Box sx={{ flex: '1 1 0', minWidth: 0 }}>
+                      <Typography variant="subtitle2" noWrap>
+                        {s.workboard?.name || '(이름 불러오는 중)'}
+                      </Typography>
+                      {s.workboard?.description && (
+                        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', whiteSpace: 'pre-wrap' }}>
+                          {s.workboard.description}
+                        </Typography>
+                      )}
+                      <Stack direction="row" spacing={0.5} sx={{ mt: 0.5 }}>
+                        {s.workboard?.outputFormat && (
+                          <Chip label={`out: ${s.workboard.outputFormat}`} size="small" variant="outlined" />
+                        )}
+                      </Stack>
+                    </Box>
+                    {idx > 0 && (
+                      <FormControlLabel
+                        control={
+                          <Switch
+                            size="small"
+                            checked={s.autoInject !== false}
+                            onChange={(e) => {
+                              const next = [...steps];
+                              next[idx] = { ...s, autoInject: e.target.checked };
+                              setSteps(next);
+                            }}
+                          />
+                        }
+                        label={<Typography variant="caption">이전 결과 자동 주입</Typography>}
+                      />
+                    )}
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      startIcon={<SettingsIcon />}
+                      onClick={() => setInputsDialogStepIdx(idx)}
+                    >
+                      입력 설정
+                      {Object.keys(s.inputs || {}).filter((k) => s.inputs[k] !== '' && s.inputs[k] != null).length > 0 && (
+                        <Chip label={Object.keys(s.inputs).filter((k) => s.inputs[k] !== '' && s.inputs[k] != null).length} size="small" sx={{ ml: 0.5, height: 18 }} />
+                      )}
+                    </Button>
+                    <IconButton size="small" disabled={idx === 0} onClick={() => moveStep(idx, -1)}>
+                      <ArrowUpward fontSize="small" />
+                    </IconButton>
+                    <IconButton size="small" disabled={idx === steps.length - 1} onClick={() => moveStep(idx, 1)}>
+                      <ArrowDownward fontSize="small" />
+                    </IconButton>
+                    <IconButton size="small" color="error" onClick={() => removeStep(idx)}>
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  </Box>
+                  {/* 단계별 메모 — 이 단계의 작업판 역할 / 사용자 가이드용 (#397 후속) */}
+                  <TextField
+                    size="small"
+                    fullWidth
+                    placeholder="이 단계에 대한 설명 / 메모 (선택)"
+                    value={s.note || ''}
+                    onChange={(e) => {
+                      const next = [...steps];
+                      next[idx] = { ...s, note: e.target.value };
+                      setSteps(next);
+                    }}
+                    multiline
+                    maxRows={3}
+                    inputProps={{ maxLength: 500 }}
+                    sx={{ mt: 1 }}
+                  />
+                </Paper>
+              ))}
+            </Stack>
+          )}
+        </Box>
+      </Stack>
+
+      {/* 단계별 사전 입력 설정 다이얼로그 */}
+      <StepInputsDialog
+        open={inputsDialogStepIdx >= 0}
+        step={inputsDialogStepIdx >= 0 ? steps[inputsDialogStepIdx] : null}
+        onClose={() => setInputsDialogStepIdx(-1)}
+        onSave={(inputs) => {
+          updateStepInputs(inputsDialogStepIdx, inputs);
+          setInputsDialogStepIdx(-1);
+        }}
+      />
+
+      {/* 단계 추가 picker — 프로젝트 소속 작업판만 */}
+      <Dialog open={pickerOpen} onClose={() => setPickerOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>단계 추가 - 작업판 선택</DialogTitle>
+        <DialogContent dividers>
+          {projectWorkboards.length === 0 ? (
+            <Alert severity="info">
+              프로젝트에 등록된 작업판이 없습니다. 먼저 "작업판" 탭에서 추가해 주세요.
+            </Alert>
+          ) : (
+            <Stack spacing={1}>
+              {projectWorkboards.map((wb) => (
+                <Box
+                  key={wb._id}
+                  onClick={() => addStep(wb)}
+                  sx={{
+                    p: 1.5, border: 1, borderColor: 'divider', borderRadius: 1, cursor: 'pointer',
+                    '&:hover': { bgcolor: 'action.hover', borderColor: 'primary.main' }
+                  }}
+                >
+                  <Typography variant="subtitle2">{wb.name}</Typography>
+                  <Stack direction="row" spacing={0.5} sx={{ mt: 0.5 }}>
+                    {wb.outputFormat && <Chip label={wb.outputFormat} size="small" variant="outlined" />}
+                    {wb.serverId?.name && <Chip label={wb.serverId.name} size="small" variant="outlined" />}
+                  </Stack>
+                </Box>
+              ))}
+            </Stack>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setPickerOpen(false)}>닫기</Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}
+
+// 파이프라인 단계의 사전 입력 설정 다이얼로그 (#397 후속).
+// 작업판의 customField 들을 렌더링해 admin 이 미리 값을 채울 수 있게 함.
+// 자동 주입 대상 (prompt/userPrompt, image 입력) 도 여기서 미리 설정 가능하나,
+// 자동 주입이 ON 이면 runtime 에 덮어쓰임.
+function StepInputsDialog({ open, step, onClose, onSave }) {
+  const wb = step?.workboard;
+  const [values, setValues] = useState({});
+
+  React.useEffect(() => {
+    if (step) {
+      setValues(step.inputs || {});
+    }
+  }, [step]);
+
+  if (!wb) return null;
+
+  // conversation_mode 같은 admin-only customField 는 사전 입력에서 숨김
+  const fields = (wb.additionalInputFields || []).filter((f) => f.name !== 'conversation_mode');
+
+  const updateValue = (name, v) => setValues({ ...values, [name]: v });
+
+  const renderField = (field) => {
+    const value = values[field.name] ?? field.defaultValue ?? '';
+
+    if (field.type === 'string') {
+      return (
+        <TextField
+          size="small"
+          fullWidth
+          label={field.label}
+          placeholder={field.placeholder}
+          value={value}
+          onChange={(e) => updateValue(field.name, e.target.value)}
+          multiline={field.name.includes('prompt')}
+          rows={field.name.includes('prompt') ? 2 : 1}
+          helperText={field.description}
+        />
+      );
+    }
+    if (field.type === 'number') {
+      return (
+        <TextField
+          size="small"
+          fullWidth
+          type="number"
+          label={field.label}
+          value={value}
+          onChange={(e) => updateValue(field.name, e.target.value)}
+          helperText={field.description}
+        />
+      );
+    }
+    if (field.type === 'boolean') {
+      return (
+        <FormControlLabel
+          control={<Switch checked={!!value} onChange={(e) => updateValue(field.name, e.target.checked)} />}
+          label={field.label}
+        />
+      );
+    }
+    if (field.type === 'select') {
+      // native select 사용 시 label 이 placeholder 와 겹쳐 보이는 문제 해결 위해 InputLabelProps.shrink 고정
+      return (
+        <TextField
+          size="small"
+          fullWidth
+          select
+          label={field.label}
+          value={value || ''}
+          onChange={(e) => updateValue(field.name, e.target.value)}
+          SelectProps={{ native: true }}
+          InputLabelProps={{ shrink: true }}
+          helperText={field.description}
+        >
+          <option value="">— 선택 없음 —</option>
+          {(field.options || []).map((opt, i) => (
+            <option key={i} value={opt.value}>{opt.key || opt.value}</option>
+          ))}
+        </TextField>
+      );
+    }
+    if (field.type === 'baseModel' || field.type === 'lora') {
+      return (
+        <MetadataFieldInput
+          kind={field.type === 'baseModel' ? 'model' : 'lora'}
+          field={field}
+          value={value || ''}
+          onChange={(v) => updateValue(field.name, v)}
+          workboardId={wb._id}
+          serverId={wb?.serverId?._id || wb?.serverId}
+        />
+      );
+    }
+    if (field.type === 'image') {
+      return (
+        <Alert severity="info">
+          이미지 필드 (`{field.name}`) — 자동 주입 또는 단계 실행 시 입력. 사전 설정 미지원.
+        </Alert>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        단계 입력 설정
+        {wb.name && <Typography variant="caption" color="text.secondary" display="block">{wb.name}</Typography>}
+      </DialogTitle>
+      <DialogContent dividers>
+        {fields.length === 0 ? (
+          <Alert severity="info">설정 가능한 입력 필드가 없습니다.</Alert>
+        ) : (
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <Alert severity="info">
+              여기서 설정한 값은 단계 실행 시 자동으로 채워집니다.
+              <strong> "이전 결과 자동 주입"</strong> 이 켜진 단계에선 prompt 등 매칭 필드는 이전 단계 결과로 덮어쓰임됩니다.
+            </Alert>
+            {fields.map((field) => (
+              <Box key={field.name}>{renderField(field)}</Box>
+            ))}
+          </Stack>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>취소</Button>
+        <Button variant="contained" onClick={() => onSave(values)}>저장</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+// 파이프라인 실행 (클라이언트 측 순차 오케스트레이션, #397)
+function PipelineRunner({ projectId, pipelineId, onClose }) {
+  const { data: pipelineData, isLoading } = useQuery(
+    ['pipeline', projectId, pipelineId],
+    () => pipelineAPI.get(projectId, pipelineId),
+    { enabled: !!pipelineId }
+  );
+  const pipeline = pipelineData?.data?.data?.pipeline;
+  // 프로젝트 tagId — 모든 단계에서 생성되는 작업 / 컨텐츠에 자동 부여 (#397 후속)
+  const { data: projectData } = useQuery(
+    ['project', projectId],
+    () => projectAPI.getById(projectId),
+    { enabled: !!projectId }
+  );
+  const projectTagId = projectData?.data?.data?.project?.tagId?._id || projectData?.data?.data?.project?.tagId;
+
+  // 단계별 상태 / 결과
+  // status: 'pending' | 'running' | 'done' | 'failed' | 'skipped'
+  const [stepStates, setStepStates] = useState([]);
+  const [running, setRunning] = useState(false);
+  const [initialPrompt, setInitialPrompt] = useState('');
+
+  React.useEffect(() => {
+    if (pipeline) {
+      setStepStates((pipeline.steps || []).map(() => ({ status: 'pending', output: null, error: null })));
+    }
+  }, [pipeline]);
+
+  // 단계 입력 빌드 (#397 후속):
+  // 1. step.inputs 의 사전 입력값으로 시작
+  // 2. 자동 주입 — 첫 단계는 initialPrompt, 그 외 단계는 prevOutput 으로 prompt/image 필드 덮어씀
+  const buildStepInput = (workboard, prevOutput, stepInputs, stepIdx) => {
+    const inputData = { ...(stepInputs || {}) };
+
+    // userPrompt 는 LLM 작업판의 텍스트 입력 키. 사전 입력에 없으면 기본 빈 문자열.
+    if (inputData.userPrompt == null) inputData.userPrompt = '';
+
+    if (stepIdx === 0) {
+      // 첫 단계 — 사용자 초기 프롬프트로 텍스트 필드 덮어쓰기
+      inputData.userPrompt = initialPrompt;
+      const promptField = (workboard.additionalInputFields || []).find(
+        (f) => f.name === 'prompt' || f.name === 'userPrompt'
+      );
+      if (promptField) inputData[promptField.name] = initialPrompt;
+    } else if (prevOutput) {
+      if (prevOutput.type === 'text') {
+        inputData.userPrompt = prevOutput.value;
+        const promptField = (workboard.additionalInputFields || []).find(
+          (f) => f.name === 'prompt' || f.name === 'userPrompt'
+        );
+        if (promptField) inputData[promptField.name] = prevOutput.value;
+      } else if (prevOutput.type === 'image' && prevOutput.imageIds?.length > 0) {
+        const imgField = (workboard.additionalInputFields || []).find((f) => f.type === 'image');
+        if (imgField) {
+          inputData[imgField.name] = prevOutput.imageIds.map((id) => ({ imageId: id }));
+        }
+      }
+    }
+    return inputData;
+  };
+
+  const runStep = async (stepIdx, prevOutput) => {
+    const step = pipeline.steps[stepIdx];
+    const wb = step.workboardId;
+    if (!wb || wb.isActive === false) {
+      throw new Error(`작업판이 비활성 또는 삭제됨`);
+    }
+    const inputData = buildStepInput(wb, prevOutput, step.inputs, stepIdx);
+
+    if (wb.outputFormat === 'text') {
+      // 텍스트 작업판 — prompt-generate. 세계관은 첫 단계 + useWorldview ON 일 때만 주입.
+      // projectId 는 모든 단계에 전달 — 백엔드가 ConversationJob.tags 에 프로젝트 태그 자동 주입.
+      const response = await jobAPI.createPromptJob({
+        workboardId: wb._id,
+        projectId: projectId || undefined,
+        useWorldview: stepIdx === 0 && pipeline.useWorldview,
+        inputData,
+      });
+      return { type: 'text', value: response.data.result, conversationId: response.data.conversationId };
+    } else {
+      // 이미지 / 영상 — 기존 /api/jobs/generate. 결과 폴링 필요.
+      // 프로젝트 태그를 inputData.tags 에 주입 — ImageGenerationJob / GeneratedImage 모두에 전파됨.
+      const mergedTags = Array.isArray(inputData.tags) ? [...inputData.tags] : [];
+      if (projectTagId && !mergedTags.some((t) => String(t) === String(projectTagId))) {
+        mergedTags.push(projectTagId);
+      }
+      const createResp = await jobAPI.create({
+        workboardId: wb._id,
+        prompt: inputData.userPrompt || '',
+        ...inputData,
+        tags: mergedTags,
+      });
+      const jobId = createResp.data.job?.id;
+      if (!jobId) throw new Error('작업 ID 를 받지 못했습니다');
+
+      // 폴링 — 최대 5분 (60회 × 5초). 첫 MVP 단순 구현.
+      for (let i = 0; i < 60; i++) {
+        await new Promise((r) => setTimeout(r, 5000));
+        const jobResp = await jobAPI.getById(jobId);
+        const job = jobResp.data.job;
+        if (job.status === 'completed') {
+          if (wb.outputFormat === 'image') {
+            const imageIds = (job.resultImages || []).map((img) => img._id);
+            return { type: 'image', imageIds, jobId };
+          }
+          return { type: wb.outputFormat, jobId };
+        }
+        if (job.status === 'failed') {
+          throw new Error(job.errorMessage || '작업 실패');
+        }
+      }
+      throw new Error('작업이 시간 내 완료되지 않음 (5분 초과)');
+    }
+  };
+
+  const handleRun = async () => {
+    if (!pipeline || pipeline.steps.length === 0) return;
+    if (!initialPrompt.trim()) {
+      toast.error('첫 단계의 입력 프롬프트를 입력해 주세요.');
+      return;
+    }
+    setRunning(true);
+    let prevOutput = null;
+    const newStates = pipeline.steps.map(() => ({ status: 'pending', output: null, error: null }));
+    setStepStates(newStates);
+
+    for (let i = 0; i < pipeline.steps.length; i++) {
+      newStates[i] = { ...newStates[i], status: 'running' };
+      setStepStates([...newStates]);
+      try {
+        const stepAutoInject = i === 0 ? false : (pipeline.steps[i].autoInject !== false);
+        const inputPrev = stepAutoInject ? prevOutput : null;
+        const result = await runStep(i, inputPrev);
+        newStates[i] = { status: 'done', output: result, error: null };
+        setStepStates([...newStates]);
+        prevOutput = result;
+      } catch (err) {
+        newStates[i] = { status: 'failed', output: null, error: err.response?.data?.message || err.message };
+        setStepStates([...newStates]);
+        // 나머지 단계는 skipped
+        for (let j = i + 1; j < pipeline.steps.length; j++) {
+          newStates[j] = { ...newStates[j], status: 'skipped' };
+        }
+        setStepStates([...newStates]);
+        toast.error(`${i + 1}단계 실패: ${err.message}`);
+        break;
+      }
+    }
+    setRunning(false);
+  };
+
+  if (isLoading || !pipeline) {
+    return <Box display="flex" justifyContent="center" py={4}><CircularProgress /></Box>;
+  }
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      <Box display="flex" alignItems="center" gap={1} mb={2}>
+        <Typography variant="h6">{pipeline.name} 실행</Typography>
+        <Box sx={{ flexGrow: 1 }} />
+        <Button onClick={onClose} disabled={running}>닫기</Button>
+      </Box>
+
+      <Stack spacing={2}>
+        <Alert severity="info">
+          첫 단계의 입력 프롬프트를 입력하고 "시작" 을 누르세요. 각 단계가 순차로 실행되며,
+          이전 단계의 결과가 다음 단계의 입력에 자동으로 매핑됩니다.
+          {pipeline.useWorldview && ' 첫 단계가 LLM 인 경우 프로젝트 세계관이 함께 주입됩니다.'}
+          {' '}이 페이지를 떠나면 실행이 중단됩니다.
+        </Alert>
+
+        <TextField
+          size="small"
+          label="초기 입력 프롬프트"
+          value={initialPrompt}
+          onChange={(e) => setInitialPrompt(e.target.value)}
+          multiline
+          minRows={2}
+          fullWidth
+          disabled={running}
+        />
+
+        <Box>
+          <Button
+            variant="contained"
+            color="success"
+            startIcon={running ? <CircularProgress size={18} color="inherit" /> : <PlayArrowIcon />}
+            onClick={handleRun}
+            disabled={running || !initialPrompt.trim()}
+          >
+            {running ? '실행 중...' : '시작'}
+          </Button>
+        </Box>
+
+        <Stepper activeStep={stepStates.findIndex((s) => s.status === 'running')} orientation="vertical">
+          {(pipeline.steps || []).map((step, idx) => {
+            const state = stepStates[idx] || { status: 'pending' };
+            return (
+              <Step key={idx} active expanded={state.status !== 'pending'}>
+                <StepLabel
+                  icon={
+                    state.status === 'done' ? <CheckCircleIcon color="success" />
+                    : state.status === 'failed' ? <ErrorIcon color="error" />
+                    : state.status === 'running' ? <CircularProgress size={20} />
+                    : state.status === 'skipped' ? <StopIcon color="disabled" />
+                    : <Chip label={idx + 1} size="small" />
+                  }
+                >
+                  <Typography variant="subtitle2">
+                    {step.workboardId?.name || '(작업판)'}
+                  </Typography>
+                  {step.workboardId?.description && (
+                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', whiteSpace: 'pre-wrap' }}>
+                      {step.workboardId.description}
+                    </Typography>
+                  )}
+                  {step.workboardId?.outputFormat && (
+                    <Typography variant="caption" color="text.secondary">
+                      출력: {step.workboardId.outputFormat}
+                    </Typography>
+                  )}
+                </StepLabel>
+                <StepContent>
+                  {step.note && (
+                    <Typography variant="body2" color="text.secondary" sx={{ mb: 1, whiteSpace: 'pre-wrap', fontStyle: 'italic' }}>
+                      {step.note}
+                    </Typography>
+                  )}
+                  {state.status === 'done' && state.output && (
+                    <Paper variant="outlined" sx={{ p: 1.5, bgcolor: 'rgba(76, 175, 80, 0.08)' }}>
+                      <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
+                        결과 ({state.output.type})
+                      </Typography>
+                      {state.output.type === 'text' && (
+                        <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', maxHeight: 200, overflow: 'auto' }}>
+                          {state.output.value}
+                        </Typography>
+                      )}
+                      {state.output.type === 'image' && (
+                        <Typography variant="caption" color="text.secondary">
+                          이미지 {state.output.imageIds?.length || 0}개 생성됨
+                        </Typography>
+                      )}
+                    </Paper>
+                  )}
+                  {state.status === 'failed' && (
+                    <Alert severity="error" sx={{ mb: 1 }}>
+                      {state.error}
+                    </Alert>
+                  )}
+                  {state.status === 'skipped' && (
+                    <Typography variant="caption" color="text.secondary">건너뜀</Typography>
+                  )}
+                </StepContent>
+              </Step>
+            );
+          })}
+        </Stepper>
+      </Stack>
+    </Box>
+  );
+}
+
+export default PipelinePanel;

--- a/frontend/src/pages/ProjectDetail.js
+++ b/frontend/src/pages/ProjectDetail.js
@@ -44,6 +44,7 @@ import toast from 'react-hot-toast';
 import { projectAPI, imageAPI, userAPI, promptDataAPI, tagAPI, workboardAPI } from '../services/api';
 import TextContentPanel from '../components/common/TextContentPanel';
 import ConversationHistoryPanel from '../components/common/ConversationHistoryPanel';
+import PipelinePanel from '../components/common/PipelinePanel';
 import MediaGrid from '../components/common/MediaGrid';
 import PromptDataPanel from '../components/common/PromptDataPanel';
 import PromptDataFormDialog from '../components/common/PromptDataFormDialog';
@@ -751,7 +752,20 @@ function ProjectDetail() {
   const { id } = useParams();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  // 탭 위치는 프로젝트별로 localStorage 영속화 (#396 후속) — 다른 프로젝트엔 영향 없음.
+  const TAB_KEY = id ? `vcc.projectDetail.tab.${id}` : '';
+  const TAB_COUNT = 7;
   const [tabValue, setTabValue] = useState(0);
+  React.useEffect(() => {
+    if (!TAB_KEY) return;
+    const stored = parseInt(localStorage.getItem(TAB_KEY), 10);
+    if (!Number.isNaN(stored) && stored >= 0 && stored < TAB_COUNT) {
+      setTabValue(stored);
+    }
+  }, [TAB_KEY]);
+  React.useEffect(() => {
+    if (TAB_KEY) localStorage.setItem(TAB_KEY, String(tabValue));
+  }, [TAB_KEY, tabValue]);
   const [editOpen, setEditOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
 
@@ -952,6 +966,7 @@ function ProjectDetail() {
           }}
         >
           <Tab label="작업판" />
+          <Tab label="파이프라인" />
           <Tab label="세계관" />
           <Tab icon={<TextSnippet fontSize="small" />} label="프롬프트 데이터" iconPosition="start" />
           <Tab icon={<ImageIcon fontSize="small" />} label="이미지" iconPosition="start" />
@@ -961,11 +976,12 @@ function ProjectDetail() {
       </Box>
 
       {tabValue === 0 && <WorkboardsTab projectId={id} />}
-      {tabValue === 1 && <WorldviewTab projectTag={project?.tagId} />}
-      {tabValue === 2 && <PromptDataTab projectId={id} />}
-      {tabValue === 3 && <ImagesTab projectId={id} />}
-      {tabValue === 4 && <JobsTab projectId={id} />}
-      {tabValue === 5 && (
+      {tabValue === 1 && <PipelinePanel projectId={id} />}
+      {tabValue === 2 && <WorldviewTab projectTag={project?.tagId} />}
+      {tabValue === 3 && <PromptDataTab projectId={id} />}
+      {tabValue === 4 && <ImagesTab projectId={id} />}
+      {tabValue === 5 && <JobsTab projectId={id} />}
+      {tabValue === 6 && (
         <Box sx={{ mt: 2 }}>
           <ConversationHistoryPanel
             fetchFn={(params) => projectAPI.getConversations(id, params)}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -269,6 +269,15 @@ export const projectAPI = {
   getConversations: (id, params) => api.get(`/projects/${id}/conversations`, { params }),
 };
 
+// 프로젝트 종속 파이프라인 (#397)
+export const pipelineAPI = {
+  list: (projectId) => api.get(`/projects/${projectId}/pipelines`),
+  get: (projectId, pipelineId) => api.get(`/projects/${projectId}/pipelines/${pipelineId}`),
+  create: (projectId, data) => api.post(`/projects/${projectId}/pipelines`, data),
+  update: (projectId, pipelineId, data) => api.patch(`/projects/${projectId}/pipelines/${pipelineId}`, data),
+  delete: (projectId, pipelineId) => api.delete(`/projects/${projectId}/pipelines/${pipelineId}`),
+};
+
 export const apiKeyAPI = {
   getAll: () => api.get('/apikeys'),
   create: (data) => api.post('/apikeys', data),

--- a/src/migrations/backfillConversationTags.js
+++ b/src/migrations/backfillConversationTags.js
@@ -1,0 +1,35 @@
+const ConversationJob = require('../models/ConversationJob');
+const Project = require('../models/Project');
+
+// projectId 가 있고 tags 가 비어 있는 ConversationJob 들에 프로젝트 태그를 backfill (#397 후속).
+// 태그 기반 필터링 통일을 위함. idempotent.
+async function backfillConversationTags() {
+  const targets = await ConversationJob.find({
+    projectId: { $ne: null, $exists: true },
+    $or: [{ tags: { $exists: false } }, { tags: { $size: 0 } }],
+  }).select('_id projectId').lean();
+
+  if (targets.length === 0) {
+    console.log('[Migration] ConversationJob tags backfill 불필요 (대상 없음)');
+    return;
+  }
+
+  // 프로젝트별 tagId 캐시
+  const projectIdSet = new Set(targets.map((t) => String(t.projectId)));
+  const projects = await Project.find({ _id: { $in: Array.from(projectIdSet) } }).select('_id tagId').lean();
+  const tagByProject = {};
+  for (const p of projects) {
+    if (p.tagId) tagByProject[String(p._id)] = p.tagId;
+  }
+
+  let updated = 0;
+  for (const conv of targets) {
+    const tagId = tagByProject[String(conv.projectId)];
+    if (!tagId) continue;
+    await ConversationJob.updateOne({ _id: conv._id }, { $set: { tags: [tagId] } });
+    updated += 1;
+  }
+  console.log(`[Migration] ConversationJob tags backfill: ${updated}건 처리`);
+}
+
+module.exports = backfillConversationTags;

--- a/src/models/ConversationJob.js
+++ b/src/models/ConversationJob.js
@@ -33,11 +33,16 @@ const conversationJobSchema = new mongoose.Schema({
   serverType: String,
   model: String,
   // 프로젝트 컨텍스트 (#396). 실행 시 사용자가 지정한 프로젝트 ID. null 가능.
-  // 프로젝트 작업 히스토리 / 사전 컨텍스트 표시에 사용.
+  // 프로젝트 작업 히스토리 / 사전 컨텍스트 표시에 사용. (#397 후속 — tags 와 함께 보존)
   projectId: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'Project',
   },
+  // 태그 기반 필터링 (이미지 작업과 동일 메커니즘으로 통일). projectId 가 있으면 자동으로 프로젝트 태그 주입.
+  tags: [{
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Tag',
+  }],
   // 합성 전 원본을 분리 저장해 display / audit 용도로 사용 (#396).
   // 실제 LLM 호출엔 둘을 합쳐 system 메시지 1개로 전송하지만, 보존은 분리.
   workboardSystemPrompt: String,

--- a/src/models/Pipeline.js
+++ b/src/models/Pipeline.js
@@ -1,0 +1,63 @@
+const mongoose = require('mongoose');
+
+// 프로젝트 종속 작업판 파이프라인 (#397 Phase 2.A).
+// 직선 (linear) 시퀀스. 분기 / DAG / 영속화 실행은 Phase 2.B 로 분리.
+// 단계의 출력 타입이 다음 단계의 입력 필드 타입과 일치하면 자동 주입 (autoInject).
+
+const pipelineStepSchema = new mongoose.Schema({
+  workboardId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Workboard',
+    required: true,
+  },
+  // 이전 단계 출력을 다음 단계 입력에 자동 주입 여부.
+  // 첫 단계는 의미 없음 (이전 단계가 없으므로). 두번째 단계부터 적용.
+  autoInject: {
+    type: Boolean,
+    default: true,
+  },
+  // 단계별 사전 입력 (#397 후속). 작업판의 customField name → 값 매핑.
+  // 자동 주입되는 필드 (예: 텍스트 결과 → prompt) 는 autoInject 가 우선 덮어씀.
+  inputs: {
+    type: mongoose.Schema.Types.Mixed,
+    default: {},
+  },
+  // 사용자 메모 (단계 설명) — 선택
+  note: String,
+}, { _id: false });
+
+const pipelineSchema = new mongoose.Schema({
+  userId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+  },
+  projectId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Project',
+    required: true,
+  },
+  name: {
+    type: String,
+    required: true,
+    trim: true,
+    maxlength: 100,
+  },
+  description: {
+    type: String,
+    trim: true,
+    maxlength: 500,
+    default: '',
+  },
+  steps: [pipelineStepSchema],
+  // 파이프라인 전체 세계관 사용 토글 — LLM 단계에 적용
+  useWorldview: {
+    type: Boolean,
+    default: true,
+  },
+}, { timestamps: true });
+
+pipelineSchema.index({ projectId: 1, createdAt: -1 });
+pipelineSchema.index({ userId: 1, createdAt: -1 });
+
+module.exports = mongoose.model('Pipeline', pipelineSchema);

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -519,10 +519,17 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
         messages.push({ role: 'system', content: composedSystem });
       }
       messages.push({ role: 'user', content: inputData.userPrompt });
+      // 프로젝트 작업 시 자동으로 프로젝트 태그 주입 (이미지 작업과 통일된 필터 메커니즘, #397 후속)
+      let projectTagIds = [];
+      if (projectId) {
+        const projectDoc = await Project.findOne({ _id: projectId, userId: req.user._id }).lean();
+        if (projectDoc?.tagId) projectTagIds = [projectDoc.tagId];
+      }
       conversation = await ConversationJob.create({
         userId: req.user._id,
         workboardId: workboard._id,
         projectId: projectId || undefined,
+        tags: projectTagIds,
         serverType: server.serverType,
         model,
         workboardSystemPrompt: systemPrompt || undefined,

--- a/src/routes/pipelines.js
+++ b/src/routes/pipelines.js
@@ -1,0 +1,141 @@
+const express = require('express');
+const { requireAuth } = require('../middleware/auth');
+const Pipeline = require('../models/Pipeline');
+const Project = require('../models/Project');
+const Workboard = require('../models/Workboard');
+
+const router = express.Router({ mergeParams: true });
+
+// 프로젝트 종속 파이프라인 CRUD (#397). mounted at /api/projects/:projectId/pipelines
+
+async function loadProject(req, res) {
+  const project = await Project.findOne({ _id: req.params.projectId, userId: req.user._id });
+  if (!project) {
+    res.status(404).json({ success: false, message: '프로젝트를 찾을 수 없습니다' });
+    return null;
+  }
+  return project;
+}
+
+// 모든 단계 워크보드가 사용자 소유인지 검증
+async function validateSteps(userId, steps) {
+  if (!Array.isArray(steps) || steps.length === 0) return { ok: false, message: '단계가 비어 있습니다' };
+  const ids = steps.map((s) => s.workboardId).filter(Boolean);
+  if (ids.length !== steps.length) return { ok: false, message: '각 단계에 workboardId 필수' };
+  const wbs = await Workboard.find({ _id: { $in: ids } }).lean();
+  if (wbs.length !== new Set(ids.map(String)).size) {
+    // 일부 id 가 중복일 수 있으므로 unique 비교
+    if (wbs.length === 0) return { ok: false, message: '존재하지 않는 작업판이 있습니다' };
+  }
+  // 권한 검사 — 작업판 자체는 admin / 공용일 수 있으므로 여기선 존재만 확인
+  return { ok: true };
+}
+
+router.get('/', requireAuth, async (req, res) => {
+  try {
+    const project = await loadProject(req, res);
+    if (!project) return;
+    const pipelines = await Pipeline.find({ projectId: project._id, userId: req.user._id })
+      .sort({ createdAt: -1 })
+      .populate('steps.workboardId', 'name description workboardType outputFormat isActive serverId')
+      .lean();
+    res.json({ success: true, data: { pipelines } });
+  } catch (error) {
+    console.error('List pipelines error:', error);
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
+router.get('/:id', requireAuth, async (req, res) => {
+  try {
+    const project = await loadProject(req, res);
+    if (!project) return;
+    const pipeline = await Pipeline.findOne({ _id: req.params.id, projectId: project._id, userId: req.user._id })
+      .populate({
+        path: 'steps.workboardId',
+        select: 'name description workboardType outputFormat isActive serverId additionalInputFields',
+        populate: { path: 'serverId', select: 'name serverType' }
+      })
+      .lean();
+    if (!pipeline) return res.status(404).json({ success: false, message: '파이프라인을 찾을 수 없습니다' });
+    res.json({ success: true, data: { pipeline } });
+  } catch (error) {
+    console.error('Get pipeline error:', error);
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
+router.post('/', requireAuth, async (req, res) => {
+  try {
+    const project = await loadProject(req, res);
+    if (!project) return;
+    const { name, description, steps, useWorldview } = req.body;
+    if (!name?.trim()) return res.status(400).json({ success: false, message: '이름 필수' });
+    if (Array.isArray(steps) && steps.length > 0) {
+      const check = await validateSteps(req.user._id, steps);
+      if (!check.ok) return res.status(400).json({ success: false, message: check.message });
+    }
+    const pipeline = await Pipeline.create({
+      userId: req.user._id,
+      projectId: project._id,
+      name: name.trim(),
+      description: (description || '').trim(),
+      steps: Array.isArray(steps) ? steps.map((s) => ({
+        workboardId: s.workboardId,
+        autoInject: s.autoInject !== false,
+        inputs: (s.inputs && typeof s.inputs === 'object') ? s.inputs : {},
+        note: s.note,
+      })) : [],
+      useWorldview: useWorldview !== false,
+    });
+    res.status(201).json({ success: true, data: { pipeline } });
+  } catch (error) {
+    console.error('Create pipeline error:', error);
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
+router.patch('/:id', requireAuth, async (req, res) => {
+  try {
+    const project = await loadProject(req, res);
+    if (!project) return;
+    const pipeline = await Pipeline.findOne({ _id: req.params.id, projectId: project._id, userId: req.user._id });
+    if (!pipeline) return res.status(404).json({ success: false, message: '파이프라인을 찾을 수 없습니다' });
+    const { name, description, steps, useWorldview } = req.body;
+    if (typeof name === 'string') pipeline.name = name.trim();
+    if (typeof description === 'string') pipeline.description = description.trim();
+    if (typeof useWorldview === 'boolean') pipeline.useWorldview = useWorldview;
+    if (Array.isArray(steps)) {
+      const check = await validateSteps(req.user._id, steps);
+      if (!check.ok) return res.status(400).json({ success: false, message: check.message });
+      pipeline.steps = steps.map((s) => ({
+        workboardId: s.workboardId,
+        autoInject: s.autoInject !== false,
+        inputs: (s.inputs && typeof s.inputs === 'object') ? s.inputs : {},
+        note: s.note,
+      }));
+      // Mixed 타입 (step.inputs) 변경은 mongoose 가 자동 감지 못 함 — 명시 markModified
+      pipeline.markModified('steps');
+    }
+    await pipeline.save();
+    res.json({ success: true, data: { pipeline } });
+  } catch (error) {
+    console.error('Update pipeline error:', error);
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
+router.delete('/:id', requireAuth, async (req, res) => {
+  try {
+    const project = await loadProject(req, res);
+    if (!project) return;
+    const result = await Pipeline.deleteOne({ _id: req.params.id, projectId: project._id, userId: req.user._id });
+    if (result.deletedCount === 0) return res.status(404).json({ success: false, message: '파이프라인을 찾을 수 없습니다' });
+    res.json({ success: true });
+  } catch (error) {
+    console.error('Delete pipeline error:', error);
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
+module.exports = router;

--- a/src/routes/projects.js
+++ b/src/routes/projects.js
@@ -536,7 +536,15 @@ router.get('/:id/conversations', requireAuth, async (req, res) => {
       return res.status(404).json({ success: false, message: '프로젝트를 찾을 수 없습니다' });
     }
     const ConversationJob = require('../models/ConversationJob');
-    const filter = { userId: req.user._id, projectId: project._id };
+    // 통일된 태그 기반 필터 (#397 후속). projectId 또는 tags 가 매칭되는 항목.
+    // 기존 데이터 호환 위해 둘 다 OR 로 검색.
+    const filter = {
+      userId: req.user._id,
+      $or: [
+        { projectId: project._id },
+        { tags: project.tagId },
+      ],
+    };
     const skip = (parseInt(page) - 1) * parseInt(limit);
     const [items, total] = await Promise.all([
       ConversationJob.find(filter)

--- a/src/server.js
+++ b/src/server.js
@@ -14,6 +14,7 @@ const imageRoutes = require('./routes/images');
 const jobRoutes = require('./routes/jobs');
 const conversationRoutes = require('./routes/conversations');
 const textRoutes = require('./routes/texts');
+const pipelineRoutes = require('./routes/pipelines');
 const adminRoutes = require('./routes/admin');
 const serverRoutes = require('./routes/servers');
 const promptDataRoutes = require('./routes/promptData');
@@ -41,6 +42,7 @@ const backfillCustomFieldRoles = require('./migrations/backfillCustomFieldRoles'
 const dropBaseInputFieldsSchema = require('./migrations/dropBaseInputFieldsSchema');
 const relocateCivitaiApiKey = require('./migrations/relocateCivitaiApiKey');
 const ensureWorldviewTag = require('./migrations/ensureWorldviewTag');
+const backfillConversationTags = require('./migrations/backfillConversationTags');
 
 dotenv.config();
 
@@ -142,6 +144,7 @@ app.use('/api/servers', serverRoutes);
 app.use('/api/prompt-data', promptDataRoutes);
 app.use('/api/tags', tagRoutes);
 app.use('/api/projects', projectRoutes);
+app.use('/api/projects/:projectId/pipelines', pipelineRoutes);
 app.use('/api/admin/backup', backupRoutes);
 app.use('/api/updatelog', updatelogRoutes);
 app.use('/api/apikeys', apiKeyRoutes);
@@ -206,6 +209,7 @@ const startServer = async () => {
     await dropBaseInputFieldsSchema();
     await relocateCivitaiApiKey();
     await ensureWorldviewTag();
+    await backfillConversationTags();
 
     // Initialize job queues after database connection
     console.log('Initializing job queues...');


### PR DESCRIPTION
## Summary
[#397](https://github.com/iceemperor-gcempire/vcc-manager/issues/397) Phase 2.A MVP — 프로젝트 종속 작업판 직선 파이프라인 + 프로젝트에서 수행되는 모든 작업이 프로젝트 태그를 자동으로 부여받도록 통일.

### 파이프라인 (#397)
- `Pipeline` 모델 + `/api/projects/:projectId/pipelines` CRUD
- 프로젝트 상세에 **파이프라인** 탭 (목록 / 빌더 / 실행 통합)
- 빌더: 단계 리스트 (드래그 reorder, 작업판 picker, **단계별 자동 주입 토글**, **단계별 사전 입력 dialog** — type-aware 입력기 (`string/number/boolean/select/baseModel/lora`), **단계별 메모**)
- 실행 (**클라이언트 측 순차 오케스트레이션**) — Stepper + 단계별 상태, 자동 매핑 (텍스트 → prompt 필드 / 이미지 → image 필드), 사전 입력 + 자동 주입 + 초기 프롬프트 우선순위, 이미지/영상 폴링 (5초/최대 5분), **파이프라인 전체 세계관 자동 주입 토글** (첫 LLM 단계에 적용)
- 페이지 떠나면 중단 — 영속화는 후속 (#397 Phase 2.A.1+)

### 프로젝트 태그 통일
- `ConversationJob.tags` 추가, `prompt-generate` 가 projectId 받으면 프로젝트 태그 자동 주입
- 기존 ConversationJob (projectId만 있던) 들은 backfill migration 으로 tags 채움
- `/api/projects/:id/conversations` 필터를 `projectId OR tags` 두 가지 union 으로 변경
- 파이프라인 runner — 이미지/영상 단계 실행 시 `inputData.tags` 에 프로젝트 태그 주입. 큐 → GeneratedImage / GeneratedVideo 까지 자동 전파.
- 텍스트 단계는 모든 단계에서 projectId 전달 (멀티턴도 태깅)

### UI 잡일
- ProjectDetail 탭 위치 localStorage 영속화 (프로젝트별 별도 키)
- 빌더 select 필드 placeholder 겹침 fix (`InputLabelProps={{ shrink: true }}`)
- 빌더 cache invalidation 누락 fix (single pipeline 쿼리도 invalidate)
- 작업판 description / 단계 note 노출 위치 정리
- 모바일 헤더 / 탭 / 우측 버튼 압축, "이미지 생성하기" → "작업판 보기" 라벨 변경

## Test plan
- [x] 빌드 (--no-cache) 성공, ConversationJob tags backfill migration 정상 (`1건 처리`)
- [x] 사용자 검증 — 파이프라인 / 단발 실행 모두 프로젝트 작업/대화 히스토리에 노출 확인
- [ ] dev 머지 후 alpha 추가 검증

## Follow-up
- **큰 개선 패스 예정** — 사용자 요청. 별개 작업으로 분리.
- 페이지 닫혀도 진행 (PipelineRun 영속화)
- 분기 / DAG (Phase 2.B)

closes #397