### PR TITLE
feat: 대시보드 재디자인 (design system v1.1) + 위젯 데이터 endpoint 3종 (#453)

### DIFF
--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -1,227 +1,677 @@
 import React, { useState } from 'react';
 import {
-  Container,
-  Grid,
-  Card,
-  CardContent,
-  CardActionArea,
-  Typography,
   Box,
-  CircularProgress,
-  Button
+  Paper,
+  Typography,
+  Button,
+  Stack,
+  LinearProgress,
+  Skeleton,
+  Tooltip,
 } from '@mui/material';
 import {
+  Add,
+  PlayArrow,
+  AccountTree,
   CloudUpload,
-  ViewModule,
-  NewReleases,
+  Autorenew,
+  FolderOpen,
   Image as ImageIcon,
-  TextSnippet,
-  History,
-  Star
+  Dns,
+  NewReleases,
+  TrendingUp,
 } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
 import { useQuery } from 'react-query';
-import { jobAPI, projectAPI } from '../services/api';
+import {
+  dashboardAPI,
+  projectAPI,
+  imageAPI,
+  serverAPI,
+} from '../services/api';
+import { useAuth } from '../contexts/AuthContext';
 import config from '../config';
 import UpdateLogDialog from '../components/common/UpdateLogDialog';
 
+const MONO = '"JetBrains Mono","SF Mono",Menlo,monospace';
+
+// 프로젝트 아바타 그라데이션 — 디자인 핸드오프 팔레트에서 id 해시로 결정적 선택
+const GRADIENTS = [
+  'linear-gradient(135deg, #7B4DD8, #5B5BD6)',
+  'linear-gradient(135deg, #2F77E4, #4E8EE8)',
+  'linear-gradient(135deg, #BE7415, #D69021)',
+  'linear-gradient(135deg, #1F9D55, #2EBA6B)',
+  'linear-gradient(135deg, #5B616E, #8A8F9A)',
+];
+function gradientFor(id = '') {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) >>> 0;
+  return GRADIENTS[h % GRADIENTS.length];
+}
+
+// 상대 시각 — "방금 / N분 전 / N시간 전 / 어제 / N일 전 / yy.M.d"
+function relativeTime(iso) {
+  if (!iso) return '';
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '';
+  const diff = Date.now() - then;
+  const min = Math.floor(diff / 60000);
+  if (min < 1) return '방금';
+  if (min < 60) return `${min}분 전`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}시간 전`;
+  const day = Math.floor(hr / 24);
+  if (day === 1) return '어제';
+  if (day < 7) return `${day}일 전`;
+  const d = new Date(then);
+  return `${String(d.getFullYear()).slice(2)}. ${d.getMonth() + 1}. ${d.getDate()}.`;
+}
+
+function dateHeroLine() {
+  const now = new Date();
+  const weekday = now.toLocaleDateString('ko-KR', { weekday: 'long' });
+  const ampm = now.getHours() < 12 ? '오전' : '오후';
+  return `${now.getFullYear()}. ${now.getMonth() + 1}. ${now.getDate()}. ${weekday} · ${ampm}`;
+}
+
+// 카드 헤더 + 본문 래퍼
+function SectionCard({ icon, title, count, action, onAction, children, sx }) {
+  return (
+    <Paper variant="outlined" sx={{ overflow: 'hidden', ...sx }}>
+      {title && (
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            px: 3.5,
+            py: 2.5,
+            borderBottom: '1px solid',
+            borderColor: 'divider',
+          }}
+        >
+          {icon}
+          <Typography variant="h6" sx={{ fontWeight: 600 }}>
+            {title}
+          </Typography>
+          {count != null && (
+            <Box
+              sx={{
+                fontSize: 11,
+                fontFamily: MONO,
+                color: 'text.secondary',
+                bgcolor: 'grey.100',
+                borderRadius: 999,
+                px: 1,
+                py: 0.25,
+                ml: 0.5,
+              }}
+            >
+              {count}
+            </Box>
+          )}
+          <Box sx={{ flex: 1 }} />
+          {action && (
+            <Typography
+              component="button"
+              onClick={onAction}
+              sx={{
+                fontSize: 12,
+                color: 'primary.main',
+                fontWeight: 500,
+                border: 0,
+                bgcolor: 'transparent',
+                cursor: 'pointer',
+                p: 0,
+                '&:hover': { textDecoration: 'underline' },
+              }}
+            >
+              {action}
+            </Typography>
+          )}
+        </Box>
+      )}
+      {children}
+    </Paper>
+  );
+}
+
+// 미니 sparkline (SVG)
+function MiniSparkline({ values, color }) {
+  if (!values || values.length < 2) {
+    return (
+      <Box sx={{ height: 32, display: 'flex', alignItems: 'center' }}>
+        <Typography variant="caption" color="text.secondary">
+          데이터 없음
+        </Typography>
+      </Box>
+    );
+  }
+  const w = 240;
+  const h = 36;
+  const max = Math.max(...values);
+  const min = Math.min(...values);
+  const range = max - min || 1;
+  const pts = values
+    .map((v, i) => `${(i / (values.length - 1)) * w},${h - ((v - min) / range) * h}`)
+    .join(' ');
+  return (
+    <svg width="100%" height={h} viewBox={`0 0 ${w} ${h}`} preserveAspectRatio="none">
+      <polyline
+        points={pts}
+        fill="none"
+        stroke={color}
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <polyline points={`${pts} ${w},${h} 0,${h}`} fill={color} opacity="0.08" />
+    </svg>
+  );
+}
 
 function Dashboard() {
   const navigate = useNavigate();
+  const { user, isAdmin } = useAuth();
   const [updateLogOpen, setUpdateLogOpen] = useState(false);
 
-  const { data: recentJobs, isLoading: jobsLoading } = useQuery(
-    'recentJobs',
-    () => jobAPI.getMy({ limit: 10 }),
+  const { data: activeRunsRes } = useQuery(
+    'dashboardActiveRuns',
+    dashboardAPI.getActivePipelineRuns,
     { refetchInterval: config.monitoring.recentJobsInterval }
   );
-
-  const { data: queueStats, isLoading: queueLoading } = useQuery(
-    'queueStats',
-    jobAPI.getQueueStats,
+  const { data: projectsRes, isLoading: projectsLoading } = useQuery(
+    'dashboardProjects',
+    () => projectAPI.getAll()
+  );
+  const { data: imagesRes, isLoading: imagesLoading } = useQuery(
+    'dashboardRecentImages',
+    () => imageAPI.getGenerated({ limit: 12 })
+  );
+  const { data: trendRes } = useQuery('dashboardImageTrend', () =>
+    dashboardAPI.getImageTrend(7)
+  );
+  const { data: serversRes } = useQuery(
+    'dashboardServers',
+    () => serverAPI.getServers(),
     { refetchInterval: config.monitoring.queueStatusInterval }
   );
-
-  const { data: favoritesData } = useQuery(
-    'favoriteProjects',
-    () => projectAPI.getFavorites()
+  const { data: workboardsRes } = useQuery('dashboardWorkboardUsage', () =>
+    dashboardAPI.getWorkboardUsage(4)
   );
 
-  const favoriteProjects = favoritesData?.data?.data?.projects || [];
+  const activeRuns = activeRunsRes?.data?.data?.runs || [];
+  const projects = (projectsRes?.data?.data?.projects || []).slice(0, 4);
+  const images = imagesRes?.data?.images || [];
+  const trend = trendRes?.data?.data?.trend || [];
+  const trendToday = trendRes?.data?.data?.today ?? 0;
+  const trendAverage = trendRes?.data?.data?.average ?? 0;
+  const trendPeak = trendRes?.data?.data?.peak ?? 0;
+  const servers = serversRes?.data?.data?.servers || [];
+  const workboards = workboardsRes?.data?.data?.workboards || [];
 
-  if (jobsLoading || queueLoading) {
-    return (
-      <Container maxWidth="xl" sx={{ mt: 4, mb: 4 }}>
-        <Box display="flex" justifyContent="center" mt={8}>
-          <CircularProgress />
-        </Box>
-      </Container>
-    );
-  }
+  // 어제 대비 증감
+  const yesterday = trend.length >= 2 ? trend[trend.length - 2].count : 0;
+  let deltaPct = null;
+  if (yesterday > 0) deltaPct = Math.round(((trendToday - yesterday) / yesterday) * 100);
 
-  const jobs = recentJobs?.data?.jobs || [];
-  const queue = queueStats?.data?.stats || {};
-  
-  // 내 작업 중 대기/처리 중인 것들 계산
-  const myPendingJobs = jobs.filter(job => job.status === 'pending').length;
-  const myProcessingJobs = jobs.filter(job => job.status === 'processing').length;
+  const userName = user?.nickname || user?.email || '사용자';
+
+  const quickActions = [
+    { label: '새 프로젝트', icon: <Add />, primary: true, to: '/projects' },
+    { label: '작업판 실행', icon: <PlayArrow />, to: '/workboards' },
+    { label: '파이프라인 만들기', icon: <AccountTree />, to: '/projects' },
+    { label: '이미지 업로드', icon: <CloudUpload />, to: '/content' },
+  ];
 
   return (
-    <Container maxWidth="xl" sx={{ mt: 4, mb: 4 }}>
-      <Typography variant="h4" gutterBottom>
-        대시보드
-      </Typography>
-      
-      <Grid container spacing={3}>
-        {/* 즐겨찾기 프로젝트 */}
-        {favoriteProjects.length > 0 && (
-          <Grid item xs={12}>
-            <Box display="flex" alignItems="center" gap={1} mb={1}>
-              <Star color="warning" />
-              <Typography variant="h6">즐겨찾기 프로젝트</Typography>
-            </Box>
-            <Grid container spacing={2}>
-              {favoriteProjects.map((project) => (
-                <Grid item xs={12} sm={6} md={4} key={project._id}>
-                  <Card>
-                    <CardActionArea onClick={() => navigate(`/projects/${project._id}`)}>
-                      <CardContent>
-                        <Typography variant="subtitle1" noWrap gutterBottom>
-                          {project.name}
+    <Box>
+      {/* Greeting hero */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'flex-end',
+          gap: 2,
+          mb: 5.5,
+          flexWrap: 'wrap',
+        }}
+      >
+        <Box sx={{ flex: '1 1 360px', minWidth: 0 }}>
+          <Typography
+            sx={{
+              fontSize: 12,
+              color: 'text.secondary',
+              fontFamily: MONO,
+              letterSpacing: '0.04em',
+              mb: 0.5,
+            }}
+          >
+            {dateHeroLine()}
+          </Typography>
+          <Typography variant="h1" sx={{ mb: 0.75 }}>
+            안녕하세요, {userName} 님
+          </Typography>
+          <Typography variant="body1" color="text.secondary" sx={{ textWrap: 'pretty' }}>
+            {activeRuns.length > 0 ? (
+              <>
+                현재{' '}
+                <Box component="b" sx={{ color: 'primary.main' }}>
+                  {activeRuns.length}개 파이프라인
+                </Box>
+                이 실행 중입니다.
+              </>
+            ) : (
+              '실행 중인 파이프라인이 없습니다.'
+            )}
+            {deltaPct != null && deltaPct !== 0 && (
+              <>
+                {' '}어제 대비 이미지 생성량이{' '}
+                <Box
+                  component="b"
+                  sx={{ color: deltaPct > 0 ? 'success.main' : 'error.main' }}
+                >
+                  {deltaPct > 0 ? '+' : ''}
+                  {deltaPct}%
+                </Box>{' '}
+                {deltaPct > 0 ? '늘었어요.' : '줄었어요.'}
+              </>
+            )}
+          </Typography>
+        </Box>
+        <Stack direction="row" spacing={0.75} sx={{ flexWrap: 'wrap', rowGap: 0.75 }}>
+          {quickActions.map((q) => (
+            <Button
+              key={q.label}
+              variant={q.primary ? 'contained' : 'outlined'}
+              startIcon={q.icon}
+              onClick={() => navigate(q.to)}
+            >
+              {q.label}
+            </Button>
+          ))}
+        </Stack>
+      </Box>
+
+      {/* Main two-column */}
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr', md: '1.4fr 1fr' },
+          gap: 2,
+          alignItems: 'start',
+        }}
+      >
+        {/* Left column */}
+        <Stack spacing={2}>
+          {/* Running pipelines */}
+          <SectionCard
+            icon={
+              <Autorenew
+                fontSize="small"
+                sx={{
+                  color: 'primary.main',
+                  animation: activeRuns.length ? 'spin 1.6s linear infinite' : 'none',
+                  '@keyframes spin': { to: { transform: 'rotate(360deg)' } },
+                }}
+              />
+            }
+            title="실행 중 파이프라인"
+            count={activeRuns.length}
+          >
+            {activeRuns.length === 0 ? (
+              <EmptyHint text="실행 중인 파이프라인이 없습니다." />
+            ) : (
+              activeRuns.map((run, i) => (
+                <Box
+                  key={run._id}
+                  onClick={() => run.projectId && navigate(`/projects/${run.projectId}`)}
+                  sx={{
+                    px: 3.5,
+                    py: 3,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1.25,
+                    cursor: run.projectId ? 'pointer' : 'default',
+                    borderTop: i > 0 ? '1px solid' : 'none',
+                    borderColor: 'divider',
+                    '&:hover': { bgcolor: 'action.hover' },
+                  }}
+                >
+                  <Box
+                    sx={{
+                      width: 8,
+                      height: 8,
+                      borderRadius: '50%',
+                      bgcolor: 'primary.main',
+                      flex: '0 0 auto',
+                      animation: 'pulse 1.4s infinite',
+                      '@keyframes pulse': { '0%,100%': { opacity: 0.45 }, '50%': { opacity: 1 } },
+                    }}
+                  />
+                  <Box sx={{ flex: 1, minWidth: 0 }}>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                      <Typography variant="body2" sx={{ fontWeight: 600 }} noWrap>
+                        {run.pipelineName}
+                      </Typography>
+                      {run.projectName && (
+                        <Typography variant="caption" color="text.secondary" noWrap>
+                          · {run.projectName}
                         </Typography>
-                        {project.description && (
-                          <Typography variant="body2" color="textSecondary" noWrap sx={{ mb: 1 }}>
-                            {project.description}
-                          </Typography>
-                        )}
-                        <Box display="flex" gap={1.5}>
-                          <Box display="flex" alignItems="center" gap={0.5}>
-                            <ImageIcon fontSize="small" color="action" />
-                            <Typography variant="body2">{project.counts?.images || 0}</Typography>
-                          </Box>
-                          <Box display="flex" alignItems="center" gap={0.5}>
-                            <TextSnippet fontSize="small" color="action" />
-                            <Typography variant="body2">{project.counts?.promptData || 0}</Typography>
-                          </Box>
-                          <Box display="flex" alignItems="center" gap={0.5}>
-                            <History fontSize="small" color="action" />
-                            <Typography variant="body2">{project.counts?.jobs || 0}</Typography>
-                          </Box>
-                        </Box>
-                      </CardContent>
-                    </CardActionArea>
-                  </Card>
-                </Grid>
-              ))}
-            </Grid>
-          </Grid>
-        )}
+                      )}
+                    </Box>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mt: 0.75 }}>
+                      <LinearProgress
+                        variant="determinate"
+                        value={run.progress}
+                        sx={{ flex: 1, height: 4, borderRadius: 2 }}
+                      />
+                      <Typography
+                        sx={{ fontSize: 10, fontFamily: MONO, color: 'text.secondary', minWidth: 30, textAlign: 'right' }}
+                      >
+                        {run.progress}%
+                      </Typography>
+                    </Box>
+                  </Box>
+                  <Typography sx={{ fontSize: 11, fontFamily: MONO, color: 'text.secondary' }}>
+                    {run.stepDone}/{run.stepTotal}
+                  </Typography>
+                </Box>
+              ))
+            )}
+          </SectionCard>
 
-        {/* 빠른 액션 */}
-        <Grid item xs={12} md={6}>
-          <Card>
-            <CardContent>
-              <Typography variant="subtitle1" gutterBottom>
-                빠른 액션
-              </Typography>
+          {/* Recent projects */}
+          <SectionCard
+            icon={<FolderOpen fontSize="small" sx={{ color: 'text.secondary' }} />}
+            title="최근 프로젝트"
+            action="모두 보기 →"
+            onAction={() => navigate('/projects')}
+          >
+            {projectsLoading ? (
+              <GridSkeleton n={4} cols={{ xs: 2, sm: 4 }} height={84} />
+            ) : projects.length === 0 ? (
+              <EmptyHint text="프로젝트가 없습니다. 새 프로젝트를 만들어 보세요." />
+            ) : (
               <Box
-                display="flex"
-                flexDirection="column"
-                gap={2}
-                justifyContent="center"
-                flexWrap="wrap"
+                sx={{
+                  p: 3.5,
+                  display: 'grid',
+                  gridTemplateColumns: { xs: 'repeat(2,1fr)', sm: 'repeat(4,1fr)' },
+                  gap: 2.5,
+                }}
               >
-                <Button
-                  variant="contained"
-                  startIcon={<ViewModule />}
-                  onClick={() => navigate('/workboards')}
-                  size="large"
-                >
-                  새 이미지 생성하기
-                </Button>
-                <Button
-                  variant="outlined"
-                  startIcon={<CloudUpload />}
-                  onClick={() => navigate('/images')}
-                  size="large"
-                >
-                  이미지 업로드하기
-                </Button>
-                <Button
-                  variant="outlined"
-                  startIcon={<NewReleases />}
-                  onClick={() => setUpdateLogOpen(true)}
-                  size="large"
-                >
-                  업데이트 내역 보기
-                </Button>
+                {projects.map((p) => (
+                  <Box
+                    key={p._id}
+                    onClick={() => navigate(`/projects/${p._id}`)}
+                    sx={{
+                      cursor: 'pointer',
+                      borderRadius: 2,
+                      p: 2,
+                      border: '1px solid',
+                      borderColor: 'divider',
+                      transition: 'all 120ms',
+                      '&:hover': { borderColor: 'primary.main', bgcolor: 'action.hover' },
+                    }}
+                  >
+                    <Box
+                      sx={{
+                        width: 36,
+                        height: 36,
+                        borderRadius: 2,
+                        background: gradientFor(String(p._id)),
+                        color: '#fff',
+                        fontWeight: 700,
+                        fontSize: 16,
+                        display: 'grid',
+                        placeItems: 'center',
+                        mb: 2.5,
+                        boxShadow: 1,
+                      }}
+                    >
+                      {(p.name || '?')[0]}
+                    </Box>
+                    <Typography variant="body2" sx={{ fontWeight: 600 }} noWrap>
+                      {p.name}
+                    </Typography>
+                    <Typography sx={{ fontSize: 11, color: 'text.secondary', mt: 0.5 }} noWrap>
+                      {(p.counts?.images ?? 0)}장 · {relativeTime(p.updatedAt)}
+                    </Typography>
+                  </Box>
+                ))}
               </Box>
-            </CardContent>
-          </Card>
-        </Grid>
+            )}
+          </SectionCard>
 
-        {/* 작업 상태 */}
-        <Grid item xs={12} sm={6}>
-          <Card>
-            <CardContent>
-              <Typography variant="subtitle1" gutterBottom>
-                작업 상태
+          {/* Recent generations */}
+          <SectionCard
+            icon={<ImageIcon fontSize="small" sx={{ color: 'text.secondary' }} />}
+            title="최근 생성 이미지"
+            action="컨텐츠 라이브러리 →"
+            onAction={() => navigate('/content')}
+          >
+            {imagesLoading ? (
+              <GridSkeleton n={6} cols={{ xs: 3, sm: 6 }} height={0} aspect />
+            ) : images.length === 0 ? (
+              <EmptyHint text="아직 생성된 이미지가 없습니다." />
+            ) : (
+              <Box
+                sx={{
+                  p: 3,
+                  display: 'grid',
+                  gridTemplateColumns: { xs: 'repeat(3,1fr)', sm: 'repeat(6,1fr)' },
+                  gap: 1.5,
+                }}
+              >
+                {images.slice(0, 12).map((img) => (
+                  <Box
+                    key={img._id}
+                    onClick={() => navigate('/content')}
+                    sx={{
+                      position: 'relative',
+                      aspectRatio: '1 / 1',
+                      borderRadius: 1,
+                      overflow: 'hidden',
+                      cursor: 'pointer',
+                      bgcolor: 'grey.100',
+                    }}
+                  >
+                    <Box
+                      component="img"
+                      src={img.url}
+                      alt=""
+                      loading="lazy"
+                      sx={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+                    />
+                  </Box>
+                ))}
+              </Box>
+            )}
+          </SectionCard>
+        </Stack>
+
+        {/* Right column */}
+        <Stack spacing={2}>
+          {/* Generation trend */}
+          <Paper variant="outlined" sx={{ p: 3.5 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <TrendingUp fontSize="small" sx={{ color: 'text.secondary' }} />
+              <Typography variant="h6" sx={{ fontWeight: 600 }}>
+                주간 생성 추이
               </Typography>
-              <Grid container spacing={2}>
-                <Grid item xs={6}>
-                  <Typography variant="caption" color="textSecondary" display="block" mb={1}>서버</Typography>
-                  <Box display="flex" gap={3}>
-                    <Box textAlign="center">
-                      <Typography variant="h4" color="warning.main">
-                        {queue.waiting || 0}
+              <Box sx={{ flex: 1 }} />
+              {deltaPct != null && (
+                <Box
+                  sx={{
+                    fontSize: 11,
+                    fontFamily: MONO,
+                    fontWeight: 600,
+                    color: deltaPct >= 0 ? 'success.main' : 'error.main',
+                    bgcolor: deltaPct >= 0 ? 'success.light' : 'error.light',
+                    borderRadius: 1,
+                    px: 0.75,
+                    py: 0.25,
+                  }}
+                >
+                  {deltaPct >= 0 ? '+' : ''}
+                  {deltaPct}%
+                </Box>
+              )}
+            </Box>
+            <Box sx={{ mt: 2 }}>
+              <MiniSparkline values={trend.map((t) => t.count)} color="#5B5BD6" />
+            </Box>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 0.5 }}>
+              {trend.map((t) => (
+                <Typography
+                  key={t.date}
+                  sx={{ fontSize: 10, fontFamily: MONO, color: 'text.secondary' }}
+                >
+                  {new Date(t.date).toLocaleDateString('ko-KR', { weekday: 'short' })}
+                </Typography>
+              ))}
+            </Box>
+            <Stack direction="row" spacing={2} sx={{ mt: 2.5 }}>
+              <TrendStat label="오늘" value={trendToday} />
+              <TrendStat label="평균" value={trendAverage} />
+              <TrendStat label="피크" value={trendPeak} />
+            </Stack>
+          </Paper>
+
+          {/* Server status */}
+          <SectionCard
+            icon={<Dns fontSize="small" sx={{ color: 'text.secondary' }} />}
+            title="서버 상태"
+          >
+            {servers.length === 0 ? (
+              <EmptyHint text="등록된 서버가 없습니다." />
+            ) : (
+              servers.map((s, i) => {
+                const status = s.healthCheck?.status;
+                const tone =
+                  status === 'healthy' ? 'success.main' : status === 'unhealthy' ? 'error.main' : 'grey.500';
+                return (
+                  <Box
+                    key={s._id}
+                    sx={{
+                      px: 3.5,
+                      py: 2.5,
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1.25,
+                      borderTop: i > 0 ? '1px solid' : 'none',
+                      borderColor: 'divider',
+                    }}
+                  >
+                    <Box sx={{ width: 6, height: 6, borderRadius: '50%', bgcolor: tone, flex: '0 0 auto' }} />
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      <Typography variant="body2" sx={{ fontWeight: 500 }} noWrap>
+                        {s.name}
                       </Typography>
-                      <Typography variant="body2" color="textSecondary">
-                        대기 중
+                      <Typography sx={{ fontSize: 11, fontFamily: MONO, color: 'text.secondary' }} noWrap>
+                        {isAdmin && s.serverUrl ? s.serverUrl : s.serverType}
                       </Typography>
                     </Box>
-                    <Box textAlign="center">
-                      <Typography variant="h4" color="info.main">
-                        {queue.active || 0}
+                    {s.healthCheck?.responseTime != null && status === 'healthy' && (
+                      <Typography sx={{ fontSize: 10, fontFamily: MONO, color: 'text.secondary' }}>
+                        {s.healthCheck.responseTime}ms
                       </Typography>
-                      <Typography variant="body2" color="textSecondary">
-                        처리 중
-                      </Typography>
-                    </Box>
+                    )}
                   </Box>
-                </Grid>
-                <Grid item xs={6}>
-                  <Typography variant="caption" color="textSecondary" display="block" mb={1}>내 작업</Typography>
-                  <Box display="flex" gap={3}>
-                    <Box textAlign="center">
-                      <Typography variant="h4" color="warning.main">
-                        {myPendingJobs}
-                      </Typography>
-                      <Typography variant="body2" color="textSecondary">
-                        대기 중
-                      </Typography>
-                    </Box>
-                    <Box textAlign="center">
-                      <Typography variant="h4" color="info.main">
-                        {myProcessingJobs}
-                      </Typography>
-                      <Typography variant="body2" color="textSecondary">
-                        처리 중
-                      </Typography>
-                    </Box>
+                );
+              })
+            )}
+          </SectionCard>
+
+          {/* Top workboards */}
+          <Paper variant="outlined" sx={{ p: 3.5 }}>
+            <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
+              자주 쓰는 작업판
+            </Typography>
+            {workboards.length === 0 ? (
+              <Typography variant="body2" color="text.secondary">
+                아직 사용 기록이 없습니다.
+              </Typography>
+            ) : (
+              <Stack spacing={1.25}>
+                {workboards.map((wb, i) => (
+                  <Box key={wb._id} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <Typography sx={{ fontSize: 11, fontFamily: MONO, color: 'text.secondary', width: 16 }}>
+                      {i + 1}
+                    </Typography>
+                    <Typography variant="body2" sx={{ flex: 1 }} noWrap>
+                      {wb.name}
+                    </Typography>
+                    <Typography sx={{ fontSize: 11, fontFamily: MONO, color: 'text.secondary' }}>
+                      {wb.usageCount ?? 0}회
+                    </Typography>
                   </Box>
-                </Grid>
-              </Grid>
-            </CardContent>
-          </Card>
-        </Grid>
-      </Grid>
+                ))}
+              </Stack>
+            )}
+          </Paper>
+
+          {/* Update log access (디자인엔 없지만 진입점 보존) */}
+          <Tooltip title="이번 버전에서 달라진 점 보기">
+            <Button
+              variant="text"
+              size="small"
+              startIcon={<NewReleases />}
+              onClick={() => setUpdateLogOpen(true)}
+              sx={{ alignSelf: 'flex-start', color: 'text.secondary' }}
+            >
+              업데이트 내역
+            </Button>
+          </Tooltip>
+        </Stack>
+      </Box>
 
       <UpdateLogDialog
         open={updateLogOpen}
         onClose={() => setUpdateLogOpen(false)}
         majorVersion={config.version.major}
       />
-    </Container>
+    </Box>
+  );
+}
+
+function TrendStat({ label, value }) {
+  return (
+    <Box sx={{ flex: 1 }}>
+      <Typography sx={{ fontSize: 11, color: 'text.secondary' }}>{label}</Typography>
+      <Typography sx={{ fontSize: 20, fontWeight: 700 }}>{value}</Typography>
+    </Box>
+  );
+}
+
+function EmptyHint({ text }) {
+  return (
+    <Box sx={{ px: 3.5, py: 4, textAlign: 'center' }}>
+      <Typography variant="body2" color="text.secondary">
+        {text}
+      </Typography>
+    </Box>
+  );
+}
+
+function GridSkeleton({ n, cols, height, aspect }) {
+  return (
+    <Box
+      sx={{
+        p: 3.5,
+        display: 'grid',
+        gridTemplateColumns: { xs: `repeat(${cols.xs},1fr)`, sm: `repeat(${cols.sm},1fr)` },
+        gap: 2,
+      }}
+    >
+      {Array.from({ length: n }).map((_, i) => (
+        <Skeleton
+          key={i}
+          variant="rounded"
+          sx={aspect ? { width: '100%', aspectRatio: '1 / 1' } : { width: '100%', height }}
+        />
+      ))}
+    </Box>
   );
 }
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -287,6 +287,13 @@ export const pipelineRunAPI = {
   delete: (projectId, runId) => api.delete(`/projects/${projectId}/pipeline-runs/${runId}`),
 };
 
+// 대시보드 위젯 전용 집계 (#453)
+export const dashboardAPI = {
+  getActivePipelineRuns: () => api.get('/dashboard/active-pipeline-runs'),
+  getImageTrend: (days = 7) => api.get('/dashboard/image-trend', { params: { days } }),
+  getWorkboardUsage: (limit = 4) => api.get('/dashboard/workboard-usage', { params: { limit } }),
+};
+
 export const apiKeyAPI = {
   getAll: () => api.get('/apikeys'),
   create: (data) => api.post('/apikeys', data),

--- a/src/routes/dashboard.js
+++ b/src/routes/dashboard.js
@@ -1,0 +1,117 @@
+const express = require('express');
+const router = express.Router();
+
+const { requireAuth, buildWorkboardAccessFilter } = require('../middleware/auth');
+const PipelineRun = require('../models/PipelineRun');
+const GeneratedImage = require('../models/GeneratedImage');
+const Workboard = require('../models/Workboard');
+
+// 대시보드 위젯 전용 읽기 전용 집계 엔드포인트 (#453).
+// req.user 는 server.js 의 전역 /api 인증 미들웨어가 주입한다.
+
+const TZ = 'Asia/Seoul'; // 한국어 사용자 기준 — 일 경계를 KST 로 맞춘다
+
+// 1) 실행 중 파이프라인 — 요청 사용자의 전 프로젝트에서 pending/running 인 런.
+//    단계 완료 비율로 progress 를 계산해 함께 반환. 대시보드에서 polling.
+router.get('/active-pipeline-runs', requireAuth, async (req, res) => {
+  try {
+    const runs = await PipelineRun.find({
+      userId: req.user._id,
+      status: { $in: ['pending', 'running'] },
+    })
+      .populate('pipelineId', 'name')
+      .populate('projectId', 'name')
+      .sort({ startedAt: -1, createdAt: -1 })
+      .limit(10)
+      .lean();
+
+    const data = runs.map((run) => {
+      const steps = run.steps || [];
+      const total = steps.length;
+      const done = steps.filter((s) => s.status === 'completed' || s.status === 'skipped').length;
+      const progress = total > 0 ? Math.round((done / total) * 100) : 0;
+      return {
+        _id: run._id,
+        projectId: run.projectId?._id || null,
+        projectName: run.projectId?.name || '',
+        pipelineName: run.pipelineId?.name || '파이프라인',
+        status: run.status,
+        progress,
+        stepTotal: total,
+        stepDone: done,
+        initialPrompt: run.initialPrompt || '',
+        startedAt: run.startedAt || run.createdAt,
+      };
+    });
+
+    res.json({ success: true, data: { runs: data } });
+  } catch (error) {
+    console.error('대시보드 active-pipeline-runs 오류:', error);
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
+// 2) 일별 생성 이미지 추이 — 최근 N일(기본 7, 최대 31). KST 기준 일별 카운트.
+//    빈 날짜는 0 으로 채워 연속 배열을 반환. 오늘/평균/피크 요약 포함.
+router.get('/image-trend', requireAuth, async (req, res) => {
+  try {
+    const days = Math.min(Math.max(parseInt(req.query.days, 10) || 7, 1), 31);
+
+    const since = new Date(Date.now() - (days - 1) * 24 * 60 * 60 * 1000);
+    since.setHours(0, 0, 0, 0);
+
+    const rows = await GeneratedImage.aggregate([
+      { $match: { userId: req.user._id, createdAt: { $gte: since } } },
+      {
+        $group: {
+          _id: { $dateToString: { format: '%Y-%m-%d', date: '$createdAt', timezone: TZ } },
+          count: { $sum: 1 },
+        },
+      },
+    ]);
+
+    const counts = new Map(rows.map((r) => [r._id, r.count]));
+    const fmt = (d) => d.toLocaleDateString('en-CA', { timeZone: TZ }); // YYYY-MM-DD
+
+    const trend = [];
+    const now = Date.now();
+    for (let i = days - 1; i >= 0; i--) {
+      const key = fmt(new Date(now - i * 24 * 60 * 60 * 1000));
+      trend.push({ date: key, count: counts.get(key) || 0 });
+    }
+
+    const values = trend.map((t) => t.count);
+    const sum = values.reduce((a, b) => a + b, 0);
+    const today = values[values.length - 1] || 0;
+    const average = Math.round(sum / days);
+    const peak = values.length ? Math.max(...values) : 0;
+
+    res.json({ success: true, data: { trend, today, average, peak, days } });
+  } catch (error) {
+    console.error('대시보드 image-trend 오류:', error);
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
+// 3) 자주 쓰는 작업판 — usageCount 상위 N(기본 4, 최대 10).
+//    활성 작업판 한정 + 사용자 접근 권한(그룹) 필터. admin 은 전체.
+router.get('/workboard-usage', requireAuth, async (req, res) => {
+  try {
+    const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 4, 1), 10);
+    const filter = { isActive: true, ...buildWorkboardAccessFilter(req.user) };
+
+    const workboards = await Workboard.find(filter)
+      .select('name usageCount outputFormat serverId')
+      .populate('serverId', 'name serverType')
+      .sort({ usageCount: -1, createdAt: -1 })
+      .limit(limit)
+      .lean();
+
+    res.json({ success: true, data: { workboards } });
+  } catch (error) {
+    console.error('대시보드 workboard-usage 오류:', error);
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
+module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -27,6 +27,7 @@ const updatelogRoutes = require('./routes/updatelog');
 const apiKeyRoutes = require('./routes/apikeys');
 const filesRoutes = require('./routes/files');
 const groupRoutes = require('./routes/groups');
+const dashboardRoutes = require('./routes/dashboard');
 const errorHandler = require('./middleware/errorHandler');
 const { verifyJWT, verifyApiKey } = require('./middleware/auth');
 const { blockDuringBackup } = require('./middleware/backupLock');
@@ -152,6 +153,7 @@ app.use('/api/admin/backup', backupRoutes);
 app.use('/api/updatelog', updatelogRoutes);
 app.use('/api/apikeys', apiKeyRoutes);
 app.use('/api/groups', groupRoutes);
+app.use('/api/dashboard', dashboardRoutes);
 
 // Health check endpoint
 app.get('/health', (req, res) => {


### PR DESCRIPTION
새 디자인 핸드오프(v1.1, #451)의 대시보드 적용. 상단 통계 4블록 제거 + 2열 위젯.

## 프론트엔드 (`pages/Dashboard.js` 재작성)
- 인사 hero(날짜 + 이름 + 실행중/추이 요약) + 빠른 액션 4종
- 좌열: 실행 중 파이프라인(진행률 바) · 최근 프로젝트(그라데이션 아바타) · 최근 생성 이미지 그리드
- 우열: 주간 생성 추이(sparkline + 오늘/평균/피크) · 서버 상태(상태 dot, host 는 admin 한정) · 자주 쓰는 작업판 top4
- theme 토큰만 사용(신규 hex 직접 추가 없음), 다크 인지형, 모바일 1열
- 업데이트 내역 진입점 보존(디자인엔 없지만 회귀 방지용 저강조 링크)

## 백엔드 (`src/routes/dashboard.js`, 읽기 전용)
- `GET /api/dashboard/active-pipeline-runs` — 전 프로젝트 실행중 런 + 단계 완료율
- `GET /api/dashboard/image-trend?days=7` — KST 일별 생성 집계 + 오늘/평균/피크
- `GET /api/dashboard/workboard-usage?limit=4` — usageCount 상위(활성 + 그룹 권한 필터)
- `req.user` 는 전역 /api 인증 미들웨어가 주입 → 라우트는 requireAuth 만

## 검증
- docker-compose 재빌드(CRA 컴파일 에러 없음) 후 3 endpoint 실데이터 응답 확인
- Playwright 헤드리스 렌더: H1 정상, console/page 에러 0
- e2e smoke '대시보드 진입' 은 사이드바 텍스트 기준이라 영향 없음

사용자 가시 변경 → 다음 버전(v3.2.0) 릴리스 사이클에 포함 예정.

closes #453