### PR TITLE
fix: HTTP 환경 클립보드 복사 fallback — 작업판 ID 복사 실패 해결 (#477)

### DIFF
--- a/frontend/src/pages/ImageGeneration.js
+++ b/frontend/src/pages/ImageGeneration.js
@@ -46,6 +46,7 @@ import { useForm, Controller } from 'react-hook-form';
 import { useDropzone } from 'react-dropzone';
 import toast from 'react-hot-toast';
 import { workboardAPI, jobAPI, imageAPI, promptDataAPI, userAPI, projectAPI } from '../services/api';
+import { copyToClipboard } from '../utils/clipboard';
 import MetadataPickerModal from '../components/common/MetadataPickerModal';
 import MetadataFieldInput from '../components/common/MetadataFieldInput';
 import { extractLoraName, insertLoraTag, insertTriggerWordWithLora } from '../utils/promptUtils';
@@ -403,7 +404,7 @@ function ImageGeneration() {
     if (!workboardData?._id) return;
 
     try {
-      await navigator.clipboard.writeText(workboardData._id);
+      await copyToClipboard(workboardData._id);
       toast.success('작업판 ID를 복사했습니다.');
     } catch (error) {
       toast.error('작업판 ID 복사에 실패했습니다.');

--- a/frontend/src/pages/PromptGeneration.js
+++ b/frontend/src/pages/PromptGeneration.js
@@ -17,6 +17,7 @@ import {
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { useQuery } from 'react-query';
 import { workboardAPI } from '../services/api';
+import { copyToClipboard } from '../utils/clipboard';
 import PromptGeneratorPanel from '../components/PromptGeneratorPanel';
 import ConversationChatPanel from '../components/common/ConversationChatPanel';
 import WorkboardChatPanel from '../components/common/WorkboardChatPanel';
@@ -52,7 +53,7 @@ function PromptGeneration() {
     if (!workboard?._id) return;
 
     try {
-      await navigator.clipboard.writeText(workboard._id);
+      await copyToClipboard(workboard._id);
       toast.success('작업판 ID를 복사했습니다.');
     } catch (error) {
       toast.error('작업판 ID 복사에 실패했습니다.');

--- a/frontend/src/pages/PromptWorkboards.js
+++ b/frontend/src/pages/PromptWorkboards.js
@@ -32,6 +32,7 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { useQuery } from 'react-query';
 import { workboardAPI } from '../services/api';
+import { copyToClipboard } from '../utils/clipboard';
 import toast from 'react-hot-toast';
 
 function PromptWorkboardCard({ workboard }) {
@@ -52,7 +53,7 @@ function PromptWorkboardCard({ workboard }) {
 
   const handleCopyWorkboardId = async () => {
     try {
-      await navigator.clipboard.writeText(workboard._id);
+      await copyToClipboard(workboard._id);
       toast.success('작업판 ID를 복사했습니다.');
     } catch (error) {
       toast.error('작업판 ID 복사에 실패했습니다.');

--- a/frontend/src/pages/WorkboardCatalogPage.js
+++ b/frontend/src/pages/WorkboardCatalogPage.js
@@ -42,6 +42,7 @@ import {
   useWorkboardFilter,
 } from '../components/common/WorkboardCatalog';
 import { WorkboardImportDialog } from '../components/admin/WorkboardManagement';
+import { copyToClipboard } from '../utils/clipboard';
 
 const MONO = '"JetBrains Mono","SF Mono",Menlo,monospace';
 
@@ -70,7 +71,7 @@ function selectWorkboard(workboard, projectId, navigate) {
 function WorkboardDetailDialog({ workboard, open, onClose, onSelect }) {
   if (!workboard) return null;
   const copyId = async () => {
-    try { await navigator.clipboard.writeText(workboard._id); toast.success('작업판 ID를 복사했습니다.'); }
+    try { await copyToClipboard(workboard._id); toast.success('작업판 ID를 복사했습니다.'); }
     catch { toast.error('작업판 ID 복사에 실패했습니다.'); }
   };
   return (

--- a/frontend/src/utils/clipboard.js
+++ b/frontend/src/utils/clipboard.js
@@ -1,0 +1,37 @@
+// 클립보드 복사 — navigator.clipboard 가 비보안 컨텍스트(HTTP)·권한정책 등으로
+// 막힌 환경에서도 동작하도록 execCommand fallback 을 제공.
+// navigator.clipboard.writeText 의 drop-in 대체 (Promise 반환, 실패 시 reject).
+export async function copyToClipboard(text) {
+  const value = text == null ? '' : String(text);
+
+  // 1순위: 표준 Clipboard API (보안 컨텍스트에서만 사용 가능)
+  if (navigator.clipboard && window.isSecureContext) {
+    try {
+      await navigator.clipboard.writeText(value);
+      return true;
+    } catch (e) {
+      // 권한정책 / 포커스 문제 등 — fallback 으로
+    }
+  }
+
+  // 2순위: execCommand fallback (HTTP / 구형 브라우저)
+  try {
+    const ta = document.createElement('textarea');
+    ta.value = value;
+    ta.setAttribute('readonly', '');
+    ta.style.position = 'fixed';
+    ta.style.top = '-1000px';
+    ta.style.opacity = '0';
+    document.body.appendChild(ta);
+    ta.select();
+    ta.setSelectionRange(0, value.length);
+    const ok = document.execCommand('copy');
+    document.body.removeChild(ta);
+    if (ok) return true;
+    throw new Error('execCommand copy returned false');
+  } catch (e) {
+    throw new Error('클립보드 복사를 지원하지 않는 환경입니다.');
+  }
+}
+
+export default copyToClipboard;


### PR DESCRIPTION
navigator.clipboard 가 막힌 비보안 컨텍스트에서 execCommand fallback 으로 복사 동작. utils/clipboard.js + 작업판 ID 복사 4경로 적용. closes #477