### PR TITLE
fix: 작업 히스토리 종류/검색 선택 뒤로가기 유지 (#458)

### DIFF
--- a/frontend/src/pages/JobHistory.js
+++ b/frontend/src/pages/JobHistory.js
@@ -34,7 +34,7 @@ import {
   Close,
 } from '@mui/icons-material';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import {
   jobAPI,
@@ -363,8 +363,21 @@ function HistoryRow({ item, onOpenMedia, onMenu, onContinue, onCross, onTextCont
 function JobHistory() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const [seg, setSeg] = useState('all');
-  const [search, setSearch] = useState('');
+
+  // 세그먼트/검색은 URL query 에 보관 — 계속하기/다른 작업 등으로 이동 후
+  // 뒤로가기로 돌아와도 선택이 유지됨 (#458). replace 로 히스토리 오염 방지.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const seg = searchParams.get('seg') || 'all';
+  const search = searchParams.get('q') || '';
+  const setParam = (key, val) => {
+    const p = new URLSearchParams(searchParams);
+    if (val) p.set(key, val);
+    else p.delete(key);
+    setSearchParams(p, { replace: true });
+  };
+  const setSeg = (v) => setParam('seg', v === 'all' ? '' : v);
+  const setSearch = (v) => setParam('q', v);
+
   const [limit, setLimit] = useState(20);
 
   // 데이터


### PR DESCRIPTION
## 증상
히스토리에서 종류(세그먼트)/검색 선택 후 계속하기·다른 작업으로 이동했다가 뒤로가기로 돌아오면 선택이 '전체'로 초기화됨.

## 수정
- `seg`/`q` 를 `useSearchParams` 로 URL query 에 보관 (`{ replace: true }`)
- 뒤로가기로 `/jobs?seg=text` 복귀 시 상태가 URL 에서 복원

## 검증
- Playwright: 텍스트 세그먼트 선택 → /workboards 이동 → 뒤로가기 → `?seg=text` 유지 + 버튼 활성 복원, 에러 0

closes #458