### PR TITLE
fix(v3.3.1): 재디자인 화면 패딩 보정 + 프로젝트 커버 이미지 복구 (#481)

### DIFF
--- a/frontend/src/components/admin/ServerManagement.js
+++ b/frontend/src/components/admin/ServerManagement.js
@@ -146,8 +146,8 @@ function ServerCard({
   const lastSync = modelSyncStatus?.lastMetadataSync || loraSyncStatus?.lastCivitaiSync || server.healthCheck?.lastChecked;
 
   return (
-    <Paper variant="outlined" sx={{ p: 2, opacity: server.isActive ? 1 : 0.7 }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap' }}>
+    <Paper variant="outlined" sx={{ p: '14px 16px', opacity: server.isActive ? 1 : 0.7 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2.5, flexWrap: 'wrap' }}>
         <Box sx={{ width: 36, height: 36, borderRadius: 1.5, flex: '0 0 auto', bgcolor: typeColor, color: '#fff',
           display: 'grid', placeItems: 'center', fontSize: 11, fontWeight: 700, fontFamily: MONO }}>
           {abbr}
@@ -719,7 +719,7 @@ function ServerManagement() {
 
   return (
     <Box>
-      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.5, flexWrap: 'wrap', mb: 2 }}>
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 3, flexWrap: 'wrap', mb: 4 }}>
         <Box sx={{ flex: 1, minWidth: 0 }}>
           <Typography variant="h1">서버 관리</Typography>
           <Typography variant="body1" color="text.secondary" sx={{ textWrap: 'pretty', mt: 0.5 }}>
@@ -733,13 +733,13 @@ function ServerManagement() {
       </Box>
 
       {/* 요약 */}
-      <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 1.5, mb: 2.5 }}>
+      <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 3, mb: 4.5 }}>
         {[
           { label: '서버', value: servers.length, suffix: '등록' },
           { label: '온라인', value: `${onlineCount} / ${servers.length}`, color: 'success.main' },
           { label: '실행 중 큐', value: activeQueue },
         ].map((st) => (
-          <Paper key={st.label} variant="outlined" sx={{ p: 1.75 }}>
+          <Paper key={st.label} variant="outlined" sx={{ p: 3.5 }}>
             <Typography sx={{ fontSize: 11, color: 'text.disabled', textTransform: 'uppercase', letterSpacing: '0.06em' }}>{st.label}</Typography>
             <Typography sx={{ fontSize: 24, fontWeight: 700, mt: 0.5, color: st.color }}>
               {st.value}{st.suffix && <Box component="span" sx={{ fontSize: 12, color: 'text.disabled', ml: 0.5 }}>{st.suffix}</Box>}
@@ -753,7 +753,7 @@ function ServerManagement() {
           <Typography variant="body2" color="text.secondary">등록된 서버가 없습니다. 서버를 추가해주세요.</Typography>
         </Box>
       ) : (
-        <Stack spacing={1.25}>
+        <Stack spacing={2.5}>
           {servers.map((server) => (
             <ServerCard
               key={server._id}

--- a/frontend/src/components/common/WorkboardCatalog.js
+++ b/frontend/src/components/common/WorkboardCatalog.js
@@ -161,10 +161,10 @@ export function WorkboardFilters({ q, setQ, outSel, toggleOut, svcSel, toggleSvc
   return (
     <Paper
       variant="outlined"
-      sx={{ bgcolor: 'background.default', p: { xs: 1.5, sm: '12px 14px' }, mb: 2.5, display: 'flex', flexDirection: 'column', gap: 1.5 }}
+      sx={{ bgcolor: 'background.default', p: { xs: 3, sm: '12px 14px' }, mb: 4.5, display: 'flex', flexDirection: 'column', gap: 2.75 }}
     >
       {/* search */}
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2.5 }}>
         <Paper variant="outlined" sx={{ flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', px: 1, height: 34, bgcolor: 'background.paper' }}>
           <Search fontSize="small" sx={{ color: 'text.disabled', mr: 0.5 }} />
           <InputBase value={q} onChange={(e) => setQ(e.target.value)} placeholder="작업판 이름 · 설명 검색" sx={{ flex: 1, fontSize: 13 }} />
@@ -175,8 +175,8 @@ export function WorkboardFilters({ q, setQ, outSel, toggleOut, svcSel, toggleSvc
       </Box>
 
       {/* two axes */}
-      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: { xs: 1.25, sm: 2.25 }, alignItems: 'center' }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: { xs: 2.5, sm: 4.5 }, alignItems: 'center' }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
           <Typography sx={{ fontSize: 11, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'text.disabled' }}>출력</Typography>
           {OUTPUT_AXIS.map((o) => (
             <FilterToggle key={o.k} active={outSel.includes(o.k)} onClick={() => toggleOut(o.k)} count={counts.out[o.k] || 0}>{o.label}</FilterToggle>
@@ -217,14 +217,14 @@ export function WorkboardCard({ wb, admin, onClick, onEdit, onMenu, onInfo, grou
       variant="outlined"
       onClick={admin ? undefined : onClick}
       sx={{
-        p: 2, display: 'flex', flexDirection: 'column', gap: 1.25, height: '100%',
+        p: 3.5, display: 'flex', flexDirection: 'column', gap: 2.5, height: '100%',
         cursor: admin ? 'default' : 'pointer', opacity: archived ? 0.72 : 1,
         transition: 'border-color 150ms, box-shadow 150ms',
         '&:hover': admin ? {} : { borderColor: 'primary.main', boxShadow: 2 },
       }}
     >
       {/* header */}
-      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.25 }}>
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2.5 }}>
         <Box sx={{ width: 32, height: 32, borderRadius: 1.5, bgcolor: kind.tint, color: kind.color, display: 'grid', placeItems: 'center', flex: '0 0 auto' }}>
           <KindIcon sx={{ fontSize: 18 }} />
         </Box>
@@ -257,7 +257,7 @@ export function WorkboardCard({ wb, admin, onClick, onEdit, onMenu, onInfo, grou
       )}
 
       {/* stats row */}
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25, pt: 1.25, mt: 'auto',
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2.5, pt: 2.5, mt: 'auto',
         borderTop: '1px solid', borderColor: 'divider', fontSize: 11, color: 'text.disabled', fontFamily: MONO }}>
         <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
           <Box sx={{ width: 6, height: 6, borderRadius: '50%', bgcolor: archived ? 'text.disabled' : 'success.main', flex: '0 0 auto' }} />

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -297,12 +297,12 @@ function Dashboard() {
         sx={{
           display: 'grid',
           gridTemplateColumns: { xs: '1fr', md: '1.4fr 1fr' },
-          gap: 2,
+          gap: 4,
           alignItems: 'start',
         }}
       >
         {/* Left column */}
-        <Stack spacing={2}>
+        <Stack spacing={4}>
           {/* Running pipelines */}
           <SectionCard
             icon={
@@ -491,7 +491,7 @@ function Dashboard() {
         </Stack>
 
         {/* Right column */}
-        <Stack spacing={2}>
+        <Stack spacing={4}>
           {/* Generation trend */}
           <Paper variant="outlined" sx={{ p: 3.5 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>

--- a/frontend/src/pages/JobHistory.js
+++ b/frontend/src/pages/JobHistory.js
@@ -530,7 +530,7 @@ function JobHistory() {
   return (
     <Box sx={{ maxWidth: 960, mx: 'auto' }}>
       {/* 헤더 */}
-      <Box sx={{ mb: 3 }}>
+      <Box sx={{ mb: 4.5 }}>
         <Typography variant="h1">작업 히스토리</Typography>
         <Typography variant="body1" color="text.secondary" sx={{ textWrap: 'pretty', mt: 0.5 }}>
           파이프라인 · 이미지 · 영상 · 텍스트 생성 기록을 한 곳에서. 최신순.
@@ -543,12 +543,12 @@ function JobHistory() {
         placeholder="히스토리 검색…"
         value={search}
         onChange={(e) => setSearch(e.target.value)}
-        sx={{ mb: 2, maxWidth: { sm: 360 }, width: '100%' }}
+        sx={{ mb: 3.5, maxWidth: { sm: 360 }, width: '100%' }}
         InputProps={{ startAdornment: <InputAdornment position="start"><Search fontSize="small" /></InputAdornment> }}
       />
 
       {/* 세그먼트 */}
-      <Stack direction="row" spacing={0.5} sx={{ mb: 2.5, overflowX: 'auto', pb: 0.5 }}>
+      <Stack direction="row" spacing={1} sx={{ mb: 4.5, overflowX: 'auto', pb: 0.5 }}>
         {[
           { k: 'all', l: '전체' },
           { k: 'pipeline', l: '파이프라인' },
@@ -581,7 +581,7 @@ function JobHistory() {
           </Typography>
         </Paper>
       ) : (
-        <Stack spacing={1}>
+        <Stack spacing={2}>
           {visible.map((item) => (
             <HistoryRow
               key={`${item.kind}-${item.id}`}

--- a/frontend/src/pages/ProjectList.js
+++ b/frontend/src/pages/ProjectList.js
@@ -137,8 +137,12 @@ function ProjectGridCard({ project, isFav, onOpen, onToggleFav, onMenu }) {
     <Paper variant="outlined" onClick={onOpen}
       sx={{ p: 0, overflow: 'hidden', cursor: 'pointer', transition: 'all 150ms', height: '100%', display: 'flex', flexDirection: 'column',
         '&:hover': { borderColor: 'primary.main', boxShadow: 2 } }}>
-      {/* cover */}
-      <Box sx={{ position: 'relative', height: 120, background: gradientFor(String(project._id)) }}>
+      {/* cover — 설정된 커버 이미지가 있으면 그걸, 없으면 그라데이션 */}
+      <Box sx={{ position: 'relative', height: 120, background: gradientFor(String(project._id)), overflow: 'hidden' }}>
+        {project.coverImage?.url && (
+          <Box component="img" src={project.coverImage.url} alt="" loading="lazy"
+            sx={{ position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover' }} />
+        )}
         <IconButton size="small" onClick={(e) => { e.stopPropagation(); onToggleFav(project); }}
           sx={{ position: 'absolute', top: 6, left: 6, color: isFav ? 'warning.main' : 'rgba(255,255,255,0.85)',
             bgcolor: 'rgba(0,0,0,0.15)', '&:hover': { bgcolor: 'rgba(0,0,0,0.3)' } }}>
@@ -156,7 +160,7 @@ function ProjectGridCard({ project, isFav, onOpen, onToggleFav, onMenu }) {
         </IconButton>
       </Box>
       {/* body */}
-      <Box sx={{ p: 1.75, flex: 1, display: 'flex', flexDirection: 'column' }}>
+      <Box sx={{ p: 3.5, flex: 1, display: 'flex', flexDirection: 'column' }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mb: 0.5 }}>
           <Typography sx={{ fontWeight: 600, fontSize: 14 }} noWrap>{project.name}</Typography>
           <TagPill tag={project.tagId} />
@@ -178,10 +182,14 @@ function ProjectGridCard({ project, isFav, onOpen, onToggleFav, onMenu }) {
 // ── 목록 행 ─────────────────────────────────────────────────
 function ProjectListRow({ project, isFav, onOpen, onToggleFav, onMenu, first }) {
   return (
-    <Box onClick={onOpen} sx={{ px: 2, py: 1.5, display: 'flex', alignItems: 'center', gap: 1.5, cursor: 'pointer',
+    <Box onClick={onOpen} sx={{ px: 3.5, py: 3, display: 'flex', alignItems: 'center', gap: 3, cursor: 'pointer',
       borderTop: first ? 'none' : '1px solid', borderColor: 'divider', '&:hover': { bgcolor: 'action.hover' } }}>
-      <Box sx={{ width: 36, height: 36, borderRadius: 1.5, flex: '0 0 auto', background: gradientFor(String(project._id)),
-        color: '#fff', fontWeight: 700, display: 'grid', placeItems: 'center' }}>{(project.name || '?')[0]}</Box>
+      <Box sx={{ width: 36, height: 36, borderRadius: 1.5, flex: '0 0 auto', overflow: 'hidden', background: gradientFor(String(project._id)),
+        color: '#fff', fontWeight: 700, display: 'grid', placeItems: 'center' }}>
+        {project.coverImage?.url
+          ? <Box component="img" src={project.coverImage.url} alt="" sx={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+          : (project.name || '?')[0]}
+      </Box>
       <Box sx={{ flex: 1, minWidth: 0 }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
           <Typography sx={{ fontWeight: 600, fontSize: 14 }} noWrap>{project.name}</Typography>
@@ -264,7 +272,7 @@ function ProjectList() {
   return (
     <Box sx={{ maxWidth: 1100, mx: 'auto' }}>
       {/* 헤더 */}
-      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.5, flexWrap: 'wrap', mb: 2.5 }}>
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 3, flexWrap: 'wrap', mb: 5 }}>
         <Box sx={{ flex: '1 1 360px', minWidth: 0 }}>
           <Typography variant="h1">프로젝트</Typography>
           <Typography variant="body1" color="text.secondary" sx={{ textWrap: 'pretty', mt: 0.5 }}>
@@ -278,7 +286,7 @@ function ProjectList() {
       </Box>
 
       {/* 검색 / 필터 */}
-      <Box sx={{ display: 'flex', gap: 1, mb: 2.5, alignItems: 'center', flexWrap: 'wrap' }}>
+      <Box sx={{ display: 'flex', gap: 2, mb: 4.5, alignItems: 'center', flexWrap: 'wrap' }}>
         <Paper variant="outlined" sx={{ display: 'flex', alignItems: 'center', px: 1, height: 34, minWidth: { sm: 300 }, flex: { xs: 1, sm: '0 1 auto' } }}>
           <Search fontSize="small" sx={{ color: 'text.disabled', mr: 0.5 }} />
           <InputBase value={search} onChange={(e) => setSearch(e.target.value)} placeholder="프로젝트 이름 · 태그 · 설명 검색" sx={{ flex: 1, fontSize: 13 }} />
@@ -310,7 +318,7 @@ function ProjectList() {
           {visible.length === 0 && <Box sx={{ p: 4, textAlign: 'center' }}><Typography variant="body2" color="text.secondary">조건에 맞는 프로젝트가 없습니다.</Typography></Box>}
         </Paper>
       ) : (
-        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: 'repeat(auto-fill, minmax(280px, 1fr))' }, gap: 1.75 }}>
+        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: 'repeat(auto-fill, minmax(280px, 1fr))' }, gap: 3.5 }}>
           {visible.map((p) => (
             <ProjectGridCard key={p._id} project={p} isFav={favoriteIds.includes(p._id)}
               onOpen={() => navigate(`/projects/${p._id}`)} onToggleFav={() => favoriteMutation.mutate(p._id)} onMenu={openMenu} />

--- a/frontend/src/pages/WorkboardCatalogPage.js
+++ b/frontend/src/pages/WorkboardCatalogPage.js
@@ -201,7 +201,7 @@ function WorkboardCatalogPage({ admin = false }) {
   return (
     <Box sx={{ maxWidth: 1100, mx: 'auto' }}>
       {/* 헤더 — admin 일 때만 관리 버튼 노출 */}
-      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.5, flexWrap: 'wrap', mb: 2 }}>
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 3, flexWrap: 'wrap', mb: 4 }}>
         <Box sx={{ flex: 1, minWidth: 0 }}>
           <Typography variant="h1">{admin ? '작업판 관리' : '작업판'}</Typography>
           <Typography variant="body1" color="text.secondary" sx={{ textWrap: 'pretty', mt: 0.5 }}>
@@ -223,7 +223,7 @@ function WorkboardCatalogPage({ admin = false }) {
 
       {/* 상태 필터 — admin 전용 축 */}
       {admin && (
-        <Stack direction="row" spacing={0.75} sx={{ mb: 1.5, overflowX: 'auto', pb: 0.5 }}>
+        <Stack direction="row" spacing={1.5} sx={{ mb: 3, overflowX: 'auto', pb: 0.5 }}>
           {[
             { k: 'all', l: '전체', c: statusCounts.all },
             { k: 'active', l: '게시됨', c: statusCounts.active },
@@ -266,7 +266,7 @@ function WorkboardCatalogPage({ admin = false }) {
           {admin && <Button variant="contained" size="small" startIcon={<Add />} onClick={handleCreate}>새 작업판</Button>}
         </Box>
       ) : (
-        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: 'repeat(auto-fill, minmax(300px, 1fr))' }, gap: 1.5 }}>
+        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: 'repeat(auto-fill, minmax(300px, 1fr))' }, gap: 3 }}>
           {filtered.map((wb) => (
             <WorkboardCard
               key={wb._id}


### PR DESCRIPTION
패딩/간격을 디자인 원안 px(카드14·그리드12~14·섹션16~18)에 맞춰 보정(절반으로 잡혀 있던 것). 프로젝트 커버 이미지 표시 복구. 작업판/서버/프로젝트/히스토리/대시보드 렌더 확인, 콘솔 에러 0. closes #481