### PR TITLE
release: v2.7.1 — 파이프라인 이미지 썸네일 + 사이드바 PC 배경 fix

### DIFF
--- a/docs/updatelogs/v2.md
+++ b/docs/updatelogs/v2.md
@@ -1,5 +1,17 @@
 # v2 업데이트 내역
 
+## v2.7.1
+
+### 신규 기능
+- feat: 파이프라인 단계의 이미지 결과 — 썸네일 + 큰 보기 (#409, #413)
+  - 백엔드 PipelineRun GET 응답에 `steps.imageGenerationJobId.resultImages` 깊은 populate
+  - `StepImageThumbnails` 컴포넌트 — 72×72 썸네일 + 클릭 시 `ImageViewerDialog` 큰 보기
+  - PipelineRunner / PipelineHistoryPanel 양쪽 모두 적용
+
+### 수정
+- fix: 사이드바 wrapper 에 PC 배경색 적용 (#414)
+  - drawer paper 만 `#2c3e50` 으로 칠해져 있고 wrapper `<Box component="nav">` 는 무색이라 컨텐츠가 짧거나 스크롤될 때 흰 영역이 어정쩡하게 보이던 문제
+
 ## v2.7.0
 
 ### 신규 기능

--- a/frontend/src/components/Sidebar.js
+++ b/frontend/src/components/Sidebar.js
@@ -256,7 +256,12 @@ function Sidebar({ mobileOpen, onMobileToggle }) {
   return (
     <Box
       component="nav"
-      sx={{ width: { md: DRAWER_WIDTH }, flexShrink: { md: 0 } }}
+      sx={{
+        width: { md: DRAWER_WIDTH },
+        flexShrink: { md: 0 },
+        // 사이드바 영역 자체의 배경색을 drawer paper 와 동일하게 — 컨텐츠 짧을 때 / 스크롤 시 흰 영역 노출 방지 (PC 도)
+        bgcolor: { md: '#2c3e50' },
+      }}
     >
       {/* 모바일용 temporary drawer */}
       <Drawer

--- a/frontend/src/components/common/PipelinePanel.js
+++ b/frontend/src/components/common/PipelinePanel.js
@@ -37,9 +37,58 @@ import {
   Stop as StopIcon,
 } from '@mui/icons-material';
 import MetadataFieldInput from './MetadataFieldInput';
+import ImageViewerDialog from './ImageViewerDialog';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import toast from 'react-hot-toast';
 import { pipelineAPI, pipelineRunAPI, projectAPI, jobAPI, tagAPI, textAPI, workboardAPI } from '../../services/api';
+
+// 파이프라인 step 의 이미지 결과 — 썸네일 그리드 + 클릭 시 큰 보기 (#409).
+// runStep.imageGenerationJobId 가 populate 되어 있어야 함 (백엔드 단일 GET 만 populate).
+// 미 populate (e.g. 진행 중인 step) 시 fallback 으로 "이미지 N개 생성됨" 텍스트만.
+function StepImageThumbnails({ runStep }) {
+  const [viewerOpen, setViewerOpen] = useState(false);
+  const [viewerIdx, setViewerIdx] = useState(0);
+  const images = runStep?.imageGenerationJobId?.resultImages || [];
+  if (images.length === 0) {
+    return (
+      <Typography variant="caption" color="text.secondary">
+        이미지 {runStep?.output?.imageIds?.length || 0}개 생성됨
+      </Typography>
+    );
+  }
+  return (
+    <>
+      <Stack direction="row" spacing={0.5} sx={{ flexWrap: 'wrap', gap: 0.5 }}>
+        {images.map((img, idx) => (
+          <Box
+            key={img._id || idx}
+            onClick={() => { setViewerIdx(idx); setViewerOpen(true); }}
+            sx={{
+              width: 72, height: 72, borderRadius: 1, overflow: 'hidden', cursor: 'pointer',
+              border: 1, borderColor: 'divider',
+              '&:hover': { borderColor: 'primary.main' },
+            }}
+          >
+            <Box
+              component="img"
+              src={img.url}
+              alt={img.originalName || `이미지 ${idx + 1}`}
+              loading="lazy"
+              sx={{ width: '100%', height: '100%', objectFit: 'cover' }}
+            />
+          </Box>
+        ))}
+      </Stack>
+      <ImageViewerDialog
+        open={viewerOpen}
+        onClose={() => setViewerOpen(false)}
+        images={images}
+        selectedIndex={viewerIdx}
+        title="파이프라인 결과"
+      />
+    </>
+  );
+}
 
 // 프로젝트 종속 작업판 파이프라인 (#397).
 // 단계: 목록 → 빌더 → 실행. 모두 한 패널에서.
@@ -995,9 +1044,7 @@ function PipelineRunner({ projectId, pipelineId, onClose }) {
                           </Typography>
                         )}
                         {runStep.output.type === 'image' && (
-                          <Typography variant="caption" color="text.secondary">
-                            이미지 {runStep.output.imageIds?.length || 0}개 생성됨
-                          </Typography>
+                          <StepImageThumbnails runStep={runStep} />
                         )}
                       </Paper>
                     )}
@@ -1142,9 +1189,7 @@ export function PipelineHistoryPanel({ projectId }) {
                       </Typography>
                     )}
                     {runStep.output.type === 'image' && (
-                      <Typography variant="caption" color="text.secondary">
-                        이미지 {runStep.output.imageIds?.length || 0}개 생성됨
-                      </Typography>
+                      <StepImageThumbnails runStep={runStep} />
                     )}
                   </Paper>
                 )}

--- a/src/routes/pipelineRuns.js
+++ b/src/routes/pipelineRuns.js
@@ -58,6 +58,16 @@ router.get('/:runId', requireAuth, async (req, res) => {
     const run = await PipelineRun.findOne({ _id: req.params.runId, projectId: project._id, userId: req.user._id })
       .populate('pipelineId', 'name description steps')
       .populate('steps.workboardId', 'name description outputFormat')
+      // 이미지 썸네일 / 큰 보기 위해 resultImages 깊은 populate (#409)
+      .populate({
+        path: 'steps.imageGenerationJobId',
+        select: 'resultImages status errorMessage',
+        populate: { path: 'resultImages', select: 'url originalName fileSize width height tags' }
+      })
+      .populate({
+        path: 'steps.conversationJobId',
+        select: 'model usage costEstimate'
+      })
       .lean();
     if (!run) return res.status(404).json({ success: false, message: 'Run 을 찾을 수 없습니다' });
     res.json({ success: true, data: { run } });


### PR DESCRIPTION
## v2.7.1 Release

### 신규 기능
- 파이프라인 단계의 이미지 결과 — 썸네일 + 큰 보기 (#409)

### 수정
- 사이드바 wrapper PC 배경색 통일

자세한 내용: `docs/updatelogs/v2.md` v2.7.1 섹션.

## Post-merge
- v2.7.1 태그 + GitHub Release
- alpha 는 dev 직결이라 추가 배포 불필요