### PR TITLE
fix: 상태/종류 칩 원본 톤 칩 스타일로 통일 (#469)

### DIFF
--- a/frontend/src/components/admin/ServerManagement.js
+++ b/frontend/src/components/admin/ServerManagement.js
@@ -45,6 +45,7 @@ import { useQuery, useMutation, useQueryClient } from 'react-query';
 import toast from 'react-hot-toast';
 import { serverAPI, jobAPI } from '../../services/api';
 import { getServerTypeColor } from '../../templates/capabilities';
+import { ToneChip, TagChip } from '../common/WorkboardCatalog';
 
 // 공식 base URL 이 알려진 provider — 서버 추가 시 자동 입력 (사용자 입력 우선)
 const KNOWN_SERVER_URLS = {
@@ -138,8 +139,8 @@ function ServerCard({
   const MONO = '"JetBrains Mono","SF Mono",Menlo,monospace';
   const statusKey = server.healthCheck?.status;
   const statusChip = statusKey === 'healthy'
-    ? { color: 'success', label: 'online' }
-    : statusKey === 'unhealthy' ? { color: 'error', label: 'offline' } : { color: undefined, label: 'unknown' };
+    ? { tone: 'success', label: 'online' }
+    : statusKey === 'unhealthy' ? { tone: 'error', label: 'offline' } : { tone: 'neutral', label: 'unknown' };
   const typeColor = getServerTypeColor(server.serverType);
   const abbr = ((server.serverType || 'SRV').replace(/[^A-Za-z]/g, '').slice(0, 3) || 'SRV').toUpperCase();
   const lastSync = modelSyncStatus?.lastMetadataSync || loraSyncStatus?.lastCivitaiSync || server.healthCheck?.lastChecked;
@@ -154,9 +155,9 @@ function ServerCard({
         <Box sx={{ flex: 1, minWidth: 180 }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flexWrap: 'wrap' }}>
             <Typography sx={{ fontWeight: 600, fontSize: 14 }}>{server.name}</Typography>
-            <Chip size="small" variant="outlined" label={getServerTypeLabel(server.serverType)} sx={{ height: 20, fontSize: 10.5 }} />
-            <Chip size="small" variant="outlined" color={statusChip.color} label={statusChip.label} sx={{ height: 20, fontSize: 10.5 }} />
-            {!server.isActive && <Chip size="small" label="비활성" sx={{ height: 20, fontSize: 10.5 }} />}
+            <TagChip label={getServerTypeLabel(server.serverType)} />
+            <ToneChip tone={statusChip.tone} label={statusChip.label} mono />
+            {!server.isActive && <ToneChip tone="neutral" label="비활성" />}
           </Box>
           <Typography sx={{ fontSize: 12, color: 'text.disabled', fontFamily: MONO, mt: 0.25 }} noWrap>{server.serverUrl}</Typography>
         </Box>

--- a/frontend/src/components/common/WorkboardCatalog.js
+++ b/frontend/src/components/common/WorkboardCatalog.js
@@ -53,7 +53,50 @@ export const SERVER_AXIS = [
   { k: 'openai', label: 'OpenAI' },
   { k: 'gemini', label: 'Gemini' },
 ];
-const OUT_CHIP_COLOR = { image: 'primary', video: 'warning', text: 'info' };
+const OUT_TONE = { image: 'accent', video: 'warning', text: 'info' };
+
+// 원본 .chip--tag 톤 칩 — 은은한 틴트 배경 + 진한 글씨 (height 20, padding 0 7px, 11.5px).
+// 상태/출력 등 의미 색이 있는 칩에 사용. light/dark 양쪽 테마 토큰 기반.
+const TONE_SX = {
+  success: { bgcolor: 'success.light', color: 'success.main' },
+  info: { bgcolor: 'info.light', color: 'info.main' },
+  warning: { bgcolor: 'warning.light', color: 'warning.main' },
+  error: { bgcolor: 'error.light', color: 'error.main' },
+  accent: { bgcolor: (t) => (t.palette.mode === 'dark' ? 'rgba(118,118,224,0.22)' : 'rgba(91,91,214,0.12)'), color: 'primary.main' },
+  neutral: { bgcolor: 'grey.100', color: 'text.secondary' },
+};
+export function ToneChip({ tone, label, mono, sx }) {
+  const ts = TONE_SX[tone] || TONE_SX.neutral;
+  return (
+    <Chip
+      size="small"
+      variant="filled"
+      label={label}
+      sx={{
+        height: 20, fontSize: '11.5px', fontWeight: 500, border: 0,
+        ...(mono && { fontFamily: MONO, fontSize: '10.5px' }),
+        '& .MuiChip-label': { px: '7px' },
+        ...ts, ...sx,
+      }}
+    />
+  );
+}
+// 의미 색 없는 태그 칩 — 투명 배경 + 옅은 테두리 + tertiary 글씨 (종류 라벨 등).
+export function TagChip({ label, mono, sx }) {
+  return (
+    <Chip
+      size="small"
+      variant="outlined"
+      label={label}
+      sx={{
+        height: 20, fontSize: mono ? '10px' : '11px', bgcolor: 'transparent',
+        borderColor: 'divider', color: 'grey.600',
+        ...(mono && { fontFamily: MONO }),
+        '& .MuiChip-label': { px: '7px' }, ...sx,
+      }}
+    />
+  );
+}
 
 // ── 필터 로직 훅 ─────────────────────────────────────────────
 export function useWorkboardFilter(workboards) {
@@ -158,15 +201,7 @@ export function WorkboardFilters({ q, setQ, outSel, toggleOut, svcSel, toggleSvc
 }
 
 function WbStatusBadge({ isActive }) {
-  return (
-    <Chip
-      size="small"
-      variant="outlined"
-      color={isActive ? 'success' : undefined}
-      label={isActive ? '게시됨' : '보관'}
-      sx={{ height: 18, fontSize: 10.5, ...(isActive ? {} : { color: 'text.disabled' }) }}
-    />
-  );
+  return <ToneChip tone={isActive ? 'success' : 'neutral'} label={isActive ? '게시됨' : '보관'} />;
 }
 
 // ── 공유 카드 ───────────────────────────────────────────────
@@ -202,8 +237,7 @@ export function WorkboardCard({ wb, admin, onClick, onEdit, onMenu, onInfo, grou
             {kind.label}{wb.version ? ` · v${wb.version}` : ''}
           </Typography>
         </Box>
-        <Chip size="small" variant="outlined" color={OUT_CHIP_COLOR[out]} label={out}
-          sx={{ flex: '0 0 auto', height: 20, fontSize: 10.5, fontFamily: MONO }} />
+        <ToneChip tone={OUT_TONE[out]} label={out} mono sx={{ flex: '0 0 auto' }} />
       </Box>
 
       {/* description */}
@@ -217,7 +251,7 @@ export function WorkboardCard({ wb, admin, onClick, onEdit, onMenu, onInfo, grou
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexWrap: 'wrap' }}>
           <Typography sx={{ fontSize: 10.5, color: 'text.disabled' }}>허용</Typography>
           {groupNames.map((g) => (
-            <Chip key={g} size="small" variant="outlined" label={g} sx={{ height: 18, fontSize: 10.5 }} />
+            <TagChip key={g} label={g} />
           ))}
         </Box>
       )}

--- a/frontend/src/pages/JobHistory.js
+++ b/frontend/src/pages/JobHistory.js
@@ -49,6 +49,7 @@ import ImageViewerDialog from '../components/common/ImageViewerDialog';
 import VideoViewerDialog from '../components/common/VideoViewerDialog';
 import WorkboardSelectDialog from '../components/common/WorkboardSelectDialog';
 import { SavePromptDialog, JobDetailDialog } from '../components/common/JobHistoryPanel';
+import { ToneChip, TagChip } from '../components/common/WorkboardCatalog';
 
 const MONO = '"JetBrains Mono","SF Mono",Menlo,monospace';
 const TYPE_LABEL = { pipeline: '파이프라인', image: '이미지', video: '영상', text: '텍스트' };
@@ -66,23 +67,15 @@ function mapStatus(s) {
   }
 }
 const STATUS_CFG = {
-  done: { color: 'success', label: '완료' },
-  running: { color: 'info', label: '실행 중' },
-  error: { color: 'error', label: '실패' },
-  queued: { color: 'default', label: '대기' },
-  cancelled: { color: 'default', label: '취소' },
+  done: { tone: 'success', label: '완료' },
+  running: { tone: 'info', label: '실행 중' },
+  error: { tone: 'error', label: '실패' },
+  queued: { tone: 'neutral', label: '대기' },
+  cancelled: { tone: 'neutral', label: '취소' },
 };
 function StatusChip({ status }) {
   const cfg = STATUS_CFG[status] || STATUS_CFG.done;
-  return (
-    <Chip
-      size="small"
-      variant="outlined"
-      color={cfg.color === 'default' ? undefined : cfg.color}
-      label={cfg.label}
-      sx={{ height: 20, fontSize: 11 }}
-    />
-  );
+  return <ToneChip tone={cfg.tone} label={cfg.label} />;
 }
 
 // ---- 필드 추출 ----------------------------------------------------------
@@ -273,8 +266,7 @@ function HistoryRow({ item, onOpenMedia, onMenu, onContinue, onCross, onTextCont
             <Typography variant="body2" sx={{ fontWeight: 600 }} noWrap>
               {item.title}
             </Typography>
-            <Chip size="small" variant="outlined" label={TYPE_LABEL[item.type]}
-              sx={{ height: 18, fontSize: 10, fontFamily: MONO, color: 'text.secondary' }} />
+            <TagChip label={TYPE_LABEL[item.type]} mono />
             <StatusChip status={item.status} />
           </Box>
 


### PR DESCRIPTION
상태 칩(완료/online 등)을 외곽선→은은한 틴트 톤 칩으로, 종류 칩을 원본 .chip--tag 스펙으로 통일. 공유 ToneChip/TagChip 추가 후 히스토리·작업판·서버 카드에 적용. 검증: 렌더 콘솔 에러 0. closes #469