### PR TITLE
feat: 문서 시스템 일반화 — builtin 태그 name 기반 통일 (#400 Phase 1.C 1차)

### DIFF
--- a/frontend/src/constants/builtinTags.js
+++ b/frontend/src/constants/builtinTags.js
@@ -1,0 +1,18 @@
+// 시스템 인식 builtin 태그 이름 (#400). 백엔드의 src/constants/builtinTags.js 와 sync.
+// flag 가 아닌 name 기반으로 식별. 모든 태그는 동등하게 취급.
+
+export const BUILTIN_TAG_NAMES = Object.freeze({
+  WORLDVIEW: '세계관',
+  SYSTEM_PROMPT: '시스템 프롬프트',
+});
+
+export const BUILTIN_TAG_META = Object.freeze({
+  [BUILTIN_TAG_NAMES.WORLDVIEW]: { label: '세계관', color: '#9c27b0' },
+  [BUILTIN_TAG_NAMES.SYSTEM_PROMPT]: { label: '시스템 프롬프트', color: '#2196f3' },
+});
+
+// 세계관 탭에 표시할 타입 chip 목록 (순서 고정)
+export const BUILTIN_DOC_TYPES = [
+  BUILTIN_TAG_NAMES.WORLDVIEW,
+  BUILTIN_TAG_NAMES.SYSTEM_PROMPT,
+];

--- a/frontend/src/pages/ProjectDetail.js
+++ b/frontend/src/pages/ProjectDetail.js
@@ -45,6 +45,7 @@ import { projectAPI, imageAPI, userAPI, promptDataAPI, tagAPI, workboardAPI } fr
 import TextContentPanel from '../components/common/TextContentPanel';
 import ConversationHistoryPanel from '../components/common/ConversationHistoryPanel';
 import PipelinePanel from '../components/common/PipelinePanel';
+import { BUILTIN_TAG_NAMES } from '../constants/builtinTags';
 import MediaGrid from '../components/common/MediaGrid';
 import PromptDataPanel from '../components/common/PromptDataPanel';
 import PromptDataFormDialog from '../components/common/PromptDataFormDialog';
@@ -539,26 +540,56 @@ function PromptDataTab({ projectId }) {
   );
 }
 
-// 세계관 (사전 컨텍스트) 탭 (#396).
-// UploadedText 중 [projectTag, worldviewTag] 모두 포함하는 항목만 노출.
-// 새 항목 생성 시 두 태그 자동 부여 (TextContentPanel 의 defaultTags).
+// 세계관 (설정 문서) 탭 (#396 → #400 일반화).
+// 프로젝트 + 타입(세계관/시스템 프롬프트/등) 태그 조합으로 문서를 분류.
+// 상단 chip 필터로 타입 전환. 문서 생성 시 현재 타입 태그가 자동 부여됨.
 function WorldviewTab({ projectTag }) {
-  const { data: wvTagData, isLoading } = useQuery('worldviewTag', () => tagAPI.getWorldview(), { staleTime: 60_000 });
+  const { data: wvTagData } = useQuery('worldviewTag', () => tagAPI.getWorldview(), { staleTime: 60_000 });
+  const { data: spTagData } = useQuery('systemPromptTag', () => tagAPI.getSystemPrompt(), { staleTime: 60_000 });
   const worldviewTag = wvTagData?.data?.tag;
-  if (isLoading) return <Box display="flex" justifyContent="center" py={4}><CircularProgress /></Box>;
-  if (!worldviewTag || !projectTag) {
-    return <Alert severity="warning" sx={{ mt: 2 }}>세계관 태그 / 프로젝트 태그를 불러오지 못했습니다.</Alert>;
+  const systemPromptTag = spTagData?.data?.tag;
+
+  // 현재 선택된 타입 — 기본은 세계관
+  const [activeTypeName, setActiveTypeName] = useState(BUILTIN_TAG_NAMES.WORLDVIEW);
+
+  if (!projectTag) {
+    return <Box display="flex" justifyContent="center" py={4}><CircularProgress /></Box>;
   }
+  if (!worldviewTag || !systemPromptTag) {
+    return <Alert severity="warning" sx={{ mt: 2 }}>역할 태그 로딩 중...</Alert>;
+  }
+
+  const typeOptions = [
+    { name: BUILTIN_TAG_NAMES.WORLDVIEW, tag: worldviewTag, hint: '작업판 실행 시 [배경 / 사전 컨텍스트] 로 LLM 에 주입' },
+    { name: BUILTIN_TAG_NAMES.SYSTEM_PROMPT, tag: systemPromptTag, hint: 'LLM 의 역할 / 작업 방침 정의 — 파이프라인 / 작업판이 참조' },
+  ];
+  const activeOption = typeOptions.find((o) => o.name === activeTypeName) || typeOptions[0];
+  const activeTag = activeOption.tag;
+
   return (
     <Box sx={{ mt: 2 }}>
+      {/* 타입 chip 필터 */}
+      <Stack direction="row" spacing={1} sx={{ mb: 1, flexWrap: 'wrap', gap: 1 }}>
+        {typeOptions.map((opt) => (
+          <Chip
+            key={opt.name}
+            label={opt.name}
+            color={activeTypeName === opt.name ? 'primary' : 'default'}
+            variant={activeTypeName === opt.name ? 'filled' : 'outlined'}
+            onClick={() => setActiveTypeName(opt.name)}
+            sx={{ fontWeight: activeTypeName === opt.name ? 600 : 400 }}
+          />
+        ))}
+      </Stack>
+
       <Alert severity="info" sx={{ mb: 2 }}>
-        여기에 작성한 텍스트는 작업판 실행 시 <strong>[배경 / 사전 컨텍스트]</strong> 로 LLM 에 주입됩니다.
-        등장인물 / 배경 / 톤 등 작업판이 알아야 할 사실을 단편으로 나눠 보관하세요.
+        <strong>{activeOption.name}</strong> — {activeOption.hint}
       </Alert>
+
       <TextContentPanel
         kind="uploaded"
-        defaultTags={[projectTag, worldviewTag]}
-        filterTags={[projectTag, worldviewTag]}
+        defaultTags={[projectTag, activeTag]}
+        filterTags={[projectTag, activeTag]}
       />
     </Box>
   );

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -293,6 +293,10 @@ export const tagAPI = {
   getMy: () => api.get('/tags/my'),
   // 세계관 역할 태그 — 없으면 자동 생성 (#396)
   getWorldview: () => api.get('/tags/worldview'),
+  // 시스템 프롬프트 역할 태그 — 없으면 자동 생성 (#400)
+  getSystemPrompt: () => api.get('/tags/system-prompt'),
+  // 임의 name 으로 lookup / 자동 생성 — builtin / custom 무관
+  getByName: (name) => api.get(`/tags/by-name/${encodeURIComponent(name)}`),
 };
 
 export default api;

--- a/src/constants/builtinTags.js
+++ b/src/constants/builtinTags.js
@@ -1,0 +1,16 @@
+// 시스템이 인식하는 well-known 태그 이름 (#400).
+// 특별한 boolean flag 대신 NAME 으로 식별 — 모든 태그는 동등하게 취급되며,
+// 시스템은 특정 역할이 필요할 때 이 상수의 name 으로 사용자의 태그를 조회 / 자동 생성한다.
+
+const BUILTIN_TAG_NAMES = Object.freeze({
+  WORLDVIEW: '세계관',        // 사전 컨텍스트 / 배경 / 인물 등
+  SYSTEM_PROMPT: '시스템 프롬프트', // LLM 작업 지침 문서
+});
+
+// UI 표시용 메타 (한국어 라벨 + 기본 색)
+const BUILTIN_TAG_META = Object.freeze({
+  [BUILTIN_TAG_NAMES.WORLDVIEW]: { label: '세계관', color: '#9c27b0' },
+  [BUILTIN_TAG_NAMES.SYSTEM_PROMPT]: { label: '시스템 프롬프트', color: '#2196f3' },
+});
+
+module.exports = { BUILTIN_TAG_NAMES, BUILTIN_TAG_META };

--- a/src/models/Tag.js
+++ b/src/models/Tag.js
@@ -24,10 +24,8 @@ const tagSchema = new mongoose.Schema({
     type: Boolean,
     default: false
   },
-  // 세계관 (사전 컨텍스트) 역할 태그 (#396).
-  // 사용자별 1개 — UploadedText.tags 가 [projectTag, worldviewTag] 두 개를 모두 포함하면
-  // 해당 프로젝트의 세계관 항목으로 인식해 LLM 호출 시 system 메시지의 [배경 / 사전 컨텍스트]
-  // 섹션으로 주입됨.
+  // @deprecated — #400 에서 일반화. 이제는 name 으로 builtin 태그를 식별 (`'세계관'`).
+  // 기존 데이터 호환 위해 필드 자체는 유지하되 새 코드에서 읽지 않음.
   isWorldviewTag: {
     type: Boolean,
     default: false

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -37,12 +37,14 @@ function composeSystemPrompt(systemPrompt, worldviewTexts) {
   return parts.join('\n\n');
 }
 
-// 프로젝트의 세계관 UploadedText 들 로드 (#396).
+// 프로젝트의 세계관 UploadedText 들 로드 (#396 → #400 일반화).
+// 더 이상 flag (isWorldviewTag) 가 아닌 name 으로 세계관 태그를 조회 — 일반화된 태그 시스템.
+const { BUILTIN_TAG_NAMES } = require('../constants/builtinTags');
 async function getProjectWorldview(userId, projectId) {
   if (!projectId) return [];
   const project = await Project.findOne({ _id: projectId, userId }).lean();
   if (!project || !project.tagId) return [];
-  const worldviewTag = await Tag.findOne({ userId, isWorldviewTag: true }).lean();
+  const worldviewTag = await Tag.findOne({ userId, name: BUILTIN_TAG_NAMES.WORLDVIEW }).lean();
   if (!worldviewTag) return [];
   const texts = await UploadedText.find({
     userId,

--- a/src/routes/projects.js
+++ b/src/routes/projects.js
@@ -277,7 +277,8 @@ router.get('/:id/workboards', requireAuth, async (req, res) => {
     const project = await Project.findOne({ _id: req.params.id, userId: req.user._id })
       .populate({
         path: 'workboardIds',
-        select: 'name description workboardType outputFormat isActive serverId',
+        // additionalInputFields 도 포함 — 파이프라인 빌더의 단계 추가 시 customField 정보 필요 (#400 후속)
+        select: 'name description workboardType outputFormat isActive serverId additionalInputFields',
         populate: { path: 'serverId', select: 'name serverType' }
       });
     if (!project) return res.status(404).json({ success: false, message: '프로젝트를 찾을 수 없습니다' });

--- a/src/routes/tags.js
+++ b/src/routes/tags.js
@@ -7,29 +7,56 @@ const PromptData = require('../models/PromptData');
 const { escapeRegex } = require('../utils/escapeRegex');
 const router = express.Router();
 
-// 세계관 역할 태그 조회 — 없으면 자동 생성 (#396). 신규 사용자 대응.
+// Builtin (well-known name) 태그 조회 / 자동 생성 헬퍼 (#400 — flag-free).
+// 시스템은 특별한 flag 대신 NAME 으로 사용자의 태그를 찾고, 없으면 자동 생성한다.
+async function ensureBuiltinTag(userId, name, color = '#1976d2') {
+  let tag = await Tag.findOne({ userId, name });
+  if (!tag) {
+    tag = await Tag.create({
+      userId,
+      createdBy: userId,
+      name,
+      color,
+    });
+  }
+  return tag;
+}
+
+const { BUILTIN_TAG_NAMES, BUILTIN_TAG_META } = require('../constants/builtinTags');
+
+// 세계관 역할 태그 (#396) — 이제는 단순히 name="세계관" 인 태그 조회/생성 (#400 일반화)
 router.get('/worldview', requireAuth, async (req, res) => {
   try {
-    let tag = await Tag.findOne({ userId: req.user._id, isWorldviewTag: true });
-    if (!tag) {
-      const sameName = await Tag.findOne({ userId: req.user._id, name: '세계관' });
-      if (sameName) {
-        sameName.isWorldviewTag = true;
-        await sameName.save();
-        tag = sameName;
-      } else {
-        tag = await Tag.create({
-          userId: req.user._id,
-          createdBy: req.user._id,
-          name: '세계관',
-          color: '#9c27b0',
-          isWorldviewTag: true,
-        });
-      }
-    }
+    const meta = BUILTIN_TAG_META[BUILTIN_TAG_NAMES.WORLDVIEW];
+    const tag = await ensureBuiltinTag(req.user._id, BUILTIN_TAG_NAMES.WORLDVIEW, meta.color);
     res.json({ tag });
   } catch (error) {
     console.error('Worldview tag fetch error:', error);
+    res.status(500).json({ message: error.message });
+  }
+});
+
+// 시스템 프롬프트 역할 태그 (#400)
+router.get('/system-prompt', requireAuth, async (req, res) => {
+  try {
+    const meta = BUILTIN_TAG_META[BUILTIN_TAG_NAMES.SYSTEM_PROMPT];
+    const tag = await ensureBuiltinTag(req.user._id, BUILTIN_TAG_NAMES.SYSTEM_PROMPT, meta.color);
+    res.json({ tag });
+  } catch (error) {
+    console.error('System prompt tag fetch error:', error);
+    res.status(500).json({ message: error.message });
+  }
+});
+
+// 일반 — name 으로 builtin / custom 무관하게 찾거나 생성
+router.get('/by-name/:name', requireAuth, async (req, res) => {
+  try {
+    const name = req.params.name?.trim();
+    if (!name) return res.status(400).json({ message: 'name 필수' });
+    const tag = await ensureBuiltinTag(req.user._id, name);
+    res.json({ tag });
+  } catch (error) {
+    console.error('Tag by-name fetch error:', error);
     res.status(500).json({ message: error.message });
   }
 });


### PR DESCRIPTION
## Summary
[#400](https://github.com/iceemperor-gcempire/vcc-manager/issues/400) Phase 1.C 첫 슬라이스. 사용자 결정에 따라 **특별 flag 없이 태그 name 기반으로 일반화**.

### 변경
- `src/constants/builtinTags.js` / `frontend/src/constants/builtinTags.js` 신설 — `WORLDVIEW='세계관'`, `SYSTEM_PROMPT='시스템 프롬프트'` 두 builtin 이름 상수화.
- `Tag.isWorldviewTag` flag @deprecated — 새 코드에서 안 읽음. 시스템은 NAME 으로 builtin 태그를 식별.
- `GET /api/tags/system-prompt`, `GET /api/tags/by-name/:name` (lazy create) 추가. `/worldview` 는 동일 lazy create.
- `getProjectWorldview` 가 flag → name 으로 조회.
- **세계관 탭 UI**: 상단 chip 필터 (`세계관` / `시스템 프롬프트`) 로 타입 전환. 선택된 타입의 문서만 표시, 새 문서 생성 시 `[프로젝트 태그, 선택 타입 태그]` 자동 부여.
- **회귀 fix**: 프로젝트 `GET /:id/workboards` populate 에 `additionalInputFields` 추가 — 파이프라인 빌더 단계 추가 시 customField 누락되던 문제.

## Test plan
- [x] 빌드 (--no-cache) 성공
- [x] 세계관 탭 chip 필터 전환 사용자 확인
- [x] 파이프라인 빌더 단계 추가 시 customField 정상 노출 사용자 확인

## Follow-up
- #401 파이프라인 단계에서 문서 picker (현 ON/OFF 토글 대체)
- #402 작업판 system_prompt 문서 참조 전환 (검토 중)

closes #400 (Phase 1.C 1차)