### PR TITLE
feat: 파이프라인 영속 실행 + 백그라운드 + 히스토리 + 부분 retry (#407)

### DIFF
--- a/frontend/src/components/common/PipelinePanel.js
+++ b/frontend/src/components/common/PipelinePanel.js
@@ -39,7 +39,7 @@ import {
 import MetadataFieldInput from './MetadataFieldInput';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import toast from 'react-hot-toast';
-import { pipelineAPI, projectAPI, jobAPI, tagAPI, textAPI } from '../../services/api';
+import { pipelineAPI, pipelineRunAPI, projectAPI, jobAPI, tagAPI, textAPI, workboardAPI } from '../../services/api';
 
 // 프로젝트 종속 작업판 파이프라인 (#397).
 // 단계: 목록 → 빌더 → 실행. 모두 한 패널에서.
@@ -217,12 +217,12 @@ function PipelineBuilder({ projectId, pipelineId, onClose }) {
   );
   const loaded = pipelineData?.data?.data?.pipeline;
 
-  // 프로젝트의 작업판 목록 (단계 선택용)
+  // 전체 작업판 목록 — 단계 picker 가 프로젝트 미가입 작업판도 보여줘야 함 (#407).
   const { data: wbData } = useQuery(
-    ['projectWorkboards', projectId],
-    () => projectAPI.getWorkboards(projectId),
+    ['allWorkboards'],
+    () => workboardAPI.getAll(),
   );
-  const projectWorkboards = wbData?.data?.data?.workboards || [];
+  const allWorkboards = wbData?.data?.workboards || wbData?.data?.data?.workboards || [];
 
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
@@ -488,13 +488,13 @@ function PipelineBuilder({ projectId, pipelineId, onClose }) {
       <Dialog open={pickerOpen} onClose={() => setPickerOpen(false)} maxWidth="sm" fullWidth>
         <DialogTitle>단계 추가 - 작업판 선택</DialogTitle>
         <DialogContent dividers>
-          {projectWorkboards.length === 0 ? (
+          {allWorkboards.length === 0 ? (
             <Alert severity="info">
-              프로젝트에 등록된 작업판이 없습니다. 먼저 "작업판" 탭에서 추가해 주세요.
+              사용 가능한 작업판이 없습니다.
             </Alert>
           ) : (
             <Stack spacing={1}>
-              {projectWorkboards.map((wb) => (
+              {allWorkboards.map((wb) => (
                 <Box
                   key={wb._id}
                   onClick={() => addStep(wb)}
@@ -811,177 +811,92 @@ function StepDocsDialog({ open, projectId, step, onClose, onSave }) {
 }
 
 // 파이프라인 실행 (클라이언트 측 순차 오케스트레이션, #397)
+// 파이프라인 실행 (백엔드 오케스트레이션, #407).
+// "시작" → POST run → runId 받음 → polling 으로 상태 갱신. 페이지 떠나도 백엔드는 계속 실행.
 function PipelineRunner({ projectId, pipelineId, onClose }) {
+  const queryClient = useQueryClient();
   const { data: pipelineData, isLoading } = useQuery(
     ['pipeline', projectId, pipelineId],
     () => pipelineAPI.get(projectId, pipelineId),
     { enabled: !!pipelineId }
   );
   const pipeline = pipelineData?.data?.data?.pipeline;
-  // 프로젝트 tagId — 모든 단계에서 생성되는 작업 / 컨텐츠에 자동 부여 (#397 후속)
-  const { data: projectData } = useQuery(
-    ['project', projectId],
-    () => projectAPI.getById(projectId),
-    { enabled: !!projectId }
-  );
-  const projectTagId = projectData?.data?.data?.project?.tagId?._id || projectData?.data?.data?.project?.tagId;
 
-  // 단계별 상태 / 결과
-  // status: 'pending' | 'running' | 'done' | 'failed' | 'skipped'
-  const [stepStates, setStepStates] = useState([]);
-  const [running, setRunning] = useState(false);
   const [initialPrompt, setInitialPrompt] = useState('');
+  const [runId, setRunId] = useState(null);
 
-  React.useEffect(() => {
-    if (pipeline) {
-      setStepStates((pipeline.steps || []).map(() => ({ status: 'pending', output: null, error: null })));
+  // 활성 run 의 상태 polling
+  const { data: runData } = useQuery(
+    ['pipelineRun', projectId, runId],
+    () => pipelineRunAPI.get(projectId, runId),
+    {
+      enabled: !!runId,
+      refetchInterval: (data) => {
+        const run = data?.data?.data?.run;
+        if (!run) return 3000;
+        if (run.status === 'pending' || run.status === 'running') return 2000;
+        return false; // 종료된 run 은 더 이상 polling 안 함
+      },
     }
-  }, [pipeline]);
+  );
+  const run = runData?.data?.data?.run;
 
-  // 단계 입력 빌드 (#397 후속):
-  // 1. step.inputs 의 사전 입력값으로 시작
-  // 2. 자동 주입 — 첫 단계는 initialPrompt, 그 외 단계는 prevOutput 으로 prompt/image 필드 덮어씀
-  const buildStepInput = (workboard, prevOutput, stepInputs, stepIdx) => {
-    const inputData = { ...(stepInputs || {}) };
-
-    // userPrompt 는 LLM 작업판의 텍스트 입력 키. 사전 입력에 없으면 기본 빈 문자열.
-    if (inputData.userPrompt == null) inputData.userPrompt = '';
-
-    if (stepIdx === 0) {
-      // 첫 단계 — 사용자 초기 프롬프트로 텍스트 필드 덮어쓰기
-      inputData.userPrompt = initialPrompt;
-      const promptField = (workboard.additionalInputFields || []).find(
-        (f) => f.name === 'prompt' || f.name === 'userPrompt'
-      );
-      if (promptField) inputData[promptField.name] = initialPrompt;
-    } else if (prevOutput) {
-      if (prevOutput.type === 'text') {
-        inputData.userPrompt = prevOutput.value;
-        const promptField = (workboard.additionalInputFields || []).find(
-          (f) => f.name === 'prompt' || f.name === 'userPrompt'
-        );
-        if (promptField) inputData[promptField.name] = prevOutput.value;
-      } else if (prevOutput.type === 'image' && prevOutput.imageIds?.length > 0) {
-        const imgField = (workboard.additionalInputFields || []).find((f) => f.type === 'image');
-        if (imgField) {
-          inputData[imgField.name] = prevOutput.imageIds.map((id) => ({ imageId: id }));
+  const startMutation = useMutation(
+    (payload) => pipelineRunAPI.start(projectId, payload),
+    {
+      onSuccess: (response) => {
+        const newRunId = response.data?.data?.run?._id;
+        if (newRunId) {
+          setRunId(newRunId);
+          queryClient.invalidateQueries(['pipelineRuns', projectId]);
         }
-      }
+      },
+      onError: (err) => toast.error(err.response?.data?.message || '시작 실패'),
     }
-    return inputData;
-  };
+  );
 
-  const runStep = async (stepIdx, prevOutput) => {
-    const step = pipeline.steps[stepIdx];
-    const wb = step.workboardId;
-    if (!wb || wb.isActive === false) {
-      throw new Error(`작업판이 비활성 또는 삭제됨`);
+  const retryMutation = useMutation(
+    ({ fromStep }) => pipelineRunAPI.retry(projectId, runId, { fromStep }),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['pipelineRun', projectId, runId]);
+        queryClient.invalidateQueries(['pipelineRuns', projectId]);
+        toast.success('재시작 요청됨');
+      },
+      onError: (err) => toast.error(err.response?.data?.message || '재시작 실패'),
     }
-    const inputData = buildStepInput(wb, prevOutput, step.inputs, stepIdx);
+  );
 
-    if (wb.outputFormat === 'text') {
-      // 텍스트 작업판 — prompt-generate. 단계별 doc IDs 전달 (#401):
-      //   - contextDocIds: 사전 컨텍스트 문서들 → [배경 / 사전 컨텍스트] 섹션
-      //   - systemPromptDocId: 시스템 프롬프트 문서 → [작업 지침] 섹션 (작업판 system_prompt 보다 우선)
-      // projectId 는 모든 단계에 전달 — 백엔드가 ConversationJob.tags 에 프로젝트 태그 자동 주입.
-      const response = await jobAPI.createPromptJob({
-        workboardId: wb._id,
-        projectId: projectId || undefined,
-        contextDocIds: step.contextDocIds || [],
-        systemPromptDocId: step.systemPromptDocId || undefined,
-        inputData,
-      });
-      return { type: 'text', value: response.data.result, conversationId: response.data.conversationId };
-    } else {
-      // 이미지 / 영상 — 기존 /api/jobs/generate. 결과 폴링 필요.
-      // 프로젝트 태그를 inputData.tags 에 주입 — ImageGenerationJob / GeneratedImage 모두에 전파됨.
-      const mergedTags = Array.isArray(inputData.tags) ? [...inputData.tags] : [];
-      if (projectTagId && !mergedTags.some((t) => String(t) === String(projectTagId))) {
-        mergedTags.push(projectTagId);
-      }
-      const createResp = await jobAPI.create({
-        workboardId: wb._id,
-        prompt: inputData.userPrompt || '',
-        ...inputData,
-        tags: mergedTags,
-      });
-      const jobId = createResp.data.job?.id;
-      if (!jobId) throw new Error('작업 ID 를 받지 못했습니다');
-
-      // 폴링 — 최대 5분 (60회 × 5초). 첫 MVP 단순 구현.
-      for (let i = 0; i < 60; i++) {
-        await new Promise((r) => setTimeout(r, 5000));
-        const jobResp = await jobAPI.getById(jobId);
-        const job = jobResp.data.job;
-        if (job.status === 'completed') {
-          if (wb.outputFormat === 'image') {
-            const imageIds = (job.resultImages || []).map((img) => img._id);
-            return { type: 'image', imageIds, jobId };
-          }
-          return { type: wb.outputFormat, jobId };
-        }
-        if (job.status === 'failed') {
-          throw new Error(job.errorMessage || '작업 실패');
-        }
-      }
-      throw new Error('작업이 시간 내 완료되지 않음 (5분 초과)');
-    }
-  };
-
-  const handleRun = async () => {
-    if (!pipeline || pipeline.steps.length === 0) return;
+  const handleStart = () => {
     if (!initialPrompt.trim()) {
       toast.error('첫 단계의 입력 프롬프트를 입력해 주세요.');
       return;
     }
-    setRunning(true);
-    let prevOutput = null;
-    const newStates = pipeline.steps.map(() => ({ status: 'pending', output: null, error: null }));
-    setStepStates(newStates);
-
-    for (let i = 0; i < pipeline.steps.length; i++) {
-      newStates[i] = { ...newStates[i], status: 'running' };
-      setStepStates([...newStates]);
-      try {
-        const stepAutoInject = i === 0 ? false : (pipeline.steps[i].autoInject !== false);
-        const inputPrev = stepAutoInject ? prevOutput : null;
-        const result = await runStep(i, inputPrev);
-        newStates[i] = { status: 'done', output: result, error: null };
-        setStepStates([...newStates]);
-        prevOutput = result;
-      } catch (err) {
-        newStates[i] = { status: 'failed', output: null, error: err.response?.data?.message || err.message };
-        setStepStates([...newStates]);
-        // 나머지 단계는 skipped
-        for (let j = i + 1; j < pipeline.steps.length; j++) {
-          newStates[j] = { ...newStates[j], status: 'skipped' };
-        }
-        setStepStates([...newStates]);
-        toast.error(`${i + 1}단계 실패: ${err.message}`);
-        break;
-      }
-    }
-    setRunning(false);
+    startMutation.mutate({ pipelineId, initialPrompt });
   };
 
   if (isLoading || !pipeline) {
     return <Box display="flex" justifyContent="center" py={4}><CircularProgress /></Box>;
   }
 
+  const isActive = run && (run.status === 'pending' || run.status === 'running');
+  const isCompleted = run && run.status === 'completed';
+  const isFailed = run && run.status === 'failed';
+  const firstFailedIdx = run ? (run.steps || []).findIndex((s) => s.status === 'failed') : -1;
+
   return (
     <Box sx={{ mt: 2 }}>
       <Box display="flex" alignItems="center" gap={1} mb={2}>
         <Typography variant="h6">{pipeline.name} 실행</Typography>
         <Box sx={{ flexGrow: 1 }} />
-        <Button onClick={onClose} disabled={running}>닫기</Button>
+        <Button onClick={onClose}>닫기</Button>
       </Box>
 
       <Stack spacing={2}>
         <Alert severity="info">
-          첫 단계의 입력 프롬프트를 입력하고 "시작" 을 누르세요. 각 단계가 순차로 실행되며,
-          이전 단계의 결과가 다음 단계의 입력에 자동으로 매핑됩니다.
+          첫 단계의 입력 프롬프트를 입력하고 "시작" 을 누르세요.
+          실행은 백엔드 백그라운드에서 진행되므로 페이지를 떠나도 계속됩니다 — 파이프라인 히스토리 탭에서 결과 / 재실행 가능.
           {' 각 LLM 단계는 빌더에서 연결한 사전 컨텍스트 / 시스템 프롬프트 문서를 사용합니다.'}
-          {' '}이 페이지를 떠나면 실행이 중단됩니다.
         </Alert>
 
         <TextField
@@ -992,86 +907,340 @@ function PipelineRunner({ projectId, pipelineId, onClose }) {
           multiline
           minRows={2}
           fullWidth
-          disabled={running}
+          disabled={isActive || !!runId}
         />
 
-        <Box>
-          <Button
-            variant="contained"
-            color="success"
-            startIcon={running ? <CircularProgress size={18} color="inherit" /> : <PlayArrowIcon />}
-            onClick={handleRun}
-            disabled={running || !initialPrompt.trim()}
-          >
-            {running ? '실행 중...' : '시작'}
-          </Button>
+        <Box display="flex" gap={1}>
+          {!runId && (
+            <Button
+              variant="contained"
+              color="success"
+              startIcon={startMutation.isLoading ? <CircularProgress size={18} color="inherit" /> : <PlayArrowIcon />}
+              onClick={handleStart}
+              disabled={startMutation.isLoading || !initialPrompt.trim()}
+            >
+              시작
+            </Button>
+          )}
+          {runId && isFailed && firstFailedIdx >= 0 && (
+            <Button
+              variant="contained"
+              color="warning"
+              startIcon={<PlayArrowIcon />}
+              onClick={() => retryMutation.mutate({ fromStep: firstFailedIdx })}
+              disabled={retryMutation.isLoading}
+            >
+              {firstFailedIdx + 1}단계부터 재시작
+            </Button>
+          )}
+          {runId && isCompleted && (
+            <Button
+              variant="outlined"
+              onClick={() => { setRunId(null); setInitialPrompt(''); }}
+            >
+              새 실행
+            </Button>
+          )}
+          {runId && (
+            <Chip
+              label={run?.status === 'pending' ? '대기' : run?.status === 'running' ? '진행 중' : run?.status === 'completed' ? '완료' : run?.status === 'failed' ? '실패' : run?.status}
+              color={run?.status === 'completed' ? 'success' : run?.status === 'failed' ? 'error' : 'default'}
+            />
+          )}
         </Box>
 
-        <Stepper activeStep={stepStates.findIndex((s) => s.status === 'running')} orientation="vertical">
-          {(pipeline.steps || []).map((step, idx) => {
-            const state = stepStates[idx] || { status: 'pending' };
-            return (
-              <Step key={idx} active expanded={state.status !== 'pending'}>
-                <StepLabel
-                  icon={
-                    state.status === 'done' ? <CheckCircleIcon color="success" />
-                    : state.status === 'failed' ? <ErrorIcon color="error" />
-                    : state.status === 'running' ? <CircularProgress size={20} />
-                    : state.status === 'skipped' ? <StopIcon color="disabled" />
-                    : <Chip label={idx + 1} size="small" />
-                  }
-                >
-                  <Typography variant="subtitle2">
-                    {step.workboardId?.name || '(작업판)'}
-                  </Typography>
-                  {step.workboardId?.description && (
-                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', whiteSpace: 'pre-wrap' }}>
-                      {step.workboardId.description}
+        {run && (
+          <Stepper activeStep={(run.steps || []).findIndex((s) => s.status === 'running')} orientation="vertical">
+            {(pipeline.steps || []).map((step, idx) => {
+              const runStep = run.steps?.[idx] || { status: 'pending' };
+              return (
+                <Step key={idx} active expanded={runStep.status !== 'pending'}>
+                  <StepLabel
+                    icon={
+                      runStep.status === 'completed' ? <CheckCircleIcon color="success" />
+                      : runStep.status === 'failed' ? <ErrorIcon color="error" />
+                      : runStep.status === 'running' ? <CircularProgress size={20} />
+                      : runStep.status === 'skipped' ? <StopIcon color="disabled" />
+                      : <Chip label={idx + 1} size="small" />
+                    }
+                  >
+                    <Typography variant="subtitle2">
+                      {step.workboardId?.name || '(작업판)'}
                     </Typography>
-                  )}
-                  {step.workboardId?.outputFormat && (
-                    <Typography variant="caption" color="text.secondary">
-                      출력: {step.workboardId.outputFormat}
-                    </Typography>
-                  )}
-                </StepLabel>
-                <StepContent>
-                  {step.note && (
-                    <Typography variant="body2" color="text.secondary" sx={{ mb: 1, whiteSpace: 'pre-wrap', fontStyle: 'italic' }}>
-                      {step.note}
-                    </Typography>
-                  )}
-                  {state.status === 'done' && state.output && (
-                    <Paper variant="outlined" sx={{ p: 1.5, bgcolor: 'rgba(76, 175, 80, 0.08)' }}>
-                      <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
-                        결과 ({state.output.type})
+                    {step.workboardId?.description && (
+                      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', whiteSpace: 'pre-wrap' }}>
+                        {step.workboardId.description}
                       </Typography>
-                      {state.output.type === 'text' && (
-                        <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', maxHeight: 200, overflow: 'auto' }}>
-                          {state.output.value}
+                    )}
+                    {step.workboardId?.outputFormat && (
+                      <Typography variant="caption" color="text.secondary">
+                        출력: {step.workboardId.outputFormat}
+                      </Typography>
+                    )}
+                  </StepLabel>
+                  <StepContent>
+                    {step.note && (
+                      <Typography variant="body2" color="text.secondary" sx={{ mb: 1, whiteSpace: 'pre-wrap', fontStyle: 'italic' }}>
+                        {step.note}
+                      </Typography>
+                    )}
+                    {runStep.status === 'completed' && runStep.output && (
+                      <Paper variant="outlined" sx={{ p: 1.5, bgcolor: 'rgba(76, 175, 80, 0.08)' }}>
+                        <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
+                          결과 ({runStep.output.type})
                         </Typography>
-                      )}
-                      {state.output.type === 'image' && (
-                        <Typography variant="caption" color="text.secondary">
-                          이미지 {state.output.imageIds?.length || 0}개 생성됨
-                        </Typography>
-                      )}
-                    </Paper>
-                  )}
-                  {state.status === 'failed' && (
-                    <Alert severity="error" sx={{ mb: 1 }}>
-                      {state.error}
-                    </Alert>
-                  )}
-                  {state.status === 'skipped' && (
-                    <Typography variant="caption" color="text.secondary">건너뜀</Typography>
-                  )}
-                </StepContent>
-              </Step>
-            );
-          })}
-        </Stepper>
+                        {runStep.output.type === 'text' && (
+                          <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', maxHeight: 200, overflow: 'auto' }}>
+                            {runStep.output.value}
+                          </Typography>
+                        )}
+                        {runStep.output.type === 'image' && (
+                          <Typography variant="caption" color="text.secondary">
+                            이미지 {runStep.output.imageIds?.length || 0}개 생성됨
+                          </Typography>
+                        )}
+                      </Paper>
+                    )}
+                    {runStep.status === 'failed' && (
+                      <Alert severity="error" sx={{ mb: 1 }}>
+                        {runStep.error?.message || '실패'}
+                      </Alert>
+                    )}
+                    {runStep.status === 'skipped' && (
+                      <Typography variant="caption" color="text.secondary">건너뜀</Typography>
+                    )}
+                  </StepContent>
+                </Step>
+              );
+            })}
+          </Stepper>
+        )}
       </Stack>
+    </Box>
+  );
+}
+
+// 파이프라인 히스토리 패널 (#407). 프로젝트 상세 탭에서 사용.
+export function PipelineHistoryPanel({ projectId }) {
+  const queryClient = useQueryClient();
+  const [selectedRunId, setSelectedRunId] = useState(null);
+
+  const { data, isLoading } = useQuery(
+    ['pipelineRuns', projectId],
+    () => pipelineRunAPI.list(projectId, { limit: 50 }),
+    { refetchInterval: 5000 }
+  );
+  const runs = data?.data?.data?.runs || [];
+
+  const { data: detailData } = useQuery(
+    ['pipelineRun', projectId, selectedRunId],
+    () => pipelineRunAPI.get(projectId, selectedRunId),
+    {
+      enabled: !!selectedRunId,
+      refetchInterval: (data) => {
+        const run = data?.data?.data?.run;
+        if (!run) return 3000;
+        return (run.status === 'pending' || run.status === 'running') ? 2000 : false;
+      },
+    }
+  );
+  const detail = detailData?.data?.data?.run;
+
+  const retryMutation = useMutation(
+    ({ runId, fromStep }) => pipelineRunAPI.retry(projectId, runId, { fromStep }),
+    {
+      onSuccess: (_, vars) => {
+        queryClient.invalidateQueries(['pipelineRuns', projectId]);
+        queryClient.invalidateQueries(['pipelineRun', projectId, vars.runId]);
+        toast.success('재시작 요청됨');
+      },
+      onError: (err) => toast.error(err.response?.data?.message || '재시작 실패'),
+    }
+  );
+
+  const deleteMutation = useMutation(
+    (id) => pipelineRunAPI.delete(projectId, id),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['pipelineRuns', projectId]);
+        if (selectedRunId) setSelectedRunId(null);
+        toast.success('삭제되었습니다.');
+      },
+      onError: (err) => toast.error(err.response?.data?.message || '삭제 실패'),
+    }
+  );
+
+  if (selectedRunId && detail) {
+    const firstFailedIdx = (detail.steps || []).findIndex((s) => s.status === 'failed');
+    return (
+      <Box sx={{ mt: 2 }}>
+        <Box display="flex" alignItems="center" gap={1} mb={2}>
+          <Button onClick={() => setSelectedRunId(null)}>← 목록</Button>
+          <Typography variant="h6">{detail.pipelineId?.name || '(파이프라인)'}</Typography>
+          <Chip
+            label={detail.status === 'pending' ? '대기' : detail.status === 'running' ? '진행 중' : detail.status === 'completed' ? '완료' : detail.status === 'failed' ? '실패' : detail.status}
+            color={detail.status === 'completed' ? 'success' : detail.status === 'failed' ? 'error' : 'default'}
+          />
+          <Box sx={{ flexGrow: 1 }} />
+          {detail.status === 'failed' && firstFailedIdx >= 0 && (
+            <Button
+              variant="contained"
+              color="warning"
+              startIcon={<PlayArrowIcon />}
+              onClick={() => retryMutation.mutate({ runId: selectedRunId, fromStep: firstFailedIdx })}
+              disabled={retryMutation.isLoading}
+            >
+              {firstFailedIdx + 1}단계부터 재시작
+            </Button>
+          )}
+        </Box>
+        <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1 }}>
+          {detail.startedAt ? `시작: ${new Date(detail.startedAt).toLocaleString('ko-KR')}` : ''}
+          {detail.completedAt ? ` · 종료: ${new Date(detail.completedAt).toLocaleString('ko-KR')}` : ''}
+          {detail.triggerCount > 1 ? ` · 재시도 ${detail.triggerCount - 1}회` : ''}
+        </Typography>
+        {detail.initialPrompt && (
+          <Paper variant="outlined" sx={{ p: 1.5, mb: 2, bgcolor: 'grey.50' }}>
+            <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
+              초기 프롬프트
+            </Typography>
+            <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
+              {detail.initialPrompt}
+            </Typography>
+          </Paper>
+        )}
+        <Stepper activeStep={(detail.steps || []).findIndex((s) => s.status === 'running')} orientation="vertical">
+          {(detail.steps || []).map((runStep, idx) => (
+            <Step key={idx} active expanded>
+              <StepLabel
+                icon={
+                  runStep.status === 'completed' ? <CheckCircleIcon color="success" />
+                  : runStep.status === 'failed' ? <ErrorIcon color="error" />
+                  : runStep.status === 'running' ? <CircularProgress size={20} />
+                  : runStep.status === 'skipped' ? <StopIcon color="disabled" />
+                  : <Chip label={idx + 1} size="small" />
+                }
+              >
+                <Typography variant="subtitle2">
+                  {runStep.workboardId?.name || '(작업판)'}
+                </Typography>
+                {runStep.workboardId?.outputFormat && (
+                  <Typography variant="caption" color="text.secondary">
+                    출력: {runStep.workboardId.outputFormat}
+                  </Typography>
+                )}
+              </StepLabel>
+              <StepContent>
+                {runStep.status === 'completed' && runStep.output && (
+                  <Paper variant="outlined" sx={{ p: 1.5, bgcolor: 'rgba(76, 175, 80, 0.08)' }}>
+                    <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
+                      결과 ({runStep.output.type})
+                    </Typography>
+                    {runStep.output.type === 'text' && (
+                      <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', maxHeight: 200, overflow: 'auto' }}>
+                        {runStep.output.value}
+                      </Typography>
+                    )}
+                    {runStep.output.type === 'image' && (
+                      <Typography variant="caption" color="text.secondary">
+                        이미지 {runStep.output.imageIds?.length || 0}개 생성됨
+                      </Typography>
+                    )}
+                  </Paper>
+                )}
+                {runStep.status === 'failed' && (
+                  <Alert severity="error">{runStep.error?.message || '실패'}</Alert>
+                )}
+                {runStep.status === 'skipped' && (
+                  <Typography variant="caption" color="text.secondary">건너뜀</Typography>
+                )}
+              </StepContent>
+            </Step>
+          ))}
+        </Stepper>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      {isLoading ? (
+        <Box display="flex" justifyContent="center" py={4}><CircularProgress /></Box>
+      ) : runs.length === 0 ? (
+        <Box textAlign="center" py={4}>
+          <Typography variant="body2" color="text.secondary">
+            아직 실행 기록이 없습니다. 파이프라인 탭에서 "실행" 으로 시작하세요.
+          </Typography>
+        </Box>
+      ) : (
+        <Stack spacing={1}>
+          {runs.map((r) => (
+            <Card key={r._id} variant="outlined">
+              <CardContent sx={{ pb: 1 }}>
+                <Box display="flex" alignItems="center" gap={1} sx={{ mb: 0.5, flexWrap: 'wrap' }}>
+                  <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                    {r.pipelineId?.name || '(파이프라인)'}
+                  </Typography>
+                  <Chip
+                    label={r.status === 'pending' ? '대기' : r.status === 'running' ? '진행 중' : r.status === 'completed' ? '완료' : r.status === 'failed' ? '실패' : r.status}
+                    size="small"
+                    color={r.status === 'completed' ? 'success' : r.status === 'failed' ? 'error' : r.status === 'running' ? 'primary' : 'default'}
+                  />
+                  {r.triggerCount > 1 && (
+                    <Chip label={`재시도 ${r.triggerCount - 1}회`} size="small" variant="outlined" />
+                  )}
+                  <Box sx={{ flexGrow: 1 }} />
+                  <Typography variant="caption" color="text.secondary">
+                    {new Date(r.createdAt).toLocaleString('ko-KR')}
+                  </Typography>
+                </Box>
+                {r.initialPrompt && (
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{
+                      overflow: 'hidden', textOverflow: 'ellipsis',
+                      display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical',
+                    }}
+                  >
+                    {r.initialPrompt}
+                  </Typography>
+                )}
+                <Stack direction="row" spacing={0.5} flexWrap="wrap" sx={{ mt: 0.5 }}>
+                  {(r.steps || []).map((s, idx) => (
+                    <Chip
+                      key={idx}
+                      label={idx + 1}
+                      size="small"
+                      color={
+                        s.status === 'completed' ? 'success'
+                        : s.status === 'failed' ? 'error'
+                        : s.status === 'running' ? 'primary'
+                        : s.status === 'skipped' ? 'default'
+                        : 'default'
+                      }
+                      variant={s.status === 'pending' ? 'outlined' : 'filled'}
+                      sx={{ height: 22, minWidth: 22 }}
+                    />
+                  ))}
+                </Stack>
+              </CardContent>
+              <CardActions sx={{ pt: 0, justifyContent: 'flex-end' }}>
+                <Button size="small" onClick={() => setSelectedRunId(r._id)}>상세</Button>
+                <IconButton
+                  size="small"
+                  color="error"
+                  onClick={() => {
+                    if (window.confirm('이 실행 기록을 삭제하시겠어요?')) deleteMutation.mutate(r._id);
+                  }}
+                >
+                  <DeleteIcon fontSize="small" />
+                </IconButton>
+              </CardActions>
+            </Card>
+          ))}
+        </Stack>
+      )}
     </Box>
   );
 }

--- a/frontend/src/pages/ProjectDetail.js
+++ b/frontend/src/pages/ProjectDetail.js
@@ -44,7 +44,7 @@ import toast from 'react-hot-toast';
 import { projectAPI, imageAPI, userAPI, promptDataAPI, tagAPI, workboardAPI } from '../services/api';
 import TextContentPanel from '../components/common/TextContentPanel';
 import ConversationHistoryPanel from '../components/common/ConversationHistoryPanel';
-import PipelinePanel from '../components/common/PipelinePanel';
+import PipelinePanel, { PipelineHistoryPanel } from '../components/common/PipelinePanel';
 import { BUILTIN_TAG_NAMES } from '../constants/builtinTags';
 import MediaGrid from '../components/common/MediaGrid';
 import PromptDataPanel from '../components/common/PromptDataPanel';
@@ -785,7 +785,7 @@ function ProjectDetail() {
   const queryClient = useQueryClient();
   // 탭 위치는 프로젝트별로 localStorage 영속화 (#396 후속) — 다른 프로젝트엔 영향 없음.
   const TAB_KEY = id ? `vcc.projectDetail.tab.${id}` : '';
-  const TAB_COUNT = 7;
+  const TAB_COUNT = 6;
   const [tabValue, setTabValue] = useState(0);
   React.useEffect(() => {
     if (!TAB_KEY) return;
@@ -996,23 +996,21 @@ function ProjectDetail() {
             '& .MuiTab-iconWrapper': { mr: 0.5 },
           }}
         >
-          <Tab label="작업판" />
           <Tab label="파이프라인" />
           <Tab label="세계관" />
           <Tab icon={<TextSnippet fontSize="small" />} label="프롬프트 데이터" iconPosition="start" />
           <Tab icon={<ImageIcon fontSize="small" />} label="이미지" iconPosition="start" />
-          <Tab icon={<History fontSize="small" />} label="작업 히스토리" iconPosition="start" />
+          <Tab icon={<History fontSize="small" />} label="파이프라인 히스토리" iconPosition="start" />
           <Tab label="대화 히스토리" />
         </Tabs>
       </Box>
 
-      {tabValue === 0 && <WorkboardsTab projectId={id} />}
-      {tabValue === 1 && <PipelinePanel projectId={id} />}
-      {tabValue === 2 && <WorldviewTab projectTag={project?.tagId} />}
-      {tabValue === 3 && <PromptDataTab projectId={id} />}
-      {tabValue === 4 && <ImagesTab projectId={id} />}
-      {tabValue === 5 && <JobsTab projectId={id} />}
-      {tabValue === 6 && (
+      {tabValue === 0 && <PipelinePanel projectId={id} />}
+      {tabValue === 1 && <WorldviewTab projectTag={project?.tagId} />}
+      {tabValue === 2 && <PromptDataTab projectId={id} />}
+      {tabValue === 3 && <ImagesTab projectId={id} />}
+      {tabValue === 4 && <PipelineHistoryPanel projectId={id} />}
+      {tabValue === 5 && (
         <Box sx={{ mt: 2 }}>
           <ConversationHistoryPanel
             fetchFn={(params) => projectAPI.getConversations(id, params)}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -278,6 +278,15 @@ export const pipelineAPI = {
   delete: (projectId, pipelineId) => api.delete(`/projects/${projectId}/pipelines/${pipelineId}`),
 };
 
+// 파이프라인 실행 영속 (#407)
+export const pipelineRunAPI = {
+  list: (projectId, params) => api.get(`/projects/${projectId}/pipeline-runs`, { params }),
+  get: (projectId, runId) => api.get(`/projects/${projectId}/pipeline-runs/${runId}`),
+  start: (projectId, data) => api.post(`/projects/${projectId}/pipeline-runs`, data),
+  retry: (projectId, runId, data) => api.post(`/projects/${projectId}/pipeline-runs/${runId}/retry`, data),
+  delete: (projectId, runId) => api.delete(`/projects/${projectId}/pipeline-runs/${runId}`),
+};
+
 export const apiKeyAPI = {
   getAll: () => api.get('/apikeys'),
   create: (data) => api.post('/apikeys', data),

--- a/src/models/PipelineRun.js
+++ b/src/models/PipelineRun.js
@@ -1,0 +1,67 @@
+const mongoose = require('mongoose');
+
+// 파이프라인 실행 영속 (#407). 백그라운드 worker 가 단계를 순차 실행하며 상태 갱신.
+// 사용자는 페이지를 떠나도 진행되며, 부분 retry 가능.
+
+const pipelineRunStepSchema = new mongoose.Schema({
+  workboardId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Workboard',
+    required: true,
+  },
+  status: {
+    type: String,
+    enum: ['pending', 'running', 'completed', 'failed', 'skipped'],
+    default: 'pending',
+  },
+  startedAt: Date,
+  completedAt: Date,
+  // 텍스트 단계의 결과 ConversationJob 또는 이미지 단계의 ImageGenerationJob 참조
+  conversationJobId: { type: mongoose.Schema.Types.ObjectId, ref: 'ConversationJob' },
+  imageGenerationJobId: { type: mongoose.Schema.Types.ObjectId, ref: 'ImageGenerationJob' },
+  // 출력 (다음 단계의 자동 주입 / 히스토리 표시용)
+  // { type: 'text'|'image', value?: string, imageIds?: [ObjectId], ... }
+  output: mongoose.Schema.Types.Mixed,
+  error: {
+    message: String,
+  },
+}, { _id: false });
+
+const pipelineRunSchema = new mongoose.Schema({
+  userId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+  },
+  projectId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Project',
+    required: true,
+  },
+  pipelineId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Pipeline',
+    required: true,
+  },
+  status: {
+    type: String,
+    enum: ['pending', 'running', 'completed', 'failed', 'cancelled'],
+    default: 'pending',
+  },
+  startedAt: Date,
+  completedAt: Date,
+  // 첫 단계 사용자 프롬프트
+  initialPrompt: { type: String, default: '' },
+  // 시작 / retry 횟수
+  triggerCount: { type: Number, default: 0 },
+  steps: [pipelineRunStepSchema],
+  error: {
+    message: String,
+  },
+}, { timestamps: true });
+
+pipelineRunSchema.index({ projectId: 1, createdAt: -1 });
+pipelineRunSchema.index({ pipelineId: 1, createdAt: -1 });
+pipelineRunSchema.index({ userId: 1, status: 1 });
+
+module.exports = mongoose.model('PipelineRun', pipelineRunSchema);

--- a/src/routes/pipelineRuns.js
+++ b/src/routes/pipelineRuns.js
@@ -1,0 +1,167 @@
+const express = require('express');
+const { requireAuth } = require('../middleware/auth');
+const Pipeline = require('../models/Pipeline');
+const PipelineRun = require('../models/PipelineRun');
+const Project = require('../models/Project');
+const { startPipelineRun, retryPipelineRun } = require('../services/pipelineRunService');
+
+const router = express.Router({ mergeParams: true });
+
+// mounted at /api/projects/:projectId/pipeline-runs (#407)
+
+async function loadProject(req, res) {
+  const project = await Project.findOne({ _id: req.params.projectId, userId: req.user._id });
+  if (!project) {
+    res.status(404).json({ success: false, message: '프로젝트를 찾을 수 없습니다' });
+    return null;
+  }
+  return project;
+}
+
+// GET — 프로젝트의 run 목록
+router.get('/', requireAuth, async (req, res) => {
+  try {
+    const project = await loadProject(req, res);
+    if (!project) return;
+    const { pipelineId, limit = 20, page = 1 } = req.query;
+    const filter = { projectId: project._id, userId: req.user._id };
+    if (pipelineId) filter.pipelineId = pipelineId;
+    const skip = (parseInt(page) - 1) * parseInt(limit);
+    const [items, total] = await Promise.all([
+      PipelineRun.find(filter)
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(parseInt(limit))
+        .populate('pipelineId', 'name')
+        .populate('steps.workboardId', 'name outputFormat')
+        .lean(),
+      PipelineRun.countDocuments(filter),
+    ]);
+    res.json({
+      success: true,
+      data: {
+        runs: items,
+        pagination: { current: parseInt(page), pages: Math.ceil(total / parseInt(limit)), total },
+      },
+    });
+  } catch (error) {
+    console.error('List pipeline runs error:', error);
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
+// GET /:runId — 단일 run 상세
+router.get('/:runId', requireAuth, async (req, res) => {
+  try {
+    const project = await loadProject(req, res);
+    if (!project) return;
+    const run = await PipelineRun.findOne({ _id: req.params.runId, projectId: project._id, userId: req.user._id })
+      .populate('pipelineId', 'name description steps')
+      .populate('steps.workboardId', 'name description outputFormat')
+      .lean();
+    if (!run) return res.status(404).json({ success: false, message: 'Run 을 찾을 수 없습니다' });
+    res.json({ success: true, data: { run } });
+  } catch (error) {
+    console.error('Get pipeline run error:', error);
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
+// POST — 새 run 시작
+router.post('/', requireAuth, async (req, res) => {
+  try {
+    const project = await loadProject(req, res);
+    if (!project) return;
+    const { pipelineId, initialPrompt = '' } = req.body;
+    if (!pipelineId) return res.status(400).json({ success: false, message: 'pipelineId 필수' });
+    const pipeline = await Pipeline.findOne({ _id: pipelineId, projectId: project._id, userId: req.user._id });
+    if (!pipeline) return res.status(404).json({ success: false, message: '파이프라인을 찾을 수 없습니다' });
+    if (!pipeline.steps?.length) {
+      return res.status(400).json({ success: false, message: '단계가 비어 있는 파이프라인입니다' });
+    }
+
+    const run = await PipelineRun.create({
+      userId: req.user._id,
+      projectId: project._id,
+      pipelineId: pipeline._id,
+      status: 'pending',
+      initialPrompt,
+      triggerCount: 1,
+      steps: pipeline.steps.map((s) => ({
+        workboardId: s.workboardId,
+        status: 'pending',
+      })),
+    });
+
+    // Bull queue 에 추가 (백그라운드 처리)
+    await startPipelineRun(run._id);
+
+    res.status(201).json({ success: true, data: { run } });
+  } catch (error) {
+    console.error('Create pipeline run error:', error);
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
+// POST /:runId/retry — 실패한 단계부터 재시작
+router.post('/:runId/retry', requireAuth, async (req, res) => {
+  try {
+    const project = await loadProject(req, res);
+    if (!project) return;
+    const run = await PipelineRun.findOne({ _id: req.params.runId, projectId: project._id, userId: req.user._id });
+    if (!run) return res.status(404).json({ success: false, message: 'Run 을 찾을 수 없습니다' });
+    if (run.status === 'running') {
+      return res.status(400).json({ success: false, message: '아직 진행 중입니다' });
+    }
+
+    const { fromStep } = req.body;
+    // fromStep 미지정 시 첫 번째 failed 단계 자동 감지
+    let resolvedFrom = fromStep;
+    if (resolvedFrom == null) {
+      resolvedFrom = run.steps.findIndex((s) => s.status !== 'completed');
+      if (resolvedFrom < 0) resolvedFrom = 0;
+    }
+    resolvedFrom = Math.max(0, Math.min(resolvedFrom, run.steps.length - 1));
+
+    // 재시작할 단계 + 이후 단계를 pending 으로
+    for (let i = resolvedFrom; i < run.steps.length; i++) {
+      run.steps[i].status = 'pending';
+      run.steps[i].startedAt = undefined;
+      run.steps[i].completedAt = undefined;
+      run.steps[i].error = undefined;
+      run.steps[i].output = undefined;
+      run.steps[i].conversationJobId = undefined;
+      run.steps[i].imageGenerationJobId = undefined;
+    }
+    run.status = 'pending';
+    run.error = undefined;
+    run.completedAt = undefined;
+    run.triggerCount = (run.triggerCount || 0) + 1;
+    await run.save();
+
+    await retryPipelineRun(run._id, resolvedFrom);
+
+    res.json({ success: true, data: { run } });
+  } catch (error) {
+    console.error('Retry pipeline run error:', error);
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
+// DELETE /:runId
+router.delete('/:runId', requireAuth, async (req, res) => {
+  try {
+    const project = await loadProject(req, res);
+    if (!project) return;
+    const result = await PipelineRun.deleteOne({ _id: req.params.runId, projectId: project._id, userId: req.user._id });
+    if (result.deletedCount === 0) {
+      return res.status(404).json({ success: false, message: 'Run 을 찾을 수 없습니다' });
+    }
+    res.json({ success: true });
+  } catch (error) {
+    console.error('Delete pipeline run error:', error);
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
+module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -15,6 +15,8 @@ const jobRoutes = require('./routes/jobs');
 const conversationRoutes = require('./routes/conversations');
 const textRoutes = require('./routes/texts');
 const pipelineRoutes = require('./routes/pipelines');
+const pipelineRunRoutes = require('./routes/pipelineRuns');
+const { initPipelineRunQueue } = require('./services/pipelineRunService');
 const adminRoutes = require('./routes/admin');
 const serverRoutes = require('./routes/servers');
 const promptDataRoutes = require('./routes/promptData');
@@ -145,6 +147,7 @@ app.use('/api/prompt-data', promptDataRoutes);
 app.use('/api/tags', tagRoutes);
 app.use('/api/projects', projectRoutes);
 app.use('/api/projects/:projectId/pipelines', pipelineRoutes);
+app.use('/api/projects/:projectId/pipeline-runs', pipelineRunRoutes);
 app.use('/api/admin/backup', backupRoutes);
 app.use('/api/updatelog', updatelogRoutes);
 app.use('/api/apikeys', apiKeyRoutes);
@@ -214,6 +217,7 @@ const startServer = async () => {
     // Initialize job queues after database connection
     console.log('Initializing job queues...');
     await initializeQueues();
+    await initPipelineRunQueue();
     
     // Start HTTP server
     const server = app.listen(PORT, () => {

--- a/src/services/pipelineRunService.js
+++ b/src/services/pipelineRunService.js
@@ -1,0 +1,337 @@
+const Queue = require('bull');
+const PipelineRun = require('../models/PipelineRun');
+const Pipeline = require('../models/Pipeline');
+const Workboard = require('../models/Workboard');
+const ConversationJob = require('../models/ConversationJob');
+const ImageGenerationJob = require('../models/ImageGenerationJob');
+const UploadedText = require('../models/UploadedText');
+const Project = require('../models/Project');
+const Tag = require('../models/Tag');
+const openAIChatService = require('./openAIChatService');
+const geminiService = require('./geminiService');
+const { getFieldValueByRole } = require('../utils/customFieldHelpers');
+const { FIELD_ROLES } = require('../constants/fieldRoles');
+const { computeOpenAITextCost, computeGeminiTextCost } = require('../utils/pricing');
+const queueService = require('./queueService');
+
+// 파이프라인 실행 background worker (#407).
+// Bull queue 사용 — 사용자가 페이지 떠나도 계속 진행. 부분 retry 지원.
+
+let pipelineRunQueue;
+
+function getRedisConfig() {
+  const REDIS_URL = process.env.REDIS_URL || 'redis://redis:6379';
+  const u = new URL(REDIS_URL);
+  return {
+    host: u.hostname,
+    port: parseInt(u.port, 10) || 6379,
+    password: u.password || undefined,
+  };
+}
+
+async function initPipelineRunQueue() {
+  if (pipelineRunQueue) return pipelineRunQueue;
+  pipelineRunQueue = new Queue('pipeline run', {
+    redis: getRedisConfig(),
+    defaultJobOptions: {
+      attempts: 1,
+      removeOnComplete: 100,
+      removeOnFail: 200,
+    },
+  });
+  pipelineRunQueue.process('runPipeline', 2, processPipelineRun);
+  pipelineRunQueue.on('failed', (job, err) => {
+    console.error(`[PipelineRun] job ${job.id} failed:`, err.message);
+  });
+  pipelineRunQueue.on('completed', (job) => {
+    console.log(`[PipelineRun] job ${job.id} completed`);
+  });
+  console.log('[PipelineRun] queue initialized');
+  return pipelineRunQueue;
+}
+
+async function startPipelineRun(runId) {
+  await initPipelineRunQueue();
+  await pipelineRunQueue.add('runPipeline', { runId: runId.toString(), fromStep: 0 });
+}
+
+async function retryPipelineRun(runId, fromStep) {
+  await initPipelineRunQueue();
+  await pipelineRunQueue.add('runPipeline', { runId: runId.toString(), fromStep });
+}
+
+// 단계 입력 빌드 — 사전 입력 + 자동 주입 + 초기 프롬프트
+function buildStepInput(workboard, prevOutput, stepInputs, stepIdx, initialPrompt) {
+  const inputData = { ...(stepInputs || {}) };
+  if (inputData.userPrompt == null) inputData.userPrompt = '';
+
+  if (stepIdx === 0) {
+    inputData.userPrompt = initialPrompt;
+    const promptField = (workboard.additionalInputFields || []).find(
+      (f) => f.name === 'prompt' || f.name === 'userPrompt'
+    );
+    if (promptField) inputData[promptField.name] = initialPrompt;
+  } else if (prevOutput) {
+    if (prevOutput.type === 'text') {
+      inputData.userPrompt = prevOutput.value;
+      const promptField = (workboard.additionalInputFields || []).find(
+        (f) => f.name === 'prompt' || f.name === 'userPrompt'
+      );
+      if (promptField) inputData[promptField.name] = prevOutput.value;
+    } else if (prevOutput.type === 'image' && prevOutput.imageIds?.length > 0) {
+      const imgField = (workboard.additionalInputFields || []).find((f) => f.type === 'image');
+      if (imgField) {
+        inputData[imgField.name] = prevOutput.imageIds.map((id) => ({ imageId: id }));
+      }
+    }
+  }
+  return inputData;
+}
+
+function extractOpt(v) {
+  return v && typeof v === 'object' && v.value !== undefined ? v.value : v;
+}
+
+function composeSystemPrompt(systemPrompt, worldviewTexts) {
+  const parts = [];
+  if (systemPrompt) parts.push('[작업 지침]\n' + systemPrompt);
+  if (worldviewTexts && worldviewTexts.length > 0) {
+    const ctx = worldviewTexts.map((t) => (t.title ? `## ${t.title}\n` : '') + (t.content || '')).join('\n\n---\n\n');
+    parts.push('[배경 / 사전 컨텍스트]\n' + ctx);
+  }
+  return parts.join('\n\n');
+}
+
+// 텍스트 단계 실행 — prompt-generate 로직 직접 호출 (HTTP 우회)
+async function runTextStep(userId, pipelineRun, step, pipelineStep, inputData, prevOutput) {
+  const workboard = await Workboard.findById(step.workboardId).populate('serverId');
+  if (!workboard) throw new Error('작업판이 삭제됨');
+  const server = workboard.serverId;
+  if (!server || !server.isActive) throw new Error('서버가 비활성');
+
+  const systemPrompt = extractOpt(getFieldValueByRole(workboard, inputData, FIELD_ROLES.SYSTEM_PROMPT)) || '';
+  const resolvedModel = extractOpt(getFieldValueByRole(workboard, inputData, FIELD_ROLES.MODEL));
+  if (!resolvedModel) throw new Error('작업판에 모델이 선택되지 않음');
+  const temperatureValue = extractOpt(getFieldValueByRole(workboard, inputData, FIELD_ROLES.TEMPERATURE));
+  const temperature = temperatureValue != null ? Number(temperatureValue) : 0.7;
+
+  // 사전 컨텍스트 / 시스템 프롬프트 문서 적용 (#401)
+  let resolvedSystem = systemPrompt;
+  let worldviewTexts = [];
+  if (pipelineStep.systemPromptDocId) {
+    const spDoc = await UploadedText.findOne({ userId, _id: pipelineStep.systemPromptDocId }).lean();
+    if (spDoc) {
+      resolvedSystem = spDoc.title ? `## ${spDoc.title}\n${spDoc.content || ''}` : (spDoc.content || '');
+    }
+  }
+  if (Array.isArray(pipelineStep.contextDocIds) && pipelineStep.contextDocIds.length > 0) {
+    worldviewTexts = await UploadedText.find({
+      userId,
+      _id: { $in: pipelineStep.contextDocIds },
+    }).sort({ createdAt: 1 }).lean();
+  }
+  const composedSystem = composeSystemPrompt(resolvedSystem, worldviewTexts);
+  const worldviewContext = worldviewTexts.length > 0
+    ? worldviewTexts.map((t) => (t.title ? `## ${t.title}\n` : '') + (t.content || '')).join('\n\n---\n\n')
+    : '';
+
+  const messages = [];
+  if (composedSystem) messages.push({ role: 'system', content: composedSystem });
+  messages.push({ role: 'user', content: inputData.userPrompt });
+
+  // 프로젝트 태그 자동 부여
+  let projectTagIds = [];
+  if (pipelineRun.projectId) {
+    const projectDoc = await Project.findOne({ _id: pipelineRun.projectId, userId }).lean();
+    if (projectDoc?.tagId) projectTagIds = [projectDoc.tagId];
+  }
+
+  const conversation = await ConversationJob.create({
+    userId,
+    workboardId: workboard._id,
+    projectId: pipelineRun.projectId,
+    tags: projectTagIds,
+    serverType: server.serverType,
+    model: resolvedModel,
+    workboardSystemPrompt: resolvedSystem || undefined,
+    worldviewContext: worldviewContext || undefined,
+    messages: messages.map((m) => ({ ...m, createdAt: new Date() })),
+    status: 'processing',
+  });
+
+  const chatService = server.serverType === 'Gemini' ? geminiService : openAIChatService;
+  let result, usage;
+  try {
+    ({ content: result, usage } = await chatService.complete(
+      server.serverUrl,
+      server.configuration?.apiKey,
+      messages,
+      { model: resolvedModel, temperature, timeout: server.configuration?.timeout || 60000 }
+    ));
+  } catch (err) {
+    conversation.status = 'failed';
+    conversation.error = { message: err.message };
+    conversation.completedAt = new Date();
+    await conversation.save();
+    throw err;
+  }
+
+  conversation.messages.push({ role: 'assistant', content: result, createdAt: new Date() });
+  conversation.usage = usage;
+  const computeCost = server.serverType === 'Gemini' ? computeGeminiTextCost : computeOpenAITextCost;
+  const turnCost = computeCost(resolvedModel, usage);
+  if (turnCost) conversation.costEstimate = turnCost;
+  conversation.status = 'completed';
+  conversation.completedAt = new Date();
+  await conversation.save();
+
+  await workboard.incrementUsage();
+
+  return {
+    conversationJobId: conversation._id,
+    output: { type: 'text', value: result },
+  };
+}
+
+// 이미지 단계 실행 — ImageGenerationJob 생성 후 폴링
+async function runImageStep(userId, pipelineRun, step, inputData) {
+  const workboard = await Workboard.findById(step.workboardId);
+  if (!workboard) throw new Error('작업판이 삭제됨');
+
+  // 프로젝트 태그 주입
+  let mergedTags = Array.isArray(inputData.tags) ? [...inputData.tags] : [];
+  if (pipelineRun.projectId) {
+    const projectDoc = await Project.findOne({ _id: pipelineRun.projectId, userId }).lean();
+    if (projectDoc?.tagId && !mergedTags.some((t) => String(t) === String(projectDoc.tagId))) {
+      mergedTags.push(projectDoc.tagId);
+    }
+  }
+
+  // queueService 의 addImageGenerationJob 재사용
+  const job = await queueService.addImageGenerationJob(userId, workboard._id, {
+    prompt: (inputData.prompt || inputData.userPrompt || '').toString(),
+    negativePrompt: inputData.negativePrompt,
+    referenceImages: inputData.referenceImages || [],
+    referenceImageMethod: inputData.referenceImageMethod,
+    stylePreset: inputData.stylePreset,
+    upscaleMethod: inputData.upscaleMethod,
+    additionalParams: inputData,
+    seed: inputData.seed,
+    randomSeed: inputData.randomSeed,
+    tags: mergedTags,
+  });
+
+  // 폴링 — 완료까지 대기 (최대 10분)
+  const start = Date.now();
+  const MAX_WAIT = 10 * 60 * 1000;
+  while (Date.now() - start < MAX_WAIT) {
+    await new Promise((r) => setTimeout(r, 3000));
+    const fresh = await ImageGenerationJob.findById(job._id).populate('resultImages').lean();
+    if (!fresh) throw new Error('Job 사라짐');
+    if (fresh.status === 'completed') {
+      const imageIds = (fresh.resultImages || []).map((img) => img._id);
+      return {
+        imageGenerationJobId: fresh._id,
+        output: { type: 'image', imageIds },
+      };
+    }
+    if (fresh.status === 'failed') {
+      throw new Error(fresh.errorMessage || '이미지 생성 실패');
+    }
+  }
+  throw new Error('이미지 생성 시간 초과 (10분)');
+}
+
+// 메인 worker 함수
+async function processPipelineRun(job) {
+  const { runId, fromStep = 0 } = job.data;
+  const run = await PipelineRun.findById(runId);
+  if (!run) throw new Error(`PipelineRun ${runId} not found`);
+
+  const pipeline = await Pipeline.findById(run.pipelineId);
+  if (!pipeline) {
+    run.status = 'failed';
+    run.error = { message: '파이프라인이 삭제됨' };
+    run.completedAt = new Date();
+    await run.save();
+    return;
+  }
+
+  run.status = 'running';
+  if (!run.startedAt) run.startedAt = new Date();
+  await run.save();
+
+  // 이전 단계의 output 회수 (retry 시)
+  let prevOutput = null;
+  if (fromStep > 0) {
+    const prevRunStep = run.steps[fromStep - 1];
+    if (prevRunStep?.output) prevOutput = prevRunStep.output;
+  }
+
+  for (let i = fromStep; i < run.steps.length; i++) {
+    const pipelineStep = pipeline.steps[i];
+    const runStep = run.steps[i];
+    if (!pipelineStep) {
+      runStep.status = 'failed';
+      runStep.error = { message: '파이프라인 단계 불일치' };
+      run.status = 'failed';
+      run.completedAt = new Date();
+      await run.save();
+      return;
+    }
+
+    runStep.status = 'running';
+    runStep.startedAt = new Date();
+    run.markModified('steps');
+    await run.save();
+
+    try {
+      const workboard = await Workboard.findById(runStep.workboardId);
+      if (!workboard) throw new Error('작업판이 삭제됨');
+
+      const autoInject = i === 0 ? false : (pipelineStep.autoInject !== false);
+      const inputData = buildStepInput(workboard, autoInject ? prevOutput : null, pipelineStep.inputs, i, run.initialPrompt);
+
+      let stepResult;
+      if (workboard.outputFormat === 'text') {
+        stepResult = await runTextStep(run.userId, run, runStep, pipelineStep, inputData, prevOutput);
+        runStep.conversationJobId = stepResult.conversationJobId;
+      } else {
+        stepResult = await runImageStep(run.userId, run, runStep, inputData);
+        runStep.imageGenerationJobId = stepResult.imageGenerationJobId;
+      }
+
+      runStep.output = stepResult.output;
+      runStep.status = 'completed';
+      runStep.completedAt = new Date();
+      prevOutput = stepResult.output;
+      run.markModified('steps');
+      await run.save();
+    } catch (err) {
+      console.error(`[PipelineRun ${runId}] step ${i} failed:`, err.message);
+      runStep.status = 'failed';
+      runStep.completedAt = new Date();
+      runStep.error = { message: err.message };
+      // 이후 단계는 건너뜀
+      for (let j = i + 1; j < run.steps.length; j++) {
+        if (run.steps[j].status === 'pending') run.steps[j].status = 'skipped';
+      }
+      run.status = 'failed';
+      run.completedAt = new Date();
+      run.error = { message: `단계 ${i + 1} 실패: ${err.message}` };
+      run.markModified('steps');
+      await run.save();
+      return;
+    }
+  }
+
+  run.status = 'completed';
+  run.completedAt = new Date();
+  await run.save();
+}
+
+module.exports = {
+  initPipelineRunQueue,
+  startPipelineRun,
+  retryPipelineRun,
+};


### PR DESCRIPTION
## Summary
[#407](https://github.com/iceemperor-gcempire/vcc-manager/issues/407). 클라이언트 측 오케스트레이션을 백엔드 Bull worker 로 이전. 페이지 떠나도 계속 진행, 부분 retry, 영속 히스토리.

### 백엔드
- `PipelineRun` 모델 신설
- `/api/projects/:pid/pipeline-runs` CRUD + retry (`?from=N`)
- Bull queue `pipeline run` + worker — 단계 순차 실행. 텍스트는 chat 서비스 직접 호출, 이미지는 ImageGenerationJob 큐 위임 + 폴링 (최대 10분). 실패 시 stop + 나머지 skipped.

### 프론트
- **작업판 탭 제거** (데이터는 유지). 파이프라인 step picker 가 전체 작업판 목록.
- **PipelineRunner 재작성** — POST run + polling. 페이지 떠나도 백엔드 계속. 실패 시 \"N단계부터 재시작\".
- **PipelineHistoryPanel 신설** — 프로젝트 탭 '작업 히스토리' → '파이프라인 히스토리' 로 대체. 카드 리스트 + 상세 (Stepper).
- `pipelineRunAPI` 추가.

## Test plan
- [x] 백엔드 빌드 + 큐 초기화 정상 (`[PipelineRun] queue initialized`)
- [x] 사용자 검증 — 실행 / 히스토리 / 재시작 동작 확인

## Follow-up
- DAG / 분기 / 동시 실행 제한 (Phase 2.B)
- 별개 이슈: 모델 목록에서 DiffusionModels 폴더 추가 노출 (wan 등) — 사용자 요청, 분리 필요

closes #407