### PR TITLE
feat: LoRA 목록 직접 접근 제거 — 작업판 권한 기반 조회로 일원화 (#485)

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -30,7 +30,6 @@ import Settings from './pages/Settings';
 import TagSearch from './pages/TagSearch';
 import ProjectList from './pages/ProjectList';
 import ProjectDetail from './pages/ProjectDetail';
-import LoraList from './pages/LoraList';
 import {
   AdminDashboardPage,
   UserManagementPage,
@@ -165,7 +164,8 @@ function MainLayout() {
             <Route path="/projects" element={<ProjectList />} />
             <Route path="/projects/:id" element={<ProjectDetail />} />
             <Route path="/tags" element={<TagSearch />} />
-            <Route path="/loras" element={<LoraList />} />
+            {/* LoRA 목록 메뉴 제거 — 이제 작업판 실행 화면에서만 조회. 직접 접근은 작업판으로 리다이렉트 */}
+            <Route path="/loras" element={<Navigate to="/workboards" replace />} />
             <Route path="/profile" element={<Profile />} />
             <Route path="/settings" element={<Settings />} />
             <Route

--- a/frontend/src/components/Sidebar.js
+++ b/frontend/src/components/Sidebar.js
@@ -79,12 +79,6 @@ const menuItems = [
     roles: ['user', 'admin']
   },
   {
-    text: 'LoRA 목록',
-    path: '/loras',
-    icon: <AutoFixHigh />,
-    roles: ['user', 'admin']
-  },
-  {
     text: '설정',
     path: '/settings',
     icon: <Settings />,

--- a/src/routes/servers.js
+++ b/src/routes/servers.js
@@ -465,6 +465,13 @@ router.get('/:id/loras', verifyJWT, async (req, res) => {
         whitelist = wb.loraWhitelist || [];
         if (whitelist.length === 0) whitelist = ['__no_loras_in_whitelist__'];
       }
+    } else if (!req.user?.isAdmin) {
+      // LoRA 직접 목록 접근 제거 — 일반 사용자는 작업판 컨텍스트(권한 + 노출정책) 로만 조회 가능.
+      // admin 만 관리 UI 용으로 작업판 없이 전체 LoRA 조회 허용.
+      return res.status(403).json({
+        success: false,
+        message: '작업판을 통해서만 LoRA 목록을 조회할 수 있습니다.'
+      });
     }
 
     const result = await loraMetadataService.searchServerLoras(server._id, {

--- a/src/routes/workboards.js
+++ b/src/routes/workboards.js
@@ -690,6 +690,11 @@ router.get('/:id/lora-models', requireAuth, async (req, res) => {
       return res.status(403).json({ message: 'Workboard is not active' });
     }
 
+    // 그룹 접근 권한 검사 — LoRA 직접 목록 제거 후, 사용자는 권한 있는 작업판의 LoRA 만 조회 가능 (admin 은 bypass)
+    if (!userHasWorkboardAccess(req.user, workboard)) {
+      return res.status(403).json({ message: '이 작업판에 접근할 권한이 없습니다.' });
+    }
+
     // 서버 정보 확인
     if (!workboard.serverId) {
       return res.status(400).json({ message: 'Workboard has no server configured' });
@@ -707,9 +712,17 @@ router.get('/:id/lora-models', requireAuth, async (req, res) => {
 
     const { search, page = 1, limit = 50 } = req.query;
 
-    // 서버 단위 캐시에서 조회
+    // 작업판의 LoRA 노출 정책 / 화이트리스트 적용 (#198 Phase D — 이 경로에 누락돼 있던 것 보강)
+    let whitelist;
+    if (workboard.loraExposurePolicy === 'whitelist') {
+      whitelist = workboard.loraWhitelist || [];
+      if (whitelist.length === 0) whitelist = ['__no_loras_in_whitelist__'];
+    }
+
+    // 서버 단위 캐시에서 조회 (노출정책 화이트리스트 필터 적용)
     const result = await loraMetadataService.searchServerLoras(server._id, {
       search,
+      whitelist,
       page: parseInt(page),
       limit: parseInt(limit)
     });


### PR DESCRIPTION
## 변경사항
LoRA 목록을 사이드바에서 직접 조회하던 경로를 제거하고, **작업판 권한(그룹) 기반 조회로 일원화**.

### 프론트엔드
- 사이드바 `LoRA 목록` 메뉴 제거
- `/loras` 라우트 → `/workboards` 리다이렉트

### 백엔드 (접근권한 도메인)
- `GET /api/servers/:id/loras`
  - `workboardId` 없이 호출: 일반 사용자 **403**, admin 만 전체 조회 허용(관리 UI)
  - `workboardId` 있을 때: `userHasWorkboardAccess` 그룹 검사 + 노출정책/화이트리스트 적용
- `GET /api/workboards/:id/lora-models`
  - `userHasWorkboardAccess` 그룹 검사 추가
  - 누락돼 있던 LoRA 노출정책/화이트리스트 필터 보강

## 검증 (로컬 docker-compose, 빌드 후 실 API 호출)
| 시나리오 | 기대 | 결과 |
|---|---|---|
| admin, workboardId 없음 | 200 (bypass) | ✅ |
| 일반사용자, workboardId 없음 | 403 | ✅ |
| 일반사용자, 권한 있는 작업판 (두 엔드포인트) | 200 | ✅ |
| 일반사용자, 권한 없는 작업판 (두 엔드포인트) | 403 | ✅ |

closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)