### PR TITLE
feat: 서버/작업판 관리·목록 UI 새 디자인 적용 (design system v1.1) (#463)

### DIFF
--- a/frontend/src/components/admin/ServerManagement.js
+++ b/frontend/src/components/admin/ServerManagement.js
@@ -23,7 +23,8 @@ import {
   Alert,
   CircularProgress,
   Tooltip,
-  Stack
+  Stack,
+  Paper
 } from '@mui/material';
 import {
   Add,
@@ -42,7 +43,8 @@ import {
 } from '@mui/icons-material';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import toast from 'react-hot-toast';
-import { serverAPI } from '../../services/api';
+import { serverAPI, jobAPI } from '../../services/api';
+import { getServerTypeColor } from '../../templates/capabilities';
 
 // 공식 base URL 이 알려진 provider — 서버 추가 시 자동 입력 (사용자 입력 우선)
 const KNOWN_SERVER_URLS = {
@@ -133,108 +135,32 @@ function ServerCard({
     }
   };
 
+  const MONO = '"JetBrains Mono","SF Mono",Menlo,monospace';
+  const statusKey = server.healthCheck?.status;
+  const statusChip = statusKey === 'healthy'
+    ? { color: 'success', label: 'online' }
+    : statusKey === 'unhealthy' ? { color: 'error', label: 'offline' } : { color: undefined, label: 'unknown' };
+  const typeColor = getServerTypeColor(server.serverType);
+  const abbr = ((server.serverType || 'SRV').replace(/[^A-Za-z]/g, '').slice(0, 3) || 'SRV').toUpperCase();
+  const lastSync = modelSyncStatus?.lastMetadataSync || loraSyncStatus?.lastCivitaiSync || server.healthCheck?.lastChecked;
+
   return (
-    <Card sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-      <CardContent sx={{ flexGrow: 1 }}>
-        {/* 서버 이름 및 상태 */}
-        <Box display="flex" justifyContent="space-between" alignItems="flex-start" mb={2}>
-          <Box>
-            <Typography variant="h6" gutterBottom>
-              {server.name}
-            </Typography>
-            <Typography variant="body2" color="textSecondary">
-              {server.description || '설명 없음'}
-            </Typography>
-          </Box>
-          <Box display="flex" alignItems="center" gap={1}>
-            {!server.isActive && <Chip label="비활성" color="default" />}
-            <Chip 
-              icon={getStatusIcon(server.healthCheck?.status)}
-              label={server.healthCheck?.status || 'unknown'}
-              color={getStatusColor(server.healthCheck?.status)}
-            />
-          </Box>
+    <Paper variant="outlined" sx={{ p: 2, opacity: server.isActive ? 1 : 0.7 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap' }}>
+        <Box sx={{ width: 36, height: 36, borderRadius: 1.5, flex: '0 0 auto', bgcolor: typeColor, color: '#fff',
+          display: 'grid', placeItems: 'center', fontSize: 11, fontWeight: 700, fontFamily: MONO }}>
+          {abbr}
         </Box>
-
-        {/* 서버 정보 */}
-        <Stack spacing={1}>
-          <Box display="flex" alignItems="center" gap={1}>
-            {getTypeIcon(server.serverType)}
-            <Typography variant="body2">
-              <strong>AI API 형식:</strong> {getServerTypeLabel(server.serverType)}
-            </Typography>
+        <Box sx={{ flex: 1, minWidth: 180 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flexWrap: 'wrap' }}>
+            <Typography sx={{ fontWeight: 600, fontSize: 14 }}>{server.name}</Typography>
+            <Chip size="small" variant="outlined" label={getServerTypeLabel(server.serverType)} sx={{ height: 20, fontSize: 10.5 }} />
+            <Chip size="small" variant="outlined" color={statusChip.color} label={statusChip.label} sx={{ height: 20, fontSize: 10.5 }} />
+            {!server.isActive && <Chip size="small" label="비활성" sx={{ height: 20, fontSize: 10.5 }} />}
           </Box>
-          
-          <Typography variant="body2">
-            <strong>URL:</strong> {server.serverUrl}
-          </Typography>
-          
-          {/* 헬스체크 정보 */}
-          {server.healthCheck?.lastChecked && (
-            <Box>
-              <Typography variant="caption" color="textSecondary">
-                마지막 확인: {new Date(server.healthCheck.lastChecked).toLocaleString()}
-              </Typography>
-              {server.healthCheck.responseTime && (
-                <Typography variant="caption" color="textSecondary" display="block">
-                  응답시간: {server.healthCheck.responseTime}ms
-                </Typography>
-              )}
-              {server.healthCheck.errorMessage && (
-                <Typography variant="caption" color="error" display="block">
-                  오류: {server.healthCheck.errorMessage}
-                </Typography>
-              )}
-            </Box>
-          )}
-
-          {/* LoRA 동기화 정보 (ComfyUI 서버만) */}
-          {isComfyUI && loraSyncStatus && (
-            <Box>
-              {loraSyncStatus.totalLoras > 0 ? (
-                <>
-                  <Typography variant="caption" color="textSecondary">
-                    LoRA: {loraSyncStatus.lorasWithMetadata}/{loraSyncStatus.totalLoras}개 (메타데이터 있음)
-                  </Typography>
-                  {loraSyncStatus.lastCivitaiSync && (
-                    <Typography variant="caption" color="textSecondary" display="block">
-                      마지막 동기화: {new Date(loraSyncStatus.lastCivitaiSync).toLocaleString()}
-                    </Typography>
-                  )}
-                </>
-              ) : (
-                <Typography variant="caption" color="textSecondary">
-                  LoRA: 동기화 필요
-                </Typography>
-              )}
-            </Box>
-          )}
-
-          {/* 모델 동기화 정보 (ComfyUI / OpenAI / OpenAI Compatible / Gemini) */}
-          {supportsModelSync && modelSyncStatus && (
-            <Box>
-              {modelSyncStatus.totalModels > 0 ? (
-                <>
-                  <Typography variant="caption" color="textSecondary">
-                    모델: {modelSyncStatus.modelsWithMetadata}/{modelSyncStatus.totalModels}개 (메타데이터 있음)
-                  </Typography>
-                  {modelSyncStatus.lastMetadataSync && (
-                    <Typography variant="caption" color="textSecondary" display="block">
-                      마지막 동기화: {new Date(modelSyncStatus.lastMetadataSync).toLocaleString()}
-                    </Typography>
-                  )}
-                </>
-              ) : (
-                <Typography variant="caption" color="textSecondary">
-                  모델: 동기화 필요
-                </Typography>
-              )}
-            </Box>
-          )}
-        </Stack>
-      </CardContent>
-      
-      <CardActions>
+          <Typography sx={{ fontSize: 12, color: 'text.disabled', fontFamily: MONO, mt: 0.25 }} noWrap>{server.serverUrl}</Typography>
+        </Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25, flex: '0 0 auto' }}>
         <Tooltip title="헬스체크">
           <span>
             <IconButton
@@ -302,8 +228,23 @@ function ServerCard({
             <Delete />
           </IconButton>
         </Tooltip>
-      </CardActions>
-    </Card>
+        </Box>
+      </Box>
+
+      {/* sync summary */}
+      <Box sx={{ display: 'flex', gap: 2, mt: 1.5, flexWrap: 'wrap', fontSize: 11.5, color: 'text.secondary', fontFamily: MONO }}>
+        {supportsModelSync && (
+          <Box component="span">모델 {modelSyncStatus?.totalModels ? `${modelSyncStatus.modelsWithMetadata}/${modelSyncStatus.totalModels}` : '동기화 필요'}</Box>
+        )}
+        {isComfyUI && (
+          <Box component="span">LoRA {loraSyncStatus?.totalLoras ? `${loraSyncStatus.lorasWithMetadata}/${loraSyncStatus.totalLoras}` : '동기화 필요'}</Box>
+        )}
+        {lastSync && <Box component="span" sx={{ ml: 'auto' }}>마지막 동기화 {new Date(lastSync).toLocaleString()}</Box>}
+      </Box>
+      {server.healthCheck?.errorMessage && (
+        <Typography variant="caption" color="error" sx={{ display: 'block', mt: 0.5 }}>오류: {server.healthCheck.errorMessage}</Typography>
+      )}
+    </Paper>
   );
 }
 
@@ -538,6 +479,16 @@ function ServerManagement() {
 
   // ComfyUI 서버들의 LoRA 동기화 상태 조회
   const servers = serversData?.data?.data?.servers || [];
+
+  // 요약: 온라인 수 + 전체 큐(서버별 큐 수집 데이터가 없어 전체 큐로 표시)
+  const { data: queueStatsData } = useQuery(
+    'serverQueueStats',
+    () => jobAPI.getQueueStats(),
+    { refetchInterval: 10000 }
+  );
+  const queueStats = queueStatsData?.data?.stats || {};
+  const onlineCount = servers.filter((s) => s.healthCheck?.status === 'healthy').length;
+  const activeQueue = (queueStats.active || 0) + (queueStats.waiting || 0);
   const comfyUIServers = servers.filter(s => s.serverType === 'ComfyUI');
   const modelSyncSupportedServers = servers.filter(s =>
     ['ComfyUI', 'OpenAI', 'OpenAI Compatible', 'Gemini'].includes(s.serverType)
@@ -767,50 +718,57 @@ function ServerManagement() {
 
   return (
     <Box>
-      <Box display="flex" justifyContent="space-between" alignItems="center" mb={3}>
-        <Typography variant="h5">서버 관리</Typography>
-        <Box display="flex" gap={1}>
-          <Button
-            variant="outlined"
-            startIcon={<Refresh />}
-            onClick={handleAllHealthCheck}
-            disabled={allHealthCheckMutation.isLoading}
-          >
-            전체 헬스체크
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={<Add />}
-            onClick={handleAddServer}
-          >
-            서버 추가
-          </Button>
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.5, flexWrap: 'wrap', mb: 2 }}>
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Typography variant="h1">서버 관리</Typography>
+          <Typography variant="body1" color="text.secondary" sx={{ textWrap: 'pretty', mt: 0.5 }}>
+            ComfyUI / OpenAI / Gemini / Compatible 백엔드 등록 및 모델 동기화.
+          </Typography>
+        </Box>
+        <Box sx={{ display: 'flex', gap: 0.75 }}>
+          <Button variant="outlined" startIcon={<Refresh />} onClick={handleAllHealthCheck} disabled={allHealthCheckMutation.isLoading}>전체 헬스체크</Button>
+          <Button variant="contained" startIcon={<Add />} onClick={handleAddServer}>서버 추가</Button>
         </Box>
       </Box>
 
+      {/* 요약 */}
+      <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 1.5, mb: 2.5 }}>
+        {[
+          { label: '서버', value: servers.length, suffix: '등록' },
+          { label: '온라인', value: `${onlineCount} / ${servers.length}`, color: 'success.main' },
+          { label: '실행 중 큐', value: activeQueue },
+        ].map((st) => (
+          <Paper key={st.label} variant="outlined" sx={{ p: 1.75 }}>
+            <Typography sx={{ fontSize: 11, color: 'text.disabled', textTransform: 'uppercase', letterSpacing: '0.06em' }}>{st.label}</Typography>
+            <Typography sx={{ fontSize: 24, fontWeight: 700, mt: 0.5, color: st.color }}>
+              {st.value}{st.suffix && <Box component="span" sx={{ fontSize: 12, color: 'text.disabled', ml: 0.5 }}>{st.suffix}</Box>}
+            </Typography>
+          </Paper>
+        ))}
+      </Box>
+
       {servers.length === 0 ? (
-        <Alert severity="info">
-          등록된 서버가 없습니다. 서버를 추가해주세요.
-        </Alert>
+        <Box sx={{ p: 5, textAlign: 'center', border: '1px dashed', borderColor: 'divider', borderRadius: 2 }}>
+          <Typography variant="body2" color="text.secondary">등록된 서버가 없습니다. 서버를 추가해주세요.</Typography>
+        </Box>
       ) : (
-        <Grid container spacing={3}>
+        <Stack spacing={1.25}>
           {servers.map((server) => (
-            <Grid item xs={12} md={6} lg={4} key={server._id}>
-              <ServerCard
-                server={server}
-                onEdit={handleEditServer}
-                onDelete={handleDeleteServer}
-                onHealthCheck={handleHealthCheck}
-                onLoraSync={handleLoraSync}
-                loraSyncStatus={loraSyncStatuses[server._id]}
-                onLoraResetSync={handleLoraResetSync}
-                onModelSync={handleModelSync}
-                modelSyncStatus={modelSyncStatuses[server._id]}
-                onModelResetSync={handleModelResetSync}
-              />
-            </Grid>
+            <ServerCard
+              key={server._id}
+              server={server}
+              onEdit={handleEditServer}
+              onDelete={handleDeleteServer}
+              onHealthCheck={handleHealthCheck}
+              onLoraSync={handleLoraSync}
+              loraSyncStatus={loraSyncStatuses[server._id]}
+              onLoraResetSync={handleLoraResetSync}
+              onModelSync={handleModelSync}
+              modelSyncStatus={modelSyncStatuses[server._id]}
+              onModelResetSync={handleModelResetSync}
+            />
           ))}
-        </Grid>
+        </Stack>
       )}
 
       {/* 서버 추가/편집 다이얼로그 */}

--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -65,6 +65,11 @@ import {
   getOutputFormatLabel,
   getServerTypeColor,
 } from '../../templates/capabilities';
+import {
+  WorkboardCard as CatalogCard,
+  WorkboardFilters,
+  useWorkboardFilter,
+} from '../common/WorkboardCatalog';
 
 // admin 의 customField 기본값 입력기 — type=baseModel/lora 일 때 서버 모델 목록 Autocomplete (#391)
 function ServerMetadataDefaultValueInput({ serverId, type, value, onChange, label }) {
@@ -1925,33 +1930,20 @@ const ADMIN_WB_OUTPUT_KEY = 'vcc.adminWorkboards.outputFormat';
 
 function WorkboardManagement() {
   const navigate = useNavigate();
-  const [search, setSearch] = useState(() => localStorage.getItem(ADMIN_WB_SEARCH_KEY) || '');
-  const [serverTypeFilter, setServerTypeFilter] = useState(() => localStorage.getItem(ADMIN_WB_SERVER_KEY) || '');
-  const [outputFormatFilter, setOutputFormatFilter] = useState(() => localStorage.getItem(ADMIN_WB_OUTPUT_KEY) || '');
-
-  // 필터 변경 시 localStorage 동기 (#370)
-  useEffect(() => {
-    if (search) localStorage.setItem(ADMIN_WB_SEARCH_KEY, search);
-    else localStorage.removeItem(ADMIN_WB_SEARCH_KEY);
-  }, [search]);
-  useEffect(() => {
-    if (serverTypeFilter) localStorage.setItem(ADMIN_WB_SERVER_KEY, serverTypeFilter);
-    else localStorage.removeItem(ADMIN_WB_SERVER_KEY);
-  }, [serverTypeFilter]);
-  useEffect(() => {
-    if (outputFormatFilter) localStorage.setItem(ADMIN_WB_OUTPUT_KEY, outputFormatFilter);
-    else localStorage.removeItem(ADMIN_WB_OUTPUT_KEY);
-  }, [outputFormatFilter]);
+  // 상태 필터(전체/게시됨/보관) + 2축 필터(출력×서버, 공유)는 클라이언트 측에서 적용.
+  const [status, setStatus] = useState('all'); // all | active | inactive
   // create / update / 편집 dialog 상태는 #437 Phase A 에서 페이지로 이전됨
   // (WorkboardEditorPage / WorkboardCreatePage 가 own mutation + 페이지 라우팅).
   // 본 컴포넌트는 목록 / 가져오기 / delete / duplicate / toggleActive / export 만 담당.
   const [importDialogOpen, setImportDialogOpen] = useState(false);
+  const [menuAnchor, setMenuAnchor] = useState(null);
+  const [menuWb, setMenuWb] = useState(null);
 
   const queryClient = useQueryClient();
 
   const { data, isLoading } = useQuery(
-    ['adminWorkboards', { search, serverTypeFilter, outputFormatFilter }],
-    () => workboardAPI.getAll({ search, limit: 50, includeAll: true, includeInactive: true, serverType: serverTypeFilter || undefined, outputFormat: outputFormatFilter || undefined }),
+    'adminWorkboards',
+    () => workboardAPI.getAll({ limit: 500, includeAll: true, includeInactive: true }),
     { keepPreviousData: true }
   );
 
@@ -2050,6 +2042,16 @@ function WorkboardManagement() {
 
   const workboards = data?.data?.workboards || [];
 
+  const statusCounts = {
+    all: workboards.length,
+    active: workboards.filter((w) => w.isActive).length,
+    inactive: workboards.filter((w) => !w.isActive).length,
+  };
+  const statusFiltered = workboards.filter((w) =>
+    status === 'all' ? true : status === 'active' ? w.isActive : !w.isActive
+  );
+  const { q, setQ, outSel, svcSel, toggleOut, toggleSvc, clear, counts, filtered } = useWorkboardFilter(statusFiltered);
+
   const handleCreate = () => {
     navigate('/admin/workboards/new');
   };
@@ -2107,87 +2109,86 @@ function WorkboardManagement() {
 
   return (
     <Box>
-      <Box display="flex" justifyContent="space-between" alignItems="center" mb={3}>
-        <Typography variant="h5">작업판 관리</Typography>
-        <Box display="flex" gap={1}>
-          <Button
-            variant="outlined"
-            onClick={() => setImportDialogOpen(true)}
-            startIcon={<FileUpload />}
-          >
-            가져오기
-          </Button>
-          <Button
-            variant="contained"
-            onClick={handleCreate}
-            startIcon={<Add />}
-          >
-            새 작업판
-          </Button>
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.5, flexWrap: 'wrap', mb: 2 }}>
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Typography variant="h1">작업판 관리</Typography>
+          <Typography variant="body1" color="text.secondary" sx={{ textWrap: 'pretty', mt: 0.5 }}>
+            작업판 정의 · 출력 형식 · 접근 권한 · 서버 매핑을 관리합니다.
+          </Typography>
+        </Box>
+        <Box sx={{ display: 'flex', gap: 0.75 }}>
+          <Button variant="outlined" startIcon={<FileUpload />} onClick={() => setImportDialogOpen(true)}>가져오기</Button>
+          <Button variant="contained" startIcon={<Add />} onClick={handleCreate}>새 작업판</Button>
         </Box>
       </Box>
 
-      <Box mb={3} display="flex" gap={2} alignItems="center" flexWrap="wrap">
-        <TextField
-          placeholder="작업판 이름으로 검색..."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          sx={{ minWidth: 300, flex: 1 }}
-        />
-        <FormControl sx={{ minWidth: 180 }}>
-          <InputLabel>서버 타입</InputLabel>
-          <Select
-            value={serverTypeFilter}
-            label="서버 타입"
-            onChange={(e) => setServerTypeFilter(e.target.value)}
+      {/* 상태 필터 (관리 전용 축) */}
+      <Stack direction="row" spacing={0.75} sx={{ mb: 1.5, overflowX: 'auto', pb: 0.5 }}>
+        {[
+          { k: 'all', l: '전체', c: statusCounts.all },
+          { k: 'active', l: '게시됨', c: statusCounts.active },
+          { k: 'inactive', l: '보관', c: statusCounts.inactive },
+        ].map((s) => (
+          <Button
+            key={s.k}
+            onClick={() => setStatus(s.k)}
+            variant={status === s.k ? 'contained' : 'outlined'}
+            color={status === s.k ? 'primary' : 'inherit'}
+            sx={{ flex: '0 0 auto', color: status === s.k ? undefined : 'text.secondary' }}
           >
-            <MenuItem value="">전체</MenuItem>
-            <MenuItem value="ComfyUI">ComfyUI</MenuItem>
-            <MenuItem value="OpenAI">OpenAI</MenuItem>
-            <MenuItem value="OpenAI Compatible">OpenAI Compatible</MenuItem>
-            <MenuItem value="Gemini">Gemini</MenuItem>
-          </Select>
-        </FormControl>
-        <FormControl sx={{ minWidth: 150 }}>
-          <InputLabel>출력 타입</InputLabel>
-          <Select
-            value={outputFormatFilter}
-            label="출력 타입"
-            onChange={(e) => setOutputFormatFilter(e.target.value)}
-          >
-            <MenuItem value="">전체</MenuItem>
-            <MenuItem value="image">이미지</MenuItem>
-            <MenuItem value="video">비디오</MenuItem>
-            <MenuItem value="text">텍스트</MenuItem>
-          </Select>
-        </FormControl>
-      </Box>
+            {s.l}
+            <Box component="span" sx={{ ml: 0.75, fontFamily: 'monospace', fontSize: 11, opacity: 0.8 }}>{s.c}</Box>
+          </Button>
+        ))}
+      </Stack>
+
+      <WorkboardFilters
+        q={q} setQ={setQ}
+        outSel={outSel} toggleOut={toggleOut}
+        svcSel={svcSel} toggleSvc={toggleSvc}
+        counts={counts} total={statusFiltered.length} shown={filtered.length}
+        onClear={clear}
+      />
 
       {isLoading ? (
-        <Box display="flex" justifyContent="center" py={4}>
-          <CircularProgress />
+        <Box display="flex" justifyContent="center" py={4}><CircularProgress /></Box>
+      ) : filtered.length === 0 ? (
+        <Box sx={{ p: 5, textAlign: 'center', border: '1px dashed', borderColor: 'divider', borderRadius: 2 }}>
+          <Typography sx={{ fontWeight: 600, mb: 0.5 }}>조건에 맞는 작업판이 없습니다</Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>필터를 줄이거나 새 작업판을 만들어 보세요.</Typography>
+          <Button variant="contained" size="small" startIcon={<Add />} onClick={handleCreate}>새 작업판</Button>
         </Box>
-      ) : workboards.length === 0 ? (
-        <Alert severity="info">
-          {(search || serverTypeFilter || outputFormatFilter) ? '검색 결과가 없습니다.' : '등록된 작업판이 없습니다.'}
-        </Alert>
       ) : (
-        <Grid container spacing={3}>
-          {workboards.map((workboard) => (
-            <Grid item xs={12} sm={6} md={4} lg={3} key={workboard._id}>
-              <WorkboardCard
-                workboard={workboard}
-                onEdit={handleEdit}
-                onDelete={handleDelete}
-                onDuplicate={handleDuplicate}
-                onExport={handleExport}
-                onView={handleView}
-                onToggleActive={handleToggleActive}
-              />
-            </Grid>
+        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: 'repeat(auto-fill, minmax(320px, 1fr))' }, gap: 1.5 }}>
+          {filtered.map((wb) => (
+            <CatalogCard
+              key={wb._id}
+              wb={wb}
+              admin
+              onEdit={handleEdit}
+              onMenu={(e, w) => { setMenuAnchor(e.currentTarget); setMenuWb(w); }}
+              groupNames={(wb.allowedGroupIds || []).map((g) => (typeof g === 'object' ? g.name : null)).filter(Boolean)}
+            />
           ))}
-        </Grid>
+        </Box>
       )}
+
+      <Menu anchorEl={menuAnchor} open={!!menuAnchor} onClose={() => setMenuAnchor(null)}>
+        <MenuItem onClick={() => { handleEdit(menuWb); setMenuAnchor(null); }}><Edit sx={{ mr: 1 }} fontSize="small" />편집</MenuItem>
+        <MenuItem onClick={() => { handleDuplicate(menuWb); setMenuAnchor(null); }}><ContentCopy sx={{ mr: 1 }} fontSize="small" />복제</MenuItem>
+        <MenuItem onClick={() => { handleExport(menuWb); setMenuAnchor(null); }}><FileDownload sx={{ mr: 1 }} fontSize="small" />내보내기</MenuItem>
+        <MenuItem
+          onClick={() => { handleToggleActive(menuWb); setMenuAnchor(null); }}
+          sx={{ color: menuWb?.isActive ? 'warning.main' : 'success.main' }}
+        >
+          {menuWb?.isActive
+            ? <><ToggleOff sx={{ mr: 1 }} fontSize="small" />비활성화</>
+            : <><ToggleOn sx={{ mr: 1 }} fontSize="small" />활성화</>}
+        </MenuItem>
+        <MenuItem onClick={() => { handleDelete(menuWb); setMenuAnchor(null); }} sx={{ color: 'error.main' }}>
+          <Delete sx={{ mr: 1 }} fontSize="small" />삭제
+        </MenuItem>
+      </Menu>
 
       <WorkboardImportDialog
         open={importDialogOpen}

--- a/frontend/src/components/common/WorkboardCatalog.js
+++ b/frontend/src/components/common/WorkboardCatalog.js
@@ -1,0 +1,266 @@
+import React, { useState, useMemo } from 'react';
+import { Box, Paper, Typography, Chip, IconButton, Button, InputBase } from '@mui/material';
+import {
+  Search,
+  Close,
+  SmartToy,
+  Image as ImageIcon,
+  Hexagon,
+  Movie,
+  AutoFixHigh,
+  Edit,
+  MoreVert,
+  AccessTime,
+  Info,
+} from '@mui/icons-material';
+
+const MONO = '"JetBrains Mono","SF Mono",Menlo,monospace';
+
+// 작업판 종류(생성 엔진) — outputFormat + serverType 로 유도. 카드 좌측 아이콘.
+export const KIND_META = {
+  'gpt-chat':  { icon: SmartToy,    label: '텍스트 생성', color: 'info.main',     tint: 'rgba(47,119,228,0.12)' },
+  'gpt-image': { icon: ImageIcon,   label: '이미지 (API)', color: '#5B2DBF',      tint: 'rgba(91,45,191,0.10)' },
+  'sdxl':      { icon: Hexagon,     label: 'SDXL',        color: 'primary.main',  tint: 'rgba(91,91,214,0.10)' },
+  'i2v':       { icon: Movie,       label: '영상 (I2V)',  color: 'warning.main',  tint: 'rgba(190,116,21,0.14)' },
+  'lora':      { icon: AutoFixHigh, label: 'LoRA 학습',    color: 'success.main',  tint: 'rgba(31,157,85,0.12)' },
+};
+
+export function deriveOut(wb) {
+  return wb.outputFormat || 'image'; // image | video | text
+}
+export function deriveSvc(wb) {
+  const t = wb.serverId?.serverType || wb.serverType || '';
+  if (t === 'Gemini') return 'gemini';
+  if (t.startsWith('OpenAI')) return 'openai';
+  if (t === 'ComfyUI') return 'comfy';
+  return 'other';
+}
+export function deriveKind(wb) {
+  const out = deriveOut(wb);
+  if (out === 'text') return 'gpt-chat';
+  if (out === 'video') return 'i2v';
+  const svc = deriveSvc(wb);
+  return svc === 'comfy' ? 'sdxl' : 'gpt-image';
+}
+
+export const OUTPUT_AXIS = [
+  { k: 'image', label: '이미지' },
+  { k: 'video', label: '영상' },
+  { k: 'text', label: '텍스트' },
+];
+export const SERVER_AXIS = [
+  { k: 'comfy', label: 'ComfyUI' },
+  { k: 'openai', label: 'OpenAI' },
+  { k: 'gemini', label: 'Gemini' },
+];
+const OUT_CHIP_COLOR = { image: 'primary', video: 'warning', text: 'info' };
+
+// ── 필터 로직 훅 ─────────────────────────────────────────────
+export function useWorkboardFilter(workboards) {
+  const [q, setQ] = useState('');
+  const [outSel, setOutSel] = useState([]);
+  const [svcSel, setSvcSel] = useState([]);
+
+  const toggleOut = (k) => setOutSel((s) => (s.includes(k) ? s.filter((x) => x !== k) : [...s, k]));
+  const toggleSvc = (k) => setSvcSel((s) => (s.includes(k) ? s.filter((x) => x !== k) : [...s, k]));
+  const clear = () => { setQ(''); setOutSel([]); setSvcSel([]); };
+
+  const counts = useMemo(() => {
+    const out = {}, svc = {};
+    workboards.forEach((w) => {
+      const o = deriveOut(w), s = deriveSvc(w);
+      out[o] = (out[o] || 0) + 1;
+      svc[s] = (svc[s] || 0) + 1;
+    });
+    return { out, svc };
+  }, [workboards]);
+
+  const filtered = useMemo(() => {
+    const needle = q.trim().toLowerCase();
+    return workboards.filter((w) => {
+      if (outSel.length && !outSel.includes(deriveOut(w))) return false;
+      if (svcSel.length && !svcSel.includes(deriveSvc(w))) return false;
+      if (needle && !(`${w.name} ${w.description || ''}`).toLowerCase().includes(needle)) return false;
+      return true;
+    });
+  }, [workboards, q, outSel, svcSel]);
+
+  return { q, setQ, outSel, svcSel, toggleOut, toggleSvc, clear, counts, filtered };
+}
+
+function FilterToggle({ active, onClick, children, count }) {
+  return (
+    <Box
+      component="button"
+      onClick={onClick}
+      sx={{
+        cursor: 'pointer', whiteSpace: 'nowrap', display: 'inline-flex', alignItems: 'center', gap: 0.5,
+        height: 28, px: 1.25, borderRadius: 999, fontSize: 12.5, fontWeight: 500,
+        bgcolor: active ? 'primary.main' : 'background.paper',
+        color: active ? 'primary.contrastText' : 'text.secondary',
+        border: '1px solid', borderColor: active ? 'primary.main' : 'divider',
+        transition: 'all 120ms',
+      }}
+    >
+      {children}
+      {count != null && (
+        <Box component="span" sx={{ fontSize: 10.5, fontFamily: MONO, color: active ? 'rgba(255,255,255,0.8)' : 'text.disabled' }}>
+          {count}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+// ── 2축 필터 바 ─────────────────────────────────────────────
+export function WorkboardFilters({ q, setQ, outSel, toggleOut, svcSel, toggleSvc, counts, total, shown, onClear }) {
+  const anyActive = outSel.length > 0 || svcSel.length > 0 || q.trim().length > 0;
+  return (
+    <Paper
+      variant="outlined"
+      sx={{ bgcolor: 'background.default', p: { xs: 1.5, sm: '12px 14px' }, mb: 2.5, display: 'flex', flexDirection: 'column', gap: 1.5 }}
+    >
+      {/* search */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25 }}>
+        <Paper variant="outlined" sx={{ flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', px: 1, height: 34, bgcolor: 'background.paper' }}>
+          <Search fontSize="small" sx={{ color: 'text.disabled', mr: 0.5 }} />
+          <InputBase value={q} onChange={(e) => setQ(e.target.value)} placeholder="작업판 이름 · 설명 검색" sx={{ flex: 1, fontSize: 13 }} />
+        </Paper>
+        <Typography sx={{ fontSize: 12, color: 'text.disabled', fontFamily: MONO, flex: '0 0 auto' }}>
+          {shown === total ? `${total}개` : `${shown} / ${total}`}
+        </Typography>
+      </Box>
+
+      {/* two axes */}
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: { xs: 1.25, sm: 2.25 }, alignItems: 'center' }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+          <Typography sx={{ fontSize: 11, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'text.disabled' }}>출력</Typography>
+          {OUTPUT_AXIS.map((o) => (
+            <FilterToggle key={o.k} active={outSel.includes(o.k)} onClick={() => toggleOut(o.k)} count={counts.out[o.k] || 0}>{o.label}</FilterToggle>
+          ))}
+        </Box>
+        <Box sx={{ width: '1px', height: 22, bgcolor: 'divider', display: { xs: 'none', sm: 'block' } }} />
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+          <Typography sx={{ fontSize: 11, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'text.disabled' }}>서버</Typography>
+          {SERVER_AXIS.map((s) => (
+            <FilterToggle key={s.k} active={svcSel.includes(s.k)} onClick={() => toggleSvc(s.k)} count={counts.svc[s.k] || 0}>{s.label}</FilterToggle>
+          ))}
+        </Box>
+        {anyActive && (
+          <>
+            <Box sx={{ flex: 1 }} />
+            <Button size="small" variant="text" startIcon={<Close />} onClick={onClear} sx={{ color: 'text.disabled' }}>초기화</Button>
+          </>
+        )}
+      </Box>
+    </Paper>
+  );
+}
+
+function WbStatusBadge({ isActive }) {
+  return (
+    <Chip
+      size="small"
+      variant="outlined"
+      color={isActive ? 'success' : undefined}
+      label={isActive ? '게시됨' : '보관'}
+      sx={{ height: 18, fontSize: 10.5, ...(isActive ? {} : { color: 'text.disabled' }) }}
+    />
+  );
+}
+
+// ── 공유 카드 ───────────────────────────────────────────────
+export function WorkboardCard({ wb, admin, onClick, onEdit, onMenu, onInfo, groupNames }) {
+  const kind = KIND_META[deriveKind(wb)] || KIND_META['gpt-image'];
+  const KindIcon = kind.icon;
+  const out = deriveOut(wb);
+  const archived = admin && !wb.isActive;
+  const serverName = wb.serverId?.name || '서버 미설정';
+
+  return (
+    <Paper
+      variant="outlined"
+      onClick={admin ? undefined : onClick}
+      sx={{
+        p: 2, display: 'flex', flexDirection: 'column', gap: 1.25, height: '100%',
+        cursor: admin ? 'default' : 'pointer', opacity: archived ? 0.72 : 1,
+        transition: 'border-color 150ms, box-shadow 150ms',
+        '&:hover': admin ? {} : { borderColor: 'primary.main', boxShadow: 2 },
+      }}
+    >
+      {/* header */}
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.25 }}>
+        <Box sx={{ width: 32, height: 32, borderRadius: 1.5, bgcolor: kind.tint, color: kind.color, display: 'grid', placeItems: 'center', flex: '0 0 auto' }}>
+          <KindIcon sx={{ fontSize: 18 }} />
+        </Box>
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+            <Typography sx={{ fontSize: 13.5, fontWeight: 600 }} noWrap>{wb.name}</Typography>
+            {admin && <WbStatusBadge isActive={wb.isActive} />}
+          </Box>
+          <Typography sx={{ fontSize: 11, color: 'text.disabled', fontFamily: MONO, mt: 0.25 }} noWrap>
+            {kind.label}{wb.version ? ` · v${wb.version}` : ''}
+          </Typography>
+        </Box>
+        <Chip size="small" variant="outlined" color={OUT_CHIP_COLOR[out]} label={out}
+          sx={{ flex: '0 0 auto', height: 20, fontSize: 10.5, fontFamily: MONO }} />
+      </Box>
+
+      {/* description */}
+      <Typography sx={{ fontSize: 11.5, color: 'text.secondary', lineHeight: 1.5, textWrap: 'pretty', minHeight: 32,
+        display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>
+        {wb.description || '설명이 없습니다.'}
+      </Typography>
+
+      {/* admin: allowed groups */}
+      {admin && groupNames && groupNames.length > 0 && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexWrap: 'wrap' }}>
+          <Typography sx={{ fontSize: 10.5, color: 'text.disabled' }}>허용</Typography>
+          {groupNames.map((g) => (
+            <Chip key={g} size="small" variant="outlined" label={g} sx={{ height: 18, fontSize: 10.5 }} />
+          ))}
+        </Box>
+      )}
+
+      {/* stats row */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25, pt: 1.25, mt: 'auto',
+        borderTop: '1px solid', borderColor: 'divider', fontSize: 11, color: 'text.disabled', fontFamily: MONO }}>
+        <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
+          <Box sx={{ width: 6, height: 6, borderRadius: '50%', bgcolor: archived ? 'text.disabled' : 'success.main', flex: '0 0 auto' }} />
+          <Box component="span" sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{serverName}</Box>
+        </Box>
+        <Box sx={{ flex: 1 }} />
+        {admin ? (
+          <Box component="span">필드 {wb.additionalInputFields?.length ?? 0}</Box>
+        ) : (
+          <Box component="span">{wb.usageCount || 0}회</Box>
+        )}
+      </Box>
+
+      {/* footer */}
+      {admin ? (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Typography sx={{ fontSize: 11, color: 'text.disabled' }} noWrap>
+            {wb.updatedAt ? new Date(wb.updatedAt).toLocaleDateString() : ''}{wb.createdBy?.nickname ? ` · ${wb.createdBy.nickname}` : ''}
+          </Typography>
+          <Box sx={{ flex: 1 }} />
+          <Button size="small" variant="outlined" startIcon={<Edit />} onClick={(e) => { e.stopPropagation(); onEdit && onEdit(wb); }}>편집</Button>
+          <IconButton size="small" onClick={(e) => { e.stopPropagation(); onMenu && onMenu(e, wb); }}><MoreVert fontSize="small" /></IconButton>
+        </Box>
+      ) : (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: -0.5 }}>
+          {onInfo && (
+            <Button size="small" variant="text" startIcon={<Info />} onClick={(e) => { e.stopPropagation(); onInfo(wb); }} sx={{ color: 'text.secondary' }}>
+              상세정보
+            </Button>
+          )}
+          <Box sx={{ flex: 1 }} />
+          <AccessTime sx={{ fontSize: 12, color: 'text.disabled' }} />
+          <Typography sx={{ fontSize: 11, color: 'text.disabled', fontFamily: MONO }}>
+            {wb.updatedAt ? new Date(wb.updatedAt).toLocaleDateString() : ''}
+          </Typography>
+        </Box>
+      )}
+    </Paper>
+  );
+}

--- a/frontend/src/pages/Workboards.js
+++ b/frontend/src/pages/Workboards.js
@@ -1,328 +1,106 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import {
-  Container,
-  Grid,
-  Card,
-  CardContent,
-  CardActions,
-  Typography,
-  Button,
   Box,
-  TextField,
-  InputAdornment,
+  Typography,
   Chip,
   CircularProgress,
   Alert,
+  Paper,
   Dialog,
   DialogTitle,
   DialogContent,
   DialogContentText,
   DialogActions,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
-  IconButton
+  Button,
+  IconButton,
 } from '@mui/material';
-import {
-  Search,
-  PlayArrow,
-  Info,
-  TrendingUp,
-  Computer,
-  ContentCopy
-} from '@mui/icons-material';
+import { PlayArrow, ContentCopy, Inventory2 } from '@mui/icons-material';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useQuery } from 'react-query';
-import { workboardAPI, userAPI, projectAPI } from '../services/api';
+import { workboardAPI, projectAPI } from '../services/api';
 import toast from 'react-hot-toast';
 import {
-  getServerTypeLabel as getServerTypeLabelShared,
+  getServerTypeLabel,
   getServerTypeColor,
-  getOutputFormatLabel as getOutputFormatLabelShared,
+  getOutputFormatLabel,
 } from '../templates/capabilities';
+import {
+  WorkboardFilters,
+  WorkboardCard,
+  useWorkboardFilter,
+} from '../components/common/WorkboardCatalog';
 
-
-function WorkboardCard({ workboard, projectId }) {
-  const navigate = useNavigate();
-  const [infoOpen, setInfoOpen] = useState(false);
-
-  const outputFormat = workboard.outputFormat || 'image';
-  const isPromptWorkboard = outputFormat === 'text';
-  const isImageWorkboard = !isPromptWorkboard;
-  const projectQuery = projectId ? `?projectId=${projectId}` : '';
-
-  const handleSelect = () => {
-    // 히스토리에서 온 데이터가 있는지 확인
-    const continueJobData = localStorage.getItem('continueJobData');
-    if (continueJobData) {
-      try {
-        const parsedData = JSON.parse(continueJobData);
-        if (parsedData.fromJobHistory) {
-          const updatedData = {
-            workboardId: workboard._id,
-            inputData: parsedData.inputData,
-            workboard: workboard
-          };
-          localStorage.setItem('continueJobData', JSON.stringify(updatedData));
-          toast.success('작업 히스토리 데이터와 작업판이 연결되었습니다');
-        }
-      } catch (error) {
-        console.warn('Failed to parse continue job data:', error);
-      }
-    }
-
-    if (isImageWorkboard) {
-      navigate(`/generate/${workboard._id}${projectQuery}`);
-    } else {
-      navigate(`/prompt-generate/${workboard._id}${projectQuery}`);
-    }
-  };
-
-  const handleInfo = () => {
-    setInfoOpen(true);
-  };
-
-  const handleInfoClose = () => {
-    setInfoOpen(false);
-  };
-
-  const handleCopyWorkboardId = async () => {
+function selectWorkboard(workboard, projectId, navigate) {
+  // 히스토리에서 온 데이터가 있으면 작업판과 연결
+  const continueJobData = localStorage.getItem('continueJobData');
+  if (continueJobData) {
     try {
-      await navigator.clipboard.writeText(workboard._id);
-      toast.success('작업판 ID를 복사했습니다.');
-    } catch (error) {
-      toast.error('작업판 ID 복사에 실패했습니다.');
+      const parsed = JSON.parse(continueJobData);
+      if (parsed.fromJobHistory) {
+        localStorage.setItem('continueJobData', JSON.stringify({
+          workboardId: workboard._id,
+          inputData: parsed.inputData,
+          workboard,
+        }));
+        toast.success('작업 히스토리 데이터와 작업판이 연결되었습니다');
+      }
+    } catch (e) {
+      console.warn('Failed to parse continue job data:', e);
     }
+  }
+  const projectQuery = projectId ? `?projectId=${projectId}` : '';
+  if ((workboard.outputFormat || 'image') === 'text') {
+    navigate(`/prompt-generate/${workboard._id}${projectQuery}`);
+  } else {
+    navigate(`/generate/${workboard._id}${projectQuery}`);
+  }
+}
+
+function WorkboardDetailDialog({ workboard, open, onClose, onSelect }) {
+  if (!workboard) return null;
+  const copyId = async () => {
+    try { await navigator.clipboard.writeText(workboard._id); toast.success('작업판 ID를 복사했습니다.'); }
+    catch { toast.error('작업판 ID 복사에 실패했습니다.'); }
   };
-
-  const getOutputFormatLabel = (format) => getOutputFormatLabelShared(format);
-  const getServerTypeLabel = (serverType) => getServerTypeLabelShared(serverType) || '서버 미설정';
-
   return (
-    <>
-      <Card sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-        <CardContent sx={{ flexGrow: 1 }}>
-          <Typography variant="h6" gutterBottom>
-            {workboard.name}
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>{workboard.name}</DialogTitle>
+      <DialogContent>
+        <DialogContentText sx={{ mb: 2 }}>{workboard.description || '설명이 없습니다.'}</DialogContentText>
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2 }}>
+          <Chip size="small"
+            label={getOutputFormatLabel(workboard.outputFormat || 'image')}
+            color={workboard.outputFormat === 'text' ? 'info' : workboard.outputFormat === 'video' ? 'warning' : 'primary'} />
+          <Chip size="small" label={getServerTypeLabel(workboard.serverId?.serverType) || '서버 미설정'}
+            sx={{ bgcolor: getServerTypeColor(workboard.serverId?.serverType), color: 'white' }} />
+        </Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 1 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+            작업판 ID: {workboard._id}
           </Typography>
-
-          {workboard.description && (
-            <Typography variant="body2" color="textSecondary" paragraph>
-              {workboard.description}
-            </Typography>
-          )}
-
-          <Box display="flex" alignItems="center" gap={1} mb={2}>
-            <Computer fontSize="small" />
-            <Typography variant="caption" color="textSecondary">
-              {workboard.serverId?.name || (workboard.serverUrl ? new URL(workboard.serverUrl).hostname : '서버 정보 없음')}
-            </Typography>
-          </Box>
-
-          <Box display="flex" alignItems="center" gap={1} mb={2}>
-            <TrendingUp fontSize="small" />
-            <Typography variant="caption" color="textSecondary">
-              사용횟수: {workboard.usageCount || 0}회
-            </Typography>
-          </Box>
-
-          <Box display="flex" alignItems="center" gap={0.5} mb={2}>
-            <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
-              ID: {workboard._id}
-            </Typography>
-            <IconButton size="small" onClick={handleCopyWorkboardId} aria-label="작업판 ID 복사">
-              <ContentCopy fontSize="inherit" />
-            </IconButton>
-          </Box>
-
-          <Box display="flex" flexWrap="wrap" gap={0.5} mb={2}>
-            <Chip
-              label={getOutputFormatLabel(workboard.outputFormat || 'image')}
-              color={workboard.outputFormat === 'text' ? 'secondary' : workboard.outputFormat === 'video' ? 'warning' : 'primary'}
-            />
-            <Chip
-              label={getServerTypeLabel(workboard.serverId?.serverType)}
-              sx={{ bgcolor: getServerTypeColor(workboard.serverId?.serverType), color: 'white' }}
-            />
-          </Box>
-
-          <Box display="flex" flexWrap="wrap" gap={1}>
-            {workboard.baseInputFields?.aiModel?.slice(0, 3).map((model, index) => (
-              <Chip
-                key={index}
-                label={model.key}
-                variant="outlined"
-                sx={{ maxWidth: '100%' }}
-              />
-            ))}
-            {workboard.baseInputFields?.aiModel?.length > 3 && (
-              <Chip
-                label={`+${workboard.baseInputFields.aiModel.length - 3}개`}
-                variant="outlined"
-              />
-            )}
-          </Box>
-        </CardContent>
-
-        <CardActions>
-          <Button
-            onClick={handleInfo}
-            startIcon={<Info />}
-          >
-            상세정보
-          </Button>
-          <Button
-            variant="contained"
-            color={isImageWorkboard ? 'primary' : 'secondary'}
-            onClick={handleSelect}
-            startIcon={<PlayArrow />}
-            sx={{ ml: 'auto' }}
-          >
-            선택하기
-          </Button>
-        </CardActions>
-      </Card>
-
-      {/* 상세정보 다이얼로그 */}
-      <Dialog open={infoOpen} onClose={handleInfoClose} maxWidth="md" fullWidth>
-        <DialogTitle>{workboard.name}</DialogTitle>
-        <DialogContent>
-          <DialogContentText paragraph>
-            {workboard.description || '설명이 없습니다.'}
-          </DialogContentText>
-
-          <Box display="flex" alignItems="center" gap={0.5} mb={2}>
-            <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
-              작업판 ID: {workboard._id}
-            </Typography>
-            <IconButton size="small" onClick={handleCopyWorkboardId} aria-label="작업판 ID 복사">
-              <ContentCopy fontSize="inherit" />
-            </IconButton>
-          </Box>
-
-          <Box display="flex" flexWrap="wrap" gap={1} mb={2}>
-            <Chip
-              label={getOutputFormatLabel(workboard.outputFormat || 'image')}
-              color={workboard.outputFormat === 'text' ? 'secondary' : workboard.outputFormat === 'video' ? 'warning' : 'primary'}
-            />
-            <Chip
-              label={getServerTypeLabel(workboard.serverId?.serverType)}
-              sx={{ bgcolor: getServerTypeColor(workboard.serverId?.serverType), color: 'white' }}
-            />
-          </Box>
-
-          <Typography variant="h6" gutterBottom sx={{ mt: 2 }}>
-            지원 AI 모델
-          </Typography>
-          <Box display="flex" flexWrap="wrap" gap={1} mb={2}>
-            {workboard.baseInputFields?.aiModel?.map((model, index) => (
-              <Chip
-                key={index}
-                label={`${model.key}`}
-                color="primary"
-                variant="outlined"
-              />
-            ))}
-          </Box>
-
-          {isImageWorkboard && workboard.baseInputFields?.imageSizes?.length > 0 && (
-            <>
-              <Typography variant="h6" gutterBottom sx={{ mt: 2 }}>
-                지원 이미지 크기
-              </Typography>
-              <Box display="flex" flexWrap="wrap" gap={1} mb={2}>
-                {workboard.baseInputFields.imageSizes.map((size, index) => (
-                  <Chip
-                    key={index}
-                    label={size.key}
-                    color="secondary"
-                    variant="outlined"
-                  />
-                ))}
-              </Box>
-            </>
-          )}
-
-          {workboard.serverId?.serverType === 'ComfyUI' && workboard.baseInputFields?.referenceImageMethods?.length > 0 && (
-            <>
-              <Typography variant="h6" gutterBottom sx={{ mt: 2 }}>
-                참고 이미지 사용 방식
-              </Typography>
-              <Box display="flex" flexWrap="wrap" gap={1} mb={2}>
-                {workboard.baseInputFields.referenceImageMethods.map((method, index) => (
-                  <Chip
-                    key={index}
-                    label={method.key}
-                    color="info"
-                    variant="outlined"
-                  />
-                ))}
-              </Box>
-            </>
-          )}
-
-          {workboard.serverId?.serverType !== 'ComfyUI' && workboard.baseInputFields?.systemPrompt && (
-            <>
-              <Typography variant="h6" gutterBottom sx={{ mt: 2 }}>
-                시스템 프롬프트
-              </Typography>
-              <Typography variant="body2" color="textSecondary" sx={{
-                whiteSpace: 'pre-wrap',
-                bgcolor: 'action.hover',
-                p: 2,
-                borderRadius: 1,
-                maxHeight: 200,
-                overflow: 'auto'
-              }}>
-                {workboard.baseInputFields.systemPrompt}
-              </Typography>
-            </>
-          )}
-
-          <Box sx={{ mt: 2 }}>
-            <Typography variant="caption" color="textSecondary">
-              생성자: {workboard.createdBy?.nickname || '알 수 없음'}
-            </Typography>
-            <br />
-            <Typography variant="caption" color="textSecondary">
-              버전: {workboard.version || 1}
-            </Typography>
-            <br />
-            <Typography variant="caption" color="textSecondary">
-              생성일: {new Date(workboard.createdAt).toLocaleDateString()}
-            </Typography>
-          </Box>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleInfoClose}>닫기</Button>
-          <Button
-            onClick={handleSelect}
-            variant="contained"
-            color={isImageWorkboard ? 'primary' : 'secondary'}
-            startIcon={<PlayArrow />}
-          >
-            선택하기
-          </Button>
-        </DialogActions>
-      </Dialog>
-    </>
+          <IconButton size="small" onClick={copyId}><ContentCopy fontSize="inherit" /></IconButton>
+        </Box>
+        <Typography variant="caption" color="text.secondary" display="block">서버: {workboard.serverId?.name || '미설정'}</Typography>
+        <Typography variant="caption" color="text.secondary" display="block">생성자: {workboard.createdBy?.nickname || '알 수 없음'}</Typography>
+        <Typography variant="caption" color="text.secondary" display="block">버전: v{workboard.version || 1}</Typography>
+        {workboard.createdAt && (
+          <Typography variant="caption" color="text.secondary" display="block">생성일: {new Date(workboard.createdAt).toLocaleDateString()}</Typography>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>닫기</Button>
+        <Button variant="contained" startIcon={<PlayArrow />} onClick={() => onSelect(workboard)}>선택하기</Button>
+      </DialogActions>
+    </Dialog>
   );
 }
 
 function Workboards() {
+  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const projectId = searchParams.get('projectId');
-  const [search, setSearch] = useState('');
-  const [page, setPage] = useState(1);
-  const [outputFormat, setOutputFormat] = useState(
-    () => localStorage.getItem('workboardFilter_outputFormat') || ''
-  );
-  const [serverType, setServerType] = useState(
-    () => localStorage.getItem('workboardFilter_serverType') || ''
-  );
+  const [detailWb, setDetailWb] = useState(null);
 
-  // 프로젝트 컨텍스트
   const { data: projectData } = useQuery(
     ['project', projectId],
     () => projectAPI.getById(projectId),
@@ -330,179 +108,71 @@ function Workboards() {
   );
   const projectContext = projectData?.data?.data?.project;
 
-  const { data: profileData } = useQuery(
-    'userProfile',
-    () => userAPI.getProfile(),
-    { staleTime: 5 * 60 * 1000 }
-  );
-
-  useEffect(() => {
-    const prefs = profileData?.data?.user?.preferences;
-    if (!prefs) return;
-
-    if (prefs.resetWorkboardOutputFormat) {
-      setOutputFormat('');
-      localStorage.removeItem('workboardFilter_outputFormat');
-    }
-    if (prefs.resetWorkboardApiFormat) {
-      setServerType('');
-      localStorage.removeItem('workboardFilter_serverType');
-      // legacy 키 정리
-      localStorage.removeItem('workboardFilter_apiFormat');
-    }
-  }, [profileData]);
-
-  const queryParams = { search, page, limit: 12 };
-  if (outputFormat) queryParams.outputFormat = outputFormat;
-  if (serverType) queryParams.serverType = serverType;
-
   const { data, isLoading, error } = useQuery(
-    ['workboards', queryParams],
-    () => workboardAPI.getAll(queryParams),
+    'workboardsCatalog',
+    () => workboardAPI.getAll({ limit: 500 }),
     { keepPreviousData: true }
   );
-
   const workboards = data?.data?.workboards || [];
-  const pagination = data?.data?.pagination || {};
 
-  const handleSearchChange = (event) => {
-    setSearch(event.target.value);
-    setPage(1);
-  };
+  const { q, setQ, outSel, svcSel, toggleOut, toggleSvc, clear, counts, filtered } = useWorkboardFilter(workboards);
 
-  const handleOutputFormatChange = (event) => {
-    const value = event.target.value;
-    setOutputFormat(value);
-    setPage(1);
-    if (value) {
-      localStorage.setItem('workboardFilter_outputFormat', value);
-    } else {
-      localStorage.removeItem('workboardFilter_outputFormat');
-    }
-  };
-
-  const handleServerTypeChange = (event) => {
-    const value = event.target.value;
-    setServerType(value);
-    setPage(1);
-    if (value) {
-      localStorage.setItem('workboardFilter_serverType', value);
-    } else {
-      localStorage.removeItem('workboardFilter_serverType');
-    }
-  };
+  const handleSelect = (wb) => { setDetailWb(null); selectWorkboard(wb, projectId, navigate); };
 
   if (error) {
-    return (
-      <Container maxWidth="xl" sx={{ mt: 4 }}>
-        <Alert severity="error">
-          작업판을 불러오는 중 오류가 발생했습니다: {error.message}
-        </Alert>
-      </Container>
-    );
+    return <Box sx={{ maxWidth: 1100, mx: 'auto' }}><Alert severity="error">작업판을 불러오는 중 오류가 발생했습니다: {error.message}</Alert></Box>;
   }
 
   return (
-    <Container maxWidth="xl" sx={{ mt: 4, mb: 4 }}>
-      <Box mb={4}>
-        <Typography variant="h4" gutterBottom>
-          작업판 선택
-        </Typography>
-        <Typography variant="body1" color="textSecondary" gutterBottom>
-          사용할 작업판을 선택하세요. 각 작업판은 서로 다른 AI 모델과 설정을 제공합니다.
+    <Box sx={{ maxWidth: 1100, mx: 'auto' }}>
+      <Box sx={{ mb: 2.5 }}>
+        <Typography variant="h1">작업판</Typography>
+        <Typography variant="body1" color="text.secondary" sx={{ textWrap: 'pretty', mt: 0.5 }}>
+          한 번의 호출로 실행하는 단위. 파이프라인의 단계로도 사용됩니다.
         </Typography>
         {projectContext && (
-          <Chip
-            label={`프로젝트: ${projectContext.name}`}
-            color="primary"
-            variant="outlined"
-            sx={{ mt: 1 }}
-          />
+          <Chip label={`프로젝트: ${projectContext.name}`} color="primary" variant="outlined" size="small" sx={{ mt: 1 }} />
         )}
       </Box>
 
-      {/* 검색 및 필터 */}
-      <Box mb={4} display="flex" gap={2} flexWrap="wrap" alignItems="center">
-        <TextField
-          placeholder="작업판 이름이나 설명으로 검색..."
-          value={search}
-          onChange={handleSearchChange}
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <Search />
-              </InputAdornment>
-            ),
-          }}
-          sx={{ minWidth: 300, flex: 1, maxWidth: 500 }}
-        />
-        <FormControl sx={{ minWidth: 150 }} size="small">
-          <InputLabel>출력 형식</InputLabel>
-          <Select
-            value={outputFormat}
-            onChange={handleOutputFormatChange}
-            label="출력 형식"
-          >
-            <MenuItem value="">전체</MenuItem>
-            <MenuItem value="image">이미지</MenuItem>
-            <MenuItem value="video">비디오</MenuItem>
-            <MenuItem value="text">텍스트</MenuItem>
-          </Select>
-        </FormControl>
-        <FormControl sx={{ minWidth: 180 }} size="small">
-          <InputLabel>서버 타입</InputLabel>
-          <Select
-            value={serverType}
-            onChange={handleServerTypeChange}
-            label="서버 타입"
-          >
-            <MenuItem value="">전체</MenuItem>
-            <MenuItem value="ComfyUI">ComfyUI</MenuItem>
-            <MenuItem value="OpenAI">OpenAI</MenuItem>
-            <MenuItem value="OpenAI Compatible">OpenAI Compatible</MenuItem>
-            <MenuItem value="Gemini">Gemini</MenuItem>
-          </Select>
-        </FormControl>
-      </Box>
+      <WorkboardFilters
+        q={q} setQ={setQ}
+        outSel={outSel} toggleOut={toggleOut}
+        svcSel={svcSel} toggleSvc={toggleSvc}
+        counts={counts} total={workboards.length} shown={filtered.length}
+        onClear={clear}
+      />
 
-      {/* 작업판 목록 */}
       {isLoading ? (
-        <Box display="flex" justifyContent="center" mt={8}>
-          <CircularProgress />
-        </Box>
-      ) : workboards.length === 0 ? (
-        <Alert severity="info">
-          {search || outputFormat || serverType ? '검색 결과가 없습니다.' : '사용 가능한 작업판이 없습니다.'}
-        </Alert>
+        <Box display="flex" justifyContent="center" mt={8}><CircularProgress /></Box>
+      ) : filtered.length === 0 ? (
+        <Paper variant="outlined" sx={{ p: 5, textAlign: 'center', borderStyle: 'dashed' }}>
+          <Inventory2 sx={{ fontSize: 32, color: 'text.disabled', mb: 1.5 }} />
+          <Typography sx={{ fontWeight: 600, mb: 0.5 }}>조건에 맞는 작업판이 없습니다</Typography>
+          <Typography variant="body2" color="text.secondary">
+            {workboards.length === 0 ? '사용 가능한 작업판이 없습니다.' : '필터를 줄이거나 초기화해 보세요.'}
+          </Typography>
+        </Paper>
       ) : (
-        <>
-          <Grid container spacing={3}>
-            {workboards.map((workboard) => (
-              <Grid item xs={12} sm={6} md={4} key={workboard._id}>
-                <WorkboardCard workboard={workboard} projectId={projectId} />
-              </Grid>
-            ))}
-          </Grid>
-
-          {/* 페이지네이션 */}
-          {pagination.pages > 1 && (
-            <Box display="flex" justifyContent="center" mt={4}>
-              <Box display="flex" gap={1}>
-                {Array.from({ length: pagination.pages }, (_, i) => i + 1).map((pageNum) => (
-                  <Button
-                    key={pageNum}
-                    variant={pageNum === page ? "contained" : "outlined"}
-                    onClick={() => setPage(pageNum)}
-                  >
-                    {pageNum}
-                  </Button>
-                ))}
-              </Box>
-            </Box>
-          )}
-        </>
+        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: 'repeat(auto-fill, minmax(300px, 1fr))' }, gap: 1.5 }}>
+          {filtered.map((wb) => (
+            <WorkboardCard
+              key={wb._id}
+              wb={wb}
+              onClick={() => handleSelect(wb)}
+              onInfo={(w) => setDetailWb(w)}
+            />
+          ))}
+        </Box>
       )}
-    </Container>
+
+      <WorkboardDetailDialog
+        workboard={detailWb}
+        open={!!detailWb}
+        onClose={() => setDetailWb(null)}
+        onSelect={handleSelect}
+      />
+    </Box>
   );
 }
 

--- a/src/routes/workboards.js
+++ b/src/routes/workboards.js
@@ -64,6 +64,7 @@ router.get('/', requireAuth, async (req, res) => {
     const workboards = await Workboard.find(filter)
       .populate('createdBy', 'nickname email')
       .populate('serverId', 'name serverType serverUrl isActive')
+      .populate('allowedGroupIds', 'name')
       .select('-workflowData')
       .sort({ usageCount: -1, createdAt: -1 })
       .skip(skip)


### PR DESCRIPTION
갱신된 핸드오프(#461) 기준 세 페이지 UI 적용.

## 작업판 목록(사용자) + 작업판 관리(admin)
- 신규 공유 컴포넌트 `components/common/WorkboardCatalog.js`: 카드 + 2축 필터(출력형식×서버타입) + `useWorkboardFilter`
- 종류 아이콘(SDXL/GPT/I2V…)은 outputFormat+serverType 로 유도
- 목록: 카드 클릭 실행 + 상세정보 + 계속하기 연동 유지
- 관리: 상태 필터(전체/게시됨/보관) + 허용 그룹 칩 + 편집/복제/내보내기/활성화/삭제 메뉴 유지
- 백엔드: workboards getAll 에 `allowedGroupIds` 그룹 이름 populate 추가
- 데이터 적응: draft/즐겨찾기/마지막실행 없음(생략), isActive→게시됨/보관

## 서버 관리(admin)
- 요약 카드(서버/온라인/큐) + 컴팩트 서버 카드(타입배지/상태/host/모델·LoRA 동기화)
- 헬스체크/동기화/리셋/편집/삭제 액션 모두 보존
- GPU%·서버별 큐 데이터 없어 생략, 큐 요약은 전체 큐

## 검증
- docker-compose 재빌드(컴파일 에러 0), 3개 페이지 Playwright 렌더 — 콘솔/page 에러 0

design system v1.1 / #461 후속. 사용자 가시 → v3.3.0 릴리스 사이클 포함 예정.

closes #463