### PR TITLE
release: v2.6.0 — 프로젝트 세계관 + 작업판 파이프라인

### DIFF
--- a/docs/updatelogs/v2.md
+++ b/docs/updatelogs/v2.md
@@ -1,5 +1,35 @@
 # v2 업데이트 내역
 
+## v2.6.0
+
+### 신규 기능
+- feat: 프로젝트 세계관 (사전 컨텍스트) + 워크보드 소속 (#396 Phase 1.A, #398)
+  - `Tag.isWorldviewTag` 추가 + migration 으로 사용자별 \"세계관\" 태그 자동 시드. 신규 사용자는 `GET /api/tags/worldview` 가 lazy 생성.
+  - `Project.workboardIds` 추가 — 프로젝트가 작업판 목록을 보유 (단방향). 한 작업판이 여러 프로젝트에 들어갈 수 있음.
+  - 세계관 = `UploadedText` + `[프로젝트 태그, 세계관 태그]` 조합 (새 모델 / 컬렉션 없음, 1:N 자연스럽게 지원)
+  - 프로젝트 상세 페이지에 \"작업판\" / \"세계관\" / \"대화 히스토리\" 탭 추가. 작업판 카드별 \"실행\" 버튼이 프로젝트 컨텍스트 자동 전달.
+  - 작업판 실행 페이지 (`/prompt-generate/:wbId`) 에 `ProjectContextSelector` — 프로젝트 드롭다운 + 세계관 사용 토글.
+  - `prompt-generate` 가 `projectId + useWorldview` 받으면 해당 프로젝트의 세계관 텍스트를 system 메시지 `[작업 지침]` / `[배경 / 사전 컨텍스트]` 두 섹션으로 합성.
+  - `ConversationJob` 에 `projectId` / `workboardSystemPrompt` / `worldviewContext` 분리 저장. 대화 상세 다이얼로그에 별도 카드 노출.
+- feat: 프로젝트 종속 작업판 파이프라인 (#397 Phase 2.A, #399)
+  - `Pipeline` 모델 + `/api/projects/:projectId/pipelines` CRUD. 프로젝트 상세에 \"파이프라인\" 탭 추가.
+  - 빌더: 단계 리스트 (작업판 picker, 위/아래 reorder, **단계별 자동 주입 토글**, **단계별 사전 입력 dialog** — type-aware 입력기 (`string/number/boolean/select/baseModel/lora`), **단계별 메모**)
+  - 실행 (클라이언트 측 순차 오케스트레이션): Stepper + 단계별 상태, 자동 매핑 (텍스트 출력 → 다음 prompt 필드 / 이미지 출력 → image 필드), 사전 입력 + 자동 주입 + 초기 프롬프트 우선순위, 이미지/영상 폴링 (5초/최대 5분)
+  - 파이프라인 전체 \"세계관 자동 주입\" 토글 (첫 LLM 단계에 적용)
+- feat: 프로젝트 작업 태그 통일 (#397 후속)
+  - 프로젝트 컨텍스트로 수행되는 모든 작업이 자동으로 프로젝트 태그를 받도록 통일
+  - `ConversationJob` 에 `tags` 필드 추가 + 기존 데이터 backfill migration
+  - `/api/projects/:id/conversations` 필터를 `projectId OR tags` union 으로 변경 (기존 + 신규 데이터 모두 포함)
+  - 파이프라인 runner — 이미지/영상 단계 실행 시 `inputData.tags` 에 프로젝트 태그 주입 (큐 → GeneratedImage / GeneratedVideo 까지 전파)
+
+### 수정 / UI
+- `customField` 기본값 / 설명 / 플레이스홀더 — 작업판 admin 편집기에서 type-aware 입력 (baseModel / lora 는 서버 메타데이터 Autocomplete) — v2.5.0 부터 보존되던 거 그대로
+- ProjectDetail 모바일 헤더 / 탭 / 우측 버튼 압축, \"이미지 생성하기\" → \"작업판 보기\" 라벨 변경 (텍스트 작업판 포함)
+- ProjectDetail 탭 위치 localStorage 영속화 (프로젝트별 별도 키)
+- 빌더 select 필드 placeholder 겹침 fix (`InputLabelProps={{ shrink: true }}`)
+- 빌더 cache invalidation 누락 fix (편집 후 재진입 시 stale 데이터 표시되던 문제)
+- 파이프라인 list 카드 / 빌더 / 실행 stepper 에 작업판 description + 단계 note 노출
+
 ## v2.5.0
 
 ### 신규 기능

--- a/frontend/src/components/PromptGeneratorPanel.js
+++ b/frontend/src/components/PromptGeneratorPanel.js
@@ -131,13 +131,15 @@ function ImageUploadField({ label, description, images, onImagesChange, maxImage
   );
 }
 
-function PromptGeneratorPanel({ 
-  workboardId, 
+function PromptGeneratorPanel({
+  workboardId,
   workboard: externalWorkboard,
   onResultChange,
   showHeader = true,
   showSystemPrompt = true,
-  compact = false
+  compact = false,
+  projectId,
+  useWorldview
 }) {
   const [isGenerating, setIsGenerating] = useState(false);
   const [generatedResult, setGeneratedResult] = useState(null);
@@ -190,18 +192,21 @@ function PromptGeneratorPanel({
       
       const jobData = {
         workboardId: workboard._id,
+        // #396: 프로젝트 컨텍스트 / 세계관 적용 (단일 샷 모드)
+        projectId: projectId || undefined,
+        useWorldview: !!useWorldview,
         inputData: {
           model: formData.model,
           userPrompt: formData.userPrompt,
           ...uploadedImages,
           ...Object.fromEntries(
-            Object.entries(formData).filter(([key]) => 
+            Object.entries(formData).filter(([key]) =>
               !['model', 'userPrompt'].includes(key)
             )
           )
         }
       };
-      
+
       return jobAPI.createPromptJob(jobData);
     },
     {

--- a/frontend/src/components/common/ConversationHistoryPanel.js
+++ b/frontend/src/components/common/ConversationHistoryPanel.js
@@ -24,26 +24,32 @@ import {
   Delete as DeleteIcon,
   Person as PersonIcon,
   SmartToy as AssistantIcon,
-  Settings as SystemIcon
+  Settings as SystemIcon,
+  Public as PublicIcon,
+  Article as ArticleIcon,
+  ExpandLess,
+  ExpandMore
 } from '@mui/icons-material';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import { Chat as ChatIcon, BookmarkAdd as BookmarkAddIcon } from '@mui/icons-material';
+import { Collapse, Paper } from '@mui/material';
 import { conversationAPI, textAPI } from '../../services/api';
 import Pagination from './Pagination';
 
 // LLM 대화 히스토리 패널 (#373).
 // JobHistory 페이지의 \"텍스트\" 탭에서 사용. 카드 리스트 + 상세 다이얼로그.
-function ConversationHistoryPanel() {
+function ConversationHistoryPanel({ fetchFn, queryKey = 'conversations' }) {
   const [page, setPage] = useState(1);
   const [detailItem, setDetailItem] = useState(null);
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const effectiveFetch = fetchFn || ((params) => conversationAPI.getMy(params));
 
   const { data, isLoading, error } = useQuery(
-    ['conversations', page],
-    () => conversationAPI.getMy({ page, limit: 20 }),
+    [queryKey, page],
+    () => effectiveFetch({ page, limit: 20 }),
     { keepPreviousData: true }
   );
 
@@ -232,7 +238,40 @@ function ConversationHistoryPanel() {
                 </Typography>
               </Stack>
               <Divider />
-              {(detailItem.messages || []).map((msg, idx) => (
+              {/* 작업 지침 / 사전 컨텍스트 분리 표시 (#396) */}
+              {(detailItem.workboardSystemPrompt || detailItem.worldviewContext) && (
+                <Stack spacing={1}>
+                  {detailItem.workboardSystemPrompt && (
+                    <Paper variant="outlined" sx={{ p: 1.5, bgcolor: 'grey.50' }}>
+                      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 0.5 }}>
+                        <SystemIcon fontSize="small" color="action" />
+                        <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>작업 지침</Typography>
+                      </Stack>
+                      <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                        {detailItem.workboardSystemPrompt}
+                      </Typography>
+                    </Paper>
+                  )}
+                  {detailItem.worldviewContext && (
+                    <Paper variant="outlined" sx={{ p: 1.5, bgcolor: 'rgba(156, 39, 176, 0.04)' }}>
+                      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 0.5 }}>
+                        <PublicIcon fontSize="small" sx={{ color: '#9c27b0' }} />
+                        <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>사전 컨텍스트 (세계관)</Typography>
+                      </Stack>
+                      <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                        {detailItem.worldviewContext}
+                      </Typography>
+                    </Paper>
+                  )}
+                </Stack>
+              )}
+              <Divider><Chip label="대화" size="small" icon={<ArticleIcon fontSize="small" />} /></Divider>
+              {(detailItem.messages || []).map((msg, idx) => {
+                // workboardSystemPrompt / worldviewContext 가 별도 섹션으로 표시되면 system 메시지는 중복이라 숨김
+                if (msg.role === 'system' && (detailItem.workboardSystemPrompt || detailItem.worldviewContext)) {
+                  return null;
+                }
+                return (
                 <Box key={idx} sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
                   <Box sx={{ pt: 0.5 }}>
                     {msg.role === 'user' && <PersonIcon fontSize="small" color="primary" />}
@@ -259,7 +298,8 @@ function ConversationHistoryPanel() {
                     </Tooltip>
                   )}
                 </Box>
-              ))}
+                );
+              })}
               {detailItem.error?.message && (
                 <Alert severity="error">{detailItem.error.message}</Alert>
               )}

--- a/frontend/src/components/common/PipelinePanel.js
+++ b/frontend/src/components/common/PipelinePanel.js
@@ -1,0 +1,891 @@
+import React, { useState, useMemo } from 'react';
+import {
+  Box,
+  Stack,
+  Typography,
+  Button,
+  IconButton,
+  TextField,
+  Card,
+  CardContent,
+  CardActions,
+  Chip,
+  CircularProgress,
+  Alert,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  FormControlLabel,
+  Switch,
+  Stepper,
+  Step,
+  StepLabel,
+  StepContent,
+  Paper,
+} from '@mui/material';
+import {
+  Add as AddIcon,
+  Edit as EditIcon,
+  Delete as DeleteIcon,
+  PlayArrow as PlayArrowIcon,
+  Settings as SettingsIcon,
+  ArrowUpward,
+  ArrowDownward,
+  CheckCircle as CheckCircleIcon,
+  Error as ErrorIcon,
+  Stop as StopIcon,
+} from '@mui/icons-material';
+import MetadataFieldInput from './MetadataFieldInput';
+import { useQuery, useMutation, useQueryClient } from 'react-query';
+import toast from 'react-hot-toast';
+import { pipelineAPI, projectAPI, jobAPI } from '../../services/api';
+
+// 프로젝트 종속 작업판 파이프라인 (#397).
+// 단계: 목록 → 빌더 → 실행. 모두 한 패널에서.
+function PipelinePanel({ projectId }) {
+  const [view, setView] = useState('list'); // list | builder | runner
+  const [editingPipelineId, setEditingPipelineId] = useState(null);
+  const [runningPipelineId, setRunningPipelineId] = useState(null);
+  const queryClient = useQueryClient();
+
+  const { data, isLoading } = useQuery(
+    ['pipelines', projectId],
+    () => pipelineAPI.list(projectId),
+    { enabled: !!projectId }
+  );
+  const pipelines = data?.data?.data?.pipelines || [];
+
+  const deleteMutation = useMutation(
+    (pid) => pipelineAPI.delete(projectId, pid),
+    {
+      onSuccess: () => {
+        toast.success('파이프라인이 삭제되었습니다.');
+        queryClient.invalidateQueries(['pipelines', projectId]);
+      },
+      onError: (err) => toast.error(err.response?.data?.message || '삭제 실패'),
+    }
+  );
+
+  if (view === 'builder') {
+    return (
+      <PipelineBuilder
+        projectId={projectId}
+        pipelineId={editingPipelineId}
+        onClose={() => { setView('list'); setEditingPipelineId(null); }}
+      />
+    );
+  }
+  if (view === 'runner') {
+    return (
+      <PipelineRunner
+        projectId={projectId}
+        pipelineId={runningPipelineId}
+        onClose={() => { setView('list'); setRunningPipelineId(null); }}
+      />
+    );
+  }
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
+        <Typography variant="subtitle1" color="text.secondary">
+          작업판 A → B → C 직선 실행. 단계의 출력 타입이 다음 단계의 입력 타입과 일치하면 자동 주입됩니다.
+        </Typography>
+        <Button
+          variant="outlined"
+          startIcon={<AddIcon />}
+          onClick={() => { setEditingPipelineId(null); setView('builder'); }}
+        >
+          새 파이프라인
+        </Button>
+      </Box>
+
+      {isLoading ? (
+        <Box display="flex" justifyContent="center" py={4}><CircularProgress /></Box>
+      ) : pipelines.length === 0 ? (
+        <Box textAlign="center" py={4}>
+          <Typography variant="body2" color="text.secondary">
+            등록된 파이프라인이 없습니다. "새 파이프라인" 으로 작성하세요.
+          </Typography>
+        </Box>
+      ) : (
+        <Stack spacing={1.5}>
+          {pipelines.map((p) => (
+            <Card key={p._id} variant="outlined">
+              <CardContent sx={{ pb: 1 }}>
+                <Box display="flex" alignItems="center" gap={1} sx={{ mb: 0.5, flexWrap: 'wrap' }}>
+                  <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>{p.name}</Typography>
+                  <Chip label={`${p.steps?.length || 0}단계`} size="small" variant="outlined" />
+                  {p.useWorldview && <Chip label="세계관 ON" size="small" color="secondary" variant="outlined" />}
+                </Box>
+                {p.description && (
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                    {p.description}
+                  </Typography>
+                )}
+                {/* 단계 미리보기 — 작업판 이름 + description (작업판/단계). 모바일에선 description 숨김. */}
+                <Stack spacing={0.75} sx={{ mt: 0.5 }}>
+                  {(p.steps || []).map((s, idx) => (
+                    <Box key={idx} sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
+                      <Chip
+                        label={idx + 1}
+                        size="small"
+                        color={s.workboardId?.isActive === false ? 'warning' : 'primary'}
+                        sx={{ height: 22, minWidth: 22, '& .MuiChip-label': { px: 1 } }}
+                      />
+                      <Box sx={{ flex: '1 1 0', minWidth: 0 }}>
+                        <Typography variant="body2" sx={{ fontWeight: 500 }} noWrap>
+                          {s.workboardId?.name || '(삭제됨)'}
+                        </Typography>
+                        {s.workboardId?.description && (
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            sx={{
+                              display: { xs: 'none', sm: '-webkit-box' },
+                              WebkitLineClamp: 2,
+                              WebkitBoxOrient: 'vertical',
+                              overflow: 'hidden',
+                              whiteSpace: 'pre-wrap',
+                            }}
+                          >
+                            {s.workboardId.description}
+                          </Typography>
+                        )}
+                        {s.note && (
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            sx={{ display: 'block', fontStyle: 'italic', whiteSpace: 'pre-wrap' }}
+                          >
+                            {s.note}
+                          </Typography>
+                        )}
+                      </Box>
+                    </Box>
+                  ))}
+                </Stack>
+              </CardContent>
+              <CardActions sx={{ pt: 0, justifyContent: 'flex-end' }}>
+                <Button
+                  size="small"
+                  color="success"
+                  variant="contained"
+                  startIcon={<PlayArrowIcon />}
+                  onClick={() => { setRunningPipelineId(p._id); setView('runner'); }}
+                  disabled={(p.steps || []).length === 0}
+                >
+                  실행
+                </Button>
+                <Button
+                  size="small"
+                  startIcon={<EditIcon />}
+                  onClick={() => { setEditingPipelineId(p._id); setView('builder'); }}
+                >
+                  편집
+                </Button>
+                <IconButton
+                  size="small"
+                  color="error"
+                  onClick={() => {
+                    if (window.confirm(`"${p.name}" 파이프라인을 삭제하시겠습니까?`)) {
+                      deleteMutation.mutate(p._id);
+                    }
+                  }}
+                >
+                  <DeleteIcon fontSize="small" />
+                </IconButton>
+              </CardActions>
+            </Card>
+          ))}
+        </Stack>
+      )}
+    </Box>
+  );
+}
+
+// 파이프라인 빌더 — 단계 목록 편집 (#397)
+function PipelineBuilder({ projectId, pipelineId, onClose }) {
+  const isNew = !pipelineId;
+  const queryClient = useQueryClient();
+
+  const { data: pipelineData, isLoading } = useQuery(
+    ['pipeline', projectId, pipelineId],
+    () => pipelineAPI.get(projectId, pipelineId),
+    { enabled: !!pipelineId }
+  );
+  const loaded = pipelineData?.data?.data?.pipeline;
+
+  // 프로젝트의 작업판 목록 (단계 선택용)
+  const { data: wbData } = useQuery(
+    ['projectWorkboards', projectId],
+    () => projectAPI.getWorkboards(projectId),
+  );
+  const projectWorkboards = wbData?.data?.data?.workboards || [];
+
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [useWorldview, setUseWorldview] = useState(true);
+  const [steps, setSteps] = useState([]);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [inputsDialogStepIdx, setInputsDialogStepIdx] = useState(-1);
+
+  // 로드 시 폼 초기화
+  React.useEffect(() => {
+    if (loaded) {
+      setName(loaded.name || '');
+      setDescription(loaded.description || '');
+      setUseWorldview(loaded.useWorldview !== false);
+      setSteps((loaded.steps || []).map((s) => ({
+        workboardId: s.workboardId?._id || s.workboardId,
+        workboard: s.workboardId, // populated
+        autoInject: s.autoInject !== false,
+        inputs: s.inputs || {},
+        note: s.note || '',
+      })));
+    }
+  }, [loaded]);
+
+  const saveMutation = useMutation(
+    (payload) => isNew
+      ? pipelineAPI.create(projectId, payload)
+      : pipelineAPI.update(projectId, pipelineId, payload),
+    {
+      onSuccess: () => {
+        toast.success('저장되었습니다.');
+        // list + single 모두 invalidate — 재진입 시 stale cache 방지
+        queryClient.invalidateQueries(['pipelines', projectId]);
+        if (pipelineId) {
+          queryClient.invalidateQueries(['pipeline', projectId, pipelineId]);
+        }
+        onClose();
+      },
+      onError: (err) => toast.error(err.response?.data?.message || '저장 실패'),
+    }
+  );
+
+  const handleSave = () => {
+    if (!name.trim()) {
+      toast.error('이름을 입력해 주세요.');
+      return;
+    }
+    if (steps.length === 0) {
+      toast.error('최소 하나 이상의 단계가 필요합니다.');
+      return;
+    }
+    saveMutation.mutate({
+      name: name.trim(),
+      description: description.trim(),
+      useWorldview,
+      steps: steps.map((s) => ({
+        workboardId: s.workboardId,
+        autoInject: s.autoInject,
+        inputs: s.inputs || {},
+        note: s.note,
+      })),
+    });
+  };
+
+  const moveStep = (idx, delta) => {
+    const next = [...steps];
+    const to = idx + delta;
+    if (to < 0 || to >= next.length) return;
+    [next[idx], next[to]] = [next[to], next[idx]];
+    setSteps(next);
+  };
+
+  const removeStep = (idx) => {
+    setSteps(steps.filter((_, i) => i !== idx));
+  };
+
+  const addStep = (wb) => {
+    setSteps([...steps, { workboardId: wb._id, workboard: wb, autoInject: true, inputs: {}, note: '' }]);
+    setPickerOpen(false);
+  };
+
+  const updateStepInputs = (idx, inputs) => {
+    const next = [...steps];
+    next[idx] = { ...next[idx], inputs };
+    setSteps(next);
+  };
+
+  if (isLoading && pipelineId) {
+    return <Box display="flex" justifyContent="center" py={4}><CircularProgress /></Box>;
+  }
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      <Box display="flex" alignItems="center" gap={1} mb={2}>
+        <Typography variant="h6">{isNew ? '새 파이프라인' : '파이프라인 편집'}</Typography>
+        <Box sx={{ flexGrow: 1 }} />
+        <Button onClick={onClose}>취소</Button>
+        <Button variant="contained" onClick={handleSave} disabled={saveMutation.isLoading}>저장</Button>
+      </Box>
+
+      <Stack spacing={2}>
+        <TextField
+          size="small"
+          label="이름"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          inputProps={{ maxLength: 100 }}
+          fullWidth
+        />
+        <TextField
+          size="small"
+          label="설명 (선택)"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          inputProps={{ maxLength: 500 }}
+          multiline
+          minRows={2}
+          fullWidth
+        />
+        <FormControlLabel
+          control={<Switch checked={useWorldview} onChange={(e) => setUseWorldview(e.target.checked)} />}
+          label="LLM 단계에서 프로젝트 세계관 자동 주입"
+        />
+
+        <Box>
+          <Box display="flex" alignItems="center" mb={1}>
+            <Typography variant="subtitle2" sx={{ flexGrow: 1 }}>단계 ({steps.length})</Typography>
+            <Button
+              size="small"
+              startIcon={<AddIcon />}
+              variant="outlined"
+              onClick={() => setPickerOpen(true)}
+            >
+              단계 추가
+            </Button>
+          </Box>
+          {steps.length === 0 ? (
+            <Alert severity="info">
+              "단계 추가" 로 프로젝트 소속 작업판을 순서대로 등록하세요.
+              먼저 프로젝트의 "작업판" 탭에서 사용할 작업판들을 추가해 두어야 합니다.
+            </Alert>
+          ) : (
+            <Stack spacing={1}>
+              {steps.map((s, idx) => (
+                <Paper key={idx} variant="outlined" sx={{ p: 1.5 }}>
+                  <Box display="flex" alignItems="center" gap={1}>
+                    <Chip label={idx + 1} size="small" color="primary" />
+                    <Box sx={{ flex: '1 1 0', minWidth: 0 }}>
+                      <Typography variant="subtitle2" noWrap>
+                        {s.workboard?.name || '(이름 불러오는 중)'}
+                      </Typography>
+                      {s.workboard?.description && (
+                        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', whiteSpace: 'pre-wrap' }}>
+                          {s.workboard.description}
+                        </Typography>
+                      )}
+                      <Stack direction="row" spacing={0.5} sx={{ mt: 0.5 }}>
+                        {s.workboard?.outputFormat && (
+                          <Chip label={`out: ${s.workboard.outputFormat}`} size="small" variant="outlined" />
+                        )}
+                      </Stack>
+                    </Box>
+                    {idx > 0 && (
+                      <FormControlLabel
+                        control={
+                          <Switch
+                            size="small"
+                            checked={s.autoInject !== false}
+                            onChange={(e) => {
+                              const next = [...steps];
+                              next[idx] = { ...s, autoInject: e.target.checked };
+                              setSteps(next);
+                            }}
+                          />
+                        }
+                        label={<Typography variant="caption">이전 결과 자동 주입</Typography>}
+                      />
+                    )}
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      startIcon={<SettingsIcon />}
+                      onClick={() => setInputsDialogStepIdx(idx)}
+                    >
+                      입력 설정
+                      {Object.keys(s.inputs || {}).filter((k) => s.inputs[k] !== '' && s.inputs[k] != null).length > 0 && (
+                        <Chip label={Object.keys(s.inputs).filter((k) => s.inputs[k] !== '' && s.inputs[k] != null).length} size="small" sx={{ ml: 0.5, height: 18 }} />
+                      )}
+                    </Button>
+                    <IconButton size="small" disabled={idx === 0} onClick={() => moveStep(idx, -1)}>
+                      <ArrowUpward fontSize="small" />
+                    </IconButton>
+                    <IconButton size="small" disabled={idx === steps.length - 1} onClick={() => moveStep(idx, 1)}>
+                      <ArrowDownward fontSize="small" />
+                    </IconButton>
+                    <IconButton size="small" color="error" onClick={() => removeStep(idx)}>
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  </Box>
+                  {/* 단계별 메모 — 이 단계의 작업판 역할 / 사용자 가이드용 (#397 후속) */}
+                  <TextField
+                    size="small"
+                    fullWidth
+                    placeholder="이 단계에 대한 설명 / 메모 (선택)"
+                    value={s.note || ''}
+                    onChange={(e) => {
+                      const next = [...steps];
+                      next[idx] = { ...s, note: e.target.value };
+                      setSteps(next);
+                    }}
+                    multiline
+                    maxRows={3}
+                    inputProps={{ maxLength: 500 }}
+                    sx={{ mt: 1 }}
+                  />
+                </Paper>
+              ))}
+            </Stack>
+          )}
+        </Box>
+      </Stack>
+
+      {/* 단계별 사전 입력 설정 다이얼로그 */}
+      <StepInputsDialog
+        open={inputsDialogStepIdx >= 0}
+        step={inputsDialogStepIdx >= 0 ? steps[inputsDialogStepIdx] : null}
+        onClose={() => setInputsDialogStepIdx(-1)}
+        onSave={(inputs) => {
+          updateStepInputs(inputsDialogStepIdx, inputs);
+          setInputsDialogStepIdx(-1);
+        }}
+      />
+
+      {/* 단계 추가 picker — 프로젝트 소속 작업판만 */}
+      <Dialog open={pickerOpen} onClose={() => setPickerOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>단계 추가 - 작업판 선택</DialogTitle>
+        <DialogContent dividers>
+          {projectWorkboards.length === 0 ? (
+            <Alert severity="info">
+              프로젝트에 등록된 작업판이 없습니다. 먼저 "작업판" 탭에서 추가해 주세요.
+            </Alert>
+          ) : (
+            <Stack spacing={1}>
+              {projectWorkboards.map((wb) => (
+                <Box
+                  key={wb._id}
+                  onClick={() => addStep(wb)}
+                  sx={{
+                    p: 1.5, border: 1, borderColor: 'divider', borderRadius: 1, cursor: 'pointer',
+                    '&:hover': { bgcolor: 'action.hover', borderColor: 'primary.main' }
+                  }}
+                >
+                  <Typography variant="subtitle2">{wb.name}</Typography>
+                  <Stack direction="row" spacing={0.5} sx={{ mt: 0.5 }}>
+                    {wb.outputFormat && <Chip label={wb.outputFormat} size="small" variant="outlined" />}
+                    {wb.serverId?.name && <Chip label={wb.serverId.name} size="small" variant="outlined" />}
+                  </Stack>
+                </Box>
+              ))}
+            </Stack>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setPickerOpen(false)}>닫기</Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}
+
+// 파이프라인 단계의 사전 입력 설정 다이얼로그 (#397 후속).
+// 작업판의 customField 들을 렌더링해 admin 이 미리 값을 채울 수 있게 함.
+// 자동 주입 대상 (prompt/userPrompt, image 입력) 도 여기서 미리 설정 가능하나,
+// 자동 주입이 ON 이면 runtime 에 덮어쓰임.
+function StepInputsDialog({ open, step, onClose, onSave }) {
+  const wb = step?.workboard;
+  const [values, setValues] = useState({});
+
+  React.useEffect(() => {
+    if (step) {
+      setValues(step.inputs || {});
+    }
+  }, [step]);
+
+  if (!wb) return null;
+
+  // conversation_mode 같은 admin-only customField 는 사전 입력에서 숨김
+  const fields = (wb.additionalInputFields || []).filter((f) => f.name !== 'conversation_mode');
+
+  const updateValue = (name, v) => setValues({ ...values, [name]: v });
+
+  const renderField = (field) => {
+    const value = values[field.name] ?? field.defaultValue ?? '';
+
+    if (field.type === 'string') {
+      return (
+        <TextField
+          size="small"
+          fullWidth
+          label={field.label}
+          placeholder={field.placeholder}
+          value={value}
+          onChange={(e) => updateValue(field.name, e.target.value)}
+          multiline={field.name.includes('prompt')}
+          rows={field.name.includes('prompt') ? 2 : 1}
+          helperText={field.description}
+        />
+      );
+    }
+    if (field.type === 'number') {
+      return (
+        <TextField
+          size="small"
+          fullWidth
+          type="number"
+          label={field.label}
+          value={value}
+          onChange={(e) => updateValue(field.name, e.target.value)}
+          helperText={field.description}
+        />
+      );
+    }
+    if (field.type === 'boolean') {
+      return (
+        <FormControlLabel
+          control={<Switch checked={!!value} onChange={(e) => updateValue(field.name, e.target.checked)} />}
+          label={field.label}
+        />
+      );
+    }
+    if (field.type === 'select') {
+      // native select 사용 시 label 이 placeholder 와 겹쳐 보이는 문제 해결 위해 InputLabelProps.shrink 고정
+      return (
+        <TextField
+          size="small"
+          fullWidth
+          select
+          label={field.label}
+          value={value || ''}
+          onChange={(e) => updateValue(field.name, e.target.value)}
+          SelectProps={{ native: true }}
+          InputLabelProps={{ shrink: true }}
+          helperText={field.description}
+        >
+          <option value="">— 선택 없음 —</option>
+          {(field.options || []).map((opt, i) => (
+            <option key={i} value={opt.value}>{opt.key || opt.value}</option>
+          ))}
+        </TextField>
+      );
+    }
+    if (field.type === 'baseModel' || field.type === 'lora') {
+      return (
+        <MetadataFieldInput
+          kind={field.type === 'baseModel' ? 'model' : 'lora'}
+          field={field}
+          value={value || ''}
+          onChange={(v) => updateValue(field.name, v)}
+          workboardId={wb._id}
+          serverId={wb?.serverId?._id || wb?.serverId}
+        />
+      );
+    }
+    if (field.type === 'image') {
+      return (
+        <Alert severity="info">
+          이미지 필드 (`{field.name}`) — 자동 주입 또는 단계 실행 시 입력. 사전 설정 미지원.
+        </Alert>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        단계 입력 설정
+        {wb.name && <Typography variant="caption" color="text.secondary" display="block">{wb.name}</Typography>}
+      </DialogTitle>
+      <DialogContent dividers>
+        {fields.length === 0 ? (
+          <Alert severity="info">설정 가능한 입력 필드가 없습니다.</Alert>
+        ) : (
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <Alert severity="info">
+              여기서 설정한 값은 단계 실행 시 자동으로 채워집니다.
+              <strong> "이전 결과 자동 주입"</strong> 이 켜진 단계에선 prompt 등 매칭 필드는 이전 단계 결과로 덮어쓰임됩니다.
+            </Alert>
+            {fields.map((field) => (
+              <Box key={field.name}>{renderField(field)}</Box>
+            ))}
+          </Stack>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>취소</Button>
+        <Button variant="contained" onClick={() => onSave(values)}>저장</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+// 파이프라인 실행 (클라이언트 측 순차 오케스트레이션, #397)
+function PipelineRunner({ projectId, pipelineId, onClose }) {
+  const { data: pipelineData, isLoading } = useQuery(
+    ['pipeline', projectId, pipelineId],
+    () => pipelineAPI.get(projectId, pipelineId),
+    { enabled: !!pipelineId }
+  );
+  const pipeline = pipelineData?.data?.data?.pipeline;
+  // 프로젝트 tagId — 모든 단계에서 생성되는 작업 / 컨텐츠에 자동 부여 (#397 후속)
+  const { data: projectData } = useQuery(
+    ['project', projectId],
+    () => projectAPI.getById(projectId),
+    { enabled: !!projectId }
+  );
+  const projectTagId = projectData?.data?.data?.project?.tagId?._id || projectData?.data?.data?.project?.tagId;
+
+  // 단계별 상태 / 결과
+  // status: 'pending' | 'running' | 'done' | 'failed' | 'skipped'
+  const [stepStates, setStepStates] = useState([]);
+  const [running, setRunning] = useState(false);
+  const [initialPrompt, setInitialPrompt] = useState('');
+
+  React.useEffect(() => {
+    if (pipeline) {
+      setStepStates((pipeline.steps || []).map(() => ({ status: 'pending', output: null, error: null })));
+    }
+  }, [pipeline]);
+
+  // 단계 입력 빌드 (#397 후속):
+  // 1. step.inputs 의 사전 입력값으로 시작
+  // 2. 자동 주입 — 첫 단계는 initialPrompt, 그 외 단계는 prevOutput 으로 prompt/image 필드 덮어씀
+  const buildStepInput = (workboard, prevOutput, stepInputs, stepIdx) => {
+    const inputData = { ...(stepInputs || {}) };
+
+    // userPrompt 는 LLM 작업판의 텍스트 입력 키. 사전 입력에 없으면 기본 빈 문자열.
+    if (inputData.userPrompt == null) inputData.userPrompt = '';
+
+    if (stepIdx === 0) {
+      // 첫 단계 — 사용자 초기 프롬프트로 텍스트 필드 덮어쓰기
+      inputData.userPrompt = initialPrompt;
+      const promptField = (workboard.additionalInputFields || []).find(
+        (f) => f.name === 'prompt' || f.name === 'userPrompt'
+      );
+      if (promptField) inputData[promptField.name] = initialPrompt;
+    } else if (prevOutput) {
+      if (prevOutput.type === 'text') {
+        inputData.userPrompt = prevOutput.value;
+        const promptField = (workboard.additionalInputFields || []).find(
+          (f) => f.name === 'prompt' || f.name === 'userPrompt'
+        );
+        if (promptField) inputData[promptField.name] = prevOutput.value;
+      } else if (prevOutput.type === 'image' && prevOutput.imageIds?.length > 0) {
+        const imgField = (workboard.additionalInputFields || []).find((f) => f.type === 'image');
+        if (imgField) {
+          inputData[imgField.name] = prevOutput.imageIds.map((id) => ({ imageId: id }));
+        }
+      }
+    }
+    return inputData;
+  };
+
+  const runStep = async (stepIdx, prevOutput) => {
+    const step = pipeline.steps[stepIdx];
+    const wb = step.workboardId;
+    if (!wb || wb.isActive === false) {
+      throw new Error(`작업판이 비활성 또는 삭제됨`);
+    }
+    const inputData = buildStepInput(wb, prevOutput, step.inputs, stepIdx);
+
+    if (wb.outputFormat === 'text') {
+      // 텍스트 작업판 — prompt-generate. 세계관은 첫 단계 + useWorldview ON 일 때만 주입.
+      // projectId 는 모든 단계에 전달 — 백엔드가 ConversationJob.tags 에 프로젝트 태그 자동 주입.
+      const response = await jobAPI.createPromptJob({
+        workboardId: wb._id,
+        projectId: projectId || undefined,
+        useWorldview: stepIdx === 0 && pipeline.useWorldview,
+        inputData,
+      });
+      return { type: 'text', value: response.data.result, conversationId: response.data.conversationId };
+    } else {
+      // 이미지 / 영상 — 기존 /api/jobs/generate. 결과 폴링 필요.
+      // 프로젝트 태그를 inputData.tags 에 주입 — ImageGenerationJob / GeneratedImage 모두에 전파됨.
+      const mergedTags = Array.isArray(inputData.tags) ? [...inputData.tags] : [];
+      if (projectTagId && !mergedTags.some((t) => String(t) === String(projectTagId))) {
+        mergedTags.push(projectTagId);
+      }
+      const createResp = await jobAPI.create({
+        workboardId: wb._id,
+        prompt: inputData.userPrompt || '',
+        ...inputData,
+        tags: mergedTags,
+      });
+      const jobId = createResp.data.job?.id;
+      if (!jobId) throw new Error('작업 ID 를 받지 못했습니다');
+
+      // 폴링 — 최대 5분 (60회 × 5초). 첫 MVP 단순 구현.
+      for (let i = 0; i < 60; i++) {
+        await new Promise((r) => setTimeout(r, 5000));
+        const jobResp = await jobAPI.getById(jobId);
+        const job = jobResp.data.job;
+        if (job.status === 'completed') {
+          if (wb.outputFormat === 'image') {
+            const imageIds = (job.resultImages || []).map((img) => img._id);
+            return { type: 'image', imageIds, jobId };
+          }
+          return { type: wb.outputFormat, jobId };
+        }
+        if (job.status === 'failed') {
+          throw new Error(job.errorMessage || '작업 실패');
+        }
+      }
+      throw new Error('작업이 시간 내 완료되지 않음 (5분 초과)');
+    }
+  };
+
+  const handleRun = async () => {
+    if (!pipeline || pipeline.steps.length === 0) return;
+    if (!initialPrompt.trim()) {
+      toast.error('첫 단계의 입력 프롬프트를 입력해 주세요.');
+      return;
+    }
+    setRunning(true);
+    let prevOutput = null;
+    const newStates = pipeline.steps.map(() => ({ status: 'pending', output: null, error: null }));
+    setStepStates(newStates);
+
+    for (let i = 0; i < pipeline.steps.length; i++) {
+      newStates[i] = { ...newStates[i], status: 'running' };
+      setStepStates([...newStates]);
+      try {
+        const stepAutoInject = i === 0 ? false : (pipeline.steps[i].autoInject !== false);
+        const inputPrev = stepAutoInject ? prevOutput : null;
+        const result = await runStep(i, inputPrev);
+        newStates[i] = { status: 'done', output: result, error: null };
+        setStepStates([...newStates]);
+        prevOutput = result;
+      } catch (err) {
+        newStates[i] = { status: 'failed', output: null, error: err.response?.data?.message || err.message };
+        setStepStates([...newStates]);
+        // 나머지 단계는 skipped
+        for (let j = i + 1; j < pipeline.steps.length; j++) {
+          newStates[j] = { ...newStates[j], status: 'skipped' };
+        }
+        setStepStates([...newStates]);
+        toast.error(`${i + 1}단계 실패: ${err.message}`);
+        break;
+      }
+    }
+    setRunning(false);
+  };
+
+  if (isLoading || !pipeline) {
+    return <Box display="flex" justifyContent="center" py={4}><CircularProgress /></Box>;
+  }
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      <Box display="flex" alignItems="center" gap={1} mb={2}>
+        <Typography variant="h6">{pipeline.name} 실행</Typography>
+        <Box sx={{ flexGrow: 1 }} />
+        <Button onClick={onClose} disabled={running}>닫기</Button>
+      </Box>
+
+      <Stack spacing={2}>
+        <Alert severity="info">
+          첫 단계의 입력 프롬프트를 입력하고 "시작" 을 누르세요. 각 단계가 순차로 실행되며,
+          이전 단계의 결과가 다음 단계의 입력에 자동으로 매핑됩니다.
+          {pipeline.useWorldview && ' 첫 단계가 LLM 인 경우 프로젝트 세계관이 함께 주입됩니다.'}
+          {' '}이 페이지를 떠나면 실행이 중단됩니다.
+        </Alert>
+
+        <TextField
+          size="small"
+          label="초기 입력 프롬프트"
+          value={initialPrompt}
+          onChange={(e) => setInitialPrompt(e.target.value)}
+          multiline
+          minRows={2}
+          fullWidth
+          disabled={running}
+        />
+
+        <Box>
+          <Button
+            variant="contained"
+            color="success"
+            startIcon={running ? <CircularProgress size={18} color="inherit" /> : <PlayArrowIcon />}
+            onClick={handleRun}
+            disabled={running || !initialPrompt.trim()}
+          >
+            {running ? '실행 중...' : '시작'}
+          </Button>
+        </Box>
+
+        <Stepper activeStep={stepStates.findIndex((s) => s.status === 'running')} orientation="vertical">
+          {(pipeline.steps || []).map((step, idx) => {
+            const state = stepStates[idx] || { status: 'pending' };
+            return (
+              <Step key={idx} active expanded={state.status !== 'pending'}>
+                <StepLabel
+                  icon={
+                    state.status === 'done' ? <CheckCircleIcon color="success" />
+                    : state.status === 'failed' ? <ErrorIcon color="error" />
+                    : state.status === 'running' ? <CircularProgress size={20} />
+                    : state.status === 'skipped' ? <StopIcon color="disabled" />
+                    : <Chip label={idx + 1} size="small" />
+                  }
+                >
+                  <Typography variant="subtitle2">
+                    {step.workboardId?.name || '(작업판)'}
+                  </Typography>
+                  {step.workboardId?.description && (
+                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', whiteSpace: 'pre-wrap' }}>
+                      {step.workboardId.description}
+                    </Typography>
+                  )}
+                  {step.workboardId?.outputFormat && (
+                    <Typography variant="caption" color="text.secondary">
+                      출력: {step.workboardId.outputFormat}
+                    </Typography>
+                  )}
+                </StepLabel>
+                <StepContent>
+                  {step.note && (
+                    <Typography variant="body2" color="text.secondary" sx={{ mb: 1, whiteSpace: 'pre-wrap', fontStyle: 'italic' }}>
+                      {step.note}
+                    </Typography>
+                  )}
+                  {state.status === 'done' && state.output && (
+                    <Paper variant="outlined" sx={{ p: 1.5, bgcolor: 'rgba(76, 175, 80, 0.08)' }}>
+                      <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
+                        결과 ({state.output.type})
+                      </Typography>
+                      {state.output.type === 'text' && (
+                        <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', maxHeight: 200, overflow: 'auto' }}>
+                          {state.output.value}
+                        </Typography>
+                      )}
+                      {state.output.type === 'image' && (
+                        <Typography variant="caption" color="text.secondary">
+                          이미지 {state.output.imageIds?.length || 0}개 생성됨
+                        </Typography>
+                      )}
+                    </Paper>
+                  )}
+                  {state.status === 'failed' && (
+                    <Alert severity="error" sx={{ mb: 1 }}>
+                      {state.error}
+                    </Alert>
+                  )}
+                  {state.status === 'skipped' && (
+                    <Typography variant="caption" color="text.secondary">건너뜀</Typography>
+                  )}
+                </StepContent>
+              </Step>
+            );
+          })}
+        </Stepper>
+      </Stack>
+    </Box>
+  );
+}
+
+export default PipelinePanel;

--- a/frontend/src/components/common/ProjectContextSelector.js
+++ b/frontend/src/components/common/ProjectContextSelector.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import {
+  Box,
+  Paper,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  FormControlLabel,
+  Switch,
+  Typography,
+  Stack,
+  Tooltip,
+} from '@mui/material';
+import { Public as PublicIcon } from '@mui/icons-material';
+import { useQuery } from 'react-query';
+import { projectAPI } from '../../services/api';
+
+// 작업판 실행 시 프로젝트 컨텍스트 / 세계관 사용 토글 (#396).
+// 프로젝트 선택 시 백엔드가 그 프로젝트의 세계관 텍스트들을 system 메시지의
+// [배경 / 사전 컨텍스트] 섹션으로 주입한다.
+function ProjectContextSelector({
+  projectId,
+  useWorldview,
+  onProjectChange,
+  onUseWorldviewChange,
+  disabled = false,
+}) {
+  const { data: projectsData } = useQuery('projects', () => projectAPI.getAll({ limit: 200 }));
+  const projects = projectsData?.data?.data?.projects || projectsData?.data?.projects || [];
+
+  return (
+    <Paper variant="outlined" sx={{ p: 1.5, mb: 2 }}>
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} alignItems={{ sm: 'center' }}>
+        <Stack direction="row" alignItems="center" spacing={1} sx={{ minWidth: { sm: 140 } }}>
+          <PublicIcon fontSize="small" color="action" />
+          <Typography variant="body2" sx={{ fontWeight: 500 }}>
+            프로젝트 컨텍스트
+          </Typography>
+        </Stack>
+        <FormControl size="small" sx={{ minWidth: 200, flexGrow: 1 }}>
+          <InputLabel>프로젝트 선택</InputLabel>
+          <Select
+            value={projectId || ''}
+            label="프로젝트 선택"
+            onChange={(e) => onProjectChange(e.target.value || '')}
+            disabled={disabled}
+          >
+            <MenuItem value=""><em>없음</em></MenuItem>
+            {projects.map((p) => (
+              <MenuItem key={p._id} value={p._id}>{p.name}</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <Tooltip title="ON 이면 선택한 프로젝트의 세계관 텍스트를 LLM 에 사전 컨텍스트로 주입">
+          <FormControlLabel
+            control={
+              <Switch
+                checked={!!useWorldview && !!projectId}
+                onChange={(e) => onUseWorldviewChange(e.target.checked)}
+                disabled={disabled || !projectId}
+              />
+            }
+            label="세계관 사용"
+          />
+        </Tooltip>
+      </Stack>
+    </Paper>
+  );
+}
+
+export default ProjectContextSelector;

--- a/frontend/src/components/common/TextContentPanel.js
+++ b/frontend/src/components/common/TextContentPanel.js
@@ -47,7 +47,7 @@ function stripExtension(filename) {
 // 텍스트 컨텐츠 패널 (#387).
 // kind: 'uploaded' (직접 작성, 편집/생성 가능) | 'generated' (대화에서 저장, 태그/삭제만 가능).
 // defaultTags: 새 항목 생성 시 기본 태그 (프로젝트 맥락에서 프로젝트 태그 자동 추가용).
-function TextContentPanel({ kind = 'uploaded', defaultTags = [] }) {
+function TextContentPanel({ kind = 'uploaded', defaultTags = [], filterTags = [], title }) {
   const isUploaded = kind === 'uploaded';
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState('');
@@ -63,9 +63,14 @@ function TextContentPanel({ kind = 'uploaded', defaultTags = [] }) {
   const deleteFn = isUploaded ? textAPI.deleteUploaded : textAPI.deleteGenerated;
   const createFn = textAPI.createUploaded;
 
+  const tagIds = (filterTags || []).map((t) => t._id || t).filter(Boolean);
   const { data, isLoading, error } = useQuery(
-    [queryKey, page, search],
-    () => listFn({ page, limit: 20, search }),
+    [queryKey, page, search, tagIds.join(',')],
+    () => {
+      const params = { page, limit: 20, search };
+      if (tagIds.length > 0) params.tags = tagIds.join(',');
+      return listFn(params);
+    },
     { keepPreviousData: true }
   );
 

--- a/frontend/src/components/common/WorkboardChatPanel.js
+++ b/frontend/src/components/common/WorkboardChatPanel.js
@@ -37,7 +37,7 @@ import MetadataFieldInput from './MetadataFieldInput';
 // PromptGeneration 페이지에서 workboard.conversation_mode = true 일 때 PromptGeneratorPanel 대신 렌더.
 // 매번 새 대화로 시작. 첫 메시지 전송 전엔 설정 (model / temperature / system_prompt 등) 편집 가능,
 // 전송 후엔 lock + collapse.
-function WorkboardChatPanel({ workboard }) {
+function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
   const [conversationId, setConversationId] = useState(null);
   const [settingsOpen, setSettingsOpen] = useState(true);
   const [newMessage, setNewMessage] = useState('');
@@ -80,6 +80,10 @@ function WorkboardChatPanel({ workboard }) {
     ({ text, settings, cid }) => jobAPI.createPromptJob({
       workboardId: workboard._id,
       conversationId: cid || undefined,
+      // 첫 메시지 (cid 없음) 일 때만 프로젝트 컨텍스트 / 세계관 적용 (#396).
+      // 이어가는 메시지엔 이미 첫 턴의 system 메시지가 보존되어 있음.
+      projectId: cid ? undefined : (projectId || undefined),
+      useWorldview: cid ? undefined : !!useWorldview,
       inputData: { ...settings, userPrompt: text },
     }),
     {

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,7 +1,7 @@
 const config = {
   version: {
     major: 2,
-    minor: 5
+    minor: 6
   },
   monitoring: {
     // 작업 목록 모니터링 주기 (3초)

--- a/frontend/src/pages/ProjectDetail.js
+++ b/frontend/src/pages/ProjectDetail.js
@@ -16,7 +16,9 @@ import {
   DialogActions,
   Tooltip,
   FormControlLabel,
-  Checkbox
+  Checkbox,
+  Stack,
+  TextField
 } from '@mui/material';
 import {
   ArrowBack,
@@ -24,6 +26,8 @@ import {
   StarBorder,
   Edit,
   Delete,
+  Delete as DeleteIcon,
+  PlayArrow,
   Image as ImageIcon,
   TextSnippet,
   History,
@@ -37,7 +41,9 @@ import {
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import toast from 'react-hot-toast';
-import { projectAPI, imageAPI, userAPI, promptDataAPI } from '../services/api';
+import { projectAPI, imageAPI, userAPI, promptDataAPI, tagAPI, workboardAPI } from '../services/api';
+import TextContentPanel from '../components/common/TextContentPanel';
+import ConversationHistoryPanel from '../components/common/ConversationHistoryPanel';
 import MediaGrid from '../components/common/MediaGrid';
 import PromptDataPanel from '../components/common/PromptDataPanel';
 import PromptDataFormDialog from '../components/common/PromptDataFormDialog';
@@ -532,12 +538,198 @@ function PromptDataTab({ projectId }) {
   );
 }
 
-// 텍스트 탭 (placeholder)
-function TextTab() {
+// 세계관 (사전 컨텍스트) 탭 (#396).
+// UploadedText 중 [projectTag, worldviewTag] 모두 포함하는 항목만 노출.
+// 새 항목 생성 시 두 태그 자동 부여 (TextContentPanel 의 defaultTags).
+function WorldviewTab({ projectTag }) {
+  const { data: wvTagData, isLoading } = useQuery('worldviewTag', () => tagAPI.getWorldview(), { staleTime: 60_000 });
+  const worldviewTag = wvTagData?.data?.tag;
+  if (isLoading) return <Box display="flex" justifyContent="center" py={4}><CircularProgress /></Box>;
+  if (!worldviewTag || !projectTag) {
+    return <Alert severity="warning" sx={{ mt: 2 }}>세계관 태그 / 프로젝트 태그를 불러오지 못했습니다.</Alert>;
+  }
   return (
-    <Alert severity="info" sx={{ mt: 2 }}>
-      준비 중인 기능입니다.
-    </Alert>
+    <Box sx={{ mt: 2 }}>
+      <Alert severity="info" sx={{ mb: 2 }}>
+        여기에 작성한 텍스트는 작업판 실행 시 <strong>[배경 / 사전 컨텍스트]</strong> 로 LLM 에 주입됩니다.
+        등장인물 / 배경 / 톤 등 작업판이 알아야 할 사실을 단편으로 나눠 보관하세요.
+      </Alert>
+      <TextContentPanel
+        kind="uploaded"
+        defaultTags={[projectTag, worldviewTag]}
+        filterTags={[projectTag, worldviewTag]}
+      />
+    </Box>
+  );
+}
+
+// 작업판 멤버십 탭 (#396).
+function WorkboardsTab({ projectId }) {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const { data, isLoading } = useQuery(
+    ['projectWorkboards', projectId],
+    () => projectAPI.getWorkboards(projectId),
+  );
+  const workboards = data?.data?.data?.workboards || [];
+
+  const addMutation = useMutation(
+    (workboardId) => projectAPI.addWorkboard(projectId, workboardId),
+    {
+      onSuccess: () => {
+        toast.success('작업판이 추가되었습니다.');
+        queryClient.invalidateQueries(['projectWorkboards', projectId]);
+        setPickerOpen(false);
+      },
+      onError: (err) => toast.error(err.response?.data?.message || '추가 실패'),
+    }
+  );
+
+  const removeMutation = useMutation(
+    (workboardId) => projectAPI.removeWorkboard(projectId, workboardId),
+    {
+      onSuccess: () => {
+        toast.success('작업판이 제거되었습니다.');
+        queryClient.invalidateQueries(['projectWorkboards', projectId]);
+      },
+      onError: (err) => toast.error(err.response?.data?.message || '제거 실패'),
+    }
+  );
+
+  if (isLoading) return <Box display="flex" justifyContent="center" py={4}><CircularProgress /></Box>;
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 2 }}>
+        <Button variant="outlined" startIcon={<TextSnippet />} onClick={() => setPickerOpen(true)}>
+          작업판 추가
+        </Button>
+      </Box>
+      {workboards.length === 0 ? (
+        <Box textAlign="center" py={4}>
+          <Typography variant="body2" color="text.secondary">
+            소속 작업판이 없습니다. 우상단 "작업판 추가" 로 등록하세요.
+          </Typography>
+        </Box>
+      ) : (
+        <Stack spacing={1.5}>
+          {workboards.map((wb) => (
+            <Box
+              key={wb._id}
+              sx={{
+                display: 'flex', alignItems: 'center', gap: 1,
+                p: 1.5, border: 1, borderColor: 'divider', borderRadius: 1,
+                '&:hover': { borderColor: 'primary.main' }
+              }}
+            >
+              <Box sx={{ flex: '1 1 0', minWidth: 0 }}>
+                <Typography variant="subtitle2" noWrap>{wb.name}</Typography>
+                {wb.description && (
+                  <Typography variant="caption" color="text.secondary" noWrap display="block">{wb.description}</Typography>
+                )}
+                <Stack direction="row" spacing={0.5} sx={{ mt: 0.5 }}>
+                  {wb.outputFormat && <Chip label={wb.outputFormat} size="small" variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />}
+                  {wb.serverId?.name && <Chip label={wb.serverId.name} size="small" variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />}
+                  {!wb.isActive && <Chip label="비활성" size="small" color="warning" variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />}
+                </Stack>
+              </Box>
+              <Button
+                size="small"
+                variant="contained"
+                color="success"
+                startIcon={<PlayArrow />}
+                onClick={() => navigate(`${wb.outputFormat === 'text' ? '/prompt-generate' : '/generate'}/${wb._id}?projectId=${projectId}`)}
+              >
+                실행
+              </Button>
+              <IconButton
+                size="small"
+                color="error"
+                onClick={() => {
+                  if (window.confirm('작업판을 프로젝트에서 제거하시겠습니까? (작업판 자체는 삭제되지 않습니다)')) {
+                    removeMutation.mutate(wb._id);
+                  }
+                }}
+              >
+                <DeleteIcon fontSize="small" />
+              </IconButton>
+            </Box>
+          ))}
+        </Stack>
+      )}
+
+      <WorkboardPickerDialog
+        open={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        existingIds={workboards.map((w) => w._id)}
+        onPick={(wbId) => addMutation.mutate(wbId)}
+      />
+    </Box>
+  );
+}
+
+// 모든 작업판 중 골라 프로젝트에 추가하는 다이얼로그 (#396).
+function WorkboardPickerDialog({ open, onClose, existingIds = [], onPick }) {
+  const [search, setSearch] = useState('');
+  const { data, isLoading } = useQuery(
+    ['allWorkboardsForPicker'],
+    () => workboardAPI.getAll(),
+    { enabled: open }
+  );
+  const all = data?.data?.workboards || data?.data?.data?.workboards || [];
+  const filtered = all.filter((wb) => {
+    if (existingIds.includes(wb._id)) return false;
+    if (!search) return true;
+    return wb.name?.toLowerCase().includes(search.toLowerCase());
+  });
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>작업판 추가</DialogTitle>
+      <DialogContent dividers>
+        <TextField
+          size="small"
+          fullWidth
+          placeholder="작업판 검색..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          sx={{ mb: 2 }}
+        />
+        {isLoading ? (
+          <Box display="flex" justifyContent="center" py={2}><CircularProgress size={20} /></Box>
+        ) : filtered.length === 0 ? (
+          <Typography variant="body2" color="text.secondary" textAlign="center" py={2}>
+            추가할 수 있는 작업판이 없습니다.
+          </Typography>
+        ) : (
+          <Stack spacing={1}>
+            {filtered.map((wb) => (
+              <Box
+                key={wb._id}
+                onClick={() => onPick(wb._id)}
+                sx={{
+                  display: 'flex', alignItems: 'center', gap: 1,
+                  p: 1.5, border: 1, borderColor: 'divider', borderRadius: 1,
+                  cursor: 'pointer',
+                  '&:hover': { bgcolor: 'action.hover', borderColor: 'primary.main' }
+                }}
+              >
+                <Box sx={{ flex: '1 1 0', minWidth: 0 }}>
+                  <Typography variant="subtitle2" noWrap>{wb.name}</Typography>
+                  <Stack direction="row" spacing={0.5} sx={{ mt: 0.5 }}>
+                    {wb.outputFormat && <Chip label={wb.outputFormat} size="small" variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />}
+                  </Stack>
+                </Box>
+              </Box>
+            ))}
+          </Stack>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>닫기</Button>
+      </DialogActions>
+    </Dialog>
   );
 }
 
@@ -623,11 +815,12 @@ function ProjectDetail() {
   }
 
   return (
-    <Container maxWidth="xl" sx={{ mt: 4, mb: 4 }}>
+    <Container maxWidth="xl" sx={{ mt: { xs: 2, md: 4 }, mb: { xs: 2, md: 4 }, px: { xs: 1.5, sm: 3 } }}>
       <Button
         startIcon={<ArrowBack />}
         onClick={() => navigate('/projects')}
-        sx={{ mb: 2 }}
+        size="small"
+        sx={{ mb: 1 }}
       >
         프로젝트 목록
       </Button>
@@ -638,9 +831,10 @@ function ProjectDetail() {
           display: 'flex',
           justifyContent: 'space-between',
           alignItems: 'flex-start',
-          mb: 3,
+          gap: 1,
+          mb: { xs: 1.5, md: 3 },
           borderRadius: 2,
-          p: 3,
+          p: { xs: 1.5, md: 3 },
           position: 'relative',
           ...(project.coverImage?.url && {
             backgroundImage: `url(${project.coverImage.url})`,
@@ -657,11 +851,14 @@ function ProjectDetail() {
           })
         }}
       >
-        <Box>
-          <Box display="flex" alignItems="center" gap={1} mb={1}>
-            <Typography variant="h4">{project.name}</Typography>
+        <Box sx={{ minWidth: 0, flex: '1 1 0' }}>
+          <Box display="flex" alignItems="center" gap={0.5} mb={0.5} sx={{ flexWrap: 'wrap' }}>
+            <Typography variant="h5" sx={{ fontSize: { xs: '1.25rem', md: '2rem' }, fontWeight: 600, wordBreak: 'break-word' }}>
+              {project.name}
+            </Typography>
             <Tooltip title={project.isFavorite ? '즐겨찾기 해제' : '즐겨찾기 추가'}>
               <IconButton
+                size="small"
                 onClick={() => favoriteMutation.mutate()}
                 color={project.isFavorite ? 'warning' : 'default'}
               >
@@ -670,12 +867,13 @@ function ProjectDetail() {
             </Tooltip>
           </Box>
           {project.description && (
-            <Typography variant="body1" color="textSecondary" sx={{ mb: 1 }}>
+            <Typography variant="body2" color="textSecondary" sx={{ mb: 1, wordBreak: 'break-word' }}>
               {project.description}
             </Typography>
           )}
-          <Box display="flex" gap={1} alignItems="center">
+          <Box display="flex" gap={0.75} alignItems="center" sx={{ flexWrap: 'wrap' }}>
             <Chip
+              size="small"
               label={project.tagId?.name}
               sx={{ bgcolor: project.tagId?.color || '#7c4dff', color: 'white' }}
             />
@@ -700,15 +898,23 @@ function ProjectDetail() {
           </Box>
         </Box>
 
-        <Box display="flex" gap={1}>
-          <Button
-            variant="contained"
-            startIcon={<ViewModule />}
-            onClick={() => navigate(`/workboards?projectId=${id}`)}
-            size="small"
-          >
-            이미지 생성하기
-          </Button>
+        <Box display="flex" gap={1} sx={{ flexShrink: 0 }}>
+          <Tooltip title="작업판 목록으로 이동">
+            <Button
+              variant="contained"
+              startIcon={<ViewModule />}
+              onClick={() => navigate(`/workboards?projectId=${id}`)}
+              size="small"
+              sx={{
+                whiteSpace: 'nowrap',
+                flexShrink: 0,
+                minWidth: 'auto',
+                '& .MuiButton-startIcon': { mx: { xs: 0, sm: '-4px' }, mr: { xs: 0, sm: 1 } }
+              }}
+            >
+              <Box component="span" sx={{ display: { xs: 'none', sm: 'inline' } }}>작업판 보기</Box>
+            </Button>
+          </Tooltip>
           <IconButton onClick={() => setEditOpen(true)}>
             <Edit />
           </IconButton>
@@ -718,22 +924,55 @@ function ProjectDetail() {
         </Box>
       </Box>
 
-      {/* 탭 */}
-      <Tabs
-        value={tabValue}
-        onChange={(e, v) => setTabValue(v)}
-        sx={{ mb: 1, borderBottom: 1, borderColor: 'divider' }}
+      {/* 탭 — 모바일에서 붕 뜨지 않도록 bgcolor 로 묶고, 컴팩트하게 (#396 후속) */}
+      <Box
+        sx={{
+          borderBottom: 1,
+          borderColor: 'divider',
+          bgcolor: 'background.paper',
+          borderRadius: 1,
+          mb: 0,
+        }}
       >
-        <Tab icon={<TextSnippet />} label="프롬프트 데이터" iconPosition="start" />
-        <Tab icon={<ImageIcon />} label="이미지" iconPosition="start" />
-        <Tab label="텍스트" />
-        <Tab icon={<History />} label="작업 히스토리" iconPosition="start" />
-      </Tabs>
+        <Tabs
+          value={tabValue}
+          onChange={(e, v) => setTabValue(v)}
+          variant="scrollable"
+          scrollButtons={false}
+          sx={{
+            minHeight: { xs: 40, md: 48 },
+            '& .MuiTab-root': {
+              minHeight: { xs: 40, md: 48 },
+              py: { xs: 0.5, md: 1 },
+              px: { xs: 1.5, md: 2 },
+              fontSize: { xs: '0.8125rem', md: '0.875rem' },
+              minWidth: 'auto',
+            },
+            '& .MuiTab-iconWrapper': { mr: 0.5 },
+          }}
+        >
+          <Tab label="작업판" />
+          <Tab label="세계관" />
+          <Tab icon={<TextSnippet fontSize="small" />} label="프롬프트 데이터" iconPosition="start" />
+          <Tab icon={<ImageIcon fontSize="small" />} label="이미지" iconPosition="start" />
+          <Tab icon={<History fontSize="small" />} label="작업 히스토리" iconPosition="start" />
+          <Tab label="대화 히스토리" />
+        </Tabs>
+      </Box>
 
-      {tabValue === 0 && <PromptDataTab projectId={id} />}
-      {tabValue === 1 && <ImagesTab projectId={id} />}
-      {tabValue === 2 && <TextTab />}
-      {tabValue === 3 && <JobsTab projectId={id} />}
+      {tabValue === 0 && <WorkboardsTab projectId={id} />}
+      {tabValue === 1 && <WorldviewTab projectTag={project?.tagId} />}
+      {tabValue === 2 && <PromptDataTab projectId={id} />}
+      {tabValue === 3 && <ImagesTab projectId={id} />}
+      {tabValue === 4 && <JobsTab projectId={id} />}
+      {tabValue === 5 && (
+        <Box sx={{ mt: 2 }}>
+          <ConversationHistoryPanel
+            fetchFn={(params) => projectAPI.getConversations(id, params)}
+            queryKey={`projectConversations-${id}`}
+          />
+        </Box>
+      )}
 
       {/* 편집 다이얼로그 */}
       <ProjectEditDialog

--- a/frontend/src/pages/ProjectDetail.js
+++ b/frontend/src/pages/ProjectDetail.js
@@ -44,6 +44,7 @@ import toast from 'react-hot-toast';
 import { projectAPI, imageAPI, userAPI, promptDataAPI, tagAPI, workboardAPI } from '../services/api';
 import TextContentPanel from '../components/common/TextContentPanel';
 import ConversationHistoryPanel from '../components/common/ConversationHistoryPanel';
+import PipelinePanel from '../components/common/PipelinePanel';
 import MediaGrid from '../components/common/MediaGrid';
 import PromptDataPanel from '../components/common/PromptDataPanel';
 import PromptDataFormDialog from '../components/common/PromptDataFormDialog';
@@ -751,7 +752,20 @@ function ProjectDetail() {
   const { id } = useParams();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  // 탭 위치는 프로젝트별로 localStorage 영속화 (#396 후속) — 다른 프로젝트엔 영향 없음.
+  const TAB_KEY = id ? `vcc.projectDetail.tab.${id}` : '';
+  const TAB_COUNT = 7;
   const [tabValue, setTabValue] = useState(0);
+  React.useEffect(() => {
+    if (!TAB_KEY) return;
+    const stored = parseInt(localStorage.getItem(TAB_KEY), 10);
+    if (!Number.isNaN(stored) && stored >= 0 && stored < TAB_COUNT) {
+      setTabValue(stored);
+    }
+  }, [TAB_KEY]);
+  React.useEffect(() => {
+    if (TAB_KEY) localStorage.setItem(TAB_KEY, String(tabValue));
+  }, [TAB_KEY, tabValue]);
   const [editOpen, setEditOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
 
@@ -952,6 +966,7 @@ function ProjectDetail() {
           }}
         >
           <Tab label="작업판" />
+          <Tab label="파이프라인" />
           <Tab label="세계관" />
           <Tab icon={<TextSnippet fontSize="small" />} label="프롬프트 데이터" iconPosition="start" />
           <Tab icon={<ImageIcon fontSize="small" />} label="이미지" iconPosition="start" />
@@ -961,11 +976,12 @@ function ProjectDetail() {
       </Box>
 
       {tabValue === 0 && <WorkboardsTab projectId={id} />}
-      {tabValue === 1 && <WorldviewTab projectTag={project?.tagId} />}
-      {tabValue === 2 && <PromptDataTab projectId={id} />}
-      {tabValue === 3 && <ImagesTab projectId={id} />}
-      {tabValue === 4 && <JobsTab projectId={id} />}
-      {tabValue === 5 && (
+      {tabValue === 1 && <PipelinePanel projectId={id} />}
+      {tabValue === 2 && <WorldviewTab projectTag={project?.tagId} />}
+      {tabValue === 3 && <PromptDataTab projectId={id} />}
+      {tabValue === 4 && <ImagesTab projectId={id} />}
+      {tabValue === 5 && <JobsTab projectId={id} />}
+      {tabValue === 6 && (
         <Box sx={{ mt: 2 }}>
           <ConversationHistoryPanel
             fetchFn={(params) => projectAPI.getConversations(id, params)}

--- a/frontend/src/pages/PromptGeneration.js
+++ b/frontend/src/pages/PromptGeneration.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Container,
   Typography,
@@ -20,6 +20,7 @@ import { workboardAPI } from '../services/api';
 import PromptGeneratorPanel from '../components/PromptGeneratorPanel';
 import ConversationChatPanel from '../components/common/ConversationChatPanel';
 import WorkboardChatPanel from '../components/common/WorkboardChatPanel';
+import ProjectContextSelector from '../components/common/ProjectContextSelector';
 import toast from 'react-hot-toast';
 
 function PromptGeneration() {
@@ -27,6 +28,17 @@ function PromptGeneration() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const conversationId = searchParams.get('conversationId');
+  const initialProjectId = searchParams.get('projectId') || '';
+
+  // 프로젝트 컨텍스트 / 세계관 토글 (#396)
+  const [projectId, setProjectId] = useState(initialProjectId);
+  const [useWorldview, setUseWorldview] = useState(!!initialProjectId);
+
+  // initialProjectId 가 바뀌면 (다른 작업판으로 이동 시) 동기화
+  useEffect(() => {
+    setProjectId(initialProjectId);
+    setUseWorldview(!!initialProjectId);
+  }, [initialProjectId, workboardId]);
 
   const { data: workboardData, isLoading: workboardLoading, error: workboardError } = useQuery(
     ['workboard', workboardId],
@@ -105,6 +117,16 @@ function PromptGeneration() {
         </Alert>
       )}
 
+      {/* 프로젝트 컨텍스트 / 세계관 토글 (#396). 멀티턴 이어가기 (conversationId 진입) 시엔 숨김 — 이미 첫 턴에 주입됨. */}
+      {!conversationId && (
+        <ProjectContextSelector
+          projectId={projectId}
+          useWorldview={useWorldview}
+          onProjectChange={(v) => { setProjectId(v); if (!v) setUseWorldview(false); else setUseWorldview(true); }}
+          onUseWorldviewChange={setUseWorldview}
+        />
+      )}
+
       {(() => {
         if (conversationId) {
           return <ConversationChatPanel workboard={workboard} conversationId={conversationId} />;
@@ -113,7 +135,13 @@ function PromptGeneration() {
         const conversationMode = !!(workboard.additionalInputFields || [])
           .find((f) => f.name === 'conversation_mode')?.defaultValue;
         if (conversationMode) {
-          return <WorkboardChatPanel workboard={workboard} />;
+          return (
+            <WorkboardChatPanel
+              workboard={workboard}
+              projectId={projectId}
+              useWorldview={useWorldview}
+            />
+          );
         }
         return (
           <PromptGeneratorPanel
@@ -121,6 +149,8 @@ function PromptGeneration() {
             showHeader={false}
             showSystemPrompt={false}
             compact={false}
+            projectId={projectId}
+            useWorldview={useWorldview}
           />
         );
       })()}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -261,6 +261,12 @@ export const projectAPI = {
   getPromptData: (id, params) => api.get(`/projects/${id}/prompt-data`, { params }),
   getJobs: (id, params) => api.get(`/projects/${id}/jobs`, { params }),
   getFavorites: () => api.get('/projects/favorites'),
+  // 작업판 멤버십 (#396)
+  getWorkboards: (id) => api.get(`/projects/${id}/workboards`),
+  addWorkboard: (id, workboardId) => api.post(`/projects/${id}/workboards/${workboardId}`),
+  removeWorkboard: (id, workboardId) => api.delete(`/projects/${id}/workboards/${workboardId}`),
+  // 프로젝트 컨텍스트로 실행된 LLM 대화 (#396)
+  getConversations: (id, params) => api.get(`/projects/${id}/conversations`, { params }),
 };
 
 export const apiKeyAPI = {
@@ -276,6 +282,8 @@ export const tagAPI = {
   delete: (id) => api.delete(`/tags/${id}`),
   search: (params) => api.get('/tags/search', { params }),
   getMy: () => api.get('/tags/my'),
+  // 세계관 역할 태그 — 없으면 자동 생성 (#396)
+  getWorldview: () => api.get('/tags/worldview'),
 };
 
 export default api;

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -269,6 +269,15 @@ export const projectAPI = {
   getConversations: (id, params) => api.get(`/projects/${id}/conversations`, { params }),
 };
 
+// 프로젝트 종속 파이프라인 (#397)
+export const pipelineAPI = {
+  list: (projectId) => api.get(`/projects/${projectId}/pipelines`),
+  get: (projectId, pipelineId) => api.get(`/projects/${projectId}/pipelines/${pipelineId}`),
+  create: (projectId, data) => api.post(`/projects/${projectId}/pipelines`, data),
+  update: (projectId, pipelineId, data) => api.patch(`/projects/${projectId}/pipelines/${pipelineId}`, data),
+  delete: (projectId, pipelineId) => api.delete(`/projects/${projectId}/pipelines/${pipelineId}`),
+};
+
 export const apiKeyAPI = {
   getAll: () => api.get('/apikeys'),
   create: (data) => api.post('/apikeys', data),

--- a/src/migrations/backfillConversationTags.js
+++ b/src/migrations/backfillConversationTags.js
@@ -1,0 +1,35 @@
+const ConversationJob = require('../models/ConversationJob');
+const Project = require('../models/Project');
+
+// projectId 가 있고 tags 가 비어 있는 ConversationJob 들에 프로젝트 태그를 backfill (#397 후속).
+// 태그 기반 필터링 통일을 위함. idempotent.
+async function backfillConversationTags() {
+  const targets = await ConversationJob.find({
+    projectId: { $ne: null, $exists: true },
+    $or: [{ tags: { $exists: false } }, { tags: { $size: 0 } }],
+  }).select('_id projectId').lean();
+
+  if (targets.length === 0) {
+    console.log('[Migration] ConversationJob tags backfill 불필요 (대상 없음)');
+    return;
+  }
+
+  // 프로젝트별 tagId 캐시
+  const projectIdSet = new Set(targets.map((t) => String(t.projectId)));
+  const projects = await Project.find({ _id: { $in: Array.from(projectIdSet) } }).select('_id tagId').lean();
+  const tagByProject = {};
+  for (const p of projects) {
+    if (p.tagId) tagByProject[String(p._id)] = p.tagId;
+  }
+
+  let updated = 0;
+  for (const conv of targets) {
+    const tagId = tagByProject[String(conv.projectId)];
+    if (!tagId) continue;
+    await ConversationJob.updateOne({ _id: conv._id }, { $set: { tags: [tagId] } });
+    updated += 1;
+  }
+  console.log(`[Migration] ConversationJob tags backfill: ${updated}건 처리`);
+}
+
+module.exports = backfillConversationTags;

--- a/src/migrations/ensureWorldviewTag.js
+++ b/src/migrations/ensureWorldviewTag.js
@@ -1,0 +1,37 @@
+const Tag = require('../models/Tag');
+const User = require('../models/User');
+
+// 세계관 (사전 컨텍스트) 역할 태그 자동 시드 (#396).
+// 각 사용자에게 isWorldviewTag=true 인 단일 태그 ("세계관") 가 없으면 생성.
+// idempotent — 이미 있으면 skip.
+async function ensureWorldviewTag() {
+  const users = await User.find({}, { _id: 1 }).lean();
+  let created = 0;
+  for (const user of users) {
+    const existing = await Tag.findOne({ userId: user._id, isWorldviewTag: true });
+    if (existing) continue;
+    // 같은 이름의 일반 태그가 이미 있다면 그것을 isWorldviewTag 로 승격
+    const sameName = await Tag.findOne({ userId: user._id, name: '세계관' });
+    if (sameName) {
+      sameName.isWorldviewTag = true;
+      await sameName.save();
+      created += 1;
+      continue;
+    }
+    await Tag.create({
+      userId: user._id,
+      createdBy: user._id,
+      name: '세계관',
+      color: '#9c27b0',
+      isWorldviewTag: true,
+    });
+    created += 1;
+  }
+  if (created > 0) {
+    console.log(`[Migration] 세계관 태그 시드: ${created}명 처리`);
+  } else {
+    console.log('[Migration] 세계관 태그 시드 불필요 (모두 보유)');
+  }
+}
+
+module.exports = ensureWorldviewTag;

--- a/src/models/ConversationJob.js
+++ b/src/models/ConversationJob.js
@@ -33,11 +33,16 @@ const conversationJobSchema = new mongoose.Schema({
   serverType: String,
   model: String,
   // 프로젝트 컨텍스트 (#396). 실행 시 사용자가 지정한 프로젝트 ID. null 가능.
-  // 프로젝트 작업 히스토리 / 사전 컨텍스트 표시에 사용.
+  // 프로젝트 작업 히스토리 / 사전 컨텍스트 표시에 사용. (#397 후속 — tags 와 함께 보존)
   projectId: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'Project',
   },
+  // 태그 기반 필터링 (이미지 작업과 동일 메커니즘으로 통일). projectId 가 있으면 자동으로 프로젝트 태그 주입.
+  tags: [{
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Tag',
+  }],
   // 합성 전 원본을 분리 저장해 display / audit 용도로 사용 (#396).
   // 실제 LLM 호출엔 둘을 합쳐 system 메시지 1개로 전송하지만, 보존은 분리.
   workboardSystemPrompt: String,

--- a/src/models/ConversationJob.js
+++ b/src/models/ConversationJob.js
@@ -32,6 +32,16 @@ const conversationJobSchema = new mongoose.Schema({
   },
   serverType: String,
   model: String,
+  // 프로젝트 컨텍스트 (#396). 실행 시 사용자가 지정한 프로젝트 ID. null 가능.
+  // 프로젝트 작업 히스토리 / 사전 컨텍스트 표시에 사용.
+  projectId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Project',
+  },
+  // 합성 전 원본을 분리 저장해 display / audit 용도로 사용 (#396).
+  // 실제 LLM 호출엔 둘을 합쳐 system 메시지 1개로 전송하지만, 보존은 분리.
+  workboardSystemPrompt: String,
+  worldviewContext: String,
   messages: [conversationMessageSchema],
   status: {
     type: String,
@@ -58,5 +68,6 @@ const conversationJobSchema = new mongoose.Schema({
 
 conversationJobSchema.index({ userId: 1, createdAt: -1 });
 conversationJobSchema.index({ workboardId: 1, createdAt: -1 });
+conversationJobSchema.index({ projectId: 1, createdAt: -1 });
 
 module.exports = mongoose.model('ConversationJob', conversationJobSchema);

--- a/src/models/Pipeline.js
+++ b/src/models/Pipeline.js
@@ -1,0 +1,63 @@
+const mongoose = require('mongoose');
+
+// 프로젝트 종속 작업판 파이프라인 (#397 Phase 2.A).
+// 직선 (linear) 시퀀스. 분기 / DAG / 영속화 실행은 Phase 2.B 로 분리.
+// 단계의 출력 타입이 다음 단계의 입력 필드 타입과 일치하면 자동 주입 (autoInject).
+
+const pipelineStepSchema = new mongoose.Schema({
+  workboardId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Workboard',
+    required: true,
+  },
+  // 이전 단계 출력을 다음 단계 입력에 자동 주입 여부.
+  // 첫 단계는 의미 없음 (이전 단계가 없으므로). 두번째 단계부터 적용.
+  autoInject: {
+    type: Boolean,
+    default: true,
+  },
+  // 단계별 사전 입력 (#397 후속). 작업판의 customField name → 값 매핑.
+  // 자동 주입되는 필드 (예: 텍스트 결과 → prompt) 는 autoInject 가 우선 덮어씀.
+  inputs: {
+    type: mongoose.Schema.Types.Mixed,
+    default: {},
+  },
+  // 사용자 메모 (단계 설명) — 선택
+  note: String,
+}, { _id: false });
+
+const pipelineSchema = new mongoose.Schema({
+  userId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+  },
+  projectId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Project',
+    required: true,
+  },
+  name: {
+    type: String,
+    required: true,
+    trim: true,
+    maxlength: 100,
+  },
+  description: {
+    type: String,
+    trim: true,
+    maxlength: 500,
+    default: '',
+  },
+  steps: [pipelineStepSchema],
+  // 파이프라인 전체 세계관 사용 토글 — LLM 단계에 적용
+  useWorldview: {
+    type: Boolean,
+    default: true,
+  },
+}, { timestamps: true });
+
+pipelineSchema.index({ projectId: 1, createdAt: -1 });
+pipelineSchema.index({ userId: 1, createdAt: -1 });
+
+module.exports = mongoose.model('Pipeline', pipelineSchema);

--- a/src/models/Project.js
+++ b/src/models/Project.js
@@ -27,7 +27,13 @@ const projectSchema = new mongoose.Schema({
     url: String,
     imageId: mongoose.Schema.Types.ObjectId,
     imageType: { type: String, enum: ['uploaded', 'generated'] }
-  }
+  },
+  // 프로젝트에 속한 작업판 목록 (#396).
+  // 단방향 참조 — 작업판은 자기가 어떤 프로젝트에 속하는지 모름. 한 작업판이 여러 프로젝트에 들어갈 수 있음.
+  workboardIds: [{
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Workboard'
+  }]
 }, {
   timestamps: true
 });

--- a/src/models/Tag.js
+++ b/src/models/Tag.js
@@ -24,6 +24,14 @@ const tagSchema = new mongoose.Schema({
     type: Boolean,
     default: false
   },
+  // 세계관 (사전 컨텍스트) 역할 태그 (#396).
+  // 사용자별 1개 — UploadedText.tags 가 [projectTag, worldviewTag] 두 개를 모두 포함하면
+  // 해당 프로젝트의 세계관 항목으로 인식해 LLM 호출 시 system 메시지의 [배경 / 사전 컨텍스트]
+  // 섹션으로 주입됨.
+  isWorldviewTag: {
+    type: Boolean,
+    default: false
+  },
   createdBy: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'User',

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -15,6 +15,41 @@ const Server = require('../models/Server');
 const { getFieldValueByRole } = require('../utils/customFieldHelpers');
 const { FIELD_ROLES } = require('../constants/fieldRoles');
 const { computeOpenAITextCost, computeGeminiTextCost } = require('../utils/pricing');
+const Project = require('../models/Project');
+const Tag = require('../models/Tag');
+const UploadedText = require('../models/UploadedText');
+
+// 세계관 (사전 컨텍스트) + 작업 지침 → 단일 system 메시지로 합성 (#396).
+// system prompt = LLM 의 역할 / 작업 방침 (작업판 admin 정의)
+// worldview = 프로젝트의 사실 / 컨텍스트 (사용자가 보유)
+function composeSystemPrompt(systemPrompt, worldviewTexts) {
+  const parts = [];
+  if (systemPrompt) {
+    parts.push('[작업 지침]\n' + systemPrompt);
+  }
+  if (worldviewTexts && worldviewTexts.length > 0) {
+    const ctx = worldviewTexts.map((t) => {
+      const head = t.title ? `## ${t.title}\n` : '';
+      return head + (t.content || '');
+    }).join('\n\n---\n\n');
+    parts.push('[배경 / 사전 컨텍스트]\n' + ctx);
+  }
+  return parts.join('\n\n');
+}
+
+// 프로젝트의 세계관 UploadedText 들 로드 (#396).
+async function getProjectWorldview(userId, projectId) {
+  if (!projectId) return [];
+  const project = await Project.findOne({ _id: projectId, userId }).lean();
+  if (!project || !project.tagId) return [];
+  const worldviewTag = await Tag.findOne({ userId, isWorldviewTag: true }).lean();
+  if (!worldviewTag) return [];
+  const texts = await UploadedText.find({
+    userId,
+    tags: { $all: [project.tagId, worldviewTag._id] },
+  }).sort({ createdAt: 1 }).lean();
+  return texts;
+}
 const router = express.Router();
 
 router.post('/generate', requireAuth, async (req, res) => {
@@ -391,7 +426,7 @@ router.post('/:id/cancel', requireAuth, async (req, res) => {
 
 router.post('/generate-prompt', requireAuth, async (req, res) => {
   try {
-    const { workboardId, inputData, conversationId } = req.body;
+    const { workboardId, inputData, conversationId, projectId, useWorldview } = req.body;
 
     if (!workboardId || !inputData?.userPrompt) {
       return res.status(400).json({
@@ -472,16 +507,26 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
       // LLM 에는 전체 시퀀스 전달
       messages = conversation.messages.map((m) => ({ role: m.role, content: m.content }));
     } else {
+      // 신규 대화 — 세계관 (#396) 주입 합성. 멀티턴 이어가기 시엔 기존 system 메시지 보존되므로
+      // 여기서만 합성.
+      const worldviewTexts = useWorldview ? await getProjectWorldview(req.user._id, projectId) : [];
+      const worldviewContext = worldviewTexts.length > 0
+        ? worldviewTexts.map((t) => (t.title ? `## ${t.title}\n` : '') + (t.content || '')).join('\n\n---\n\n')
+        : '';
+      const composedSystem = composeSystemPrompt(systemPrompt, worldviewTexts);
       messages = [];
-      if (systemPrompt) {
-        messages.push({ role: 'system', content: systemPrompt });
+      if (composedSystem) {
+        messages.push({ role: 'system', content: composedSystem });
       }
       messages.push({ role: 'user', content: inputData.userPrompt });
       conversation = await ConversationJob.create({
         userId: req.user._id,
         workboardId: workboard._id,
+        projectId: projectId || undefined,
         serverType: server.serverType,
         model,
+        workboardSystemPrompt: systemPrompt || undefined,
+        worldviewContext: worldviewContext || undefined,
         messages: messages.map((m) => ({ ...m, createdAt: new Date() })),
         status: 'processing',
       });

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -519,10 +519,17 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
         messages.push({ role: 'system', content: composedSystem });
       }
       messages.push({ role: 'user', content: inputData.userPrompt });
+      // 프로젝트 작업 시 자동으로 프로젝트 태그 주입 (이미지 작업과 통일된 필터 메커니즘, #397 후속)
+      let projectTagIds = [];
+      if (projectId) {
+        const projectDoc = await Project.findOne({ _id: projectId, userId: req.user._id }).lean();
+        if (projectDoc?.tagId) projectTagIds = [projectDoc.tagId];
+      }
       conversation = await ConversationJob.create({
         userId: req.user._id,
         workboardId: workboard._id,
         projectId: projectId || undefined,
+        tags: projectTagIds,
         serverType: server.serverType,
         model,
         workboardSystemPrompt: systemPrompt || undefined,

--- a/src/routes/pipelines.js
+++ b/src/routes/pipelines.js
@@ -1,0 +1,141 @@
+const express = require('express');
+const { requireAuth } = require('../middleware/auth');
+const Pipeline = require('../models/Pipeline');
+const Project = require('../models/Project');
+const Workboard = require('../models/Workboard');
+
+const router = express.Router({ mergeParams: true });
+
+// 프로젝트 종속 파이프라인 CRUD (#397). mounted at /api/projects/:projectId/pipelines
+
+async function loadProject(req, res) {
+  const project = await Project.findOne({ _id: req.params.projectId, userId: req.user._id });
+  if (!project) {
+    res.status(404).json({ success: false, message: '프로젝트를 찾을 수 없습니다' });
+    return null;
+  }
+  return project;
+}
+
+// 모든 단계 워크보드가 사용자 소유인지 검증
+async function validateSteps(userId, steps) {
+  if (!Array.isArray(steps) || steps.length === 0) return { ok: false, message: '단계가 비어 있습니다' };
+  const ids = steps.map((s) => s.workboardId).filter(Boolean);
+  if (ids.length !== steps.length) return { ok: false, message: '각 단계에 workboardId 필수' };
+  const wbs = await Workboard.find({ _id: { $in: ids } }).lean();
+  if (wbs.length !== new Set(ids.map(String)).size) {
+    // 일부 id 가 중복일 수 있으므로 unique 비교
+    if (wbs.length === 0) return { ok: false, message: '존재하지 않는 작업판이 있습니다' };
+  }
+  // 권한 검사 — 작업판 자체는 admin / 공용일 수 있으므로 여기선 존재만 확인
+  return { ok: true };
+}
+
+router.get('/', requireAuth, async (req, res) => {
+  try {
+    const project = await loadProject(req, res);
+    if (!project) return;
+    const pipelines = await Pipeline.find({ projectId: project._id, userId: req.user._id })
+      .sort({ createdAt: -1 })
+      .populate('steps.workboardId', 'name description workboardType outputFormat isActive serverId')
+      .lean();
+    res.json({ success: true, data: { pipelines } });
+  } catch (error) {
+    console.error('List pipelines error:', error);
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
+router.get('/:id', requireAuth, async (req, res) => {
+  try {
+    const project = await loadProject(req, res);
+    if (!project) return;
+    const pipeline = await Pipeline.findOne({ _id: req.params.id, projectId: project._id, userId: req.user._id })
+      .populate({
+        path: 'steps.workboardId',
+        select: 'name description workboardType outputFormat isActive serverId additionalInputFields',
+        populate: { path: 'serverId', select: 'name serverType' }
+      })
+      .lean();
+    if (!pipeline) return res.status(404).json({ success: false, message: '파이프라인을 찾을 수 없습니다' });
+    res.json({ success: true, data: { pipeline } });
+  } catch (error) {
+    console.error('Get pipeline error:', error);
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
+router.post('/', requireAuth, async (req, res) => {
+  try {
+    const project = await loadProject(req, res);
+    if (!project) return;
+    const { name, description, steps, useWorldview } = req.body;
+    if (!name?.trim()) return res.status(400).json({ success: false, message: '이름 필수' });
+    if (Array.isArray(steps) && steps.length > 0) {
+      const check = await validateSteps(req.user._id, steps);
+      if (!check.ok) return res.status(400).json({ success: false, message: check.message });
+    }
+    const pipeline = await Pipeline.create({
+      userId: req.user._id,
+      projectId: project._id,
+      name: name.trim(),
+      description: (description || '').trim(),
+      steps: Array.isArray(steps) ? steps.map((s) => ({
+        workboardId: s.workboardId,
+        autoInject: s.autoInject !== false,
+        inputs: (s.inputs && typeof s.inputs === 'object') ? s.inputs : {},
+        note: s.note,
+      })) : [],
+      useWorldview: useWorldview !== false,
+    });
+    res.status(201).json({ success: true, data: { pipeline } });
+  } catch (error) {
+    console.error('Create pipeline error:', error);
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
+router.patch('/:id', requireAuth, async (req, res) => {
+  try {
+    const project = await loadProject(req, res);
+    if (!project) return;
+    const pipeline = await Pipeline.findOne({ _id: req.params.id, projectId: project._id, userId: req.user._id });
+    if (!pipeline) return res.status(404).json({ success: false, message: '파이프라인을 찾을 수 없습니다' });
+    const { name, description, steps, useWorldview } = req.body;
+    if (typeof name === 'string') pipeline.name = name.trim();
+    if (typeof description === 'string') pipeline.description = description.trim();
+    if (typeof useWorldview === 'boolean') pipeline.useWorldview = useWorldview;
+    if (Array.isArray(steps)) {
+      const check = await validateSteps(req.user._id, steps);
+      if (!check.ok) return res.status(400).json({ success: false, message: check.message });
+      pipeline.steps = steps.map((s) => ({
+        workboardId: s.workboardId,
+        autoInject: s.autoInject !== false,
+        inputs: (s.inputs && typeof s.inputs === 'object') ? s.inputs : {},
+        note: s.note,
+      }));
+      // Mixed 타입 (step.inputs) 변경은 mongoose 가 자동 감지 못 함 — 명시 markModified
+      pipeline.markModified('steps');
+    }
+    await pipeline.save();
+    res.json({ success: true, data: { pipeline } });
+  } catch (error) {
+    console.error('Update pipeline error:', error);
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
+router.delete('/:id', requireAuth, async (req, res) => {
+  try {
+    const project = await loadProject(req, res);
+    if (!project) return;
+    const result = await Pipeline.deleteOne({ _id: req.params.id, projectId: project._id, userId: req.user._id });
+    if (result.deletedCount === 0) return res.status(404).json({ success: false, message: '파이프라인을 찾을 수 없습니다' });
+    res.json({ success: true });
+  } catch (error) {
+    console.error('Delete pipeline error:', error);
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
+module.exports = router;

--- a/src/routes/projects.js
+++ b/src/routes/projects.js
@@ -536,7 +536,15 @@ router.get('/:id/conversations', requireAuth, async (req, res) => {
       return res.status(404).json({ success: false, message: '프로젝트를 찾을 수 없습니다' });
     }
     const ConversationJob = require('../models/ConversationJob');
-    const filter = { userId: req.user._id, projectId: project._id };
+    // 통일된 태그 기반 필터 (#397 후속). projectId 또는 tags 가 매칭되는 항목.
+    // 기존 데이터 호환 위해 둘 다 OR 로 검색.
+    const filter = {
+      userId: req.user._id,
+      $or: [
+        { projectId: project._id },
+        { tags: project.tagId },
+      ],
+    };
     const skip = (parseInt(page) - 1) * parseInt(limit);
     const [items, total] = await Promise.all([
       ConversationJob.find(filter)

--- a/src/routes/projects.js
+++ b/src/routes/projects.js
@@ -239,6 +239,55 @@ router.put('/:id', requireAuth, async (req, res) => {
   }
 });
 
+// POST /:id/workboards/:workboardId - 작업판을 프로젝트에 추가 (#396)
+router.post('/:id/workboards/:workboardId', requireAuth, async (req, res) => {
+  try {
+    const project = await Project.findOne({ _id: req.params.id, userId: req.user._id });
+    if (!project) return res.status(404).json({ success: false, message: '프로젝트를 찾을 수 없습니다' });
+    const wbId = req.params.workboardId;
+    if (!project.workboardIds.some((id) => id.toString() === wbId)) {
+      project.workboardIds.push(wbId);
+      await project.save();
+    }
+    res.json({ success: true, data: { workboardIds: project.workboardIds } });
+  } catch (error) {
+    console.error('Add workboard to project error:', error);
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
+// DELETE /:id/workboards/:workboardId - 작업판을 프로젝트에서 제거
+router.delete('/:id/workboards/:workboardId', requireAuth, async (req, res) => {
+  try {
+    const project = await Project.findOne({ _id: req.params.id, userId: req.user._id });
+    if (!project) return res.status(404).json({ success: false, message: '프로젝트를 찾을 수 없습니다' });
+    const wbId = req.params.workboardId;
+    project.workboardIds = project.workboardIds.filter((id) => id.toString() !== wbId);
+    await project.save();
+    res.json({ success: true, data: { workboardIds: project.workboardIds } });
+  } catch (error) {
+    console.error('Remove workboard from project error:', error);
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
+// GET /:id/workboards - 프로젝트의 작업판 목록 (populate)
+router.get('/:id/workboards', requireAuth, async (req, res) => {
+  try {
+    const project = await Project.findOne({ _id: req.params.id, userId: req.user._id })
+      .populate({
+        path: 'workboardIds',
+        select: 'name description workboardType outputFormat isActive serverId',
+        populate: { path: 'serverId', select: 'name serverType' }
+      });
+    if (!project) return res.status(404).json({ success: false, message: '프로젝트를 찾을 수 없습니다' });
+    res.json({ success: true, data: { workboards: project.workboardIds || [] } });
+  } catch (error) {
+    console.error('Project workboards fetch error:', error);
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
 // DELETE /:id - 프로젝트 삭제 (전용 태그 + 관련 아이템 태그 해제)
 router.delete('/:id', requireAuth, async (req, res) => {
   try {
@@ -475,6 +524,43 @@ router.get('/:id/jobs', requireAuth, async (req, res) => {
   } catch (error) {
     console.error('Get project jobs error:', error);
     res.status(500).json({ success: false, message: '프로젝트 작업 히스토리 조회 실패' });
+  }
+});
+
+// GET /:id/conversations - 프로젝트 컨텍스트로 실행된 LLM 대화 히스토리 (#396)
+router.get('/:id/conversations', requireAuth, async (req, res) => {
+  try {
+    const { page = 1, limit = 20 } = req.query;
+    const project = await Project.findOne({ _id: req.params.id, userId: req.user._id });
+    if (!project) {
+      return res.status(404).json({ success: false, message: '프로젝트를 찾을 수 없습니다' });
+    }
+    const ConversationJob = require('../models/ConversationJob');
+    const filter = { userId: req.user._id, projectId: project._id };
+    const skip = (parseInt(page) - 1) * parseInt(limit);
+    const [items, total] = await Promise.all([
+      ConversationJob.find(filter)
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(parseInt(limit))
+        .populate('workboardId', 'name workboardType outputFormat')
+        .lean(),
+      ConversationJob.countDocuments(filter),
+    ]);
+    res.json({
+      success: true,
+      data: {
+        conversations: items,
+        pagination: {
+          current: parseInt(page),
+          pages: Math.ceil(total / parseInt(limit)),
+          total,
+        },
+      },
+    });
+  } catch (error) {
+    console.error('Get project conversations error:', error);
+    res.status(500).json({ success: false, message: error.message });
   }
 });
 

--- a/src/routes/tags.js
+++ b/src/routes/tags.js
@@ -7,6 +7,33 @@ const PromptData = require('../models/PromptData');
 const { escapeRegex } = require('../utils/escapeRegex');
 const router = express.Router();
 
+// 세계관 역할 태그 조회 — 없으면 자동 생성 (#396). 신규 사용자 대응.
+router.get('/worldview', requireAuth, async (req, res) => {
+  try {
+    let tag = await Tag.findOne({ userId: req.user._id, isWorldviewTag: true });
+    if (!tag) {
+      const sameName = await Tag.findOne({ userId: req.user._id, name: '세계관' });
+      if (sameName) {
+        sameName.isWorldviewTag = true;
+        await sameName.save();
+        tag = sameName;
+      } else {
+        tag = await Tag.create({
+          userId: req.user._id,
+          createdBy: req.user._id,
+          name: '세계관',
+          color: '#9c27b0',
+          isWorldviewTag: true,
+        });
+      }
+    }
+    res.json({ tag });
+  } catch (error) {
+    console.error('Worldview tag fetch error:', error);
+    res.status(500).json({ message: error.message });
+  }
+});
+
 router.get('/', requireAuth, async (req, res) => {
   try {
     const { search, limit = 50 } = req.query;

--- a/src/routes/texts.js
+++ b/src/routes/texts.js
@@ -13,8 +13,19 @@ const router = express.Router();
 
 function buildListFilter(req) {
   const filter = { userId: req.user._id };
-  const { tag, search } = req.query;
-  if (tag) filter.tags = tag;
+  const { tag, tags, search } = req.query;
+  // 다중 태그 — AND 조건 (모두 포함). 콤마 분리 또는 배열.
+  // 세계관 조회처럼 [projectTag, worldviewTag] 모두 포함하는 항목을 찾을 때 사용 (#396).
+  let tagList = [];
+  if (tags) {
+    tagList = Array.isArray(tags) ? tags : String(tags).split(',').filter(Boolean);
+  }
+  if (tag) tagList.push(tag);
+  if (tagList.length === 1) {
+    filter.tags = tagList[0];
+  } else if (tagList.length > 1) {
+    filter.tags = { $all: tagList };
+  }
   if (search) {
     const re = new RegExp(search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
     filter.$or = [{ title: re }, { content: re }];

--- a/src/server.js
+++ b/src/server.js
@@ -40,6 +40,7 @@ const assignDefaultGroupToWorkboards = require('./migrations/assignDefaultGroupT
 const backfillCustomFieldRoles = require('./migrations/backfillCustomFieldRoles');
 const dropBaseInputFieldsSchema = require('./migrations/dropBaseInputFieldsSchema');
 const relocateCivitaiApiKey = require('./migrations/relocateCivitaiApiKey');
+const ensureWorldviewTag = require('./migrations/ensureWorldviewTag');
 
 dotenv.config();
 
@@ -204,6 +205,7 @@ const startServer = async () => {
     await backfillCustomFieldRoles();
     await dropBaseInputFieldsSchema();
     await relocateCivitaiApiKey();
+    await ensureWorldviewTag();
 
     // Initialize job queues after database connection
     console.log('Initializing job queues...');

--- a/src/server.js
+++ b/src/server.js
@@ -14,6 +14,7 @@ const imageRoutes = require('./routes/images');
 const jobRoutes = require('./routes/jobs');
 const conversationRoutes = require('./routes/conversations');
 const textRoutes = require('./routes/texts');
+const pipelineRoutes = require('./routes/pipelines');
 const adminRoutes = require('./routes/admin');
 const serverRoutes = require('./routes/servers');
 const promptDataRoutes = require('./routes/promptData');
@@ -41,6 +42,7 @@ const backfillCustomFieldRoles = require('./migrations/backfillCustomFieldRoles'
 const dropBaseInputFieldsSchema = require('./migrations/dropBaseInputFieldsSchema');
 const relocateCivitaiApiKey = require('./migrations/relocateCivitaiApiKey');
 const ensureWorldviewTag = require('./migrations/ensureWorldviewTag');
+const backfillConversationTags = require('./migrations/backfillConversationTags');
 
 dotenv.config();
 
@@ -142,6 +144,7 @@ app.use('/api/servers', serverRoutes);
 app.use('/api/prompt-data', promptDataRoutes);
 app.use('/api/tags', tagRoutes);
 app.use('/api/projects', projectRoutes);
+app.use('/api/projects/:projectId/pipelines', pipelineRoutes);
 app.use('/api/admin/backup', backupRoutes);
 app.use('/api/updatelog', updatelogRoutes);
 app.use('/api/apikeys', apiKeyRoutes);
@@ -206,6 +209,7 @@ const startServer = async () => {
     await dropBaseInputFieldsSchema();
     await relocateCivitaiApiKey();
     await ensureWorldviewTag();
+    await backfillConversationTags();
 
     // Initialize job queues after database connection
     console.log('Initializing job queues...');


### PR DESCRIPTION
## v2.6.0 Release

### 신규 기능
- 프로젝트 세계관 (사전 컨텍스트) + 워크보드 소속 (#396)
- 프로젝트 종속 작업판 파이프라인 (#397)
- 프로젝트 작업 태그 통일 — 프로젝트 컨텍스트로 수행되는 모든 작업이 자동으로 프로젝트 태그를 받음

### 수정 / UI
- ProjectDetail 모바일 헤더 / 탭 / 라벨 정리
- 탭 위치 localStorage 영속화
- 빌더 select placeholder / cache invalidation fix
- 작업판 description / 단계 note 노출

자세한 내용: `docs/updatelogs/v2.md` v2.6.0 섹션.

## Post-merge
- v2.6.0 태그 + GitHub Release
- alpha 는 dev 직결이라 추가 배포 불필요

## Follow-up (계획됨)
- #400 문서 시스템 일반화 (사전 컨텍스트 / 시스템 프롬프트 / 분류 태그)
- #401 파이프라인 문서 선택 (현 ON/OFF 토글 대체)
- #402 작업판 system_prompt 문서 참조 전환 (검토 중)