### PR TITLE
feat: MCP 도구 — 프로젝트 + 파이프라인 호출 + 통합 테스트 (#448)

### DIFF
--- a/docs/MCP_SERVER_API.md
+++ b/docs/MCP_SERVER_API.md
@@ -274,3 +274,152 @@ base64 인코딩된 이미지를 VCC 서버에 업로드. 반환된 `imageId`를
 2. generate(workboardId, prompt, aiModel, additionalParams: { "referenceImage": "abc123" })
    → 이미지 타입 필드가 자동으로 { imageId: "abc123" } 형식으로 변환됨
 ```
+
+---
+
+## Projects (프로젝트)
+
+### `list_projects`
+
+사용자의 프로젝트 목록 조회. 파이프라인 호출 전에 `projectId` 를 얻기 위해 가장 먼저 호출.
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|------|------|
+| `search` | string | - | 이름/설명 검색 |
+
+**응답 필드:**
+
+| 필드 | 설명 |
+|------|------|
+| `projects[].id` | 프로젝트 ID |
+| `projects[].name` | 프로젝트 이름 |
+| `projects[].description` | 설명 |
+| `projects[].isFavorite` | 즐겨찾기 여부 |
+| `projects[].createdAt` | 생성 시각 |
+| `projects[].counts` | (있을 때만) 콘텐츠 카운트 |
+
+---
+
+## Pipelines (파이프라인)
+
+### `list_pipelines`
+
+프로젝트에 속한 파이프라인 목록.
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|------|------|
+| `projectId` | string | **필수** | 프로젝트 ID (`list_projects` 로 획득) |
+
+**응답 필드:**
+
+| 필드 | 설명 |
+|------|------|
+| `pipelines[].id` | 파이프라인 ID |
+| `pipelines[].name` | 이름 |
+| `pipelines[].description` | 설명 |
+| `pipelines[].stepCount` | 단계 수 |
+| `pipelines[].createdAt` / `updatedAt` | 생성 / 수정 시각 |
+
+---
+
+### `get_pipeline`
+
+파이프라인 상세 — 단계 구성, 자동 주입 여부, 사전 입력, 연결 문서.
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|------|------|
+| `projectId` | string | **필수** | 프로젝트 ID |
+| `pipelineId` | string | **필수** | 파이프라인 ID |
+
+**응답 필드:**
+
+| 필드 | 설명 |
+|------|------|
+| `id`, `name`, `description` | 파이프라인 메타 |
+| `steps[].index` | 단계 순서 |
+| `steps[].workboardId` / `workboardName` / `outputFormat` | 단계의 작업판 |
+| `steps[].autoInject` | 이전 결과 자동 주입 여부 |
+| `steps[].inputs` | 사전 입력 (customField name → value 매핑) |
+| `steps[].contextDocIds` | 컨텍스트 문서 ID 들 |
+| `steps[].systemPromptDocId` | 시스템 프롬프트 문서 ID |
+| `steps[].note` | 사용자 메모 |
+
+---
+
+### `run_pipeline`
+
+새 파이프라인 실행 시작. `runId` 를 반환하므로 `get_pipeline_run` 로 폴링.
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|------|------|
+| `projectId` | string | **필수** | 프로젝트 ID |
+| `pipelineId` | string | **필수** | 파이프라인 ID |
+| `initialPrompt` | string | - | 첫 단계의 초기 프롬프트 (기본: 빈 문자열) |
+
+**응답 필드:**
+
+| 필드 | 설명 |
+|------|------|
+| `runId` | 실행 ID (이후 `get_pipeline_run` 인자) |
+| `status` | 초기 상태 (`pending`) |
+| `startedAt` | 시작 시각 |
+| `stepCount` | 단계 수 |
+
+---
+
+### `get_pipeline_run`
+
+파이프라인 실행 상태 + 단계별 출력. 완료 / 실패까지 폴링.
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|------|------|
+| `projectId` | string | **필수** | 프로젝트 ID |
+| `runId` | string | **필수** | 실행 ID |
+
+**응답 필드:**
+
+| 필드 | 설명 |
+|------|------|
+| `runId`, `pipelineName` | 실행 메타 |
+| `status` | `pending` / `running` / `completed` / `failed` |
+| `startedAt` / `completedAt` / `errorMessage` | 시각 / 오류 |
+| `initialPrompt` | 시작 prompt |
+| `steps[].index` | 단계 순서 |
+| `steps[].workboardName` / `outputFormat` | 단계의 작업판 |
+| `steps[].status` | 단계 상태 |
+| `steps[].imageGenerationJobId` | 이미지 step 의 job ID (`download_result` 인자) |
+| `steps[].conversationJobId` | 텍스트 step 의 conversation ID |
+| `steps[].textOutput` | 텍스트 step 의 직접 출력 |
+| `steps[].imageIds` | 이미지 step 의 결과 image ID 들 |
+
+**사용 패턴:**
+```
+1. list_projects → projectId
+2. list_pipelines(projectId) → pipelineId
+3. run_pipeline(projectId, pipelineId, initialPrompt) → runId
+4. get_pipeline_run(projectId, runId) — status 가 completed 될 때까지 폴링
+5. download_result(imageGenerationJobId) — 이미지 step 결과 회수
+```
+
+---
+
+### `list_pipeline_runs`
+
+프로젝트의 최근 실행 목록 (최신순).
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|------|------|
+| `projectId` | string | **필수** | 프로젝트 ID |
+| `pipelineId` | string | - | 특정 파이프라인만 필터 |
+| `limit` | number (max 50) | - | 페이지당 항목 수 (기본 20) |
+| `page` | number | - | 페이지 번호 (기본 1) |
+
+**응답 필드:**
+
+| 필드 | 설명 |
+|------|------|
+| `runs[].runId` / `pipelineId` / `pipelineName` | 실행 / 파이프라인 메타 |
+| `runs[].status` | 실행 상태 |
+| `runs[].startedAt` / `completedAt` | 시각 |
+| `runs[].stepCount` | 단계 수 |
+| `pagination` | 페이지네이션 |

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -40,6 +40,12 @@ claude mcp add --transport stdio vcc-manager -- node /absolute/path/to/mcp-serve
 | `get_job_status` | 생성 작업 상태 확인 |
 | `list_jobs` | 생성 작업 목록 조회 |
 | `download_result` | 결과 다운로드 |
+| `list_projects` | 프로젝트 목록 조회 |
+| `list_pipelines` | 프로젝트의 파이프라인 목록 |
+| `get_pipeline` | 파이프라인 단계 상세 |
+| `run_pipeline` | 파이프라인 실행 시작 (runId 반환) |
+| `get_pipeline_run` | 실행 상태 / 단계별 출력 |
+| `list_pipeline_runs` | 최근 실행 목록 |
 
 ## 검증
 
@@ -50,3 +56,25 @@ npx @modelcontextprotocol/inspector node index.js
 # HTTP 모드
 npx @modelcontextprotocol/inspector --url http://localhost:3100/mcp
 ```
+
+### 통합 테스트 (#448)
+
+`test/integration.mjs` — 실제 MCP 서버에 접속해 프로젝트 / 파이프라인 도구 흐름을 검증.
+
+```bash
+# 로컬 (docker-compose 기동 + 컨테이너 안에서 실행, /app 기준)
+MCP_TEST_API_KEY=<VCC API Key> npm run test:integration
+
+# dev 환경
+MCP_TEST_URL=https://alpha-vccm-mcp.gcempire.net/mcp \
+MCP_TEST_API_KEY=<VCC API Key> npm run test:integration
+```
+
+| 환경변수 | 설명 |
+|---|---|
+| `MCP_TEST_API_KEY` | VCC API Key (필수, Bearer 전달) |
+| `MCP_TEST_URL` | MCP endpoint (기본 `http://localhost:3100/mcp`) |
+| `MCP_TEST_RUN_PIPELINE` | `1` 이면 `run_pipeline` 까지 실제 실행 (LLM/ComfyUI 호출 발생 — 기본 skip) |
+| `MCP_TEST_INITIAL_PROMPT` | run 시 사용할 prompt |
+
+프로젝트 / 파이프라인 데이터가 없으면 해당 단계는 skip (read-only 검증만). API Key 사용자 소유 자원만 보임.

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "start": "node index.js",
     "start:http": "MCP_TRANSPORT=http node index.js",
+    "test:integration": "node test/integration.mjs",
     "inspect": "npx @modelcontextprotocol/inspector node index.js",
     "inspect:http": "MCP_TRANSPORT=http node index.js & sleep 2 && npx @modelcontextprotocol/inspector --url http://localhost:${MCP_PORT:-3100}/mcp"
   },

--- a/mcp-server/src/server.js
+++ b/mcp-server/src/server.js
@@ -3,6 +3,8 @@ import { createApiClient } from './utils/apiClient.js';
 import { registerWorkboardTools } from './tools/workboards.js';
 import { registerJobTools } from './tools/jobs.js';
 import { registerMediaTools } from './tools/media.js';
+import { registerProjectTools } from './tools/projects.js';
+import { registerPipelineTools } from './tools/pipelines.js';
 
 /**
  * Create and configure an McpServer instance with all tools registered.
@@ -26,6 +28,8 @@ export function createServer(options = {}) {
   registerWorkboardTools(server, api);
   registerJobTools(server, api);
   registerMediaTools(server, api, options);
+  registerProjectTools(server, api);
+  registerPipelineTools(server, api);
 
   return server;
 }

--- a/mcp-server/src/tools/pipelines.js
+++ b/mcp-server/src/tools/pipelines.js
@@ -1,0 +1,202 @@
+import { z } from 'zod';
+
+/**
+ * Register pipeline + pipeline-run tools (#448).
+ *
+ * Flow: list_projects → list_pipelines → run_pipeline → get_pipeline_run (poll)
+ *       → download_result (existing media tool) 로 산출물 회수.
+ *
+ * @param {import('@modelcontextprotocol/sdk/server/mcp.js').McpServer} server
+ * @param {(path: string, options?: object) => Promise<any>} apiRequest
+ */
+export function registerPipelineTools(server, apiRequest) {
+
+  // ── list_pipelines ─────────────────────────────────────────────────
+  server.tool(
+    'list_pipelines',
+    'List pipelines in a project. Call list_projects first to obtain projectId.',
+    {
+      projectId: z.string().describe('Project ID (from list_projects)'),
+    },
+    async ({ projectId }) => {
+      const result = await apiRequest(`/projects/${projectId}/pipelines`);
+      const pipelines = (result?.data?.pipelines || []).map((p) => ({
+        id: p._id,
+        name: p.name,
+        description: p.description || '',
+        stepCount: (p.steps || []).length,
+        createdAt: p.createdAt,
+        updatedAt: p.updatedAt,
+      }));
+
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({ pipelines }, null, 2),
+        }],
+      };
+    },
+  );
+
+  // ── get_pipeline ───────────────────────────────────────────────────
+  server.tool(
+    'get_pipeline',
+    'Get pipeline details including step composition (workboards used, autoInject, pre-filled inputs, attached docs). Useful to inspect before running.',
+    {
+      projectId: z.string().describe('Project ID'),
+      pipelineId: z.string().describe('Pipeline ID (from list_pipelines)'),
+    },
+    async ({ projectId, pipelineId }) => {
+      const result = await apiRequest(`/projects/${projectId}/pipelines/${pipelineId}`);
+      const p = result?.data?.pipeline;
+      if (!p) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: '파이프라인을 찾을 수 없음' }) }],
+        };
+      }
+      const detail = {
+        id: p._id,
+        name: p.name,
+        description: p.description || '',
+        steps: (p.steps || []).map((s, idx) => ({
+          index: idx,
+          workboardId: s.workboardId?._id || s.workboardId,
+          workboardName: s.workboardId?.name,
+          outputFormat: s.workboardId?.outputFormat,
+          autoInject: s.autoInject !== false,
+          inputs: s.inputs || {},
+          contextDocIds: s.contextDocIds || [],
+          systemPromptDocId: s.systemPromptDocId || null,
+          note: s.note || '',
+        })),
+      };
+
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify(detail, null, 2),
+        }],
+      };
+    },
+  );
+
+  // ── run_pipeline ───────────────────────────────────────────────────
+  server.tool(
+    'run_pipeline',
+    'Start a new pipeline run with an optional initial prompt. Returns runId — poll get_pipeline_run for progress.',
+    {
+      projectId: z.string().describe('Project ID'),
+      pipelineId: z.string().describe('Pipeline ID'),
+      initialPrompt: z.string().optional().describe('Initial prompt for step 0 (텍스트 입력). 비우면 빈 문자열.'),
+    },
+    async ({ projectId, pipelineId, initialPrompt = '' }) => {
+      const result = await apiRequest(`/projects/${projectId}/pipeline-runs`, {
+        method: 'POST',
+        body: { pipelineId, initialPrompt },
+      });
+      const run = result?.data?.run;
+      if (!run) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: 'run 생성 실패' }) }],
+        };
+      }
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            runId: run._id,
+            status: run.status,
+            startedAt: run.startedAt || run.createdAt,
+            stepCount: (run.steps || []).length,
+          }, null, 2),
+        }],
+      };
+    },
+  );
+
+  // ── get_pipeline_run ───────────────────────────────────────────────
+  server.tool(
+    'get_pipeline_run',
+    'Get pipeline run status and per-step outputs. Poll this after run_pipeline until status is completed or failed.',
+    {
+      projectId: z.string().describe('Project ID'),
+      runId: z.string().describe('Pipeline run ID (from run_pipeline)'),
+    },
+    async ({ projectId, runId }) => {
+      const result = await apiRequest(`/projects/${projectId}/pipeline-runs/${runId}`);
+      const run = result?.data?.run;
+      if (!run) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: 'run 을 찾을 수 없음' }) }],
+        };
+      }
+
+      const summary = {
+        runId: run._id,
+        pipelineName: run.pipelineId?.name,
+        status: run.status,
+        startedAt: run.startedAt || run.createdAt,
+        completedAt: run.completedAt || null,
+        errorMessage: run.errorMessage || null,
+        initialPrompt: run.initialPrompt || '',
+        steps: (run.steps || []).map((s, idx) => ({
+          index: idx,
+          workboardName: s.workboardId?.name,
+          outputFormat: s.workboardId?.outputFormat,
+          status: s.status,
+          startedAt: s.startedAt || null,
+          completedAt: s.completedAt || null,
+          errorMessage: s.errorMessage || null,
+          imageGenerationJobId: s.imageGenerationJobId?._id || s.imageGenerationJobId || null,
+          conversationJobId: s.conversationJobId?._id || s.conversationJobId || null,
+          // text step 의 직접 출력 (텍스트). image step 은 imageGenerationJobId 로 download_result 사용.
+          textOutput: s.output?.type === 'text' ? s.output.value : null,
+          imageIds: s.output?.type === 'image' ? (s.output.imageIds || []) : [],
+        })),
+      };
+
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify(summary, null, 2),
+        }],
+      };
+    },
+  );
+
+  // ── list_pipeline_runs ─────────────────────────────────────────────
+  server.tool(
+    'list_pipeline_runs',
+    'List recent pipeline runs in a project (most recent first).',
+    {
+      projectId: z.string().describe('Project ID'),
+      pipelineId: z.string().optional().describe('Filter to a specific pipeline'),
+      limit: z.coerce.number().int().positive().max(50).optional().describe('Items per page (default 20)'),
+      page: z.coerce.number().int().positive().optional().describe('Page number (default 1)'),
+    },
+    async ({ projectId, pipelineId, limit, page }) => {
+      const result = await apiRequest(`/projects/${projectId}/pipeline-runs`, {
+        params: { pipelineId, limit, page },
+      });
+      const runs = (result?.data?.runs || []).map((r) => ({
+        runId: r._id,
+        pipelineId: r.pipelineId?._id || r.pipelineId,
+        pipelineName: r.pipelineId?.name,
+        status: r.status,
+        startedAt: r.startedAt || r.createdAt,
+        completedAt: r.completedAt || null,
+        stepCount: (r.steps || []).length,
+      }));
+
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            runs,
+            pagination: result?.data?.pagination,
+          }, null, 2),
+        }],
+      };
+    },
+  );
+}

--- a/mcp-server/src/tools/projects.js
+++ b/mcp-server/src/tools/projects.js
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+
+/**
+ * Register project-related tools on the MCP server. (#448)
+ *
+ * 현재는 list_projects 만 — 파이프라인 호출의 입구로 프로젝트 ID 를 노출하는 게 핵심.
+ * 프로젝트 CRUD (생성/수정/삭제/즐겨찾기) 는 자동화 needs 확인 후 별도 진입.
+ *
+ * @param {import('@modelcontextprotocol/sdk/server/mcp.js').McpServer} server
+ * @param {(path: string, options?: object) => Promise<any>} apiRequest
+ */
+export function registerProjectTools(server, apiRequest) {
+
+  // ── list_projects ─────────────────────────────────────────────────
+  server.tool(
+    'list_projects',
+    'List the user\'s projects. Use this first to find a project ID before listing pipelines or running them.',
+    {
+      search: z.string().optional().describe('Search by name or description'),
+    },
+    async ({ search }) => {
+      const result = await apiRequest('/projects', { params: { search } });
+      const projects = (result?.data?.projects || []).map((p) => ({
+        id: p._id,
+        name: p.name,
+        description: p.description || '',
+        isFavorite: Boolean(p.isFavorite),
+        createdAt: p.createdAt,
+        // 콘텐츠 카운트 (있을 때만 — favorites endpoint 만 채워줌)
+        ...(p.counts ? { counts: p.counts } : {}),
+      }));
+
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({ projects }, null, 2),
+        }],
+      };
+    },
+  );
+}

--- a/mcp-server/test/integration.mjs
+++ b/mcp-server/test/integration.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+// MCP 통합 테스트 (#448) — 실제 MCP 서버에 Streamable HTTP 로 접속해 프로젝트 / 파이프라인
+// 도구의 핸드셰이크 ~ 호출 흐름을 검증.
+//
+// 실행:
+//   MCP_TEST_API_KEY=<VCC API Key> node test/integration.mjs
+//   MCP_TEST_URL=https://alpha-vccm-mcp.gcempire.net/mcp MCP_TEST_API_KEY=... node test/integration.mjs
+//
+// 환경변수:
+//   MCP_TEST_URL          MCP endpoint (기본 http://localhost:3100/mcp)
+//   MCP_TEST_API_KEY      VCC API Key (필수) — Bearer 토큰으로 전달
+//   MCP_TEST_RUN_PIPELINE 1 이면 run_pipeline 까지 실제 실행 (LLM/ComfyUI 호출 발생 — 기본 skip)
+//   MCP_TEST_INITIAL_PROMPT  run_pipeline 시 사용할 prompt (기본 "통합 테스트 prompt")
+//
+// 검증 범위:
+//   1) initialize + tools/list — 신규 6개 도구 노출 확인
+//   2) list_projects — 응답 shape 검증
+//   3) 프로젝트가 있으면: list_pipelines → get_pipeline → list_pipeline_runs
+//   4) MCP_TEST_RUN_PIPELINE=1 + 파이프라인 존재 시: run_pipeline → get_pipeline_run 폴링
+//
+// 파이프라인 / 프로젝트 데이터가 없으면 해당 단계는 skip (read-only 라 안전).
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+const MCP_URL = process.env.MCP_TEST_URL || 'http://localhost:3100/mcp';
+const API_KEY = process.env.MCP_TEST_API_KEY;
+const RUN_PIPELINE = process.env.MCP_TEST_RUN_PIPELINE === '1';
+const INITIAL_PROMPT = process.env.MCP_TEST_INITIAL_PROMPT || '통합 테스트 prompt';
+
+const EXPECTED_TOOLS = [
+  'list_projects',
+  'list_pipelines',
+  'get_pipeline',
+  'run_pipeline',
+  'get_pipeline_run',
+  'list_pipeline_runs',
+];
+
+let passed = 0;
+let failed = 0;
+const log = (...a) => console.log(...a);
+function check(label, cond, detail = '') {
+  if (cond) { passed++; log(`  ✓ ${label}`); }
+  else { failed++; log(`  ✗ ${label}${detail ? ' — ' + detail : ''}`); }
+}
+
+// tool 응답에서 JSON 텍스트를 파싱.
+function parseToolJson(result) {
+  const text = result?.content?.find((c) => c.type === 'text')?.text;
+  if (!text) throw new Error('tool 응답에 text content 없음');
+  return JSON.parse(text);
+}
+
+async function main() {
+  if (!API_KEY) {
+    console.error('Error: MCP_TEST_API_KEY 환경변수가 필요합니다.');
+    process.exit(2);
+  }
+
+  log(`\n▶ MCP 통합 테스트 — ${MCP_URL}\n`);
+
+  const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), {
+    requestInit: { headers: { Authorization: `Bearer ${API_KEY}` } },
+  });
+  const client = new Client({ name: 'vcc-mcp-integration-test', version: '1.0.0' });
+
+  await client.connect(transport);
+  log('① 연결 + initialize 완료');
+
+  // ── 1) tools/list ────────────────────────────────────────────────
+  log('\n② tools/list — 신규 도구 노출 확인');
+  const { tools } = await client.listTools();
+  const names = tools.map((t) => t.name);
+  for (const t of EXPECTED_TOOLS) {
+    check(`tool '${t}' 등록됨`, names.includes(t), `등록된 도구: ${names.join(', ')}`);
+  }
+
+  // ── 2) list_projects ─────────────────────────────────────────────
+  log('\n③ list_projects');
+  const projRes = await client.callTool({ name: 'list_projects', arguments: {} });
+  const projData = parseToolJson(projRes);
+  check('projects 배열 반환', Array.isArray(projData.projects), `received: ${typeof projData.projects}`);
+  const projects = projData.projects || [];
+  log(`     → ${projects.length}개 프로젝트`);
+
+  if (projects.length === 0) {
+    log('\n⚠ 프로젝트가 없어 파이프라인 단계는 skip (read-only 검증만 완료)');
+    return finish(client);
+  }
+
+  const project = projects[0];
+  check('project.id 존재', !!project.id);
+  check('project.name 존재', typeof project.name === 'string');
+
+  // ── 3) list_pipelines ────────────────────────────────────────────
+  log(`\n④ list_pipelines (project: ${project.name})`);
+  const plRes = await client.callTool({ name: 'list_pipelines', arguments: { projectId: project.id } });
+  const plData = parseToolJson(plRes);
+  check('pipelines 배열 반환', Array.isArray(plData.pipelines));
+  const pipelines = plData.pipelines || [];
+  log(`     → ${pipelines.length}개 파이프라인`);
+
+  // ── list_pipeline_runs (프로젝트 단위, 파이프라인 없어도 호출 가능) ──
+  log('\n⑤ list_pipeline_runs');
+  const runsRes = await client.callTool({ name: 'list_pipeline_runs', arguments: { projectId: project.id, limit: 5 } });
+  const runsData = parseToolJson(runsRes);
+  check('runs 배열 반환', Array.isArray(runsData.runs));
+  log(`     → 최근 ${runsData.runs.length}개 run`);
+
+  if (pipelines.length === 0) {
+    log('\n⚠ 파이프라인이 없어 get_pipeline / run_pipeline 은 skip');
+    return finish(client);
+  }
+
+  const pipeline = pipelines[0];
+
+  // ── get_pipeline ─────────────────────────────────────────────────
+  log(`\n⑥ get_pipeline (${pipeline.name})`);
+  const gpRes = await client.callTool({ name: 'get_pipeline', arguments: { projectId: project.id, pipelineId: pipeline.id } });
+  const gpData = parseToolJson(gpRes);
+  check('pipeline.id 일치', gpData.id === pipeline.id);
+  check('steps 배열 반환', Array.isArray(gpData.steps));
+  log(`     → ${gpData.steps?.length || 0} 단계`);
+
+  // ── run_pipeline (gated) ─────────────────────────────────────────
+  if (!RUN_PIPELINE) {
+    log('\n⚠ run_pipeline 은 MCP_TEST_RUN_PIPELINE=1 일 때만 실행 (실제 생성 호출 발생). 현재 skip.');
+    return finish(client);
+  }
+
+  log(`\n⑦ run_pipeline (initialPrompt: "${INITIAL_PROMPT}")`);
+  const runRes = await client.callTool({
+    name: 'run_pipeline',
+    arguments: { projectId: project.id, pipelineId: pipeline.id, initialPrompt: INITIAL_PROMPT },
+  });
+  const runData = parseToolJson(runRes);
+  check('runId 반환', !!runData.runId, JSON.stringify(runData));
+  check('초기 status 존재', !!runData.status);
+  log(`     → runId: ${runData.runId}, status: ${runData.status}`);
+
+  if (!runData.runId) return finish(client);
+
+  // ── get_pipeline_run 폴링 (최대 2분, 완료/실패 또는 timeout 까지) ──
+  log('\n⑧ get_pipeline_run 폴링 (최대 2분)');
+  const start = Date.now();
+  const MAX = 2 * 60 * 1000;
+  let last = null;
+  while (Date.now() - start < MAX) {
+    const grRes = await client.callTool({ name: 'get_pipeline_run', arguments: { projectId: project.id, runId: runData.runId } });
+    last = parseToolJson(grRes);
+    log(`     status=${last.status}`);
+    if (last.status === 'completed' || last.status === 'failed') break;
+    await new Promise((r) => setTimeout(r, 5000));
+  }
+  check('run 상태 조회 성공', !!last?.status);
+  check('steps 배열 반환', Array.isArray(last?.steps));
+  // 완료까지 못 가도 (timeout) 도구 자체는 정상 동작한 것으로 간주 — LLM/ComfyUI 가용성 별개.
+  log(`     → 최종 status: ${last?.status}`);
+
+  return finish(client);
+}
+
+async function finish(client) {
+  await client.close().catch(() => {});
+  log(`\n━━━ 결과: ${passed} passed, ${failed} failed ━━━\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error('\n✗ 테스트 실행 오류:', err?.message || err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- MCP 서버에 프로젝트 / 파이프라인 도구 6종 추가 — AI agent 가 사용자 프로젝트의 파이프라인을 자율 실행 가능
- 신규 백엔드 endpoint 없음 (기존 projects / pipelines / pipeline-runs 라우트 사용)
- MCP 통합 테스트 추가 (SDK Client 로 실제 서버 흐름 검증)

## 추가 도구
| Tool | 설명 |
|---|---|
| `list_projects` | 프로젝트 목록 |
| `list_pipelines` | 프로젝트의 파이프라인 목록 |
| `get_pipeline` | 파이프라인 단계 상세 (workboard / autoInject / inputs / 문서 연결) |
| `run_pipeline` | 실행 시작 → runId |
| `get_pipeline_run` | 상태 + 단계별 output (텍스트 inline / 이미지 imageGenerationJobId) |
| `list_pipeline_runs` | 최근 실행 목록 |

## 표준 흐름
`list_projects` → `list_pipelines` → `run_pipeline` → 폴링 `get_pipeline_run` → `download_result` (기존)

## 통합 테스트 (`mcp-server/test/integration.mjs`)
- MCP SDK Client + Streamable HTTP 로 실제 서버 접속 → initialize → tools/list → 도구 호출 검증
- `npm run test:integration` (`MCP_TEST_API_KEY` 필수, `MCP_TEST_URL` 로 dev 환경 대상 가능)
- `run_pipeline` 은 `MCP_TEST_RUN_PIPELINE=1` gate (실제 생성 호출 비용 회피)
- 프로젝트 / 파이프라인 데이터 없으면 graceful skip
- **로컬 검증 통과**: 13 passed / 0 failed (tools/list 6종 + list_projects → list_pipelines → get_pipeline → list_pipeline_runs)

## 인증
기존 MCP HTTP 모드와 동일 — API Key Bearer. project 소유자 = API Key 사용자 (백엔드가 `req.user._id` 필터).

## 후속 (별도 이슈)
- `get_project` (상세), `retry_pipeline_run`, 프로젝트 CRUD — 자동화 needs 확인 후

## Test plan
- [x] docker-compose 빌드 + MCP health 200
- [x] 통합 테스트 로컬 통과 (13 passed)
- [ ] dev 환경 (`alpha-vccm-mcp.gcempire.net`) 대상 사용자 API Key 로 재검증 (선택)

closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)