### PR TITLE
fix: 파이프라인 빌더 좌측 문서 팔레트가 빈 값으로 나오던 버그

### DIFF
--- a/frontend/src/components/common/PipelinePanel.js
+++ b/frontend/src/components/common/PipelinePanel.js
@@ -719,8 +719,9 @@ function ContextDocPalette({ projectId, selectedStepIdx, selectedStep, onAddDoc 
     () => textAPI.getUploaded({ tags: [projectTag?._id, systemPromptTag?._id].filter(Boolean).join(','), limit: 50 }),
     { enabled: !!projectTag && !!systemPromptTag, staleTime: 60_000 }
   );
-  const wvDocs = wvDocsData?.data?.data?.uploadedTexts || wvDocsData?.data?.uploadedTexts || [];
-  const spDocs = spDocsData?.data?.data?.uploadedTexts || spDocsData?.data?.uploadedTexts || [];
+  // 백엔드 texts 라우트는 { success, data: { items, pagination } } shape
+  const wvDocs = wvDocsData?.data?.data?.items || [];
+  const spDocs = spDocsData?.data?.data?.items || [];
 
   const ctxIds = new Set(selectedStep?.contextDocIds || []);
   const spId = selectedStep?.systemPromptDocId;


### PR DESCRIPTION
## Summary
PR #429 회귀. textAPI.getUploaded 응답이 \`{ data: { items, pagination } }\` 인데 팔레트에서 \`uploadedTexts\` 키 사용해 항상 빈 배열.

수정: \`.data.data.items\` 로 일관화 + 주석으로 shape 문서화.

## Test plan
- [x] Build 200
- [x] 사용자 검증 — \"네 잘 나옵니다\"