### PR TITLE
fix: 전체 페이지 패딩 디자인값(32px) + maxWidth 폭제한 제거

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -144,7 +144,10 @@ function MainLayout() {
           flexGrow: 1,
           minWidth: 0, // flex item 이 content intrinsic width 로 늘어나 body 가로 스크롤 유발하는 것 방지 (#383)
           overflowX: 'hidden',
-          p: 3,
+          // 디자인 .vcc-body: padding 24px 32px 48px (모바일 16px). theme.spacing=4 → px/4.
+          pt: { xs: 4, sm: 6 },   // 16 / 24px
+          px: { xs: 4, sm: 8 },   // 16 / 32px
+          pb: { xs: 4, sm: 12 },  // 16 / 48px
           bgcolor: 'background.default',
           minHeight: 'calc(100vh - 64px)'
         }}>

--- a/frontend/src/pages/JobHistory.js
+++ b/frontend/src/pages/JobHistory.js
@@ -528,7 +528,7 @@ function JobHistory() {
   };
 
   return (
-    <Box sx={{ maxWidth: 960, mx: 'auto' }}>
+    <Box>
       {/* 헤더 */}
       <Box sx={{ mb: 4.5 }}>
         <Typography variant="h1">작업 히스토리</Typography>

--- a/frontend/src/pages/ProjectList.js
+++ b/frontend/src/pages/ProjectList.js
@@ -266,11 +266,11 @@ function ProjectList() {
   const openMenu = (e, project) => { setMenuAnchor(e.currentTarget); setMenuProject(project); };
   const closeMenu = () => { setMenuAnchor(null); setMenuProject(null); };
 
-  if (isLoading) return <Box sx={{ maxWidth: 1100, mx: 'auto' }}><Box display="flex" justifyContent="center" mt={8}><CircularProgress /></Box></Box>;
-  if (error) return <Box sx={{ maxWidth: 1100, mx: 'auto' }}><Alert severity="error">프로젝트 목록을 불러올 수 없습니다.</Alert></Box>;
+  if (isLoading) return <Box><Box display="flex" justifyContent="center" mt={8}><CircularProgress /></Box></Box>;
+  if (error) return <Box><Alert severity="error">프로젝트 목록을 불러올 수 없습니다.</Alert></Box>;
 
   return (
-    <Box sx={{ maxWidth: 1100, mx: 'auto' }}>
+    <Box>
       {/* 헤더 */}
       <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 3, flexWrap: 'wrap', mb: 5 }}>
         <Box sx={{ flex: '1 1 360px', minWidth: 0 }}>

--- a/frontend/src/pages/WorkboardCatalogPage.js
+++ b/frontend/src/pages/WorkboardCatalogPage.js
@@ -199,7 +199,7 @@ function WorkboardCatalogPage({ admin = false }) {
   };
 
   return (
-    <Box sx={{ maxWidth: 1100, mx: 'auto' }}>
+    <Box>
       {/* 헤더 — admin 일 때만 관리 버튼 노출 */}
       <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 3, flexWrap: 'wrap', mb: 4 }}>
         <Box sx={{ flex: 1, minWidth: 0 }}>


### PR DESCRIPTION
콘텐츠 패딩을 디자인 .vcc-body(24/32/48px)에 맞춤(기존 24px 사방), 임의 maxWidth 캡 제거. Playwright 측정으로 좌우 32px 확인. #481 후속.