### PR TITLE
feat: 디자인 시스템 Phase 5a — 프로젝트 상세 헤더/탭

### DIFF
--- a/frontend/src/pages/ProjectDetail.js
+++ b/frontend/src/pages/ProjectDetail.js
@@ -18,8 +18,10 @@ import {
   FormControlLabel,
   Checkbox,
   Stack,
-  TextField
+  TextField,
+  useMediaQuery
 } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import {
   ArrowBack,
   Star,
@@ -775,10 +777,137 @@ function JobsTab({ projectId }) {
   );
 }
 
+// 프로젝트 헤더 — gradient avatar tile + 제목/설명/메타 / 데스크탑 액션 버튼 (Phase 5a).
+function ProjectHero({ project, isMobile, onEdit, onDelete, onToggleFavorite, onViewWorkboards }) {
+  const initial = (project.name?.trim()?.[0] || '?').toUpperCase();
+  const isFav = project.isFavorite;
+  const hasCover = !!project.coverImage?.url;
+
+  return (
+    // 간격은 mockup px 그대로 — theme.spacing(4) = 16px 이므로 gap=4 가 16px
+    <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: { xs: 3, md: 4 }, mb: { xs: 3.5, md: 4.5 } }}>
+      <Box
+        sx={{
+          width: { xs: 56, md: 72 },
+          height: { xs: 56, md: 72 },
+          flexShrink: 0,
+          borderRadius: 2,
+          display: 'grid',
+          placeItems: 'center',
+          color: 'white',
+          fontWeight: 700,
+          fontSize: { xs: 22, md: 26 },
+          letterSpacing: '-0.02em',
+          overflow: 'hidden',
+          backgroundImage: hasCover
+            ? `url(${project.coverImage.url})`
+            : 'linear-gradient(135deg, #7B4DD8 0%, #5B5BD6 50%, #2F77E4 100%)',
+          backgroundSize: 'cover',
+          backgroundPosition: 'center',
+          boxShadow: 1,
+          '&::after': hasCover ? undefined : {
+            content: '""',
+            position: 'absolute',
+            inset: 0,
+            boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.2)',
+            borderRadius: 'inherit',
+            pointerEvents: 'none',
+          },
+          position: 'relative',
+        }}
+      >
+        {!hasCover && initial}
+      </Box>
+
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Box display="flex" alignItems="center" gap={0.5} sx={{ flexWrap: 'wrap' }}>
+          <Typography
+            variant="h4"
+            component="h1"
+            sx={{
+              fontSize: { xs: '1.25rem', md: '1.5rem' },
+              fontWeight: 700,
+              letterSpacing: '-0.01em',
+              wordBreak: 'break-word',
+              mr: 1,
+            }}
+          >
+            {project.name}
+          </Typography>
+          <Tooltip title={isFav ? '즐겨찾기 해제' : '즐겨찾기 추가'}>
+            <IconButton onClick={onToggleFavorite} color={isFav ? 'warning' : 'default'}>
+              {isFav ? <Star /> : <StarBorder />}
+            </IconButton>
+          </Tooltip>
+        </Box>
+        {project.description && (
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1, wordBreak: 'break-word' }}>
+            {project.description}
+          </Typography>
+        )}
+        <Box display="flex" gap={1.5} alignItems="center" sx={{ flexWrap: 'wrap', mt: 2.5 }}>
+          {project.tagId?.name && (
+            <Chip
+              label={project.tagId.name}
+              sx={{ bgcolor: project.tagId?.color || 'primary.main', color: 'white' }}
+            />
+          )}
+          <Chip icon={<ImageIcon />} label={`이미지 ${project.counts?.images || 0}`} variant="outlined" />
+          <Chip icon={<TextSnippet />} label={`프롬프트 ${project.counts?.promptData || 0}`} variant="outlined" />
+          <Chip icon={<History />} label={`작업 ${project.counts?.jobs || 0}`} variant="outlined" />
+        </Box>
+      </Box>
+
+      {!isMobile && (
+        <Box display="flex" gap={1.5} sx={{ flexShrink: 0 }}>
+          <Button variant="outlined" startIcon={<Edit />} onClick={onEdit}>
+            편집
+          </Button>
+          <Button variant="outlined" startIcon={<ViewModule />} onClick={onViewWorkboards}>
+            작업판 보기
+          </Button>
+          <Tooltip title="삭제">
+            <IconButton color="error" onClick={onDelete}><Delete /></IconButton>
+          </Tooltip>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+// 탭 라벨 + count badge — count 가 0/null 이면 그냥 라벨만.
+function TabLabel({ label, count }) {
+  if (!count) return label;
+  return (
+    <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.75 }}>
+      {label}
+      <Box
+        component="span"
+        sx={{
+          fontSize: '0.7rem',
+          fontWeight: 600,
+          px: 0.75,
+          py: 0.125,
+          borderRadius: 1,
+          bgcolor: 'action.selected',
+          color: 'text.secondary',
+          lineHeight: 1.4,
+          minWidth: 18,
+          textAlign: 'center',
+        }}
+      >
+        {count}
+      </Box>
+    </Box>
+  );
+}
+
 function ProjectDetail() {
   const { id } = useParams();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   // 탭 위치는 프로젝트별로 localStorage 영속화 (#396 후속) — 다른 프로젝트엔 영향 없음.
   const TAB_KEY = id ? `vcc.projectDetail.tab.${id}` : '';
   const TAB_COUNT = 6;
@@ -865,101 +994,34 @@ function ProjectDetail() {
         프로젝트 목록
       </Button>
 
-      {/* 프로젝트 헤더 */}
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'flex-start',
-          gap: 1,
-          mb: { xs: 1.5, md: 3 },
-          borderRadius: 2,
-          p: { xs: 1.5, md: 3 },
-          position: 'relative',
-          ...(project.coverImage?.url && {
-            backgroundImage: `url(${project.coverImage.url})`,
-            backgroundSize: 'cover',
-            backgroundPosition: 'center',
-            '&::before': {
-              content: '""',
-              position: 'absolute',
-              inset: 0,
-              bgcolor: 'rgba(255,255,255,0.85)',
-              borderRadius: 2
-            },
-            '& > *': { position: 'relative', zIndex: 1 }
-          })
-        }}
-      >
-        <Box sx={{ minWidth: 0, flex: '1 1 0' }}>
-          <Box display="flex" alignItems="center" gap={0.5} mb={0.5} sx={{ flexWrap: 'wrap' }}>
-            <Typography variant="h5" sx={{ fontSize: { xs: '1.25rem', md: '2rem' }, fontWeight: 600, wordBreak: 'break-word' }}>
-              {project.name}
-            </Typography>
-            <Tooltip title={project.isFavorite ? '즐겨찾기 해제' : '즐겨찾기 추가'}>
-              <IconButton
-                size="small"
-                onClick={() => favoriteMutation.mutate()}
-                color={project.isFavorite ? 'warning' : 'default'}
-              >
-                {project.isFavorite ? <Star /> : <StarBorder />}
-              </IconButton>
-            </Tooltip>
-          </Box>
-          {project.description && (
-            <Typography variant="body2" color="textSecondary" sx={{ mb: 1, wordBreak: 'break-word' }}>
-              {project.description}
-            </Typography>
-          )}
-          <Box display="flex" gap={0.75} alignItems="center" sx={{ flexWrap: 'wrap' }}>
-            <Chip
-              label={project.tagId?.name}
-              sx={{ bgcolor: project.tagId?.color || '#7c4dff', color: 'white' }}
-            />
-            <Chip
-              icon={<ImageIcon />}
-              label={`이미지 ${project.counts?.images || 0}`}
-              variant="outlined"
-            />
-            <Chip
-              icon={<TextSnippet />}
-              label={`프롬프트 ${project.counts?.promptData || 0}`}
-              variant="outlined"
-            />
-            <Chip
-              icon={<History />}
-              label={`작업 ${project.counts?.jobs || 0}`}
-              variant="outlined"
-            />
-          </Box>
-        </Box>
+      <ProjectHero
+        project={project}
+        isMobile={isMobile}
+        onEdit={() => setEditOpen(true)}
+        onDelete={() => setDeleteOpen(true)}
+        onToggleFavorite={() => favoriteMutation.mutate()}
+        onViewWorkboards={() => navigate(`/workboards?projectId=${id}`)}
+      />
 
-        <Box display="flex" gap={1} sx={{ flexShrink: 0 }}>
-          <Tooltip title="작업판 목록으로 이동">
-            <Button
-              variant="contained"
-              startIcon={<ViewModule />}
-              onClick={() => navigate(`/workboards?projectId=${id}`)}
-              sx={{
-                whiteSpace: 'nowrap',
-                flexShrink: 0,
-                minWidth: 'auto',
-                '& .MuiButton-startIcon': { mx: { xs: 0, sm: '-4px' }, mr: { xs: 0, sm: 1 } }
-              }}
-            >
-              <Box component="span" sx={{ display: { xs: 'none', sm: 'inline' } }}>작업판 보기</Box>
-            </Button>
-          </Tooltip>
-          <IconButton onClick={() => setEditOpen(true)}>
+      {isMobile && (
+        <Box sx={{ display: 'flex', gap: 0.75, mb: 2 }}>
+          <Button
+            variant="contained"
+            startIcon={<ViewModule />}
+            onClick={() => navigate(`/workboards?projectId=${id}`)}
+            sx={{ flex: 1 }}
+          >
+            작업판 보기
+          </Button>
+          <IconButton onClick={() => setEditOpen(true)} sx={{ border: 1, borderColor: 'divider' }}>
             <Edit />
           </IconButton>
-          <IconButton color="error" onClick={() => setDeleteOpen(true)}>
+          <IconButton color="error" onClick={() => setDeleteOpen(true)} sx={{ border: 1, borderColor: 'divider' }}>
             <Delete />
           </IconButton>
         </Box>
-      </Box>
+      )}
 
-      {/* 탭 — 모바일에서 붕 뜨지 않도록 bgcolor 로 묶고, 컴팩트하게 (#396 후속) */}
       <Box
         sx={{
           borderBottom: 1,
@@ -988,9 +1050,9 @@ function ProjectDetail() {
         >
           <Tab label="파이프라인" />
           <Tab label="세계관" />
-          <Tab icon={<TextSnippet fontSize="small" />} label="프롬프트 데이터" iconPosition="start" />
-          <Tab icon={<ImageIcon fontSize="small" />} label="이미지" iconPosition="start" />
-          <Tab icon={<History fontSize="small" />} label="파이프라인 히스토리" iconPosition="start" />
+          <Tab icon={<TextSnippet fontSize="small" />} iconPosition="start" label={<TabLabel label="프롬프트 데이터" count={project.counts?.promptData} />} />
+          <Tab icon={<ImageIcon fontSize="small" />} iconPosition="start" label={<TabLabel label="이미지" count={project.counts?.images} />} />
+          <Tab icon={<History fontSize="small" />} iconPosition="start" label="파이프라인 히스토리" />
           <Tab label="대화 히스토리" />
         </Tabs>
       </Box>


### PR DESCRIPTION
## Summary
디자인 핸드오프 마이그레이션 Phase 5a — 프로젝트 상세 페이지 (\`page-project-detail.jsx\` mockup) 의 shell 부분 적용. 탭 컨텐츠 내부는 후속.

### 변경
- **ProjectHero** 헬퍼: gradient avatar tile (cover 없을 시), 제목 + 즐겨찾기 + 설명 + 메타 chip 4단, 데스크탑 액션 (편집 / 작업판 보기 / 삭제) 우측 그룹
- **모바일 액션 행**: 작업판 보기 contained primary + 편집 / 삭제 icon (border)
- **TabLabel** 헬퍼: count badge — 현재 \`project.counts\` 에 있는 promptData / images 만. 나머지는 별도 API 필요해 후속
- 기존 cover-image full-bleed 헤더 제거

### Spacing 메모
vccTheme 의 \`spacing: 4\` (1단위 = 4px) 기준. mockup px / 4 = sx 단위. 첫 시도에서 MUI 기본 spacing(8) 관성으로 절반 값 쓰는 실수 → 사용자 피드백 반영 후 재조정.

## Test plan
- [x] Docker rebuild 성공
- [x] 사용자 1차 검증 — \"잘 된 듯요\"

## Follow-up
- 5b: 파이프라인 실행 + 히스토리 (Stepper · 결과 카드)
- 5c: 컨텐츠 라이브러리
- 5d: 파이프라인 빌더 (lane variant)
- 5e: 작업판 빌더
- 탭 컨텐츠 내부 (PipelinePanel / WorldviewTab / ImagesTab / JobHistoryPanel 등) 의 mockup 적용은 별도 phase 로