### PR TITLE
feat: 작업판 편집기 페이지화 — Phase A 라우트 전환 (#437)

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -35,6 +35,8 @@ import {
   AdminDashboardPage,
   UserManagementPage,
   WorkboardManagementPage,
+  WorkboardEditorPage,
+  WorkboardCreatePage,
   ServerManagementPage,
   SystemStatsPage,
   BackupRestorePage,
@@ -184,6 +186,22 @@ function MainLayout() {
               element={
                 <AdminRoute>
                   <WorkboardManagementPage />
+                </AdminRoute>
+              }
+            />
+            <Route
+              path="/admin/workboards/new"
+              element={
+                <AdminRoute>
+                  <WorkboardCreatePage />
+                </AdminRoute>
+              }
+            />
+            <Route
+              path="/admin/workboards/:id/edit"
+              element={
+                <AdminRoute>
+                  <WorkboardEditorPage />
                 </AdminRoute>
               }
             />

--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -54,11 +54,11 @@ import {
 import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import { useForm, Controller } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import { workboardAPI, serverAPI, groupAPI } from '../../services/api';
 import WorkboardBasicInfoForm from './WorkboardBasicInfoForm';
 import MetadataPickerModal from '../common/MetadataPickerModal';
-import { getWorkboardTemplate } from '../../templates';
 import { BUILTIN_WORKFLOW_VARIABLES, WORKFLOW_VARIABLE_CATEGORIES, formatValueType } from '../../constants/workflowVariables';
 import {
   getServerTypeLabel,
@@ -704,7 +704,11 @@ function PreviewField({ field }) {
 }
 
 // 상세 편집을 위한 새로운 다이얼로그 컴포넌트
-function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
+// asPage 모드 (#437 Phase A) — Dialog 대신 페이지 안에 인라인 렌더. 데이터 fetch 게이트는
+// open 또는 asPage 가 true 일 때 열림. 페이지 경로는 WorkboardEditorPage 가 wrap.
+export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage = false, onCancel }) {
+  const isOpen = asPage || open;
+  const handleCancel = onCancel || onClose;
   const [tabValue, setTabValue] = useState(0);
   // 5e-3 — 입력 양식 탭의 선택 필드 (인스펙터 패턴)
   const [selectedFieldIdx, setSelectedFieldIdx] = useState(-1);
@@ -745,7 +749,7 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
   // ComfyUI 서버의 availableBaseModels (#252) — allowedModelTypes 옵션 풀.
   // ServerModelCache 의 detailed endpoint 에서 derived (limit 1 로 가벼운 호출).
   useEffect(() => {
-    if (!open || !isComfyUI || !watchedServerId) {
+    if (!isOpen || !isComfyUI || !watchedServerId) {
       setAvailableBaseModels([]);
       return;
     }
@@ -754,15 +758,15 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
         setAvailableBaseModels(res.data?.data?.availableBaseModels || []);
       })
       .catch(() => setAvailableBaseModels([]));
-  }, [open, isComfyUI, watchedServerId]);
+  }, [isOpen, isComfyUI, watchedServerId]);
 
   // 그룹 목록 fetch (#198) — 모달 open 시 1회
   useEffect(() => {
-    if (!open) return;
+    if (!isOpen) return;
     groupAPI.getAll()
       .then((res) => setAvailableGroups(res.data?.data?.groups || []))
       .catch(() => setAvailableGroups([]));
-  }, [open]);
+  }, [isOpen]);
 
   useEffect(() => {
     return () => {
@@ -808,7 +812,7 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
 
   // 관리자 전용 API로 완전한 데이터 로딩
   useEffect(() => {
-    if (workboard && workboard._id && open) {
+    if (workboard && workboard._id && isOpen) {
       setLoading(true);
       console.log('Fetching full workboard data with ID:', workboard._id);
       
@@ -854,7 +858,7 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
           setLoading(false);
         });
     }
-  }, [workboard?._id, open, reset]);
+  }, [workboard?._id, isOpen, reset]);
 
   const addArrayItem = (fieldName, defaultItem = { key: '', value: '' }) => {
     const currentItems = watch(fieldName) || [];
@@ -961,12 +965,39 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
     onSave(updateData);
   };
 
+  // asPage (#437 Phase A) — Dialog wrapper 대신 React.Fragment 로 감싸 페이지 안에 그대로 렌더.
+  // 사용자가 외부에서 form submit 할 수 있도록 form 에 id 부여 + sticky header 의 저장 버튼은
+  // form="wbEditForm" 으로 연결.
+  const Wrapper = asPage ? React.Fragment : Dialog;
+  const wrapperProps = asPage ? {} : { open, onClose: handleCancel, maxWidth: 'xl', fullWidth: true };
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="xl" fullWidth>
-      <DialogTitle>
-        작업판 상세 편집 - {workboard?.name}
-      </DialogTitle>
-      <form onSubmit={handleSubmit(onSubmit)}>
+    <Wrapper {...wrapperProps}>
+      {asPage ? (
+        <Box sx={{
+          position: 'sticky', top: 0, zIndex: 10,
+          bgcolor: 'background.paper', borderBottom: 1, borderColor: 'divider',
+          py: 2, mb: 2,
+          display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap',
+        }}>
+          <Button onClick={handleCancel} size="small" sx={{ flexShrink: 0 }}>← 작업판 관리</Button>
+          <Typography variant="h6" sx={{ fontWeight: 700, wordBreak: 'break-word' }}>
+            {workboard?.name || '작업판 편집'}
+          </Typography>
+          <Chip
+            label={watch('isActive') ? '활성' : '비활성'}
+            color={watch('isActive') ? 'success' : 'default'}
+            variant="outlined"
+          />
+          <Box sx={{ flex: 1 }} />
+          <Button onClick={handleCancel}>취소</Button>
+          <Button form="wbEditForm" type="submit" variant="contained" disabled={loading}>저장</Button>
+        </Box>
+      ) : (
+        <DialogTitle>
+          작업판 상세 편집 - {workboard?.name}
+        </DialogTitle>
+      )}
+      <form id="wbEditForm" onSubmit={handleSubmit(onSubmit)}>
         <DialogContent>
           {loading ? (
             <Box display="flex" justifyContent="center" alignItems="center" minHeight="200px">
@@ -1005,7 +1036,7 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
               errors={errors}
               showActiveSwitch={true}
               showTypeSelector={true}
-              isDialogOpen={open}
+              isDialogOpen={isOpen}
             />
           )}
 
@@ -1572,18 +1603,22 @@ function WorkboardDetailDialog({ open, onClose, workboard, onSave }) {
             </>
           )}
       </DialogContent>
-        <DialogActions>
-          <Button onClick={onClose}>취소</Button>
-          <Button type="submit" variant="contained" disabled={loading}>
-            저장
-          </Button>
-        </DialogActions>
+        {!asPage && (
+          <DialogActions>
+            <Button onClick={handleCancel}>취소</Button>
+            <Button type="submit" variant="contained" disabled={loading}>
+              저장
+            </Button>
+          </DialogActions>
+        )}
       </form>
-    </Dialog>
+    </Wrapper>
   );
 }
 
-function WorkboardCreateDialog({ open, onClose, onSave }) {
+export function WorkboardCreateDialog({ open, onClose, onSave, asPage = false, onCancel }) {
+  const isOpen = asPage || open;
+  const handleCancel = onCancel || onClose;
   const { control, handleSubmit, reset, setValue, formState: { errors } } = useForm({
     defaultValues: {
       name: '',
@@ -1596,7 +1631,7 @@ function WorkboardCreateDialog({ open, onClose, onSave }) {
   });
 
   useEffect(() => {
-    if (open) {
+    if (isOpen) {
       reset({
         name: '',
         description: '',
@@ -1606,16 +1641,33 @@ function WorkboardCreateDialog({ open, onClose, onSave }) {
         isActive: true
       });
     }
-  }, [open, reset]);
+  }, [isOpen, reset]);
 
   const onSubmit = (data) => {
     onSave(data);
   };
 
+  const Wrapper = asPage ? React.Fragment : Dialog;
+  const wrapperProps = asPage ? {} : { open, onClose: handleCancel, maxWidth: 'md', fullWidth: true };
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
-      <DialogTitle>새 작업판 생성</DialogTitle>
-      <form onSubmit={handleSubmit(onSubmit)}>
+    <Wrapper {...wrapperProps}>
+      {asPage ? (
+        <Box sx={{
+          position: 'sticky', top: 0, zIndex: 10,
+          bgcolor: 'background.paper', borderBottom: 1, borderColor: 'divider',
+          py: 2, mb: 2,
+          display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap',
+        }}>
+          <Button onClick={handleCancel} size="small" sx={{ flexShrink: 0 }}>← 작업판 관리</Button>
+          <Typography variant="h6" sx={{ fontWeight: 700 }}>새 작업판</Typography>
+          <Box sx={{ flex: 1 }} />
+          <Button onClick={handleCancel}>취소</Button>
+          <Button form="wbCreateForm" type="submit" variant="contained">생성</Button>
+        </Box>
+      ) : (
+        <DialogTitle>새 작업판 생성</DialogTitle>
+      )}
+      <form id="wbCreateForm" onSubmit={handleSubmit(onSubmit)}>
         <DialogContent>
           <WorkboardBasicInfoForm
             control={control}
@@ -1623,7 +1675,7 @@ function WorkboardCreateDialog({ open, onClose, onSave }) {
             errors={errors}
             showActiveSwitch={false}
             showTypeSelector={true}
-            isDialogOpen={open}
+            isDialogOpen={isOpen}
           />
 
           <Alert severity="info" sx={{ mt: 2 }}>
@@ -1631,12 +1683,14 @@ function WorkboardCreateDialog({ open, onClose, onSave }) {
             생성 후 편집에서 추가할 수 있습니다.
           </Alert>
         </DialogContent>
-        <DialogActions>
-          <Button onClick={onClose}>취소</Button>
-          <Button type="submit" variant="contained">생성</Button>
-        </DialogActions>
+        {!asPage && (
+          <DialogActions>
+            <Button onClick={handleCancel}>취소</Button>
+            <Button type="submit" variant="contained">생성</Button>
+          </DialogActions>
+        )}
       </form>
-    </Dialog>
+    </Wrapper>
   );
 }
 
@@ -1870,6 +1924,7 @@ const ADMIN_WB_SERVER_KEY = 'vcc.adminWorkboards.serverType';
 const ADMIN_WB_OUTPUT_KEY = 'vcc.adminWorkboards.outputFormat';
 
 function WorkboardManagement() {
+  const navigate = useNavigate();
   const [search, setSearch] = useState(() => localStorage.getItem(ADMIN_WB_SEARCH_KEY) || '');
   const [serverTypeFilter, setServerTypeFilter] = useState(() => localStorage.getItem(ADMIN_WB_SERVER_KEY) || '');
   const [outputFormatFilter, setOutputFormatFilter] = useState(() => localStorage.getItem(ADMIN_WB_OUTPUT_KEY) || '');
@@ -1887,10 +1942,10 @@ function WorkboardManagement() {
     if (outputFormatFilter) localStorage.setItem(ADMIN_WB_OUTPUT_KEY, outputFormatFilter);
     else localStorage.removeItem(ADMIN_WB_OUTPUT_KEY);
   }, [outputFormatFilter]);
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [detailDialogOpen, setDetailDialogOpen] = useState(false);
+  // create / update / 편집 dialog 상태는 #437 Phase A 에서 페이지로 이전됨
+  // (WorkboardEditorPage / WorkboardCreatePage 가 own mutation + 페이지 라우팅).
+  // 본 컴포넌트는 목록 / 가져오기 / delete / duplicate / toggleActive / export 만 담당.
   const [importDialogOpen, setImportDialogOpen] = useState(false);
-  const [selectedWorkboard, setSelectedWorkboard] = useState(null);
 
   const queryClient = useQueryClient();
 
@@ -1898,86 +1953,6 @@ function WorkboardManagement() {
     ['adminWorkboards', { search, serverTypeFilter, outputFormatFilter }],
     () => workboardAPI.getAll({ search, limit: 50, includeAll: true, includeInactive: true, serverType: serverTypeFilter || undefined, outputFormat: outputFormatFilter || undefined }),
     { keepPreviousData: true }
-  );
-
-  const createMutation = useMutation(
-    workboardAPI.create,
-    {
-      onSuccess: (response) => {
-        console.log('✨ New workboard created, updating cache immediately');
-        toast.success('작업판이 생성되었습니다');
-        
-        // 즉시 캐시 업데이트 - 새 작업판을 목록에 추가
-        queryClient.setQueryData('adminWorkboards', (oldData) => {
-          if (!oldData?.data?.workboards || !response.data?.workboard) {
-            queryClient.refetchQueries('adminWorkboards');
-            return oldData;
-          }
-          
-          return {
-            ...oldData,
-            data: {
-              ...oldData.data,
-              workboards: [response.data.workboard, ...oldData.data.workboards],
-              pagination: {
-                ...oldData.data.pagination,
-                total: oldData.data.pagination.total + 1
-              }
-            }
-          };
-        });
-        
-        // 강제 리패치로 정확한 데이터 보장
-        queryClient.refetchQueries('adminWorkboards');
-        setDialogOpen(false);
-      },
-      onError: (error) => {
-        console.error('❌ Workboard creation failed:', error);
-        toast.error('생성 실패: ' + error.message);
-      }
-    }
-  );
-
-  const updateMutation = useMutation(
-    ({ id, data }) => workboardAPI.update(id, data),
-    {
-      onSuccess: (response) => {
-        console.log('🔄 Workboard update success, immediately updating cache');
-        toast.success('작업판이 수정되었습니다');
-        
-        // 즉시 캐시 업데이트 - 기존 데이터를 새 데이터로 교체
-        queryClient.setQueryData('adminWorkboards', (oldData) => {
-          if (!oldData?.data?.workboards || !response.data?.workboard) return oldData;
-          
-          const updatedWorkboards = oldData.data.workboards.map(wb => 
-            wb._id === response.data.workboard._id ? response.data.workboard : wb
-          );
-          
-          return {
-            ...oldData,
-            data: {
-              ...oldData.data,
-              workboards: updatedWorkboards
-            }
-          };
-        });
-        
-        // 강제 리패치도 수행하여 확실히 최신 데이터 보장
-        queryClient.refetchQueries('adminWorkboards');
-        
-        // 상세 편집 다이얼로그가 열려있으면 선택된 작업판 데이터를 업데이트
-        if (detailDialogOpen && response.data?.workboard) {
-          setSelectedWorkboard(response.data.workboard);
-        }
-        setDialogOpen(false);
-        
-        console.log('✅ Cache updated immediately with new workboard data');
-      },
-      onError: (error) => {
-        console.error('❌ Workboard update failed:', error);
-        toast.error('수정 실패: ' + error.message);
-      }
-    }
   );
 
   const deleteMutation = useMutation(
@@ -2076,17 +2051,11 @@ function WorkboardManagement() {
   const workboards = data?.data?.workboards || [];
 
   const handleCreate = () => {
-    setSelectedWorkboard(null);
-    setDialogOpen(true);
+    navigate('/admin/workboards/new');
   };
 
-  const handleEdit = (workboard, editType = 'basic') => {
-    setSelectedWorkboard(workboard);
-    if (editType === 'detailed') {
-      setDetailDialogOpen(true);
-    } else {
-      setDialogOpen(true);
-    }
+  const handleEdit = (workboard /* editType ignored — 단일 편집 페이지로 통합 (#437 Phase A) */) => {
+    navigate(`/admin/workboards/${workboard._id}/edit`);
   };
 
   const handleDelete = (workboard) => {
@@ -2134,33 +2103,6 @@ function WorkboardManagement() {
   const handleView = (workboard) => {
     // 상세 보기 구현
     console.log('View workboard:', workboard);
-  };
-
-  const handleSave = (data) => {
-    if (selectedWorkboard) {
-      const { serverType: _omit, ...normalizedData } = data;
-      updateMutation.mutate({ id: selectedWorkboard._id, data: normalizedData });
-    } else {
-      // 생성: serverType + outputFormat → 템플릿 적용
-      const serverType = data.serverType || 'ComfyUI';
-      const outputFormat = data.outputFormat || 'image';
-      const template = getWorkboardTemplate(serverType, outputFormat);
-
-      const { serverType: _omit, ...rest } = data;
-      const workboardData = {
-        ...rest,
-        outputFormat,
-        ...template,
-      };
-      createMutation.mutate(workboardData);
-    }
-  };
-
-  const handleDetailSave = (data) => {
-    if (selectedWorkboard) {
-      updateMutation.mutate({ id: selectedWorkboard._id, data });
-      // 다이얼로그는 닫지 않고 데이터만 업데이트 - updateMutation의 onSuccess에서 처리
-    }
   };
 
   return (
@@ -2246,19 +2188,6 @@ function WorkboardManagement() {
           ))}
         </Grid>
       )}
-
-      <WorkboardCreateDialog
-        open={dialogOpen}
-        onClose={() => setDialogOpen(false)}
-        onSave={handleSave}
-      />
-
-      <WorkboardDetailDialog
-        open={detailDialogOpen}
-        onClose={() => setDetailDialogOpen(false)}
-        workboard={selectedWorkboard}
-        onSave={handleDetailSave}
-      />
 
       <WorkboardImportDialog
         open={importDialogOpen}

--- a/frontend/src/pages/admin/WorkboardCreatePage.js
+++ b/frontend/src/pages/admin/WorkboardCreatePage.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useMutation, useQueryClient } from 'react-query';
+import { Container } from '@mui/material';
+import toast from 'react-hot-toast';
+import { workboardAPI } from '../../services/api';
+import { getWorkboardTemplate } from '../../templates';
+import { WorkboardCreateDialog } from '../../components/admin/WorkboardManagement';
+
+// #437 Phase A — WorkboardCreateDialog 를 페이지로. 생성 성공 시 편집 페이지로 이동.
+function WorkboardCreatePage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const createMutation = useMutation(
+    workboardAPI.create,
+    {
+      onSuccess: (response) => {
+        toast.success('작업판이 생성되었습니다');
+        queryClient.invalidateQueries('adminWorkboards');
+        const newId = response?.data?.workboard?._id;
+        if (newId) {
+          navigate(`/admin/workboards/${newId}/edit`, { replace: true });
+        } else {
+          navigate('/admin/workboards', { replace: true });
+        }
+      },
+      onError: (err) => {
+        toast.error('생성 실패: ' + (err?.message || ''));
+      }
+    }
+  );
+
+  const handleSave = (data) => {
+    const serverType = data.serverType || 'ComfyUI';
+    const outputFormat = data.outputFormat || 'image';
+    const template = getWorkboardTemplate(serverType, outputFormat);
+    const { serverType: _omit, ...rest } = data;
+    const workboardData = {
+      ...rest,
+      outputFormat,
+      ...template,
+    };
+    createMutation.mutate(workboardData);
+  };
+
+  return (
+    <Container maxWidth="md" sx={{ mt: 2, mb: 4 }}>
+      <WorkboardCreateDialog
+        asPage
+        onCancel={() => navigate('/admin/workboards')}
+        onSave={handleSave}
+      />
+    </Container>
+  );
+}
+
+export default WorkboardCreatePage;

--- a/frontend/src/pages/admin/WorkboardEditorPage.js
+++ b/frontend/src/pages/admin/WorkboardEditorPage.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { Container, Box, CircularProgress, Alert } from '@mui/material';
+import toast from 'react-hot-toast';
+import { workboardAPI } from '../../services/api';
+import { WorkboardDetailDialog } from '../../components/admin/WorkboardManagement';
+
+// #437 Phase A — 기존 WorkboardDetailDialog 를 페이지 안에 그대로 렌더 (asPage prop).
+// 데이터 fetch / update mutation / unsaved 경고는 본 페이지가 소유.
+function WorkboardEditorPage() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const { data, isLoading, error } = useQuery(
+    ['adminWorkboard', id],
+    () => workboardAPI.getByIdAdmin(id),
+    { enabled: !!id, staleTime: 0 }
+  );
+
+  const workboard = data?.data?.workboard;
+
+  // unsaved 경고: WorkboardDetailDialog 내부 react-hook-form 의 dirty 신호를 외부로 끌어올려야
+  // 정밀하게 동작 (false-positive 회피). Phase B 에서 dirty lift + useBlocker 로 처리.
+
+  const updateMutation = useMutation(
+    (updateData) => workboardAPI.update(id, updateData),
+    {
+      onSuccess: () => {
+        toast.success('작업판이 수정되었습니다');
+        queryClient.invalidateQueries('adminWorkboards');
+        queryClient.invalidateQueries(['adminWorkboard', id]);
+        navigate('/admin/workboards');
+      },
+      onError: (err) => {
+        toast.error('수정 실패: ' + (err?.message || ''));
+      }
+    }
+  );
+
+  if (isLoading) {
+    return (
+      <Container maxWidth="xl" sx={{ mt: 4 }}>
+        <Box display="flex" justifyContent="center" py={6}>
+          <CircularProgress />
+        </Box>
+      </Container>
+    );
+  }
+
+  if (error || !workboard) {
+    return (
+      <Container maxWidth="xl" sx={{ mt: 4 }}>
+        <Alert severity="error">작업판을 불러올 수 없습니다.</Alert>
+      </Container>
+    );
+  }
+
+  return (
+    <Container maxWidth="xl" sx={{ mt: 2, mb: 4 }}>
+      <WorkboardDetailDialog
+        asPage
+        workboard={workboard}
+        onCancel={() => navigate('/admin/workboards')}
+        onSave={(updateData) => updateMutation.mutate(updateData)}
+      />
+    </Container>
+  );
+}
+
+export default WorkboardEditorPage;

--- a/frontend/src/pages/admin/index.js
+++ b/frontend/src/pages/admin/index.js
@@ -1,6 +1,8 @@
 export { default as AdminDashboardPage } from './AdminDashboardPage';
 export { default as UserManagementPage } from './UserManagementPage';
 export { default as WorkboardManagementPage } from './WorkboardManagementPage';
+export { default as WorkboardEditorPage } from './WorkboardEditorPage';
+export { default as WorkboardCreatePage } from './WorkboardCreatePage';
 export { default as ServerManagementPage } from './ServerManagementPage';
 export { default as SystemStatsPage } from './SystemStatsPage';
 export { default as BackupRestorePage } from './BackupRestorePage';


### PR DESCRIPTION
## Summary
- 작업판 편집기 / 생성기를 Dialog → 라우트 페이지로 전환 (#437 Phase A)
- 사용자 가시 변화: 카드 편집 / 새 작업판 클릭 시 모달 대신 별도 페이지로 이동, 페이지 폭 제약 사라지고 라우트 공유 가능
- Phase A 는 페이지 전환 자체만. mockup 정밀 매칭 (탭 폐기 / 인스펙터 추출 / 3-pane reflow) 은 #440 (Phase B) 로 분리

## 변경
- `pages/admin/WorkboardEditorPage.js` (신규) — `/admin/workboards/:id/edit`
  - `useParams` + `getByIdAdmin` fetch
  - own update mutation, 성공 시 목록 페이지로 navigate
  - `<WorkboardDetailDialog asPage>` 렌더
- `pages/admin/WorkboardCreatePage.js` (신규) — `/admin/workboards/new`
  - own create mutation + 템플릿 적용 (`getWorkboardTemplate`)
  - 성공 시 새 작업판의 편집 페이지로 redirect
- `pages/admin/index.js` — 두 페이지 export
- `App.js` — 두 라우트 등록 (AdminRoute 안)
- `components/admin/WorkboardManagement.js`
  - `WorkboardDetailDialog` / `WorkboardCreateDialog` 에 `asPage` prop 추가:
    - `Wrapper = asPage ? React.Fragment : Dialog`
    - asPage 시 sticky header (이름 + 활성 chip + 취소 / 저장) 추가
    - `form` 에 id (`wbEditForm` / `wbCreateForm`) — sticky 저장 버튼이 `form=\"...\"` 로 외부 submit
    - DialogActions 는 `!asPage` 조건부 렌더
  - 두 컴포넌트 named export
  - `WorkboardManagement` 에서 dialog state (`dialogOpen` / `detailDialogOpen` / `selectedWorkboard`) + `createMutation` / `updateMutation` / `handleSave` / `handleDetailSave` 제거 (페이지가 own)
  - \"새 작업판\" → `navigate('/admin/workboards/new')`, 카드 \"편집\" → `navigate('/admin/workboards/:id/edit')`
  - 카드 메뉴 `editType='basic'/'detailed'` 구분 폐기 — 통합 편집 페이지로

## 의도적으로 안 한 것 (Phase B = #440)
- dialog mode 코드 경로 정리 (현재는 asPage 분기로 공존)
- unsaved 경고 — react-hook-form dirty 신호를 페이지로 lift 후 `useBlocker`/beforeunload 적용
- 탭 4개 폐기 → header config 4-col grid (mockup 매칭)
- `CustomFieldInspector` 별도 컴포넌트 추출 (Accordion 인라인 expansion → 우측 sticky inspector)

## Test plan
- [x] docker-compose --no-cache 빌드 통과 (eslint warning 모두 기존)
- [x] `/admin/workboards/new` 200 응답, 번들에 form id 진입 확인
- [x] 사용자 동작 확인 — \"네 괜찮은 거 같습니다\"
- [x] 카드 \"편집\" → 페이지 이동 → 4탭 / 3-pane / 저장 / 취소 / 뒤로가기 동작
- [x] \"새 작업판\" → 페이지 이동 → 생성 → 편집 페이지 redirect

closes #437
related #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)