### PR TITLE
fix: 톤/태그 칩 크기 통일 + 좌우 패딩 확대 (#470)

### DIFF
--- a/frontend/src/components/common/WorkboardCatalog.js
+++ b/frontend/src/components/common/WorkboardCatalog.js
@@ -73,9 +73,9 @@ export function ToneChip({ tone, label, mono, sx }) {
       variant="filled"
       label={label}
       sx={{
-        height: 20, fontSize: '11.5px', fontWeight: 500, border: 0,
-        ...(mono && { fontFamily: MONO, fontSize: '10.5px' }),
-        '& .MuiChip-label': { px: '7px' },
+        height: 22, fontSize: '11.5px', fontWeight: 500, border: 0,
+        ...(mono && { fontFamily: MONO, fontSize: '11px' }),
+        '& .MuiChip-label': { px: '9px' },
         ...ts, ...sx,
       }}
     />
@@ -89,10 +89,10 @@ export function TagChip({ label, mono, sx }) {
       variant="outlined"
       label={label}
       sx={{
-        height: 20, fontSize: mono ? '10px' : '11px', bgcolor: 'transparent',
+        height: 22, fontSize: mono ? '10.5px' : '11.5px', bgcolor: 'transparent',
         borderColor: 'divider', color: 'grey.600',
         ...(mono && { fontFamily: MONO }),
-        '& .MuiChip-label': { px: '7px' }, ...sx,
+        '& .MuiChip-label': { px: '9px' }, ...sx,
       }}
     />
   );

--- a/frontend/src/pages/JobHistory.js
+++ b/frontend/src/pages/JobHistory.js
@@ -266,7 +266,7 @@ function HistoryRow({ item, onOpenMedia, onMenu, onContinue, onCross, onTextCont
             <Typography variant="body2" sx={{ fontWeight: 600 }} noWrap>
               {item.title}
             </Typography>
-            <TagChip label={TYPE_LABEL[item.type]} mono />
+            <TagChip label={TYPE_LABEL[item.type]} />
             <StatusChip status={item.status} />
           </Box>
 


### PR DESCRIPTION
칩 높이 20→22, 좌우 패딩 7→9px, 폰트 통일, 한국어 종류 칩 mono 제거. 상태/종류 칩 크기 일치. closes #470