### PR TITLE
feat: 디자인 시스템 Phase 3 + 4 — size prop 정리 + 한국어 본문 자연 줄바꿈

### DIFF
--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -94,7 +94,6 @@ function Header({ onMobileToggle }) {
               <Chip
                 label="Admin"
                 color="secondary"
-                size="small"
                 variant="outlined"
                 sx={{ color: 'white', borderColor: 'white' }}
               />

--- a/frontend/src/components/admin/CivitaiAdminHeader.js
+++ b/frontend/src/components/admin/CivitaiAdminHeader.js
@@ -126,11 +126,11 @@ function CivitaiAdminHeader({
             Civitai API 키:
           </Typography>
           {hasCivitaiApiKey ? (
-            <Chip label="등록됨" color="success" size="small" variant="outlined" />
+            <Chip label="등록됨" color="success" variant="outlined" />
           ) : (
-            <Chip label="미등록" size="small" variant="outlined" />
+            <Chip label="미등록" variant="outlined" />
           )}
-          <Button size="small" onClick={() => setShowApiKeyInput(!showApiKeyInput)}>
+          <Button onClick={() => setShowApiKeyInput(!showApiKeyInput)}>
             {showApiKeyInput ? '취소' : hasCivitaiApiKey ? '변경' : '등록'}
           </Button>
         </Box>
@@ -181,7 +181,6 @@ function CivitaiAdminHeader({
       {showApiKeyInput && (
         <Box sx={{ display: 'flex', gap: 1, mt: 2, alignItems: 'center', flexWrap: 'wrap' }}>
           <TextField
-            size="small"
             type="password"
             placeholder={hasCivitaiApiKey ? '새 API 키 (빈칸=삭제)' : 'API 키 입력'}
             value={apiKeyInput}
@@ -191,7 +190,6 @@ function CivitaiAdminHeader({
           />
           <Button
             variant="contained"
-            size="small"
             onClick={handleSaveApiKey}
             disabled={savingKey}
             startIcon={savingKey ? <CircularProgress size={16} /> : <SaveIcon />}

--- a/frontend/src/components/admin/MetadataImageListItem.js
+++ b/frontend/src/components/admin/MetadataImageListItem.js
@@ -100,21 +100,20 @@ function MetadataImageListItem({
 
         {/* chip 들 */}
         <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', mt: 0.5 }}>
-          <Chip label={getKindLabel(item.kind)} size="small" variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />
+          <Chip label={getKindLabel(item.kind)} variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />
           {item.baseModel && (
             <Chip
               label={item.baseModel}
-              size="small"
               color={baseModelColorFn(item.baseModel)}
               variant="outlined"
               sx={{ height: 20, fontSize: '0.7rem' }}
             />
           )}
           {item.capabilities?.slice(0, 2).map((c) => (
-            <Chip key={c} label={c} size="small" variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />
+            <Chip key={c} label={c} variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />
           ))}
           {!item.hasMetadata && (
-            <Chip label={item.hash ? '미등록' : '메타데이터 없음'} size="small" variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />
+            <Chip label={item.hash ? '미등록' : '메타데이터 없음'} variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />
           )}
         </Box>
 
@@ -125,7 +124,6 @@ function MetadataImageListItem({
               <Chip
                 key={i}
                 label={w}
-                size="small"
                 onClick={onTrainedWordClick ? (e) => { e.stopPropagation(); onTrainedWordClick(w, item); } : undefined}
                 color={trainedWordInsertMode ? 'primary' : 'default'}
                 variant={trainedWordInsertMode ? 'outlined' : 'filled'}
@@ -133,7 +131,7 @@ function MetadataImageListItem({
               />
             ))}
             {item.trainedWords.length > 4 && (
-              <Chip label={`+${item.trainedWords.length - 4}`} size="small" variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />
+              <Chip label={`+${item.trainedWords.length - 4}`} variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />
             )}
           </Box>
         ) : (
@@ -161,7 +159,6 @@ function MetadataImageListItem({
         )}
         {onPrimary && !cardClickable && (
           <Button
-            size="small"
             startIcon={primaryVariant === 'select' ? null : <AddIcon />}
             onClick={(e) => { e.stopPropagation(); onPrimary(item); }}
             variant={primaryVariant === 'insert' ? 'contained' : 'text'}

--- a/frontend/src/components/admin/MetadataManagementBody.js
+++ b/frontend/src/components/admin/MetadataManagementBody.js
@@ -295,7 +295,6 @@ function MetadataManagementBody({ kind, selectedServerId, selectedServer, nsfwMo
           placeholder={adapter.searchPlaceholder}
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          size="small"
           sx={{ flexGrow: 1, minWidth: 0 }}
           InputProps={{
             startAdornment: <InputAdornment position="start"><SearchIcon fontSize="small" /></InputAdornment>
@@ -341,7 +340,6 @@ function MetadataManagementBody({ kind, selectedServerId, selectedServer, nsfwMo
           <span>
             <Button
               variant="contained"
-              size="small"
               startIcon={syncing ? <CircularProgress size={16} /> : <RefreshIcon />}
               onClick={handleSync}
               disabled={!selectedServerId || syncing}
@@ -352,7 +350,7 @@ function MetadataManagementBody({ kind, selectedServerId, selectedServer, nsfwMo
         </Tooltip>
         {syncStatus?.status === 'failed' && (
           <Tooltip title={`강제 리셋 — 오류: ${syncStatus.errorMessage || '알 수 없음'}`}>
-            <Button variant="outlined" color="warning" size="small" startIcon={<RestartAltIcon />} onClick={handleResetSync}>
+            <Button variant="outlined" color="warning" startIcon={<RestartAltIcon />} onClick={handleResetSync}>
               리셋
             </Button>
           </Tooltip>
@@ -362,7 +360,6 @@ function MetadataManagementBody({ kind, selectedServerId, selectedServer, nsfwMo
             <Button
               variant="outlined"
               color="error"
-              size="small"
               startIcon={<DeleteSweepIcon />}
               onClick={() => setClearCacheConfirmOpen(true)}
               disabled={!selectedServerId || syncing || clearingCache}
@@ -485,7 +482,7 @@ function MetadataManagementBody({ kind, selectedServerId, selectedServer, nsfwMo
                       {item.hash ? '미등록' : '메타 없음'}
                     </Typography>
                   )}
-                  <Button size="small" onClick={() => setDetailItem(item)} sx={{ flexShrink: 0, minWidth: 'auto' }}>상세</Button>
+                  <Button onClick={() => setDetailItem(item)} sx={{ flexShrink: 0, minWidth: 'auto' }}>상세</Button>
                 </Box>
               ))}
             </Box>

--- a/frontend/src/components/admin/ServerManagement.js
+++ b/frontend/src/components/admin/ServerManagement.js
@@ -147,11 +147,10 @@ function ServerCard({
             </Typography>
           </Box>
           <Box display="flex" alignItems="center" gap={1}>
-            {!server.isActive && <Chip label="비활성" size="small" color="default" />}
+            {!server.isActive && <Chip label="비활성" color="default" />}
             <Chip 
               icon={getStatusIcon(server.healthCheck?.status)}
               label={server.healthCheck?.status || 'unknown'}
-              size="small"
               color={getStatusColor(server.healthCheck?.status)}
             />
           </Box>

--- a/frontend/src/components/admin/SystemStats.js
+++ b/frontend/src/components/admin/SystemStats.js
@@ -297,7 +297,6 @@ function SystemStats() {
                           <Chip
                             label={job.status}
                             color={getStatusColor(job.status)}
-                            size="small"
                             variant="outlined"
                           />
                         </TableCell>

--- a/frontend/src/components/admin/UserManagement.js
+++ b/frontend/src/components/admin/UserManagement.js
@@ -127,7 +127,6 @@ function UserManagement() {
           <Chip
             label="승인됨"
             color="success"
-            size="small"
             icon={<Check fontSize="small" />}
           />
         );
@@ -136,7 +135,6 @@ function UserManagement() {
           <Chip
             label="거절됨"
             color="error"
-            size="small"
             icon={<Close fontSize="small" />}
           />
         );
@@ -146,7 +144,6 @@ function UserManagement() {
           <Chip
             label="대기중"
             color="warning"
-            size="small"
             icon={<HourglassEmpty fontSize="small" />}
           />
         );
@@ -249,14 +246,12 @@ function UserManagement() {
                             <Chip
                               label="관리자"
                               color="secondary"
-                              size="small"
                               icon={<AdminPanelSettings fontSize="small" />}
                             />
                           ) : (
                             <Chip
                               label="일반 사용자"
                               color="default"
-                              size="small"
                               icon={<Person fontSize="small" />}
                             />
                           )}
@@ -265,7 +260,6 @@ function UserManagement() {
                           <Chip
                             label={user.isActive ? '활성' : '비활성'}
                             color={user.isActive ? 'success' : 'default'}
-                            size="small"
                             variant="outlined"
                           />
                         </TableCell>

--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -108,7 +108,6 @@ function ServerMetadataDefaultValueInput({ serverId, type, value, onChange, labe
       renderInput={(params) => (
         <TextField
           {...params}
-          size="small"
           fullWidth
           label={label}
           helperText={!serverId ? '서버 선택 후 사용 가능' : (isLoading ? '모델 목록 로딩 중...' : `${items.length}개 중 선택`)}
@@ -212,19 +211,16 @@ function WorkboardCard({ workboard, onEdit, onDelete, onDuplicate, onExport, onV
         <Box display="flex" flexWrap="wrap" gap={1} mb={2}>
           <Chip
             label={getWorkboardChipLabel(workboard)}
-            size="small"
             sx={{ bgcolor: getServerTypeColor(workboard.serverId?.serverType), color: 'white' }}
           />
           <Chip
             label={workboard.isActive ? '활성' : '비활성'}
             color={workboard.isActive ? 'success' : 'default'}
-            size="small"
             variant="outlined"
           />
           <Chip
             label={`v${workboard.version || 1}`}
             color="info"
-            size="small"
             variant="outlined"
           />
         </Box>
@@ -323,19 +319,17 @@ function WhitelistField({ name, control, kind, serverId, outputFormat, placehold
                       {...getTagProps({ index })}
                       key={option}
                       label={option}
-                      size="small"
                       variant="outlined"
                     />
                   ))
                 }
                 renderInput={(params) => (
-                  <TextField {...params} size="small" placeholder={placeholder} />
+                  <TextField {...params} placeholder={placeholder} />
                 )}
               />
               {showPicker && (
                 <Button
                   variant="outlined"
-                  size="small"
                   startIcon={<PlaylistAdd />}
                   onClick={() => setPickerOpen(true)}
                   disabled={!serverId}
@@ -399,7 +393,6 @@ function PermissionsAndExposurePanel({ control, isComfyUI, serverId, outputForma
                         {...getTagProps({ index })}
                         key={option}
                         label={g ? `${g.name}${g.isDefault ? ' (기본)' : ''}` : option}
-                        size="small"
                         color="primary"
                         variant="outlined"
                       />
@@ -409,7 +402,6 @@ function PermissionsAndExposurePanel({ control, isComfyUI, serverId, outputForma
                 renderInput={(params) => (
                   <TextField
                     {...params}
-                    size="small"
                     placeholder={groups.length === 0 ? '그룹 없음 — 관리 메뉴에서 먼저 그룹 생성' : '그룹 선택'}
                   />
                 )}
@@ -831,7 +823,6 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
                           imageConfig: { maxImages: 1 }
                         }]);
                       }}
-                      size="small"
                     >
                       필드 추가
                     </Button>
@@ -867,7 +858,6 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
                                   fullWidth
                                   label="필드명 (영문)"
                                   placeholder="예: customField1"
-                                  size="small"
                                   sx={{ fontFamily: 'monospace' }}
                                 />
                               )}
@@ -883,7 +873,6 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
                                   fullWidth
                                   label="표시명"
                                   placeholder="예: 커스텀 옵션"
-                                  size="small"
                                 />
                               )}
                             />
@@ -898,7 +887,6 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
                                   fullWidth
                                   select
                                   label="입력 타입"
-                                  size="small"
                                 >
                                   <MenuItem value="string">텍스트</MenuItem>
                                   <MenuItem value="number">숫자</MenuItem>
@@ -921,7 +909,6 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
                                   fullWidth
                                   label="Workflow 형식 문자열"
                                   placeholder={`예: {{##${field.name || 'field_name'}##}}`}
-                                  size="small"
                                   sx={{ fontFamily: 'monospace' }}
                                 />
                               )}
@@ -962,7 +949,6 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
                                       fullWidth
                                       select
                                       label="기본값 (선택)"
-                                      size="small"
                                       SelectProps={{ displayEmpty: true }}
                                     >
                                       <MenuItem value="">선택 없음</MenuItem>
@@ -994,7 +980,6 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
                                     type={field.type === 'number' ? 'number' : 'text'}
                                     label="기본값"
                                     placeholder="비워두면 기본값 없음"
-                                    size="small"
                                   />
                                 );
                               }}
@@ -1011,7 +996,6 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
                                   fullWidth
                                   label="플레이스홀더"
                                   placeholder="입력창 안내 문구"
-                                  size="small"
                                   disabled={['boolean', 'image', 'baseModel', 'lora'].includes(field.type)}
                                 />
                               )}
@@ -1028,7 +1012,6 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
                                   fullWidth
                                   label="설명"
                                   placeholder="필드 아래에 표시될 설명"
-                                  size="small"
                                 />
                               )}
                             />
@@ -1056,7 +1039,6 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
                                     fullWidth
                                     select
                                     label="최대 이미지 수"
-                                    size="small"
                                     value={imageField.value || 1}
                                   >
                                     <MenuItem value={1}>1개</MenuItem>
@@ -1082,7 +1064,6 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
                                     const currentOptions = watch(`additionalCustomFields.${index}.options`) || [];
                                     setValue(`additionalCustomFields.${index}.options`, [...currentOptions, { key: '', value: '' }]);
                                   }}
-                                  size="small"
                                 >
                                   옵션 추가
                                 </Button>
@@ -1106,7 +1087,6 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
                                                   <TextField
                                                     {...optionField}
                                                     label="표시명"
-                                                    size="small"
                                                     sx={{ flex: 1 }}
                                                   />
                                                 )}
@@ -1118,7 +1098,6 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
                                                   <TextField
                                                     {...optionField}
                                                     label="실제 값"
-                                                    size="small"
                                                     sx={{ flex: 1 }}
                                                   />
                                                 )}
@@ -1284,7 +1263,6 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
                                 {...getTagProps({ index })}
                                 key={option}
                                 label={option}
-                                size="small"
                                 color="primary"
                                 variant="outlined"
                               />
@@ -1293,7 +1271,6 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
                           renderInput={(params) => (
                             <TextField
                               {...params}
-                              size="small"
                               placeholder={availableBaseModels.length === 0 ? '서버 모델 sync 후 baseModel 자동 채움' : '예: SDXL, Illustrious, Pony'}
                             />
                           )}

--- a/frontend/src/components/common/ConversationChatPanel.js
+++ b/frontend/src/components/common/ConversationChatPanel.js
@@ -106,13 +106,12 @@ function ConversationChatPanel({ workboard, conversationId }) {
   return (
     <Paper elevation={1} sx={{ p: { xs: 2, md: 3 } }}>
       <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 2, flexWrap: 'wrap' }}>
-        <Chip label="대화 이어가기" color="secondary" size="small" />
-        {conversation.model && <Chip label={conversation.model} size="small" variant="outlined" />}
-        {conversation.serverType && <Chip label={conversation.serverType} size="small" variant="outlined" />}
+        <Chip label="대화 이어가기" color="secondary" />
+        {conversation.model && <Chip label={conversation.model} variant="outlined" />}
+        {conversation.serverType && <Chip label={conversation.serverType} variant="outlined" />}
         {conversation.costEstimate?.amount != null && (
           <Chip
             label={`누적 $${conversation.costEstimate.amount.toFixed(6)}`}
-            size="small"
             variant="outlined"
             color="info"
           />

--- a/frontend/src/components/common/ConversationHistoryPanel.js
+++ b/frontend/src/components/common/ConversationHistoryPanel.js
@@ -109,19 +109,17 @@ function ConversationHistoryPanel({ fetchFn, queryKey = 'conversations' }) {
             <Card key={conv._id} variant="outlined">
               <CardContent sx={{ pb: 1 }}>
                 <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 0.5, flexWrap: 'wrap' }}>
-                  <Chip label={conv.workboardId?.name || '(작업판 없음)'} size="small" color="primary" variant="outlined" />
-                  {conv.model && <Chip label={conv.model} size="small" variant="outlined" />}
-                  {conv.serverType && <Chip label={conv.serverType} size="small" variant="outlined" />}
+                  <Chip label={conv.workboardId?.name || '(작업판 없음)'} color="primary" variant="outlined" />
+                  {conv.model && <Chip label={conv.model} variant="outlined" />}
+                  {conv.serverType && <Chip label={conv.serverType} variant="outlined" />}
                   <Chip
                     label={conv.status}
-                    size="small"
                     color={conv.status === 'completed' ? 'success' : conv.status === 'failed' ? 'error' : 'default'}
                     variant="outlined"
                   />
                   {(conv.messages?.filter((m) => m.role !== 'system').length || 0) > 2 && (
                     <Chip
                       label={`${conv.messages.filter((m) => m.role !== 'system').length}턴`}
-                      size="small"
                       variant="outlined"
                     />
                   )}
@@ -171,7 +169,6 @@ function ConversationHistoryPanel({ fetchFn, queryKey = 'conversations' }) {
                 }}
               >
                 <Button
-                  size="small"
                   onClick={() => setDetailItem(conv)}
                   startIcon={<InfoIcon />}
                   sx={{ '& .MuiButton-startIcon': { mx: { xs: 0, sm: '-4px' }, mr: { xs: 0.5, sm: 1 } } }}
@@ -180,7 +177,6 @@ function ConversationHistoryPanel({ fetchFn, queryKey = 'conversations' }) {
                 </Button>
                 {conv.workboardId?._id && (
                   <Button
-                    size="small"
                     color="success"
                     variant="contained"
                     onClick={() =>
@@ -229,9 +225,9 @@ function ConversationHistoryPanel({ fetchFn, queryKey = 'conversations' }) {
           {detailItem && (
             <Stack spacing={1.5}>
               <Stack direction="row" spacing={1} flexWrap="wrap">
-                <Chip label={detailItem.workboardId?.name || '(작업판 없음)'} size="small" color="primary" variant="outlined" />
-                {detailItem.model && <Chip label={detailItem.model} size="small" variant="outlined" />}
-                {detailItem.serverType && <Chip label={detailItem.serverType} size="small" variant="outlined" />}
+                <Chip label={detailItem.workboardId?.name || '(작업판 없음)'} color="primary" variant="outlined" />
+                {detailItem.model && <Chip label={detailItem.model} variant="outlined" />}
+                {detailItem.serverType && <Chip label={detailItem.serverType} variant="outlined" />}
                 <Box sx={{ flexGrow: 1 }} />
                 <Typography variant="caption" color="text.secondary">
                   {new Date(detailItem.createdAt).toLocaleString('ko-KR')}
@@ -265,7 +261,7 @@ function ConversationHistoryPanel({ fetchFn, queryKey = 'conversations' }) {
                   )}
                 </Stack>
               )}
-              <Divider><Chip label="대화" size="small" icon={<ArticleIcon fontSize="small" />} /></Divider>
+              <Divider><Chip label="대화" icon={<ArticleIcon fontSize="small" />} /></Divider>
               {(detailItem.messages || []).map((msg, idx) => {
                 // workboardSystemPrompt / worldviewContext 가 별도 섹션으로 표시되면 system 메시지는 중복이라 숨김
                 if (msg.role === 'system' && (detailItem.workboardSystemPrompt || detailItem.worldviewContext)) {

--- a/frontend/src/components/common/JobHistoryPanel.js
+++ b/frontend/src/components/common/JobHistoryPanel.js
@@ -297,7 +297,6 @@ function JobStatusChip({ status }) {
     <Chip
       label={cfg.label}
       color={cfg.color}
-      size="small"
       icon={cfg.icon}
       variant="outlined"
     />
@@ -563,7 +562,7 @@ function JobCard({ job, onView, onRetry, onCancel, onDelete, onImageView, onCont
                 '& .MuiButton-root': { fontSize: { xs: '0.75rem', sm: '0.875rem' }, px: { xs: 1, sm: 1.5 }, minWidth: { xs: 'auto', sm: 'auto' } }
               }}
             >
-              <Button size="small" onClick={() => onView(job)} startIcon={<Info />}
+              <Button onClick={() => onView(job)} startIcon={<Info />}
                 sx={{ '& .MuiButton-startIcon': { mx: { xs: 0, sm: '-4px' }, mr: { xs: 0.5, sm: 1 } } }}
               >
                 상세
@@ -571,19 +570,19 @@ function JobCard({ job, onView, onRetry, onCancel, onDelete, onImageView, onCont
 
               {canContinue && (
                 <>
-                  <Button size="small" onClick={() => onContinue(job)} startIcon={<PlayArrow />} color="success" variant="contained"
+                  <Button onClick={() => onContinue(job)} startIcon={<PlayArrow />} color="success" variant="contained"
                     sx={{ '& .MuiButton-startIcon': { mx: { xs: 0, sm: '-4px' }, mr: { xs: 0.5, sm: 1 } } }}
                   >
                     <Box component="span" sx={{ display: { xs: 'none', sm: 'inline' } }}>계속하기</Box>
                     <Box component="span" sx={{ display: { xs: 'inline', sm: 'none' } }}>계속</Box>
                   </Button>
-                  <Button size="small" onClick={() => onCrossWorkboard(job)} startIcon={<SwapHoriz />} color="info" variant="outlined"
+                  <Button onClick={() => onCrossWorkboard(job)} startIcon={<SwapHoriz />} color="info" variant="outlined"
                     sx={{ '& .MuiButton-startIcon': { mx: { xs: 0, sm: '-4px' }, mr: { xs: 0.5, sm: 1 } } }}
                   >
                     <Box component="span" sx={{ display: { xs: 'none', sm: 'inline' } }}>다른 작업</Box>
                     <Box component="span" sx={{ display: { xs: 'inline', sm: 'none' } }}>다른</Box>
                   </Button>
-                  <Button size="small" onClick={() => onSavePrompt(job)} startIcon={<Save />} color="secondary"
+                  <Button onClick={() => onSavePrompt(job)} startIcon={<Save />} color="secondary"
                     sx={{ '& .MuiButton-startIcon': { mx: { xs: 0, sm: '-4px' }, mr: { xs: 0.5, sm: 1 } } }}
                   >
                     <Box component="span" sx={{ display: { xs: 'none', sm: 'inline' } }}>프롬프트 저장</Box>
@@ -593,7 +592,7 @@ function JobCard({ job, onView, onRetry, onCancel, onDelete, onImageView, onCont
               )}
 
               {canRetry && (
-                <Button size="small" onClick={() => onRetry(job)} startIcon={<Refresh />} color="primary"
+                <Button onClick={() => onRetry(job)} startIcon={<Refresh />} color="primary"
                   sx={{ '& .MuiButton-startIcon': { mx: { xs: 0, sm: '-4px' }, mr: { xs: 0.5, sm: 1 } } }}
                 >
                   재시도
@@ -601,14 +600,14 @@ function JobCard({ job, onView, onRetry, onCancel, onDelete, onImageView, onCont
               )}
 
               {canCancel && (
-                <Button size="small" onClick={() => onCancel(job)} startIcon={<Stop />} color="warning"
+                <Button onClick={() => onCancel(job)} startIcon={<Stop />} color="warning"
                   sx={{ '& .MuiButton-startIcon': { mx: { xs: 0, sm: '-4px' }, mr: { xs: 0.5, sm: 1 } } }}
                 >
                   취소
                 </Button>
               )}
 
-              <Button size="small" onClick={() => onDelete(job)} startIcon={<Delete />} color="error"
+              <Button onClick={() => onDelete(job)} startIcon={<Delete />} color="error"
                 sx={{ '& .MuiButton-startIcon': { mx: { xs: 0, sm: '-4px' }, mr: { xs: 0.5, sm: 1 } } }}
               >
                 삭제

--- a/frontend/src/components/common/MediaGrid.js
+++ b/frontend/src/components/common/MediaGrid.js
@@ -190,21 +190,21 @@ function ImageCard({ image, type, onEdit, onDelete, onView, readOnly = false, sh
               <ProjectTagChip key={tag._id || tag} tag={typeof tag === 'object' ? tag : { name: tag }} />
             ))}
             {image.tags.length > 2 && (
-              <Chip label={`+${image.tags.length - 2}`} size="small" variant="outlined" />
+              <Chip label={`+${image.tags.length - 2}`} variant="outlined" />
             )}
           </Box>
         )}
 
         {type === 'uploaded' && image.isReferenced && (
-          <Chip label="참조됨" color="primary" size="small" variant="outlined" sx={{ mt: 1 }} />
+          <Chip label="참조됨" color="primary" variant="outlined" sx={{ mt: 1 }} />
         )}
         {type === 'generated' && image.isPublic && (
-          <Chip label="공개" color="success" size="small" variant="outlined" sx={{ mt: 1 }} />
+          <Chip label="공개" color="success" variant="outlined" sx={{ mt: 1 }} />
         )}
       </CardContent>
       {!readOnly && !bulkMode && (
         <CardActions sx={{ justifyContent: 'space-between', pt: 0 }}>
-          <Button size="small" onClick={() => onView(image)} startIcon={<Info />}>상세보기</Button>
+          <Button onClick={() => onView(image)} startIcon={<Info />}>상세보기</Button>
           <IconButton size="small" onClick={(e) => setAnchorEl(e.currentTarget)}><MoreVert /></IconButton>
           <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={() => setAnchorEl(null)}>
             <MenuItem onClick={() => { onEdit(image); setAnchorEl(null); }}>
@@ -304,17 +304,17 @@ function VideoCard({ video, onEdit, onDelete, onView, readOnly = false, showTags
               <ProjectTagChip key={tag._id || tag} tag={typeof tag === 'object' ? tag : { name: tag }} />
             ))}
             {video.tags.length > 2 && (
-              <Chip label={`+${video.tags.length - 2}`} size="small" variant="outlined" />
+              <Chip label={`+${video.tags.length - 2}`} variant="outlined" />
             )}
           </Box>
         )}
         {video.isPublic && (
-          <Chip label="공개" color="success" size="small" variant="outlined" sx={{ mt: 1 }} />
+          <Chip label="공개" color="success" variant="outlined" sx={{ mt: 1 }} />
         )}
       </CardContent>
       {!readOnly && !bulkMode && (
         <CardActions sx={{ justifyContent: 'space-between', pt: 0 }}>
-          <Button size="small" onClick={() => onView(video)} startIcon={<Info />}>상세보기</Button>
+          <Button onClick={() => onView(video)} startIcon={<Info />}>상세보기</Button>
           <IconButton size="small" onClick={(e) => setAnchorEl(e.currentTarget)}><MoreVert /></IconButton>
           <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={() => setAnchorEl(null)}>
             <MenuItem onClick={() => { onEdit(video); setAnchorEl(null); }}>

--- a/frontend/src/components/common/MetadataDetailDialog.js
+++ b/frontend/src/components/common/MetadataDetailDialog.js
@@ -65,17 +65,16 @@ function MetadataDetailDialog({ open, onClose, item, nsfwImageFilter = true, bas
       <DialogContent dividers>
         {/* 배지 */}
         <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', mb: 2 }}>
-          <Chip label={getKindLabel(item.kind)} size="small" variant="outlined" />
+          <Chip label={getKindLabel(item.kind)} variant="outlined" />
           {item.baseModel && (
             <Chip
               label={item.baseModel}
-              size="small"
               color={baseModelColorFn(item.baseModel)}
               variant="outlined"
             />
           )}
           {item.capabilities?.map((c) => (
-            <Chip key={c} label={c} size="small" variant="outlined" />
+            <Chip key={c} label={c} variant="outlined" />
           ))}
         </Box>
 
@@ -130,7 +129,7 @@ function MetadataDetailDialog({ open, onClose, item, nsfwImageFilter = true, bas
             </Typography>
             <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
               {item.trainedWords.map((word, i) => (
-                <Chip key={i} label={word} size="small" />
+                <Chip key={i} label={word} />
               ))}
             </Box>
           </Box>

--- a/frontend/src/components/common/MetadataFieldInput.js
+++ b/frontend/src/components/common/MetadataFieldInput.js
@@ -51,7 +51,6 @@ function MetadataFieldInput({ kind, field, value, onChange, workboardId, serverI
                 )}
                 <Button
                   variant="text"
-                  size="small"
                   startIcon={<SearchIcon />}
                   onClick={() => setPickerOpen(true)}
                   disabled={!serverId && !workboardId}

--- a/frontend/src/components/common/MetadataItemCard.js
+++ b/frontend/src/components/common/MetadataItemCard.js
@@ -137,26 +137,25 @@ const MetadataItemCard = React.memo(function MetadataItemCard({
 
         {/* 배지: kind + baseModel + capabilities + 메타데이터 상태 */}
         <Box sx={{ mt: 1, display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
-          <Chip label={getKindLabel(item.kind)} size="small" variant="outlined" />
+          <Chip label={getKindLabel(item.kind)} variant="outlined" />
           {item.baseModel && (
             <Chip
               label={item.baseModel}
-              size="small"
               color={baseModelColorFn(item.baseModel)}
               variant="outlined"
             />
           )}
           {item.capabilities.slice(0, 3).map((c) => (
-            <Chip key={c} label={c} size="small" variant="outlined" />
+            <Chip key={c} label={c} variant="outlined" />
           ))}
           {!item.hasMetadata && !item.hash && (
             <Tooltip title={item.hashError || '메타데이터 없음 — sync 가 아직 안 됐거나 Civitai/provider 미등록'}>
-              <Chip icon={<InfoIcon />} label="메타데이터 없음" size="small" variant="outlined" />
+              <Chip icon={<InfoIcon />} label="메타데이터 없음" variant="outlined" />
             </Tooltip>
           )}
           {item.hash && !item.hasMetadata && (
             <Tooltip title="Civitai 미등록 (custom merge / private 모델)">
-              <Chip label="미등록" size="small" variant="outlined" />
+              <Chip label="미등록" variant="outlined" />
             </Tooltip>
           )}
         </Box>
@@ -179,7 +178,6 @@ const MetadataItemCard = React.memo(function MetadataItemCard({
                 <Chip
                   key={i}
                   label={word}
-                  size="small"
                   onClick={onTrainedWordClick ? (e) => {
                     e.stopPropagation();
                     onTrainedWordClick(word, item);
@@ -190,7 +188,7 @@ const MetadataItemCard = React.memo(function MetadataItemCard({
                 />
               ))}
               {item.trainedWords.length > 3 && (
-                <Chip label={`+${item.trainedWords.length - 3}`} size="small" variant="outlined" />
+                <Chip label={`+${item.trainedWords.length - 3}`} variant="outlined" />
               )}
             </Box>
           </Box>
@@ -228,7 +226,6 @@ const MetadataItemCard = React.memo(function MetadataItemCard({
         </Stack>
         {onPrimary && !cardClickable && (
           <Button
-            size="small"
             startIcon={primaryVariant === 'select' ? null : <AddIcon />}
             onClick={(e) => {
               e.stopPropagation();

--- a/frontend/src/components/common/MetadataPickerModal.js
+++ b/frontend/src/components/common/MetadataPickerModal.js
@@ -322,7 +322,6 @@ function MetadataPickerModal({
         <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} sx={{ mb: 2 }}>
           <TextField
             placeholder="이름 / 파일명 / 트리거워드 검색"
-            size="small"
             fullWidth
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
@@ -374,7 +373,6 @@ function MetadataPickerModal({
           <Box sx={{ mb: 1.5 }}>
             <Chip
               label={`${selectedItems.length}개 선택됨`}
-              size="small"
               color={selectedItems.length > 0 ? 'primary' : 'default'}
               variant="outlined"
             />
@@ -427,7 +425,7 @@ function MetadataPickerModal({
               작업판 허용 타입:
             </Typography>
             {allowedModelTypes.map((t) => (
-              <Chip key={t} label={t} size="small" color="primary" variant="outlined" />
+              <Chip key={t} label={t} color="primary" variant="outlined" />
             ))}
           </Box>
         )}
@@ -576,9 +574,9 @@ function MetadataPickerModal({
                           {item.baseModel}
                         </Typography>
                       )}
-                      <Button size="small" onClick={(e) => { e.stopPropagation(); setDetailItem(item); }} sx={{ flexShrink: 0, minWidth: 'auto' }}>상세</Button>
+                      <Button onClick={(e) => { e.stopPropagation(); setDetailItem(item); }} sx={{ flexShrink: 0, minWidth: 'auto' }}>상세</Button>
                       {!cardClickable && (
-                        <Button size="small" variant={mode === 'prompt-insert' ? 'contained' : 'text'} onClick={(e) => { e.stopPropagation(); handlePrimary(rawItem); }} sx={{ flexShrink: 0, minWidth: 'auto' }}>
+                        <Button variant={mode === 'prompt-insert' ? 'contained' : 'text'} onClick={(e) => { e.stopPropagation(); handlePrimary(rawItem); }} sx={{ flexShrink: 0, minWidth: 'auto' }}>
                           {mode === 'prompt-insert' ? '추가' : mode === 'multi-add' ? (isSelected ? '제거' : '추가') : '선택'}
                         </Button>
                       )}

--- a/frontend/src/components/common/PipelinePanel.js
+++ b/frontend/src/components/common/PipelinePanel.js
@@ -165,7 +165,7 @@ function PipelinePanel({ projectId }) {
               <CardContent sx={{ pb: 1 }}>
                 <Box display="flex" alignItems="center" gap={1} sx={{ mb: 0.5, flexWrap: 'wrap' }}>
                   <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>{p.name}</Typography>
-                  <Chip label={`${p.steps?.length || 0}단계`} size="small" variant="outlined" />
+                  <Chip label={`${p.steps?.length || 0}단계`} variant="outlined" />
                   {/* #401: useWorldview chip 제거 — 단계별 문서 연결로 표현 */}
                 </Box>
                 {p.description && (
@@ -179,7 +179,6 @@ function PipelinePanel({ projectId }) {
                     <Box key={idx} sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
                       <Chip
                         label={idx + 1}
-                        size="small"
                         color={s.workboardId?.isActive === false ? 'warning' : 'primary'}
                         sx={{ height: 22, minWidth: 22, '& .MuiChip-label': { px: 1 } }}
                       />
@@ -218,7 +217,6 @@ function PipelinePanel({ projectId }) {
               </CardContent>
               <CardActions sx={{ pt: 0, justifyContent: 'flex-end' }}>
                 <Button
-                  size="small"
                   color="success"
                   variant="contained"
                   startIcon={<PlayArrowIcon />}
@@ -228,7 +226,6 @@ function PipelinePanel({ projectId }) {
                   실행
                 </Button>
                 <Button
-                  size="small"
                   startIcon={<EditIcon />}
                   onClick={() => { setEditingPipelineId(p._id); setView('builder'); }}
                 >
@@ -376,7 +373,6 @@ function PipelineBuilder({ projectId, pipelineId, onClose }) {
 
       <Stack spacing={2}>
         <TextField
-          size="small"
           label="이름"
           value={name}
           onChange={(e) => setName(e.target.value)}
@@ -384,7 +380,6 @@ function PipelineBuilder({ projectId, pipelineId, onClose }) {
           fullWidth
         />
         <TextField
-          size="small"
           label="설명 (선택)"
           value={description}
           onChange={(e) => setDescription(e.target.value)}
@@ -399,7 +394,6 @@ function PipelineBuilder({ projectId, pipelineId, onClose }) {
           <Box display="flex" alignItems="center" mb={1}>
             <Typography variant="subtitle2" sx={{ flexGrow: 1 }}>단계 ({steps.length})</Typography>
             <Button
-              size="small"
               startIcon={<AddIcon />}
               variant="outlined"
               onClick={() => setPickerOpen(true)}
@@ -417,7 +411,7 @@ function PipelineBuilder({ projectId, pipelineId, onClose }) {
               {steps.map((s, idx) => (
                 <Paper key={idx} variant="outlined" sx={{ p: 1.5 }}>
                   <Box display="flex" alignItems="center" gap={1}>
-                    <Chip label={idx + 1} size="small" color="primary" />
+                    <Chip label={idx + 1} color="primary" />
                     <Box sx={{ flex: '1 1 0', minWidth: 0 }}>
                       <Typography variant="subtitle2" noWrap>
                         {s.workboard?.name || '(이름 불러오는 중)'}
@@ -429,7 +423,7 @@ function PipelineBuilder({ projectId, pipelineId, onClose }) {
                       )}
                       <Stack direction="row" spacing={0.5} sx={{ mt: 0.5 }}>
                         {s.workboard?.outputFormat && (
-                          <Chip label={`out: ${s.workboard.outputFormat}`} size="small" variant="outlined" />
+                          <Chip label={`out: ${s.workboard.outputFormat}`} variant="outlined" />
                         )}
                       </Stack>
                     </Box>
@@ -450,19 +444,17 @@ function PipelineBuilder({ projectId, pipelineId, onClose }) {
                       />
                     )}
                     <Button
-                      size="small"
                       variant="outlined"
                       startIcon={<SettingsIcon />}
                       onClick={() => setInputsDialogStepIdx(idx)}
                     >
                       입력 설정
                       {Object.keys(s.inputs || {}).filter((k) => s.inputs[k] !== '' && s.inputs[k] != null).length > 0 && (
-                        <Chip label={Object.keys(s.inputs).filter((k) => s.inputs[k] !== '' && s.inputs[k] != null).length} size="small" sx={{ ml: 0.5, height: 18 }} />
+                        <Chip label={Object.keys(s.inputs).filter((k) => s.inputs[k] !== '' && s.inputs[k] != null).length} sx={{ ml: 0.5, height: 18 }} />
                       )}
                     </Button>
                     {/* 단계별 문서 연결 (#401) — LLM 단계만 의미 있지만 UI 는 모든 단계에 노출 (간소화) */}
                     <Button
-                      size="small"
                       variant="outlined"
                       onClick={() => setDocsDialogStepIdx(idx)}
                     >
@@ -470,7 +462,6 @@ function PipelineBuilder({ projectId, pipelineId, onClose }) {
                       {((s.contextDocIds?.length || 0) + (s.systemPromptDocId ? 1 : 0)) > 0 && (
                         <Chip
                           label={(s.contextDocIds?.length || 0) + (s.systemPromptDocId ? 1 : 0)}
-                          size="small"
                           sx={{ ml: 0.5, height: 18 }}
                         />
                       )}
@@ -487,7 +478,6 @@ function PipelineBuilder({ projectId, pipelineId, onClose }) {
                   </Box>
                   {/* 단계별 메모 — 이 단계의 작업판 역할 / 사용자 가이드용 (#397 후속) */}
                   <TextField
-                    size="small"
                     fullWidth
                     placeholder="이 단계에 대한 설명 / 메모 (선택)"
                     value={s.note || ''}
@@ -554,8 +544,8 @@ function PipelineBuilder({ projectId, pipelineId, onClose }) {
                 >
                   <Typography variant="subtitle2">{wb.name}</Typography>
                   <Stack direction="row" spacing={0.5} sx={{ mt: 0.5 }}>
-                    {wb.outputFormat && <Chip label={wb.outputFormat} size="small" variant="outlined" />}
-                    {wb.serverId?.name && <Chip label={wb.serverId.name} size="small" variant="outlined" />}
+                    {wb.outputFormat && <Chip label={wb.outputFormat} variant="outlined" />}
+                    {wb.serverId?.name && <Chip label={wb.serverId.name} variant="outlined" />}
                   </Stack>
                 </Box>
               ))}
@@ -597,7 +587,6 @@ function StepInputsDialog({ open, step, onClose, onSave }) {
     if (field.type === 'string') {
       return (
         <TextField
-          size="small"
           fullWidth
           label={field.label}
           placeholder={field.placeholder}
@@ -612,7 +601,6 @@ function StepInputsDialog({ open, step, onClose, onSave }) {
     if (field.type === 'number') {
       return (
         <TextField
-          size="small"
           fullWidth
           type="number"
           label={field.label}
@@ -634,7 +622,6 @@ function StepInputsDialog({ open, step, onClose, onSave }) {
       // native select 사용 시 label 이 placeholder 와 겹쳐 보이는 문제 해결 위해 InputLabelProps.shrink 고정
       return (
         <TextField
-          size="small"
           fullWidth
           select
           label={field.label}
@@ -797,7 +784,6 @@ function StepDocsDialog({ open, projectId, step, onClose, onSave }) {
                       <Box display="flex" alignItems="center" gap={1}>
                         <Chip
                           label={selected ? '선택' : ''}
-                          size="small"
                           color={selected ? 'primary' : 'default'}
                           variant={selected ? 'filled' : 'outlined'}
                           sx={{ minWidth: 50 }}
@@ -827,7 +813,6 @@ function StepDocsDialog({ open, projectId, step, onClose, onSave }) {
               system 메시지의 [작업 지침] 으로 사용됩니다. 작업판의 system_prompt customField 보다 우선합니다.
             </Typography>
             <TextField
-              size="small"
               fullWidth
               select
               SelectProps={{ native: true }}
@@ -949,7 +934,6 @@ function PipelineRunner({ projectId, pipelineId, onClose }) {
         </Alert>
 
         <TextField
-          size="small"
           label="초기 입력 프롬프트"
           value={initialPrompt}
           onChange={(e) => setInitialPrompt(e.target.value)}
@@ -1010,7 +994,7 @@ function PipelineRunner({ projectId, pipelineId, onClose }) {
                       : runStep.status === 'failed' ? <ErrorIcon color="error" />
                       : runStep.status === 'running' ? <CircularProgress size={20} />
                       : runStep.status === 'skipped' ? <StopIcon color="disabled" />
-                      : <Chip label={idx + 1} size="small" />
+                      : <Chip label={idx + 1} />
                     }
                   >
                     <Typography variant="subtitle2">
@@ -1165,7 +1149,7 @@ export function PipelineHistoryPanel({ projectId }) {
                   : runStep.status === 'failed' ? <ErrorIcon color="error" />
                   : runStep.status === 'running' ? <CircularProgress size={20} />
                   : runStep.status === 'skipped' ? <StopIcon color="disabled" />
-                  : <Chip label={idx + 1} size="small" />
+                  : <Chip label={idx + 1} />
                 }
               >
                 <Typography variant="subtitle2">
@@ -1228,11 +1212,10 @@ export function PipelineHistoryPanel({ projectId }) {
                   </Typography>
                   <Chip
                     label={r.status === 'pending' ? '대기' : r.status === 'running' ? '진행 중' : r.status === 'completed' ? '완료' : r.status === 'failed' ? '실패' : r.status}
-                    size="small"
                     color={r.status === 'completed' ? 'success' : r.status === 'failed' ? 'error' : r.status === 'running' ? 'primary' : 'default'}
                   />
                   {r.triggerCount > 1 && (
-                    <Chip label={`재시도 ${r.triggerCount - 1}회`} size="small" variant="outlined" />
+                    <Chip label={`재시도 ${r.triggerCount - 1}회`} variant="outlined" />
                   )}
                   <Box sx={{ flexGrow: 1 }} />
                   <Typography variant="caption" color="text.secondary">
@@ -1256,7 +1239,6 @@ export function PipelineHistoryPanel({ projectId }) {
                     <Chip
                       key={idx}
                       label={idx + 1}
-                      size="small"
                       color={
                         s.status === 'completed' ? 'success'
                         : s.status === 'failed' ? 'error'
@@ -1271,7 +1253,7 @@ export function PipelineHistoryPanel({ projectId }) {
                 </Stack>
               </CardContent>
               <CardActions sx={{ pt: 0, justifyContent: 'flex-end' }}>
-                <Button size="small" onClick={() => setSelectedRunId(r._id)}>상세</Button>
+                <Button onClick={() => setSelectedRunId(r._id)}>상세</Button>
                 <IconButton
                   size="small"
                   color="error"

--- a/frontend/src/components/common/ProjectEditDialog.js
+++ b/frontend/src/components/common/ProjectEditDialog.js
@@ -119,7 +119,7 @@ function ProjectEditDialog({ open, onClose, project, onSuccess }) {
       <Dialog open={open} onClose={handleBrowseCancel} maxWidth="md" fullWidth>
         <DialogTitle>
           <Box display="flex" alignItems="center" gap={1}>
-            <Button size="small" startIcon={<ArrowBack />} onClick={handleBrowseCancel}>
+            <Button startIcon={<ArrowBack />} onClick={handleBrowseCancel}>
               돌아가기
             </Button>
             <Typography variant="h6">커버 이미지 선택</Typography>
@@ -201,7 +201,6 @@ function ProjectEditDialog({ open, onClose, project, onSuccess }) {
               }}
             />
             <Button
-              size="small"
               color="error"
               startIcon={<Close />}
               onClick={handleImageRemove}
@@ -210,7 +209,6 @@ function ProjectEditDialog({ open, onClose, project, onSuccess }) {
               이미지 제거
             </Button>
             <Button
-              size="small"
               startIcon={<ImageIcon />}
               onClick={() => setBrowseMode(true)}
               sx={{ mt: 1, ml: 1 }}
@@ -231,7 +229,7 @@ function ProjectEditDialog({ open, onClose, project, onSuccess }) {
 
         <Box>
           <Typography variant="body2" color="textSecondary">
-            태그명: <Chip size="small" label={project?.tagId?.name} sx={{ bgcolor: project?.tagId?.color, color: 'white' }} />
+            태그명: <Chip label={project?.tagId?.name} sx={{ bgcolor: project?.tagId?.color, color: 'white' }} />
           </Typography>
           <Typography variant="caption" color="textSecondary">
             태그명은 변경할 수 없습니다.

--- a/frontend/src/components/common/PromptDataFormDialog.js
+++ b/frontend/src/components/common/PromptDataFormDialog.js
@@ -107,13 +107,11 @@ function PromptDataFormDialog({ open, onClose, promptData = null, onSave }) {
                 {selectedImage && (
                   <Box sx={{ mt: 1, display: 'flex', gap: 1 }}>
                     <Button
-                      size="small"
                       onClick={() => setImageSelectOpen(true)}
                     >
                       이미지 변경
                     </Button>
                     <Button
-                      size="small"
                       color="error"
                       onClick={() => setSelectedImage(null)}
                     >

--- a/frontend/src/components/common/PromptDataPanel.js
+++ b/frontend/src/components/common/PromptDataPanel.js
@@ -203,7 +203,6 @@ function PromptDataPanel({
                       {item.tags?.length > 3 && (
                         <Chip
                           label={`+${item.tags.length - 3}`}
-                          size="small"
                           variant="outlined"
                           sx={{ mb: 0.5 }}
                         />
@@ -214,7 +213,6 @@ function PromptDataPanel({
                     <CardActions>
                       {onQuickGenerate && (
                         <Button
-                          size="small"
                           startIcon={<PlayArrow />}
                           onClick={() => onQuickGenerate(item)}
                         >
@@ -223,7 +221,6 @@ function PromptDataPanel({
                       )}
                       {onEdit && (
                         <Button
-                          size="small"
                           startIcon={<Edit />}
                           onClick={() => onEdit(item)}
                         >

--- a/frontend/src/components/common/TagInput.js
+++ b/frontend/src/components/common/TagInput.js
@@ -92,7 +92,6 @@ function TagInput({
             {...getTagProps({ index })}
             key={option._id || index}
             label={option.name}
-            size="small"
             sx={{ 
               bgcolor: option.color || '#1976d2',
               color: 'white',
@@ -125,7 +124,6 @@ function TagInput({
       renderOption={(props, option) => (
         <Box component="li" {...props}>
           <Chip
-            size="small"
             label={option.name}
             sx={{ 
               bgcolor: option.color || '#1976d2',

--- a/frontend/src/components/common/TextContentPanel.js
+++ b/frontend/src/components/common/TextContentPanel.js
@@ -146,7 +146,6 @@ function TextContentPanel({ kind = 'uploaded', defaultTags = [], filterTags = []
     <Box>
       <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} sx={{ mb: 2 }} alignItems={{ sm: 'center' }}>
         <TextField
-          size="small"
           placeholder={isUploaded ? '제목 / 본문 검색...' : '본문 검색...'}
           value={search}
           onChange={(e) => { setSearch(e.target.value); setPage(1); }}
@@ -155,7 +154,6 @@ function TextContentPanel({ kind = 'uploaded', defaultTags = [], filterTags = []
         {isUploaded && (
           <Button
             variant="outlined"
-            size="small"
             startIcon={<UploadFileIcon />}
             onClick={() => setUploadOpen(true)}
             sx={{ alignSelf: { xs: 'flex-start', sm: 'auto' } }}
@@ -190,12 +188,11 @@ function TextContentPanel({ kind = 'uploaded', defaultTags = [], filterTags = []
                     <Chip
                       key={t._id || t}
                       label={t.name || t}
-                      size="small"
                       sx={{ backgroundColor: t.color, color: '#fff' }}
                     />
                   ))}
                   {!isUploaded && item.model && (
-                    <Chip label={item.model} size="small" variant="outlined" />
+                    <Chip label={item.model} variant="outlined" />
                   )}
                   <Box sx={{ flexGrow: 1 }} />
                   <Typography variant="caption" color="text.secondary">
@@ -287,7 +284,6 @@ function TextContentPanel({ kind = 'uploaded', defaultTags = [], filterTags = []
             <Stack spacing={2} sx={{ mt: 1 }}>
               <TextField
                 label="제목 (선택)"
-                size="small"
                 value={editingItem.title || ''}
                 onChange={(e) => setEditingItem({ ...editingItem, title: e.target.value })}
                 inputProps={{ maxLength: 200 }}
@@ -333,12 +329,11 @@ function TextContentPanel({ kind = 'uploaded', defaultTags = [], filterTags = []
                   <Chip
                     key={t._id || t}
                     label={t.name || t}
-                    size="small"
                     sx={{ backgroundColor: t.color, color: '#fff' }}
                   />
                 ))}
                 {!isUploaded && viewerItem.model && (
-                  <Chip label={viewerItem.model} size="small" variant="outlined" />
+                  <Chip label={viewerItem.model} variant="outlined" />
                 )}
                 <Box sx={{ flexGrow: 1 }} />
                 <Typography variant="caption" color="text.secondary">

--- a/frontend/src/components/common/WorkboardChatPanel.js
+++ b/frontend/src/components/common/WorkboardChatPanel.js
@@ -138,7 +138,6 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
             <TextField
               {...formField}
               fullWidth
-              size="small"
               label={field.label}
               placeholder={field.placeholder}
               multiline={field.name.includes('prompt')}
@@ -159,7 +158,6 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
             <TextField
               {...formField}
               fullWidth
-              size="small"
               type="number"
               label={field.label}
               disabled={locked}
@@ -209,13 +207,12 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
     <Paper elevation={1} sx={{ p: { xs: 2, md: 3 } }}>
       {/* 헤더 */}
       <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 2, flexWrap: 'wrap' }}>
-        <Chip label="대화 모드" color="secondary" size="small" />
-        {conversation?.model && <Chip label={conversation.model} size="small" variant="outlined" />}
-        {conversation?.serverType && <Chip label={conversation.serverType} size="small" variant="outlined" />}
+        <Chip label="대화 모드" color="secondary" />
+        {conversation?.model && <Chip label={conversation.model} variant="outlined" />}
+        {conversation?.serverType && <Chip label={conversation.serverType} variant="outlined" />}
         {conversation?.costEstimate?.amount != null && (
           <Chip
             label={`누적 $${conversation.costEstimate.amount.toFixed(6)}`}
-            size="small"
             variant="outlined"
             color="info"
           />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,15 +1,16 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: 'Pretendard', 'Pretendard Variable', -apple-system, BlinkMacSystemFont,
+    'Segoe UI', 'Roboto', 'Noto Sans KR', 'Helvetica Neue', sans-serif;
+  /* Pretendard 스타일 셋: ss06 (한글 자간), ss07 (라틴 자간 보정) */
+  font-feature-settings: "ss06" on, "ss07" on;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+  font-family: 'JetBrains Mono', source-code-pro, Menlo, Monaco, Consolas,
+    'Courier New', monospace;
 }
 
 * {
@@ -18,4 +19,10 @@ code {
 
 html, body, #root {
   height: 100%;
+}
+
+/* 한국어 본문 줄바꿈 — 마지막 단어가 한 줄 차지하는 미관 회피 (Phase 4). */
+.MuiTypography-body1,
+.MuiTypography-body2 {
+  text-wrap: pretty;
 }

--- a/frontend/src/pages/ImageGeneration.js
+++ b/frontend/src/pages/ImageGeneration.js
@@ -85,7 +85,6 @@ function PromptDataSelectDialog({ open, onClose, onSelect }) {
             setSearch(e.target.value);
             setPage(1);
           }}
-          size="small"
           sx={{ mb: 2 }}
         />
 
@@ -258,7 +257,6 @@ function CustomImageField({ field, value, onChange, maxImages = 1, isComfyUI = f
           variant="outlined"
           onClick={() => setDialogOpen(true)}
           startIcon={<ImageIcon />}
-          size="small"
         >
           갤러리에서 선택
         </Button>
@@ -828,7 +826,6 @@ function ImageGeneration() {
               label={`프로젝트: ${projectContext.name}`}
               color="primary"
               variant="outlined"
-              size="small"
               sx={{ mb: 1 }}
             />
           )}
@@ -859,14 +856,12 @@ function ImageGeneration() {
               {/* 프롬프트 */}
               <Box display="flex" justifyContent="flex-end" gap={1} mb={1}>
                 <Button
-                  size="small"
                   startIcon={<FolderOpen />}
                   onClick={() => setPromptDataDialogOpen(true)}
                 >
                   프롬프트 불러오기
                 </Button>
                 <Button
-                  size="small"
                   color="secondary"
                   variant="outlined"
                   startIcon={<AutoAwesome />}
@@ -905,7 +900,6 @@ function ImageGeneration() {
                 <Box sx={{ mb: 3, display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
                   <Button
                     variant="outlined"
-                    size="small"
                     onClick={handleLoraModalOpen}
                     startIcon={<AutoFixHigh />}
                   >

--- a/frontend/src/pages/LoraList.js
+++ b/frontend/src/pages/LoraList.js
@@ -166,7 +166,6 @@ function LoraCard({ lora, expanded, onToggleExpand, onCopyTriggerWord, getBaseMo
           {lora.civitai?.baseModel && (
             <Chip
               label={lora.civitai.baseModel}
-              size="small"
               color={getBaseModelColor(lora.civitai.baseModel)}
               variant="outlined"
               disableRipple
@@ -176,7 +175,6 @@ function LoraCard({ lora, expanded, onToggleExpand, onCopyTriggerWord, getBaseMo
             <Chip
               icon={<InfoIcon />}
               label="메타데이터 없음"
-              size="small"
               variant="outlined"
               title={lora.hashError || '해시 정보 없음'}
               disableRipple
@@ -185,7 +183,6 @@ function LoraCard({ lora, expanded, onToggleExpand, onCopyTriggerWord, getBaseMo
           {lora.hash && !hasCivitai && (
             <Chip
               label="미등록"
-              size="small"
               variant="outlined"
               title="Civitai에서 찾을 수 없음"
               disableRipple
@@ -204,7 +201,6 @@ function LoraCard({ lora, expanded, onToggleExpand, onCopyTriggerWord, getBaseMo
                 <Chip
                   key={i}
                   label={word}
-                  size="small"
                   onClick={() => onCopyTriggerWord(word)}
                   sx={{ cursor: 'pointer' }}
                 />
@@ -212,7 +208,6 @@ function LoraCard({ lora, expanded, onToggleExpand, onCopyTriggerWord, getBaseMo
               {!expanded && trainedWords.length > 3 && (
                 <Chip
                   label={`+${trainedWords.length - 3}`}
-                  size="small"
                   variant="outlined"
                 />
               )}
@@ -400,7 +395,6 @@ function LoraListItem({ lora, onCopyTriggerWord, getBaseModelColor, nsfwImageFil
             {lora.civitai?.baseModel && (
               <Chip
                 label={lora.civitai.baseModel}
-                size="small"
                 color={getBaseModelColor(lora.civitai.baseModel)}
                 variant="outlined"
                 sx={{ height: 20, fontSize: '0.7rem' }}
@@ -408,7 +402,7 @@ function LoraListItem({ lora, onCopyTriggerWord, getBaseModelColor, nsfwImageFil
               />
             )}
             {!hasCivitai && (
-              <Chip label={lora.hash ? "미등록" : "메타데이터 없음"} size="small" variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} disableRipple />
+              <Chip label={lora.hash ? "미등록" : "메타데이터 없음"} variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} disableRipple />
             )}
           </Box>
 
@@ -419,7 +413,6 @@ function LoraListItem({ lora, onCopyTriggerWord, getBaseModelColor, nsfwImageFil
                 <Chip
                   key={i}
                   label={word}
-                  size="small"
                   onClick={() => onCopyTriggerWord(word)}
                   title={word}
                   sx={{
@@ -436,7 +429,7 @@ function LoraListItem({ lora, onCopyTriggerWord, getBaseModelColor, nsfwImageFil
                 />
               ))}
               {trainedWords.length > 5 && (
-                <Chip label={`+${trainedWords.length - 5}`} size="small" variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />
+                <Chip label={`+${trainedWords.length - 5}`} variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />
               )}
             </Box>
           )}
@@ -670,7 +663,6 @@ function LoraList() {
               placeholder="LoRA 검색..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              size="small"
               fullWidth
               sx={{ mb: 2 }}
               InputProps={{

--- a/frontend/src/pages/MyImages.js
+++ b/frontend/src/pages/MyImages.js
@@ -400,7 +400,6 @@ function MyImages() {
             variant="outlined"
             startIcon={<CheckBoxIcon />}
             onClick={() => setBulkMode(true)}
-            size="small"
           >
             선택
           </Button>
@@ -415,18 +414,17 @@ function MyImages() {
             bgcolor: 'action.hover', borderRadius: 1, flexWrap: 'wrap'
           }}
         >
-          <Button size="small" variant="outlined" startIcon={<Close />} onClick={() => { setBulkMode(false); setSelectedIds(new Set()); }}>
+          <Button variant="outlined" startIcon={<Close />} onClick={() => { setBulkMode(false); setSelectedIds(new Set()); }}>
             선택 모드 종료
           </Button>
           <Chip label={`${selectedIds.size}개 선택됨`} color="primary" variant="outlined" />
-          <Button size="small" startIcon={<SelectAll />} onClick={handleSelectAllPage}>
+          <Button startIcon={<SelectAll />} onClick={handleSelectAllPage}>
             이 페이지 전체 선택
           </Button>
-          <Button size="small" startIcon={<Deselect />} onClick={handleDeselectAll} disabled={selectedIds.size === 0}>
+          <Button startIcon={<Deselect />} onClick={handleDeselectAll} disabled={selectedIds.size === 0}>
             선택 해제
           </Button>
           <Button
-            size="small"
             variant="contained"
             color="error"
             startIcon={<DeleteSweep />}
@@ -437,7 +435,6 @@ function MyImages() {
           </Button>
           {mediaState.search && mediaState.pagination?.total > 0 && (
             <Button
-              size="small"
               variant="outlined"
               color="error"
               onClick={() => openConfirmDialog('allFiltered')}

--- a/frontend/src/pages/Profile.js
+++ b/frontend/src/pages/Profile.js
@@ -343,7 +343,6 @@ function SecuritySettings() {
                 secondary={`외부 프로그램에서 API에 접근할 때 사용합니다 (${activeKeyCount}/10)`}
               />
               <Button
-                size="small"
                 variant="outlined"
                 startIcon={<Add />}
                 onClick={() => setCreateKeyDialogOpen(true)}
@@ -375,7 +374,7 @@ function SecuritySettings() {
                           {apiKey.name}
                         </Typography>
                         {apiKey.isRevoked && (
-                          <Chip label="파기됨" size="small" color="error" variant="outlined" />
+                          <Chip label="파기됨" color="error" variant="outlined" />
                         )}
                       </Box>
                       <Typography variant="caption" color="textSecondary" component="div">

--- a/frontend/src/pages/ProjectDetail.js
+++ b/frontend/src/pages/ProjectDetail.js
@@ -279,7 +279,6 @@ function ImagesTab({ projectId }) {
             variant="outlined"
             startIcon={<CheckBoxIcon />}
             onClick={() => setBulkMode(true)}
-            size="small"
           >
             선택
           </Button>
@@ -292,11 +291,11 @@ function ImagesTab({ projectId }) {
             bgcolor: 'action.hover', borderRadius: 1, flexWrap: 'wrap'
           }}
         >
-          <Button size="small" variant="outlined" startIcon={<Close />} onClick={() => { setBulkMode(false); setImageSelectedIds(new Set()); setVideoSelectedIds(new Set()); }}>
+          <Button variant="outlined" startIcon={<Close />} onClick={() => { setBulkMode(false); setImageSelectedIds(new Set()); setVideoSelectedIds(new Set()); }}>
             선택 모드 종료
           </Button>
           <Chip label={`${totalSelected}개 선택됨`} color="primary" variant="outlined" />
-          <Button size="small" startIcon={<SelectAll />} onClick={() => {
+          <Button startIcon={<SelectAll />} onClick={() => {
             const nextImg = new Set(imageSelectedIds);
             imageMediaState.items.forEach(item => nextImg.add(item._id));
             setImageSelectedIds(nextImg);
@@ -306,11 +305,10 @@ function ImagesTab({ projectId }) {
           }}>
             이 페이지 전체 선택
           </Button>
-          <Button size="small" startIcon={<Deselect />} onClick={() => { setImageSelectedIds(new Set()); setVideoSelectedIds(new Set()); }} disabled={totalSelected === 0}>
+          <Button startIcon={<Deselect />} onClick={() => { setImageSelectedIds(new Set()); setVideoSelectedIds(new Set()); }} disabled={totalSelected === 0}>
             선택 해제
           </Button>
           <Button
-            size="small"
             variant="contained"
             color="error"
             startIcon={<DeleteSweep />}
@@ -661,13 +659,12 @@ function WorkboardsTab({ projectId }) {
                   <Typography variant="caption" color="text.secondary" noWrap display="block">{wb.description}</Typography>
                 )}
                 <Stack direction="row" spacing={0.5} sx={{ mt: 0.5 }}>
-                  {wb.outputFormat && <Chip label={wb.outputFormat} size="small" variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />}
-                  {wb.serverId?.name && <Chip label={wb.serverId.name} size="small" variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />}
-                  {!wb.isActive && <Chip label="비활성" size="small" color="warning" variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />}
+                  {wb.outputFormat && <Chip label={wb.outputFormat} variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />}
+                  {wb.serverId?.name && <Chip label={wb.serverId.name} variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />}
+                  {!wb.isActive && <Chip label="비활성" color="warning" variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />}
                 </Stack>
               </Box>
               <Button
-                size="small"
                 variant="contained"
                 color="success"
                 startIcon={<PlayArrow />}
@@ -721,7 +718,6 @@ function WorkboardPickerDialog({ open, onClose, existingIds = [], onPick }) {
       <DialogTitle>작업판 추가</DialogTitle>
       <DialogContent dividers>
         <TextField
-          size="small"
           fullWidth
           placeholder="작업판 검색..."
           value={search}
@@ -750,7 +746,7 @@ function WorkboardPickerDialog({ open, onClose, existingIds = [], onPick }) {
                 <Box sx={{ flex: '1 1 0', minWidth: 0 }}>
                   <Typography variant="subtitle2" noWrap>{wb.name}</Typography>
                   <Stack direction="row" spacing={0.5} sx={{ mt: 0.5 }}>
-                    {wb.outputFormat && <Chip label={wb.outputFormat} size="small" variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />}
+                    {wb.outputFormat && <Chip label={wb.outputFormat} variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />}
                   </Stack>
                 </Box>
               </Box>
@@ -864,7 +860,6 @@ function ProjectDetail() {
       <Button
         startIcon={<ArrowBack />}
         onClick={() => navigate('/projects')}
-        size="small"
         sx={{ mb: 1 }}
       >
         프로젝트 목록
@@ -918,24 +913,20 @@ function ProjectDetail() {
           )}
           <Box display="flex" gap={0.75} alignItems="center" sx={{ flexWrap: 'wrap' }}>
             <Chip
-              size="small"
               label={project.tagId?.name}
               sx={{ bgcolor: project.tagId?.color || '#7c4dff', color: 'white' }}
             />
             <Chip
-              size="small"
               icon={<ImageIcon />}
               label={`이미지 ${project.counts?.images || 0}`}
               variant="outlined"
             />
             <Chip
-              size="small"
               icon={<TextSnippet />}
               label={`프롬프트 ${project.counts?.promptData || 0}`}
               variant="outlined"
             />
             <Chip
-              size="small"
               icon={<History />}
               label={`작업 ${project.counts?.jobs || 0}`}
               variant="outlined"
@@ -949,7 +940,6 @@ function ProjectDetail() {
               variant="contained"
               startIcon={<ViewModule />}
               onClick={() => navigate(`/workboards?projectId=${id}`)}
-              size="small"
               sx={{
                 whiteSpace: 'nowrap',
                 flexShrink: 0,

--- a/frontend/src/pages/ProjectList.js
+++ b/frontend/src/pages/ProjectList.js
@@ -273,7 +273,6 @@ function ProjectList() {
 
                     <Box mb={1.5}>
                       <Chip
-                        size="small"
                         label={project.tagId?.name}
                         sx={{
                           bgcolor: project.tagId?.color || '#7c4dff',

--- a/frontend/src/pages/PromptGeneration.js
+++ b/frontend/src/pages/PromptGeneration.js
@@ -99,7 +99,7 @@ function PromptGeneration() {
           <Chat color="secondary" />
           <Typography variant="h5">{workboard.name}</Typography>
         </Box>
-        <Chip label={conversationId ? '대화 이어가기' : '프롬프트 생성'} color="secondary" size="small" />
+        <Chip label={conversationId ? '대화 이어가기' : '프롬프트 생성'} color="secondary" />
       </Box>
 
       <Box display="flex" alignItems="center" gap={0.5} mb={2}>

--- a/frontend/src/pages/PromptWorkboards.js
+++ b/frontend/src/pages/PromptWorkboards.js
@@ -104,7 +104,6 @@ function PromptWorkboardCard({ workboard }) {
               <Chip
                 key={index}
                 label={model.key}
-                size="small"
                 variant="outlined"
                 color="secondary"
                 sx={{ maxWidth: '100%' }}
@@ -113,7 +112,6 @@ function PromptWorkboardCard({ workboard }) {
             {workboard.baseInputFields?.aiModel?.length > 3 && (
               <Chip
                 label={`+${workboard.baseInputFields.aiModel.length - 3}개`}
-                size="small"
                 variant="outlined"
               />
             )}
@@ -122,14 +120,12 @@ function PromptWorkboardCard({ workboard }) {
 
         <CardActions>
           <Button
-            size="small"
             onClick={handleInfo}
             startIcon={<Info />}
           >
             상세정보
           </Button>
           <Button
-            size="small"
             variant="contained"
             color="secondary"
             onClick={handleSelect}
@@ -170,7 +166,6 @@ function PromptWorkboardCard({ workboard }) {
               <Chip
                 key={index}
                 label={`${model.key}`}
-                size="small"
                 color="secondary"
                 variant="outlined"
               />
@@ -205,7 +200,6 @@ function PromptWorkboardCard({ workboard }) {
                   <Chip
                     key={index}
                     label={ref.key}
-                    size="small"
                     color="info"
                     variant="outlined"
                   />
@@ -325,7 +319,6 @@ function PromptWorkboards() {
                     variant={pageNum === page ? "contained" : "outlined"}
                     color="secondary"
                     onClick={() => setPage(pageNum)}
-                    size="small"
                   >
                     {pageNum}
                   </Button>

--- a/frontend/src/pages/TagSearch.js
+++ b/frontend/src/pages/TagSearch.js
@@ -337,7 +337,6 @@ function TagSearch() {
                               {img.tags?.map(tag => (
                                 <Chip
                                   key={tag._id}
-                                  size="small"
                                   label={tag.name}
                                   sx={{ bgcolor: tag.color, color: 'white', mr: 0.5, mb: 0.5, fontSize: '0.7rem' }}
                                 />
@@ -374,7 +373,6 @@ function TagSearch() {
                               {img.tags?.map(tag => (
                                 <Chip
                                   key={tag._id}
-                                  size="small"
                                   label={tag.name}
                                   sx={{ bgcolor: tag.color, color: 'white', mr: 0.5, mb: 0.5, fontSize: '0.7rem' }}
                                 />
@@ -432,7 +430,6 @@ function TagSearch() {
                                 {pd.tags?.map(tag => (
                                   <Chip
                                     key={tag._id}
-                                    size="small"
                                     label={tag.name}
                                     sx={{ bgcolor: tag.color, color: 'white', mr: 0.5, fontSize: '0.7rem' }}
                                   />
@@ -463,7 +460,7 @@ function TagSearch() {
           ) : (
             <>
               <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
-                <Chip label={`총 ${totalTags}개`} size="small" />
+                <Chip label={`총 ${totalTags}개`} />
                 <Button
                   variant="contained"
                   startIcon={<Add />}

--- a/frontend/src/pages/Workboards.js
+++ b/frontend/src/pages/Workboards.js
@@ -139,12 +139,10 @@ function WorkboardCard({ workboard, projectId }) {
           <Box display="flex" flexWrap="wrap" gap={0.5} mb={2}>
             <Chip
               label={getOutputFormatLabel(workboard.outputFormat || 'image')}
-              size="small"
               color={workboard.outputFormat === 'text' ? 'secondary' : workboard.outputFormat === 'video' ? 'warning' : 'primary'}
             />
             <Chip
               label={getServerTypeLabel(workboard.serverId?.serverType)}
-              size="small"
               sx={{ bgcolor: getServerTypeColor(workboard.serverId?.serverType), color: 'white' }}
             />
           </Box>
@@ -154,7 +152,6 @@ function WorkboardCard({ workboard, projectId }) {
               <Chip
                 key={index}
                 label={model.key}
-                size="small"
                 variant="outlined"
                 sx={{ maxWidth: '100%' }}
               />
@@ -162,7 +159,6 @@ function WorkboardCard({ workboard, projectId }) {
             {workboard.baseInputFields?.aiModel?.length > 3 && (
               <Chip
                 label={`+${workboard.baseInputFields.aiModel.length - 3}개`}
-                size="small"
                 variant="outlined"
               />
             )}
@@ -171,14 +167,12 @@ function WorkboardCard({ workboard, projectId }) {
 
         <CardActions>
           <Button
-            size="small"
             onClick={handleInfo}
             startIcon={<Info />}
           >
             상세정보
           </Button>
           <Button
-            size="small"
             variant="contained"
             color={isImageWorkboard ? 'primary' : 'secondary'}
             onClick={handleSelect}
@@ -210,12 +204,10 @@ function WorkboardCard({ workboard, projectId }) {
           <Box display="flex" flexWrap="wrap" gap={1} mb={2}>
             <Chip
               label={getOutputFormatLabel(workboard.outputFormat || 'image')}
-              size="small"
               color={workboard.outputFormat === 'text' ? 'secondary' : workboard.outputFormat === 'video' ? 'warning' : 'primary'}
             />
             <Chip
               label={getServerTypeLabel(workboard.serverId?.serverType)}
-              size="small"
               sx={{ bgcolor: getServerTypeColor(workboard.serverId?.serverType), color: 'white' }}
             />
           </Box>
@@ -228,7 +220,6 @@ function WorkboardCard({ workboard, projectId }) {
               <Chip
                 key={index}
                 label={`${model.key}`}
-                size="small"
                 color="primary"
                 variant="outlined"
               />
@@ -245,7 +236,6 @@ function WorkboardCard({ workboard, projectId }) {
                   <Chip
                     key={index}
                     label={size.key}
-                    size="small"
                     color="secondary"
                     variant="outlined"
                   />
@@ -264,7 +254,6 @@ function WorkboardCard({ workboard, projectId }) {
                   <Chip
                     key={index}
                     label={method.key}
-                    size="small"
                     color="info"
                     variant="outlined"
                   />
@@ -504,7 +493,6 @@ function Workboards() {
                     key={pageNum}
                     variant={pageNum === page ? "contained" : "outlined"}
                     onClick={() => setPage(pageNum)}
-                    size="small"
                   >
                     {pageNum}
                   </Button>

--- a/frontend/src/pages/admin/BackupRestorePage.js
+++ b/frontend/src/pages/admin/BackupRestorePage.js
@@ -74,7 +74,6 @@ function getStatusChip(status) {
   const config = statusConfig[status] || statusConfig.pending;
   return (
     <Chip
-      size="small"
       label={config.label}
       color={config.color}
       icon={config.icon}
@@ -440,13 +439,13 @@ function BackupRestorePage() {
                             {restore.options && (
                               <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
                                 {restore.options.overwriteExisting && (
-                                  <Chip size="small" label="덮어쓰기" />
+                                  <Chip label="덮어쓰기" />
                                 )}
                                 {restore.options.skipFiles && (
-                                  <Chip size="small" label="파일 제외" />
+                                  <Chip label="파일 제외" />
                                 )}
                                 {restore.options.skipDatabase && (
-                                  <Chip size="small" label="DB 제외" />
+                                  <Chip label="DB 제외" />
                                 )}
                               </Box>
                             )}

--- a/frontend/src/pages/admin/GroupManagementPage.js
+++ b/frontend/src/pages/admin/GroupManagementPage.js
@@ -70,7 +70,6 @@ function GroupFormDialog({ open, onClose, group, onSave }) {
             onChange={(e) => setName(e.target.value)}
             fullWidth
             required
-            size="small"
           />
           <TextField
             label="설명"
@@ -79,7 +78,6 @@ function GroupFormDialog({ open, onClose, group, onSave }) {
             fullWidth
             multiline
             rows={2}
-            size="small"
           />
           <FormControlLabel
             control={
@@ -155,7 +153,6 @@ function GroupMembersDialog({ open, onClose, group }) {
         <TextField
           placeholder="이메일 / 닉네임 검색"
           fullWidth
-          size="small"
           value={memberFilter}
           onChange={(e) => setMemberFilter(e.target.value)}
           sx={{ mb: 2 }}
@@ -177,7 +174,6 @@ function GroupMembersDialog({ open, onClose, group }) {
                   <ListItemSecondaryAction>
                     {member ? (
                       <Button
-                        size="small"
                         color="warning"
                         startIcon={<PersonRemoveIcon />}
                         onClick={() => memberMutation.mutate({ userId: u._id, action: 'remove' })}
@@ -187,7 +183,6 @@ function GroupMembersDialog({ open, onClose, group }) {
                       </Button>
                     ) : (
                       <Button
-                        size="small"
                         startIcon={<PersonAddIcon />}
                         onClick={() => memberMutation.mutate({ userId: u._id, action: 'add' })}
                         disabled={memberMutation.isLoading}
@@ -337,11 +332,10 @@ function GroupManagementPage() {
                       {group.name}
                     </Typography>
                     {group.isDefault && (
-                      <Chip label="기본" size="small" color="primary" variant="outlined" />
+                      <Chip label="기본" color="primary" variant="outlined" />
                     )}
                     <Chip
                       label={`${group.memberCount || 0}명`}
-                      size="small"
                       variant="outlined"
                     />
                   </Stack>
@@ -353,7 +347,7 @@ function GroupManagementPage() {
                   {group.permissions && group.permissions.length > 0 && (
                     <Box sx={{ mt: 1, display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
                       {group.permissions.map((p) => (
-                        <Chip key={p} label={p} size="small" variant="outlined" />
+                        <Chip key={p} label={p} variant="outlined" />
                       ))}
                     </Box>
                   )}


### PR DESCRIPTION
## Summary
디자인 핸드오프 마이그레이션 Phase 3 + 4 묶음.

### Phase 3 — \`size=\"small\"\` 일괄 제거 (Button / Chip / TextField 한정)
- theme defaultProps 에 \`size: 'small'\` 적용된 컴포넌트만 명시 prop 제거. **229곳 / 35 파일 / -235 줄**
- AST 인지 codemod — 부모 JSX 요소가 Button/Chip/TextField 일 때만 strip
- **유지** (theme defaultProps 없는 컴포넌트, MUI 기본 medium 이라 회귀 위험): IconButton (70), FormControl (9), Switch (5), ToggleButtonGroup (3), Autocomplete (1), Alert (1), 커스텀 ProjectTagChip (1)

### Phase 4 — 한국어 본문 가독성 (\`index.css\`)
- body font-family 에 Pretendard 추가 (Typography 외 raw text 도 적용)
- \`font-feature-settings: \"ss06\" on, \"ss07\" on\` (Pretendard 한글 자간 + 라틴 자간 보정)
- code 폰트에 JetBrains Mono 추가
- \`.MuiTypography-body1/body2\` 에 \`text-wrap: pretty\` — 마지막 단어 한 줄 차지 방지
- letter-spacing 은 vccTheme 에 이미 들어가 있음 (중복 적용 안 함)

## Test plan
- [x] Docker rebuild 성공 (`docker-compose up --build -d frontend` → 200)
- [x] 사용자 1차 검증 — \"큰 문제 없음\"

## Follow-up
- Phase 5: 핵심 페이지 mockup 적용 (페이지별 별개 PR)
- Phase 6: ⌘K + 알림
- Phase 7: 다크모드