### PR TITLE
feat: 디자인 시스템 Phase 7 — 다크모드 (디바이스별 + OS preference)

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,9 +1,10 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { QueryClient, QueryClientProvider, useQueryClient } from 'react-query';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { Box } from '@mui/material';
-import { vccTheme } from './theme';
+import { buildVccTheme } from './theme';
+import { ColorSchemeProvider, useColorScheme } from './contexts/ColorSchemeContext';
 import CssBaseline from '@mui/material/CssBaseline';
 import { Toaster } from 'react-hot-toast';
 
@@ -54,19 +55,28 @@ export const queryClient = new QueryClient({
   },
 });
 
-// Design v1 — theme.js 의 vccTheme 적용 (#design-handoff Phase 1)
-const theme = createTheme(vccTheme);
+function ThemedApp({ children }) {
+  // ColorScheme 변화에 반응해 light/dark theme 재계산
+  const { effective } = useColorScheme();
+  const theme = useMemo(() => createTheme(buildVccTheme(effective)), [effective]);
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      {children}
+    </ThemeProvider>
+  );
+}
 
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider theme={theme}>
-        <CssBaseline />
-        <AuthProvider>
-          <Router>
-            <div className="App">
-              <Toaster position="top-right" />
-              <Routes>
+      <ColorSchemeProvider>
+        <ThemedApp>
+          <AuthProvider>
+            <Router>
+              <div className="App">
+                <Toaster position="top-right" />
+                <Routes>
                 <Route path="/login" element={<Login />} />
                 <Route path="/signup" element={<Signup />} />
                 <Route path="/forgot-password" element={<ForgotPassword />} />
@@ -83,8 +93,9 @@ function App() {
               </Routes>
             </div>
           </Router>
-        </AuthProvider>
-      </ThemeProvider>
+          </AuthProvider>
+        </ThemedApp>
+      </ColorSchemeProvider>
     </QueryClientProvider>
   );
 }
@@ -132,7 +143,7 @@ function MainLayout() {
           minWidth: 0, // flex item 이 content intrinsic width 로 늘어나 body 가로 스크롤 유발하는 것 방지 (#383)
           overflowX: 'hidden',
           p: 3,
-          backgroundColor: '#f5f5f5',
+          bgcolor: 'background.default',
           minHeight: 'calc(100vh - 64px)'
         }}>
           <Routes>

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -22,10 +22,15 @@ import {
   AdminPanelSettings,
   Dashboard,
   Menu as MenuIcon,
-  Search as SearchIcon
+  Search as SearchIcon,
+  LightMode as LightModeIcon,
+  DarkMode as DarkModeIcon,
+  BrightnessAuto as SystemModeIcon,
+  Check as CheckIcon
 } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
+import { useColorScheme } from '../contexts/ColorSchemeContext';
 import NotificationsPopover from './common/NotificationsPopover';
 
 function Header({ onMobileToggle, onOpenPalette }) {
@@ -33,6 +38,7 @@ function Header({ onMobileToggle, onOpenPalette }) {
   const navigate = useNavigate();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  const { mode: colorMode, setMode: setColorMode } = useColorScheme();
   const [anchorEl, setAnchorEl] = useState(null);
   const open = Boolean(anchorEl);
 
@@ -168,7 +174,7 @@ function Header({ onMobileToggle, onOpenPalette }) {
                 </ListItemIcon>
                 <ListItemText>프로필 설정</ListItemText>
               </MenuItem>
-              
+
               {isAdmin && (
                 <MenuItem onClick={handleAdmin}>
                   <ListItemIcon>
@@ -177,9 +183,28 @@ function Header({ onMobileToggle, onOpenPalette }) {
                   <ListItemText>관리자 패널</ListItemText>
                 </MenuItem>
               )}
-              
+
               <Divider />
-              
+
+              {/* 다크모드 설정 (Phase 7) */}
+              {[
+                { v: 'system', label: '시스템 설정 따름', icon: <SystemModeIcon fontSize="small" /> },
+                { v: 'light',  label: '라이트',          icon: <LightModeIcon fontSize="small" /> },
+                { v: 'dark',   label: '다크',            icon: <DarkModeIcon fontSize="small" /> },
+              ].map((opt) => (
+                <MenuItem
+                  key={opt.v}
+                  onClick={(e) => { e.stopPropagation(); setColorMode(opt.v); }}
+                  selected={colorMode === opt.v}
+                >
+                  <ListItemIcon>{opt.icon}</ListItemIcon>
+                  <ListItemText>{opt.label}</ListItemText>
+                  {colorMode === opt.v && <CheckIcon fontSize="small" sx={{ color: 'primary.main' }} />}
+                </MenuItem>
+              ))}
+
+              <Divider />
+
               <MenuItem onClick={handleLogout}>
                 <ListItemIcon>
                   <Logout fontSize="small" />

--- a/frontend/src/components/Sidebar.js
+++ b/frontend/src/components/Sidebar.js
@@ -289,7 +289,7 @@ function Sidebar({ mobileOpen, onMobileToggle }) {
             width: DRAWER_WIDTH,
             position: 'relative',
             height: '100%',
-            backgroundColor: '#2c3e50',  // 컨텐츠가 Paper 높이를 초과할 때 하단 흰색 노출 방지 (#327)
+            bgcolor: 'navbar.main',  // 컨텐츠가 Paper 높이를 초과할 때 하단 흰색 노출 방지 (#327)
           },
         }}
         open

--- a/frontend/src/contexts/ColorSchemeContext.js
+++ b/frontend/src/contexts/ColorSchemeContext.js
@@ -1,0 +1,59 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+
+// 사용자 선택 ('light' | 'dark' | 'system') 와 system preference 를 통합해
+// 실제 effective scheme ('light' | 'dark') 을 계산.
+//
+// 영속: localStorage. 백엔드 user preferences 까지 연동하면 디바이스 간 동기화 가능 — 후속.
+const STORAGE_KEY = 'vcc.colorScheme';
+const ColorSchemeContext = createContext(null);
+
+function readStored() {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY);
+    if (v === 'light' || v === 'dark' || v === 'system') return v;
+  } catch (_) {}
+  return 'system';
+}
+
+export function ColorSchemeProvider({ children }) {
+  const [mode, setModeState] = useState(readStored);
+  const [systemDark, setSystemDark] = useState(
+    () => typeof window !== 'undefined' && window.matchMedia?.('(prefers-color-scheme: dark)').matches
+  );
+
+  // prefers-color-scheme 변경 구독
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mql = window.matchMedia('(prefers-color-scheme: dark)');
+    const onChange = (e) => setSystemDark(e.matches);
+    // addEventListener for modern browsers, addListener for older
+    if (mql.addEventListener) mql.addEventListener('change', onChange);
+    else mql.addListener(onChange);
+    return () => {
+      if (mql.removeEventListener) mql.removeEventListener('change', onChange);
+      else mql.removeListener(onChange);
+    };
+  }, []);
+
+  const setMode = (next) => {
+    try { localStorage.setItem(STORAGE_KEY, next); } catch (_) {}
+    setModeState(next);
+  };
+
+  const effective = mode === 'system' ? (systemDark ? 'dark' : 'light') : mode;
+
+  // tokens.css 의 [data-theme="dark"] 셀렉터 활용 위해 html 에 data-theme 부여
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    document.documentElement.setAttribute('data-theme', effective);
+  }, [effective]);
+
+  const value = useMemo(() => ({ mode, setMode, effective, systemDark }), [mode, effective, systemDark]);
+  return <ColorSchemeContext.Provider value={value}>{children}</ColorSchemeContext.Provider>;
+}
+
+export function useColorScheme() {
+  const ctx = useContext(ColorSchemeContext);
+  if (!ctx) throw new Error('useColorScheme must be used inside ColorSchemeProvider');
+  return ctx;
+}

--- a/frontend/src/pages/PromptWorkboards.js
+++ b/frontend/src/pages/PromptWorkboards.js
@@ -177,10 +177,10 @@ function PromptWorkboardCard({ workboard }) {
               <Typography variant="h6" gutterBottom sx={{ mt: 2 }}>
                 시스템 프롬프트
               </Typography>
-              <Typography variant="body2" color="textSecondary" sx={{ 
-                whiteSpace: 'pre-wrap', 
-                backgroundColor: '#f5f5f5', 
-                p: 2, 
+              <Typography variant="body2" color="textSecondary" sx={{
+                whiteSpace: 'pre-wrap',
+                bgcolor: 'action.hover',
+                p: 2,
                 borderRadius: 1,
                 maxHeight: 200,
                 overflow: 'auto'

--- a/frontend/src/pages/Workboards.js
+++ b/frontend/src/pages/Workboards.js
@@ -269,7 +269,7 @@ function WorkboardCard({ workboard, projectId }) {
               </Typography>
               <Typography variant="body2" color="textSecondary" sx={{
                 whiteSpace: 'pre-wrap',
-                backgroundColor: '#f5f5f5',
+                bgcolor: 'action.hover',
                 p: 2,
                 borderRadius: 1,
                 maxHeight: 200,

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -1,97 +1,135 @@
-// VCC Manager design tokens — MUI ThemeOptions v1 (#design-handoff Phase 1).
-// 디자인 시스템 단일 진입점. createTheme(vccTheme) 로 적용.
+// VCC Manager design tokens — MUI ThemeOptions (#design-handoff).
 //
-// 변경 요약 (대비 v0 = MUI 기본 primary/secondary):
-//   - primary: #1976d2 → #5B5BD6 (Iris)
-//   - secondary: #dc004e → #7B4DD8 (Violet)
-//   - background.default: #FFFFFF → #F7F7F4 (warm-neutral)
-//   - 신설 palette.navbar (sidebar/header 의 hardcoded hex 통합)
-//   - radius 기본 4 → 6 (r-2), Paper 는 8 (r-3)
-//   - shadow scale 4단계 + focus ring
-//   - defaultProps 일괄 (Button/Chip/Paper/TextField size: small / variant: outlined)
-//   - 한국어 letter-spacing -0.005em 본문, font: Pretendard
+// 디자인 시스템 단일 진입점. createTheme(buildVccTheme(mode)) 로 light/dark 적용.
+//
+// 변경 요약:
+//   - primary: Iris #5B5BD6 (light) / #7676E0 (dark, 가독성 보정)
+//   - background warm-neutral (light) / 깊은 회색 (dark)
+//   - 신설 palette.navbar (사이드바/헤더 통합)
+//   - 한국어 letter-spacing -0.005em, font: Pretendard
 
-export const vccTheme = {
-  palette: {
-    mode: 'light',
-    primary:   { main: '#5B5BD6', light: '#A6A8E6', dark: '#4040AD', contrastText: '#FFFFFF' },
-    secondary: { main: '#7B4DD8', light: '#B69CEC', dark: '#5B2DBF', contrastText: '#FFFFFF' },
-    success:   { main: '#1F9D55', light: '#DCF4E5', dark: '#0F7A40', contrastText: '#FFFFFF' },
-    warning:   { main: '#BE7415', light: '#FAEBC8', dark: '#95580B', contrastText: '#FFFFFF' },
-    error:     { main: '#D5383E', light: '#FBE0E0', dark: '#A8222A', contrastText: '#FFFFFF' },
-    info:      { main: '#2F77E4', light: '#DCEBFC', dark: '#1955B0', contrastText: '#FFFFFF' },
-    // 신설 — 흩어진 #2c3e50 / #34495e / #ecf0f1 / #bdc3c7 통합 (Phase 2 에서 사이드바 적용)
-    navbar:    { main: '#161A22', light: '#262C39', dark: '#0F1218', contrastText: '#E4E5E9' },
-    background:{ default: '#F7F7F4', paper: '#FFFFFF' },
-    text: { primary: '#16181D', secondary: '#5B616E', disabled: '#B6BAC2' },
-    divider: '#E2E2DC',
-    grey: {
-      50:  '#F7F7F4', 100: '#F1F1ED', 200: '#EBEAE5', 300: '#E2E2DC',
-      400: '#D2D2CA', 500: '#B6BAC2', 600: '#8A8F9A', 700: '#5B616E',
-      800: '#16181D', 900: '#0F1218',
-    },
-  },
-  typography: {
-    fontFamily: '"Pretendard","Pretendard Variable",-apple-system,BlinkMacSystemFont,"Noto Sans KR",Roboto,sans-serif',
-    h1: { fontSize: 28, lineHeight: '36px', fontWeight: 700, letterSpacing: '-0.01em' },
-    h2: { fontSize: 22, lineHeight: '30px', fontWeight: 700, letterSpacing: '-0.01em' },
-    h3: { fontSize: 18, lineHeight: '26px', fontWeight: 700, letterSpacing: '-0.005em' },
-    h4: { fontSize: 18, lineHeight: '26px', fontWeight: 600 },
-    h5: { fontSize: 15, lineHeight: '22px', fontWeight: 600 },
-    h6: { fontSize: 14, lineHeight: '22px', fontWeight: 600 },
-    body1:    { fontSize: 14, lineHeight: '22px', letterSpacing: '-0.005em' },
-    body2:    { fontSize: 13, lineHeight: '20px', letterSpacing: '-0.005em' },
-    caption:  { fontSize: 12, lineHeight: '18px', fontWeight: 500 },
-    overline: { fontSize: 11, lineHeight: '16px', fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase' },
-    button:   { fontWeight: 500, letterSpacing: '-0.005em', textTransform: 'none' },
-  },
-  shape:   { borderRadius: 6 },
-  spacing: 4,
-  shadows: [
-    'none',
-    '0 1px 2px rgba(15,18,28,0.05), 0 0 0 1px rgba(15,18,28,0.04)',
-    '0 2px 6px rgba(15,18,28,0.07), 0 1px 2px rgba(15,18,28,0.04)',
-    '0 8px 24px rgba(15,18,28,0.10), 0 2px 6px rgba(15,18,28,0.06)',
-    '0 20px 48px rgba(15,18,28,0.16), 0 4px 12px rgba(15,18,28,0.08)',
-    // 5..24 → shadow-4 폴백 (MUI 가 25개 요구)
-    ...Array(20).fill('0 20px 48px rgba(15,18,28,0.16), 0 4px 12px rgba(15,18,28,0.08)'),
-  ],
-  components: {
-    MuiButton: {
-      defaultProps:  { size: 'small', disableElevation: true },
-      styleOverrides: {
-        root: { borderRadius: 6, fontWeight: 500, paddingInline: 12 },
-        sizeSmall: { height: 30, fontSize: 13 },
-      },
-    },
-    MuiChip: {
-      defaultProps:  { size: 'small', variant: 'outlined' },
-      styleOverrides: {
-        root: { borderRadius: 999, fontWeight: 500, fontSize: 12 },
-      },
-    },
-    MuiPaper: {
-      // defaultProps variant 강제 미적용 — Drawer / Menu / Dialog 등이 모두 Paper 기반이라
-      // 강제로 outlined 입히면 사방에 어색한 테두리가 생김. outlined 변형은 explicit 적용한 곳만 영향.
-      styleOverrides: {
-        outlined: { borderColor: '#E2E2DC', borderRadius: 8 },
-      },
-    },
-    MuiTextField: { defaultProps: { size: 'small', variant: 'outlined' } },
-    MuiOutlinedInput: {
-      styleOverrides: {
-        root: { borderRadius: 6, fontSize: 13 },
-        notchedOutline: { borderColor: '#E2E2DC' },
-      },
-    },
-    MuiTabs: { styleOverrides: { indicator: { height: 2, borderRadius: 1 } } },
-    MuiTab:  { styleOverrides: { root: { fontWeight: 500, fontSize: 13, textTransform: 'none', minHeight: 40 } } },
-    MuiAppBar: {
-      defaultProps: { elevation: 0 },
-      styleOverrides: { root: { backgroundColor: '#161A22', color: '#E4E5E9' } },
-    },
-    MuiDivider: { styleOverrides: { root: { borderColor: '#ECECE7' } } },
+const LIGHT = {
+  primary:   { main: '#5B5BD6', light: '#A6A8E6', dark: '#4040AD', contrastText: '#FFFFFF' },
+  secondary: { main: '#7B4DD8', light: '#B69CEC', dark: '#5B2DBF', contrastText: '#FFFFFF' },
+  success:   { main: '#1F9D55', light: '#DCF4E5', dark: '#0F7A40', contrastText: '#FFFFFF' },
+  warning:   { main: '#BE7415', light: '#FAEBC8', dark: '#95580B', contrastText: '#FFFFFF' },
+  error:     { main: '#D5383E', light: '#FBE0E0', dark: '#A8222A', contrastText: '#FFFFFF' },
+  info:      { main: '#2F77E4', light: '#DCEBFC', dark: '#1955B0', contrastText: '#FFFFFF' },
+  navbar:    { main: '#161A22', light: '#262C39', dark: '#0F1218', contrastText: '#E4E5E9' },
+  background:{ default: '#F7F7F4', paper: '#FFFFFF' },
+  text:      { primary: '#16181D', secondary: '#5B616E', disabled: '#B6BAC2' },
+  divider:   '#E2E2DC',
+  grey: {
+    50:  '#F7F7F4', 100: '#F1F1ED', 200: '#EBEAE5', 300: '#E2E2DC',
+    400: '#D2D2CA', 500: '#B6BAC2', 600: '#8A8F9A', 700: '#5B616E',
+    800: '#16181D', 900: '#0F1218',
   },
 };
+
+const DARK = {
+  primary:   { main: '#7676E0', light: '#9B9BEC', dark: '#5050A8', contrastText: '#FFFFFF' },
+  secondary: { main: '#9870E5', light: '#BFA4F0', dark: '#6E4DB5', contrastText: '#FFFFFF' },
+  success:   { main: '#2EBA6B', light: 'rgba(31,157,85,0.22)', dark: '#1F8C50', contrastText: '#0E1015' },
+  warning:   { main: '#D69021', light: 'rgba(190,116,21,0.24)', dark: '#A56B15', contrastText: '#0E1015' },
+  error:     { main: '#E84B52', light: 'rgba(213,56,62,0.24)', dark: '#A8222A', contrastText: '#FFFFFF' },
+  info:      { main: '#4E8EE8', light: 'rgba(47,119,228,0.24)', dark: '#2F77E4', contrastText: '#FFFFFF' },
+  // 다크에선 사이드바가 컨텐츠보다 더 어둡게 (디자이너 권장)
+  navbar:    { main: '#0A0C10', light: '#1A1E27', dark: '#05070A', contrastText: '#E4E5E9' },
+  background:{ default: '#0E1015', paper: '#161A22' },
+  text:      { primary: '#E8E9EE', secondary: '#A0A4AF', disabled: '#4A4E58' },
+  divider:   '#2A2F3B',
+  grey: {
+    50:  '#F7F7F4', 100: '#F1F1ED', 200: '#EBEAE5', 300: '#E2E2DC',
+    400: '#D2D2CA', 500: '#717684', 600: '#A0A4AF', 700: '#E8E9EE',
+    800: '#F1F1ED', 900: '#FFFFFF',
+  },
+};
+
+const SHADOWS_LIGHT = [
+  'none',
+  '0 1px 2px rgba(15,18,28,0.05), 0 0 0 1px rgba(15,18,28,0.04)',
+  '0 2px 6px rgba(15,18,28,0.07), 0 1px 2px rgba(15,18,28,0.04)',
+  '0 8px 24px rgba(15,18,28,0.10), 0 2px 6px rgba(15,18,28,0.06)',
+  '0 20px 48px rgba(15,18,28,0.16), 0 4px 12px rgba(15,18,28,0.08)',
+  ...Array(20).fill('0 20px 48px rgba(15,18,28,0.16), 0 4px 12px rgba(15,18,28,0.08)'),
+];
+
+const SHADOWS_DARK = [
+  'none',
+  '0 1px 2px rgba(0,0,0,0.40), 0 0 0 1px rgba(255,255,255,0.04)',
+  '0 2px 6px rgba(0,0,0,0.50), 0 1px 2px rgba(0,0,0,0.30)',
+  '0 8px 24px rgba(0,0,0,0.55), 0 2px 6px rgba(0,0,0,0.40)',
+  '0 20px 48px rgba(0,0,0,0.60), 0 4px 12px rgba(0,0,0,0.45)',
+  ...Array(20).fill('0 20px 48px rgba(0,0,0,0.60), 0 4px 12px rgba(0,0,0,0.45)'),
+];
+
+export function buildVccTheme(mode = 'light') {
+  const palette = mode === 'dark' ? DARK : LIGHT;
+  return {
+    palette: { mode, ...palette },
+    typography: {
+      fontFamily: '"Pretendard","Pretendard Variable",-apple-system,BlinkMacSystemFont,"Noto Sans KR",Roboto,sans-serif',
+      h1: { fontSize: 28, lineHeight: '36px', fontWeight: 700, letterSpacing: '-0.01em' },
+      h2: { fontSize: 22, lineHeight: '30px', fontWeight: 700, letterSpacing: '-0.01em' },
+      h3: { fontSize: 18, lineHeight: '26px', fontWeight: 700, letterSpacing: '-0.005em' },
+      h4: { fontSize: 18, lineHeight: '26px', fontWeight: 600 },
+      h5: { fontSize: 15, lineHeight: '22px', fontWeight: 600 },
+      h6: { fontSize: 14, lineHeight: '22px', fontWeight: 600 },
+      body1:    { fontSize: 14, lineHeight: '22px', letterSpacing: '-0.005em' },
+      body2:    { fontSize: 13, lineHeight: '20px', letterSpacing: '-0.005em' },
+      caption:  { fontSize: 12, lineHeight: '18px', fontWeight: 500 },
+      overline: { fontSize: 11, lineHeight: '16px', fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase' },
+      button:   { fontWeight: 500, letterSpacing: '-0.005em', textTransform: 'none' },
+    },
+    shape: { borderRadius: 6 },
+    spacing: 4,
+    shadows: mode === 'dark' ? SHADOWS_DARK : SHADOWS_LIGHT,
+    components: {
+      MuiButton: {
+        defaultProps: { size: 'small', disableElevation: true },
+        styleOverrides: {
+          root: { borderRadius: 6, fontWeight: 500, paddingInline: 12 },
+          sizeSmall: { height: 30, fontSize: 13 },
+        },
+      },
+      MuiChip: {
+        defaultProps: { size: 'small', variant: 'outlined' },
+        styleOverrides: { root: { borderRadius: 999, fontWeight: 500, fontSize: 12 } },
+      },
+      MuiPaper: {
+        styleOverrides: {
+          outlined: ({ theme }) => ({
+            borderColor: theme.palette.divider,
+            borderRadius: 8,
+          }),
+        },
+      },
+      MuiTextField:    { defaultProps: { size: 'small', variant: 'outlined' } },
+      MuiOutlinedInput: {
+        styleOverrides: {
+          root: { borderRadius: 6, fontSize: 13 },
+          notchedOutline: ({ theme }) => ({ borderColor: theme.palette.divider }),
+        },
+      },
+      MuiTabs: { styleOverrides: { indicator: { height: 2, borderRadius: 1 } } },
+      MuiTab:  { styleOverrides: { root: { fontWeight: 500, fontSize: 13, textTransform: 'none', minHeight: 40 } } },
+      MuiAppBar: {
+        defaultProps: { elevation: 0 },
+        styleOverrides: {
+          root: ({ theme }) => ({
+            backgroundColor: theme.palette.navbar.main,
+            color: theme.palette.navbar.contrastText,
+          }),
+        },
+      },
+      MuiDivider: {
+        styleOverrides: { root: ({ theme }) => ({ borderColor: theme.palette.divider }) },
+      },
+    },
+  };
+}
+
+// 하위 호환 — Phase 1 에서 `import { vccTheme }` 한 곳이 있어서 유지
+export const vccTheme = buildVccTheme('light');
 
 export default vccTheme;


### PR DESCRIPTION
## Summary
mockup tokens.css 의 dark scheme 적용. 영속은 디바이스별 localStorage — 백엔드 sync 없음.

### 핵심 구조
- \`theme.js\` 에 \`buildVccTheme(mode)\` 함수 — light / dark palette 양쪽
- \`contexts/ColorSchemeContext.js\` — 'light' / 'dark' / 'system' mode, matchMedia 구독, localStorage 영속
- \`App.js\` 의 \`ThemedApp\` 이 effective scheme 변화 감지해 createTheme 재계산
- Header 사용자 메뉴에 3-row 토글 (시스템 / 라이트 / 다크)

### 정리
- Sidebar wrapper #2c3e50 → navbar.main
- Workboards / PromptWorkboards #f5f5f5 → action.hover
- MuiAppBar / Divider / OutlinedInput / Paper outlined → theme.palette 함수형 styleOverrides

### 디바이스별 정책
디바이스마다 모드 선호 다를 수 있어 (예: 데스크탑 라이트, 모바일 다크) **userPreferences 동기화 안 함**. 의도적 결정.

## Test plan
- [x] Build 200
- [x] 사용자 검증 — \"잘 동작하네요\"
- [x] system mode + OS 다크모드 토글 동시 작동

## Follow-up / 미적용
- 일부 컴포넌트의 inline hex 정리 (PipelineRunner / 기타 page)
- 디자이너 mockup 의 dark accent scale (-3/-9/-11) 더 정밀 매핑
- 5e (#423) — 작업판 빌더 admin 3-pane