### PR TITLE
fix: 사이드바 wrapper PC 배경색 통일

### DIFF
--- a/frontend/src/components/Sidebar.js
+++ b/frontend/src/components/Sidebar.js
@@ -256,7 +256,12 @@ function Sidebar({ mobileOpen, onMobileToggle }) {
   return (
     <Box
       component="nav"
-      sx={{ width: { md: DRAWER_WIDTH }, flexShrink: { md: 0 } }}
+      sx={{
+        width: { md: DRAWER_WIDTH },
+        flexShrink: { md: 0 },
+        // 사이드바 영역 자체의 배경색을 drawer paper 와 동일하게 — 컨텐츠 짧을 때 / 스크롤 시 흰 영역 노출 방지 (PC 도)
+        bgcolor: { md: '#2c3e50' },
+      }}
     >
       {/* 모바일용 temporary drawer */}
       <Drawer


### PR DESCRIPTION
## Summary
Drawer paper 는 `#2c3e50` 으로 칠해져 있지만 wrapper `<Box component=\"nav\">` 는 무색. PC 에서 사이드바 영역 일부가 흰색으로 어정쩡하게 보이던 문제. wrapper 에도 동일 색 적용.

## Test plan
- [x] 사용자 확인 — 흰 영역 사라짐