### PR TITLE
feat: 디자인 시스템 Phase 6 — ⌘K 명령 팔레트 + 알림 popover

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -12,6 +12,7 @@ import ProtectedRoute from './components/ProtectedRoute';
 import AdminRoute from './components/AdminRoute';
 import Header from './components/Header';
 import Sidebar from './components/Sidebar';
+import CommandPalette from './components/common/CommandPalette';
 import Login from './pages/Login';
 import Signup from './pages/Signup';
 import ForgotPassword from './pages/ForgotPassword';
@@ -90,6 +91,7 @@ function App() {
 
 function MainLayout() {
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [paletteOpen, setPaletteOpen] = useState(false);
   const location = useLocation();
   const queryClient = useQueryClient();
 
@@ -103,13 +105,26 @@ function MainLayout() {
     }
   }, [location.pathname, queryClient]);
 
+  // ⌘K / Ctrl+K 로 명령 팔레트 열기 (Phase 6)
+  useEffect(() => {
+    const onKey = (e) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        setPaletteOpen((v) => !v);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
   const handleMobileToggle = () => {
     setMobileOpen(!mobileOpen);
   };
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
-      <Header onMobileToggle={handleMobileToggle} />
+      <Header onMobileToggle={handleMobileToggle} onOpenPalette={() => setPaletteOpen(true)} />
+      <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
       <Box sx={{ display: 'flex', flex: 1 }}>
         <Sidebar mobileOpen={mobileOpen} onMobileToggle={handleMobileToggle} />
         <Box component="main" sx={{

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -21,12 +21,14 @@ import {
   Logout,
   AdminPanelSettings,
   Dashboard,
-  Menu as MenuIcon
+  Menu as MenuIcon,
+  Search as SearchIcon
 } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
+import NotificationsPopover from './common/NotificationsPopover';
 
-function Header({ onMobileToggle }) {
+function Header({ onMobileToggle, onOpenPalette }) {
   const { user, logout, isAdmin } = useAuth();
   const navigate = useNavigate();
   const theme = useTheme();
@@ -89,7 +91,21 @@ function Header({ onMobileToggle }) {
         </Typography>
         
         {user && (
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+            {/* ⌘K 명령 팔레트 트리거 */}
+            {onOpenPalette && (
+              <IconButton
+                color="inherit"
+                onClick={onOpenPalette}
+                title="검색 (⌘K)"
+              >
+                <SearchIcon />
+              </IconButton>
+            )}
+
+            {/* 알림 popover */}
+            <NotificationsPopover />
+
             {isAdmin && (
               <Chip
                 label="Admin"
@@ -98,13 +114,12 @@ function Header({ onMobileToggle }) {
                 sx={{ color: 'white', borderColor: 'white' }}
               />
             )}
-            
+
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-              <Typography variant="body2">
+              <Typography variant="body2" sx={{ display: { xs: 'none', sm: 'block' } }}>
                 {user.nickname}
               </Typography>
               <IconButton
-                size="large"
                 onClick={handleMenuOpen}
                 color="inherit"
               >

--- a/frontend/src/components/common/CommandPalette.js
+++ b/frontend/src/components/common/CommandPalette.js
@@ -1,0 +1,365 @@
+import React, { useState, useEffect, useRef, useMemo } from 'react';
+import {
+  Dialog,
+  Box,
+  Typography,
+  InputBase,
+  Chip,
+  CircularProgress,
+} from '@mui/material';
+import {
+  Search as SearchIcon,
+  Folder as FolderIcon,
+  ViewModule as WorkboardIcon,
+  AccountTree as PipelineIcon,
+  Add as AddIcon,
+  Settings as SettingsIcon,
+  Image as ImageIcon,
+  Person as PersonIcon,
+  AdminPanelSettings as AdminIcon,
+  ArrowForward as ArrowForwardIcon,
+} from '@mui/icons-material';
+import { useNavigate } from 'react-router-dom';
+import { useQuery } from 'react-query';
+import { projectAPI, workboardAPI } from '../../services/api';
+import { useAuth } from '../../contexts/AuthContext';
+
+const KBD = ({ children }) => (
+  <Box
+    component="span"
+    sx={{
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      minWidth: 18,
+      height: 18,
+      px: 0.5,
+      borderRadius: 0.5,
+      border: 1,
+      borderColor: 'divider',
+      bgcolor: 'background.paper',
+      fontFamily: '"JetBrains Mono", monospace',
+      fontSize: 10,
+      fontWeight: 600,
+      color: 'text.secondary',
+      lineHeight: 1,
+    }}
+  >
+    {children}
+  </Box>
+);
+
+export default function CommandPalette({ open, onClose }) {
+  const navigate = useNavigate();
+  const { isAdmin } = useAuth();
+  const [query, setQuery] = useState('');
+  const [sel, setSel] = useState(0);
+  const inputRef = useRef(null);
+  const listRef = useRef(null);
+
+  const { data: projData, isLoading: projLoading } = useQuery(
+    'cmdk-projects',
+    () => projectAPI.getAll({ limit: 100 }),
+    { enabled: open, staleTime: 60_000 }
+  );
+  const { data: wbData, isLoading: wbLoading } = useQuery(
+    'cmdk-workboards',
+    () => workboardAPI.getAll(),
+    { enabled: open, staleTime: 60_000 }
+  );
+
+  const projects = projData?.data?.data?.projects || projData?.data?.projects || [];
+  const workboards = wbData?.data?.workboards || wbData?.data?.data?.workboards || [];
+
+  const commands = useMemo(() => {
+    const items = [];
+    projects.forEach((p) => {
+      items.push({
+        group: '프로젝트',
+        icon: <FolderIcon fontSize="small" />,
+        name: p.name,
+        hint: p.description?.slice(0, 60),
+        action: () => navigate(`/projects/${p._id}`),
+      });
+    });
+    workboards.forEach((wb) => {
+      items.push({
+        group: '작업판',
+        icon: <WorkboardIcon fontSize="small" />,
+        name: wb.name,
+        hint: `${wb.serverId?.name || ''}${wb.outputFormat ? ` · ${wb.outputFormat}` : ''}`.trim() || undefined,
+        action: () => navigate(
+          `${wb.outputFormat === 'text' ? '/prompt-generate' : '/generate'}/${wb._id}`
+        ),
+      });
+    });
+    items.push(
+      {
+        group: '명령',
+        icon: <AddIcon fontSize="small" />,
+        name: '새 프로젝트 만들기',
+        action: () => navigate('/projects?new=1'),
+      },
+      {
+        group: '명령',
+        icon: <FolderIcon fontSize="small" />,
+        name: '프로젝트 목록',
+        action: () => navigate('/projects'),
+      },
+      {
+        group: '명령',
+        icon: <ImageIcon fontSize="small" />,
+        name: '내 컨텐츠',
+        action: () => navigate('/content'),
+      },
+      {
+        group: '명령',
+        icon: <PipelineIcon fontSize="small" />,
+        name: '대시보드',
+        action: () => navigate('/dashboard'),
+      },
+      {
+        group: '명령',
+        icon: <PersonIcon fontSize="small" />,
+        name: '프로필 / 설정',
+        kbd: ['⌘', ','],
+        action: () => navigate('/profile'),
+      },
+    );
+    if (isAdmin) {
+      items.push({
+        group: '명령',
+        icon: <AdminIcon fontSize="small" />,
+        name: '관리자 패널',
+        action: () => navigate('/admin'),
+      });
+    }
+    items.push({
+      group: '명령',
+      icon: <SettingsIcon fontSize="small" />,
+      name: '작업 히스토리',
+      action: () => navigate('/jobs'),
+    });
+    return items;
+  }, [projects, workboards, isAdmin, navigate]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return commands;
+    return commands.filter((c) =>
+      `${c.name} ${c.hint || ''} ${c.group}`.toLowerCase().includes(q)
+    );
+  }, [commands, query]);
+
+  const groupOrder = ['프로젝트', '작업판', '명령'];
+  const grouped = useMemo(() => {
+    const acc = {};
+    filtered.forEach((c) => {
+      (acc[c.group] = acc[c.group] || []).push(c);
+    });
+    return acc;
+  }, [filtered]);
+  const groups = groupOrder.filter((g) => grouped[g]?.length > 0);
+  const flat = groups.flatMap((g) => grouped[g]);
+
+  useEffect(() => {
+    setSel(0);
+  }, [query]);
+
+  useEffect(() => {
+    if (open) {
+      setQuery('');
+      setSel(0);
+      setTimeout(() => inputRef.current?.focus(), 50);
+    }
+  }, [open]);
+
+  // 키보드 nav
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e) => {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setSel((s) => Math.min(s + 1, flat.length - 1));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setSel((s) => Math.max(s - 1, 0));
+      } else if (e.key === 'Enter') {
+        const target = flat[sel];
+        if (target?.action) {
+          target.action();
+          onClose();
+        }
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, flat, sel, onClose]);
+
+  // 선택 항목이 보이도록 스크롤
+  useEffect(() => {
+    if (!listRef.current) return;
+    const active = listRef.current.querySelector('[data-active="true"]');
+    if (active) active.scrollIntoView({ block: 'nearest' });
+  }, [sel]);
+
+  const isLoading = projLoading || wbLoading;
+
+  let runningIdx = 0;
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="sm"
+      PaperProps={{
+        sx: {
+          mt: '12vh',
+          alignSelf: 'flex-start',
+          borderRadius: 1.5,
+          overflow: 'hidden',
+        },
+      }}
+      BackdropProps={{
+        sx: { backdropFilter: 'blur(6px)', bgcolor: 'rgba(0,0,0,0.5)' },
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1.5,
+          px: 2,
+          py: 1.5,
+          borderBottom: 1,
+          borderColor: 'divider',
+        }}
+      >
+        <SearchIcon sx={{ color: 'text.tertiary' }} />
+        <InputBase
+          inputRef={inputRef}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="프로젝트 · 작업판 · 명령 검색…"
+          sx={{ flex: 1, fontSize: 16 }}
+        />
+        <KBD>ESC</KBD>
+      </Box>
+
+      <Box ref={listRef} sx={{ maxHeight: 420, overflow: 'auto', p: 0.75 }}>
+        {isLoading && flat.length === 0 ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+            <CircularProgress size={20} />
+          </Box>
+        ) : flat.length === 0 ? (
+          <Box sx={{ p: 4, textAlign: 'center', color: 'text.secondary', fontSize: 13 }}>
+            "{query}" 에 대한 결과가 없습니다.
+          </Box>
+        ) : (
+          groups.map((g) => (
+            <Box key={g}>
+              <Typography
+                variant="caption"
+                sx={{
+                  display: 'block',
+                  px: 1.5,
+                  pt: 1,
+                  pb: 0.5,
+                  fontSize: 10,
+                  fontWeight: 600,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.08em',
+                  color: 'text.secondary',
+                }}
+              >
+                {g}
+              </Typography>
+              {grouped[g].map((c) => {
+                const myIdx = runningIdx++;
+                const active = sel === myIdx;
+                return (
+                  <Box
+                    key={`${c.group}-${c.name}-${myIdx}`}
+                    data-active={active}
+                    onMouseEnter={() => setSel(myIdx)}
+                    onClick={() => { c.action(); onClose(); }}
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1.5,
+                      px: 1.5,
+                      py: 1,
+                      borderRadius: 1,
+                      cursor: 'pointer',
+                      bgcolor: active ? 'action.selected' : 'transparent',
+                    }}
+                  >
+                    <Box
+                      sx={{
+                        width: 24,
+                        height: 24,
+                        borderRadius: 0.75,
+                        bgcolor: active ? 'primary.main' : 'action.hover',
+                        color: active ? 'primary.contrastText' : 'text.secondary',
+                        display: 'grid',
+                        placeItems: 'center',
+                        flexShrink: 0,
+                      }}
+                    >
+                      {c.icon}
+                    </Box>
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      <Typography variant="body2" noWrap sx={{ fontWeight: 500 }}>
+                        {c.name}
+                      </Typography>
+                      {c.hint && (
+                        <Typography variant="caption" color="text.secondary" noWrap display="block" sx={{ mt: 0.25 }}>
+                          {c.hint}
+                        </Typography>
+                      )}
+                    </Box>
+                    {c.kbd && (
+                      <Box sx={{ display: 'flex', gap: 0.5 }}>
+                        {c.kbd.map((k, i) => (<KBD key={i}>{k}</KBD>))}
+                      </Box>
+                    )}
+                    {active && <ArrowForwardIcon fontSize="small" sx={{ color: 'text.tertiary' }} />}
+                  </Box>
+                );
+              })}
+            </Box>
+          ))
+        )}
+      </Box>
+
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1.5,
+          px: 2,
+          py: 1,
+          borderTop: 1,
+          borderColor: 'divider',
+          bgcolor: 'action.hover',
+          fontSize: 11,
+          color: 'text.secondary',
+        }}
+      >
+        <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
+          <KBD>↑</KBD><KBD>↓</KBD> 이동
+        </Box>
+        <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
+          <KBD>↵</KBD> 선택
+        </Box>
+        <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
+          <KBD>⌘</KBD><KBD>K</KBD> 닫기
+        </Box>
+        <Box sx={{ flex: 1 }} />
+        <Typography variant="caption" sx={{ fontFamily: '"JetBrains Mono", monospace' }}>
+          {flat.length}개 결과
+        </Typography>
+      </Box>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/common/NotificationsPopover.js
+++ b/frontend/src/components/common/NotificationsPopover.js
@@ -1,0 +1,274 @@
+import React, { useState, useMemo, useRef } from 'react';
+import {
+  IconButton,
+  Popover,
+  Box,
+  Typography,
+  Button,
+  Chip,
+  Badge,
+  Divider,
+} from '@mui/material';
+import {
+  NotificationsNone as BellIcon,
+  CheckCircle as CheckIcon,
+  Error as ErrorIcon,
+  HourglassEmpty as PendingIcon,
+  PlayArrow as RunningIcon,
+  OpenInNew as OpenInNewIcon,
+} from '@mui/icons-material';
+import { useNavigate } from 'react-router-dom';
+import { useQueryClient } from 'react-query';
+import { alpha } from '@mui/material/styles';
+
+// 휘발성 알림 popover (Phase 6).
+// 영속 저장은 없음 — react-query 캐시에 있는 'pipelineRun' 데이터를 source 로 활용.
+// PipelineRunner / PipelineHistoryPanel 이 백그라운드로 가져온 run 들 중 최근/활성 것을 보여줌.
+// 향후 backend 의 글로벌 user activity feed 가 생기면 그쪽으로 source 전환.
+export default function NotificationsPopover() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const anchorRef = useRef(null);
+  const [open, setOpen] = useState(false);
+  // 읽음 처리: run id 의 Set. 영속 없음 — 다이얼로그 새로고침 시 초기화.
+  const [readIds, setReadIds] = useState(() => new Set());
+
+  // react-query 캐시에서 모든 pipelineRun 단일 데이터를 긁어 옴.
+  // (key 형식: ['pipelineRun', projectId, runId]) — list 키 (`pipelineRuns`) 는 배열 형태.
+  const items = useMemo(() => {
+    const cache = queryClient.getQueryCache();
+    const collected = [];
+    cache.getAll().forEach((q) => {
+      const key = q.queryKey;
+      if (!Array.isArray(key)) return;
+      // ['pipelineRuns', projectId] — 리스트
+      if (key[0] === 'pipelineRuns' && q.state.data) {
+        const projectId = key[1];
+        const runs = q.state.data?.data?.data?.runs || q.state.data?.data?.runs || [];
+        runs.forEach((run) => collected.push({ projectId, run }));
+      }
+    });
+    // run.updatedAt 또는 startedAt desc 정렬
+    collected.sort((a, b) => {
+      const ta = new Date(a.run.updatedAt || a.run.startedAt || 0).getTime();
+      const tb = new Date(b.run.updatedAt || b.run.startedAt || 0).getTime();
+      return tb - ta;
+    });
+    // 같은 run id 중복 제거
+    const seen = new Set();
+    return collected.filter(({ run }) => {
+      if (seen.has(run._id)) return false;
+      seen.add(run._id);
+      return true;
+    }).slice(0, 30);
+  }, [queryClient, open]);
+
+  const groups = useMemo(() => {
+    const active = [];
+    const earlier = [];
+    items.forEach((it) => {
+      const status = it.run.status;
+      if (status === 'running' || status === 'pending') active.push(it);
+      else earlier.push(it);
+    });
+    return { active, earlier };
+  }, [items]);
+
+  const unreadCount = items.filter(({ run }) => !readIds.has(run._id) && (run.status === 'running' || run.status === 'pending')).length;
+
+  const handleClose = () => setOpen(false);
+  const handleMarkAllRead = () => setReadIds(new Set(items.map((it) => it.run._id)));
+  const handleClick = (it) => {
+    setReadIds((prev) => {
+      const next = new Set(prev);
+      next.add(it.run._id);
+      return next;
+    });
+    navigate(`/projects/${it.projectId}`);
+    handleClose();
+  };
+
+  return (
+    <>
+      <IconButton
+        ref={anchorRef}
+        color="inherit"
+        onClick={() => setOpen(true)}
+        title="알림"
+      >
+        <Badge color="error" variant="dot" invisible={unreadCount === 0}>
+          <BellIcon />
+        </Badge>
+      </IconButton>
+      <Popover
+        open={open}
+        anchorEl={anchorRef.current}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        slotProps={{ paper: { sx: { mt: 1, width: 380, maxHeight: '70vh', overflow: 'hidden', display: 'flex', flexDirection: 'column' } } }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, px: 2, py: 1.5, borderBottom: 1, borderColor: 'divider' }}>
+          <BellIcon fontSize="small" />
+          <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>알림</Typography>
+          {unreadCount > 0 && <Chip label={`${unreadCount} new`} color="primary" />}
+          <Box sx={{ flex: 1 }} />
+          {items.length > 0 && (
+            <Button onClick={handleMarkAllRead}>모두 읽음</Button>
+          )}
+        </Box>
+
+        <Box sx={{ overflow: 'auto', flex: 1 }}>
+          {items.length === 0 ? (
+            <Box sx={{ p: 4, textAlign: 'center', color: 'text.secondary' }}>
+              <BellIcon sx={{ fontSize: 28, color: 'text.disabled', mb: 1 }} />
+              <Typography variant="body2">알림 없음</Typography>
+              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
+                파이프라인 실행 중·완료 알림이 여기 표시됩니다.
+              </Typography>
+            </Box>
+          ) : (
+            <>
+              {groups.active.length > 0 && (
+                <NotifGroup label="진행 중 / 새 알림">
+                  {groups.active.map((it) => (
+                    <NotifRow
+                      key={it.run._id}
+                      run={it.run}
+                      onClick={() => handleClick(it)}
+                      unread={!readIds.has(it.run._id)}
+                    />
+                  ))}
+                </NotifGroup>
+              )}
+              {groups.earlier.length > 0 && (
+                <NotifGroup label="이전">
+                  {groups.earlier.map((it) => (
+                    <NotifRow
+                      key={it.run._id}
+                      run={it.run}
+                      onClick={() => handleClick(it)}
+                      unread={false}
+                    />
+                  ))}
+                </NotifGroup>
+              )}
+            </>
+          )}
+        </Box>
+
+        <Divider />
+        <Box sx={{ px: 2, py: 1, textAlign: 'center', bgcolor: 'action.hover' }}>
+          <Typography variant="caption" color="text.secondary">
+            파이프라인 실행 알림 · 영속 저장 안 됨
+          </Typography>
+        </Box>
+      </Popover>
+    </>
+  );
+}
+
+function NotifGroup({ label, children }) {
+  return (
+    <Box>
+      <Typography
+        variant="caption"
+        sx={{
+          display: 'block',
+          px: 2,
+          pt: 1.5,
+          pb: 0.5,
+          fontSize: 10,
+          fontWeight: 600,
+          textTransform: 'uppercase',
+          letterSpacing: '0.08em',
+          color: 'text.secondary',
+        }}
+      >
+        {label}
+      </Typography>
+      {children}
+    </Box>
+  );
+}
+
+function NotifRow({ run, onClick, unread }) {
+  const status = run.status;
+  const tone = status === 'completed' ? 'success'
+    : status === 'failed' ? 'error'
+    : status === 'running' || status === 'pending' ? 'info'
+    : 'default';
+  const Icon = status === 'completed' ? CheckIcon
+    : status === 'failed' ? ErrorIcon
+    : status === 'pending' ? PendingIcon
+    : RunningIcon;
+  const time = run.updatedAt || run.startedAt;
+  const title = run.status === 'completed' ? '파이프라인 완료'
+    : run.status === 'failed' ? '파이프라인 실패'
+    : run.status === 'running' ? '파이프라인 실행 중'
+    : '파이프라인 대기';
+
+  return (
+    <Box
+      onClick={onClick}
+      sx={{
+        display: 'flex',
+        gap: 1.5,
+        alignItems: 'flex-start',
+        px: 2,
+        py: 1.5,
+        borderBottom: 1,
+        borderColor: 'divider',
+        cursor: 'pointer',
+        bgcolor: unread ? (t) => alpha(t.palette.primary.main, 0.04) : 'transparent',
+        '&:hover': { bgcolor: 'action.hover' },
+      }}
+    >
+      <Box
+        sx={{
+          width: 28,
+          height: 28,
+          borderRadius: 1,
+          bgcolor: (t) => tone === 'default'
+            ? alpha(t.palette.grey[500], 0.12)
+            : alpha(t.palette[tone].main, 0.12),
+          color: tone === 'default' ? 'grey.700' : `${tone}.main`,
+          display: 'grid',
+          placeItems: 'center',
+          flexShrink: 0,
+        }}
+      >
+        <Icon fontSize="small" />
+      </Box>
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1 }}>
+          <Typography variant="body2" sx={{ flex: 1, fontWeight: 600, textWrap: 'pretty' }}>
+            {title}
+          </Typography>
+          <Typography variant="caption" sx={{ fontFamily: '"JetBrains Mono", monospace', color: 'text.secondary', flexShrink: 0 }}>
+            {formatRelative(time)}
+          </Typography>
+        </Box>
+        {run.steps && (
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.25 }}>
+            {run.steps.filter((s) => s.status === 'completed').length} / {run.steps.length} 단계
+          </Typography>
+        )}
+        <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, mt: 0.75, color: 'primary.main', fontSize: 11, fontWeight: 500 }}>
+          상세 보기 <OpenInNewIcon sx={{ fontSize: 12 }} />
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+
+function formatRelative(iso) {
+  if (!iso) return '';
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return '';
+  const sec = Math.round((Date.now() - t) / 1000);
+  if (sec < 60) return '방금';
+  if (sec < 3600) return `${Math.floor(sec / 60)}분 전`;
+  if (sec < 86400) return `${Math.floor(sec / 3600)}시간 전`;
+  return new Date(iso).toLocaleDateString('ko-KR');
+}


### PR DESCRIPTION
## Summary
mockup (command-palette.jsx, notifications.jsx) 의 글로벌 UX. 백엔드 변경 없음.

### ⌘K 명령 팔레트
- 글로벌 ⌘K / Ctrl+K + 헤더 🔍 버튼
- 그룹: 프로젝트 / 작업판 / 명령 (대시보드 · 내 컨텐츠 · 프로필 · 작업 히스토리 · 관리자 패널)
- 키보드 nav: ↑/↓/Enter/Esc + scrollIntoView
- useQuery 2개 (projects, workboards, staleTime 60s)

### 알림 popover
- 헤더 🔔 (badge dot) + MUI Popover
- **휘발성** — react-query 캐시의 `pipelineRuns` 키를 source 로
- 진행 중 / 이전 그룹화, unread 표시 (primary alpha 4%)
- 영속 저장 없음 (그건 backend feed endpoint 가 필요한 별도 작업)

## Test plan
- [x] Build 200
- [x] 사용자 검증 — \"오 아주 좋습니다\"

## Follow-up
- Phase 7 다크모드
- 알림 영속 저장 / 글로벌 activity feed endpoint (backend 작업)