### PR TITLE
feat: 텍스트 챗 응답 SSE 스트리밍 (#490)

### DIFF
--- a/frontend/src/components/PromptGeneratorPanel.js
+++ b/frontend/src/components/PromptGeneratorPanel.js
@@ -25,11 +25,12 @@ import {
   Chat,
   ContentCopy
 } from '@mui/icons-material';
-import { useQuery, useMutation } from 'react-query';
+import { useQuery } from 'react-query';
 import { useForm, Controller } from 'react-hook-form';
 import { useDropzone } from 'react-dropzone';
 import toast from 'react-hot-toast';
-import { workboardAPI, jobAPI, imageAPI } from '../services/api';
+import { workboardAPI, imageAPI } from '../services/api';
+import { useStreamingPrompt } from '../hooks/useStreamingPrompt';
 import MetadataFieldInput from './common/MetadataFieldInput';
 
 function ImageUploadField({ label, description, images, onImagesChange, maxImages = 1 }) {
@@ -145,6 +146,7 @@ function PromptGeneratorPanel({
   const [isGenerating, setIsGenerating] = useState(false);
   const [generatedResult, setGeneratedResult] = useState(null);
   const [referenceImages, setReferenceImages] = useState({});
+  const { send: streamSend, streamingText, isStreaming } = useStreamingPrompt();
 
   const { control, handleSubmit, setValue, formState: { errors } } = useForm({
     defaultValues: {
@@ -169,10 +171,13 @@ function PromptGeneratorPanel({
     }
   }, [generatedResult, onResultChange]);
 
-  const generateMutation = useMutation(
-    async (formData) => {
-      const uploadedImages = {};
-      
+  // 참조 이미지를 먼저 업로드한 뒤 스트리밍 생성 (#490)
+  const onSubmit = async (formData) => {
+    setIsGenerating(true);
+    setGeneratedResult(null);
+
+    let uploadedImages = {};
+    try {
       for (const [fieldName, images] of Object.entries(referenceImages)) {
         if (images && images.length > 0) {
           const imageIds = [];
@@ -190,8 +195,14 @@ function PromptGeneratorPanel({
           uploadedImages[fieldName] = imageIds;
         }
       }
-      
-      const jobData = {
+    } catch (error) {
+      toast.error('이미지 업로드 실패: ' + (error.response?.data?.message || error.message));
+      setIsGenerating(false);
+      return;
+    }
+
+    streamSend(
+      {
         workboardId: workboard._id,
         // #396: 프로젝트 컨텍스트 / 세계관 적용 (단일 샷 모드)
         projectId: projectId || undefined,
@@ -206,27 +217,19 @@ function PromptGeneratorPanel({
             )
           )
         }
-      };
-
-      return jobAPI.createPromptJob(jobData);
-    },
-    {
-      onSuccess: (response) => {
-        setGeneratedResult(response.data);
-        toast.success('프롬프트가 생성되었습니다!');
-        setIsGenerating(false);
       },
-      onError: (error) => {
-        toast.error('생성 실패: ' + (error.response?.data?.message || error.message));
-        setIsGenerating(false);
+      {
+        onDone: (info, fullText) => {
+          setGeneratedResult({ ...info, result: info.result ?? fullText });
+          toast.success('프롬프트가 생성되었습니다!');
+          setIsGenerating(false);
+        },
+        onError: (error) => {
+          toast.error('생성 실패: ' + (error.message || '알 수 없는 오류'));
+          setIsGenerating(false);
+        }
       }
-    }
-  );
-
-  const onSubmit = (data) => {
-    setIsGenerating(true);
-    setGeneratedResult(null);
-    generateMutation.mutate(data);
+    );
   };
 
   const handleCopyResult = () => {
@@ -387,7 +390,7 @@ function PromptGeneratorPanel({
                 )}
               </Box>
 
-              {isGenerating && (
+              {isGenerating && !streamingText && (
                 <Box>
                   <LinearProgress color="secondary" sx={{ mb: 2 }} />
                   <Typography variant="body2" color="textSecondary" textAlign="center">
@@ -396,7 +399,7 @@ function PromptGeneratorPanel({
                 </Box>
               )}
 
-              {generatedResult?.result ? (
+              {(streamingText || generatedResult?.result) ? (
                 <Box>
                   <Typography
                     variant="body1"
@@ -411,10 +414,11 @@ function PromptGeneratorPanel({
                       fontSize: compact ? '0.875rem' : '1rem'
                     }}
                   >
-                    {generatedResult.result}
+                    {streamingText || generatedResult.result}
+                    {isStreaming && <Box component="span" sx={{ opacity: 0.5 }}>▍</Box>}
                   </Typography>
-                  
-                  {generatedResult.usage && (
+
+                  {!isStreaming && generatedResult?.usage && (
                     <Box mt={1}>
                       <Typography variant="caption" color="textSecondary">
                         토큰: 입력 {generatedResult.usage.promptTokens} / 출력 {generatedResult.usage.completionTokens}

--- a/frontend/src/components/common/ConversationChatPanel.js
+++ b/frontend/src/components/common/ConversationChatPanel.js
@@ -22,7 +22,8 @@ import {
 } from '@mui/icons-material';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import toast from 'react-hot-toast';
-import { conversationAPI, jobAPI, textAPI } from '../../services/api';
+import { conversationAPI, textAPI } from '../../services/api';
+import { useStreamingPrompt } from '../../hooks/useStreamingPrompt';
 
 // 멀티턴 대화 모드 패널 (#375).
 // `conversationId` 가 주어졌을 때 PromptGeneration 페이지에서 PromptGeneratorPanel 대신 렌더.
@@ -58,33 +59,42 @@ function ConversationChatPanel({ workboard, conversationId }) {
     }
   );
 
-  const sendMutation = useMutation(
-    async (text) => {
-      return jobAPI.createPromptJob({
-        workboardId: workboard._id,
-        conversationId,
-        inputData: { userPrompt: text },
-      });
-    },
-    {
-      onSuccess: () => {
-        setNewMessage('');
-        queryClient.invalidateQueries(['conversation', conversationId]);
-        queryClient.invalidateQueries('conversations');
-      },
-      onError: (err) => {
-        toast.error('전송 실패: ' + (err.response?.data?.message || err.message));
-        // 실패 시에도 서버 측 conversation 은 failed 상태로 마킹돼 있으므로 refetch
-        queryClient.invalidateQueries(['conversation', conversationId]);
-      },
+  // 스트리밍 전송 (#490)
+  const { send: streamSend, streamingText, isStreaming } = useStreamingPrompt();
+  const [pendingUserMsg, setPendingUserMsg] = useState(null);
+
+  // 스트리밍 중 자동 스크롤
+  useEffect(() => {
+    if (transcriptRef.current) {
+      transcriptRef.current.scrollTop = transcriptRef.current.scrollHeight;
     }
-  );
+  }, [streamingText, pendingUserMsg]);
 
   const handleSend = (e) => {
     e.preventDefault();
     const trimmed = newMessage.trim();
-    if (!trimmed) return;
-    sendMutation.mutate(trimmed);
+    if (!trimmed || isStreaming) return;
+    setPendingUserMsg(trimmed);
+    setNewMessage('');
+    streamSend(
+      {
+        workboardId: workboard._id,
+        conversationId,
+        inputData: { userPrompt: trimmed },
+      },
+      {
+        onDone: () => {
+          setPendingUserMsg(null);
+          queryClient.invalidateQueries(['conversation', conversationId]);
+          queryClient.invalidateQueries('conversations');
+        },
+        onError: (err) => {
+          toast.error('전송 실패: ' + (err.message || '알 수 없는 오류'));
+          setPendingUserMsg(null);
+          queryClient.invalidateQueries(['conversation', conversationId]);
+        },
+      }
+    );
   };
 
   if (isLoading) {
@@ -101,7 +111,7 @@ function ConversationChatPanel({ workboard, conversationId }) {
     return <Alert severity="warning">대화를 찾을 수 없습니다.</Alert>;
   }
 
-  const isSending = sendMutation.isLoading;
+  const isSending = isStreaming;
 
   return (
     <Paper elevation={1} sx={{ p: { xs: 2, md: 3 } }}>
@@ -162,11 +172,40 @@ function ConversationChatPanel({ workboard, conversationId }) {
               )}
             </Box>
           ))}
+          {/* 낙관적 사용자 말풍선 + 실시간 어시스턴트 말풍선 (#490) */}
+          {pendingUserMsg && (
+            <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
+              <Box sx={{ pt: 0.5 }}><PersonIcon fontSize="small" color="primary" /></Box>
+              <Box sx={{ flex: '1 1 0', minWidth: 0 }}>
+                <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'uppercase', letterSpacing: 0.5 }}>
+                  user
+                </Typography>
+                <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', mt: 0.25 }}>
+                  {pendingUserMsg}
+                </Typography>
+              </Box>
+            </Box>
+          )}
+          {isStreaming && (
+            <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
+              <Box sx={{ pt: 0.5 }}><AssistantIcon fontSize="small" color="action" /></Box>
+              <Box sx={{ flex: '1 1 0', minWidth: 0 }}>
+                <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'uppercase', letterSpacing: 0.5 }}>
+                  assistant
+                </Typography>
+                <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', mt: 0.25 }}>
+                  {streamingText}
+                  {!streamingText && <CircularProgress size={14} color="secondary" sx={{ ml: 0.5 }} />}
+                  {streamingText && <Box component="span" sx={{ opacity: 0.5 }}>▍</Box>}
+                </Typography>
+              </Box>
+            </Box>
+          )}
         </Stack>
-        {isSending && (
-          <Box display="flex" justifyContent="center" mt={2}>
-            <CircularProgress size={20} color="secondary" />
-          </Box>
+        {conversation.status === 'processing' && !isStreaming && (
+          <Alert severity="info" sx={{ mt: 2 }}>
+            이 대화는 다른 곳에서 생성 중입니다. 완료되면 새로고침해 주세요.
+          </Alert>
         )}
         {conversation.status === 'failed' && conversation.error?.message && (
           <Alert severity="error" sx={{ mt: 2 }}>

--- a/frontend/src/components/common/WorkboardChatPanel.js
+++ b/frontend/src/components/common/WorkboardChatPanel.js
@@ -30,7 +30,8 @@ import {
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { Controller, useForm } from 'react-hook-form';
 import toast from 'react-hot-toast';
-import { jobAPI, conversationAPI, textAPI } from '../../services/api';
+import { conversationAPI, textAPI } from '../../services/api';
+import { useStreamingPrompt } from '../../hooks/useStreamingPrompt';
 import MetadataFieldInput from './MetadataFieldInput';
 
 // 텍스트 작업판의 멀티턴 대화 모드 패널 (#391).
@@ -76,35 +77,45 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
     }
   }, [messages.length]);
 
-  const sendMutation = useMutation(
-    ({ text, settings, cid }) => jobAPI.createPromptJob({
-      workboardId: workboard._id,
-      conversationId: cid || undefined,
-      // 첫 메시지 (cid 없음) 일 때만 프로젝트 컨텍스트 / 세계관 적용 (#396).
-      // 이어가는 메시지엔 이미 첫 턴의 system 메시지가 보존되어 있음.
-      projectId: cid ? undefined : (projectId || undefined),
-      useWorldview: cid ? undefined : !!useWorldview,
-      inputData: { ...settings, userPrompt: text },
-    }),
-    {
-      onSuccess: (response) => {
-        const cid = response.data?.conversationId;
-        if (cid && !conversationId) {
-          setConversationId(cid);
-          setSettingsOpen(false);
-        }
-        setNewMessage('');
-        queryClient.invalidateQueries(['conversation', cid || conversationId]);
-        queryClient.invalidateQueries('conversations');
+  // 스트리밍 전송 (#490). 보낸 직후 사용자 말풍선 + 실시간 어시스턴트 말풍선을 낙관적으로 표시,
+  // 완료되면 저장된 메시지를 refetch 하고 낙관적 상태를 정리.
+  const { send: streamSend, streamingText, isStreaming } = useStreamingPrompt();
+  const [pendingUserMsg, setPendingUserMsg] = useState(null);
+
+  const doSend = ({ text, settings, cid }) => {
+    setPendingUserMsg(text);
+    streamSend(
+      {
+        workboardId: workboard._id,
+        conversationId: cid || undefined,
+        // 첫 메시지 (cid 없음) 일 때만 프로젝트 컨텍스트 / 세계관 적용 (#396).
+        // 이어가는 메시지엔 이미 첫 턴의 system 메시지가 보존되어 있음.
+        projectId: cid ? undefined : (projectId || undefined),
+        useWorldview: cid ? undefined : !!useWorldview,
+        inputData: { ...settings, userPrompt: text },
       },
-      onError: (err) => {
-        toast.error('전송 실패: ' + (err.response?.data?.message || err.message));
-        if (conversationId) {
-          queryClient.invalidateQueries(['conversation', conversationId]);
-        }
-      },
-    }
-  );
+      {
+        onDone: (info) => {
+          const newCid = info?.conversationId;
+          if (newCid && !conversationId) {
+            setConversationId(newCid);
+            setSettingsOpen(false);
+          }
+          setPendingUserMsg(null);
+          queryClient.invalidateQueries(['conversation', newCid || cid || conversationId]);
+          queryClient.invalidateQueries('conversations');
+        },
+        onError: (err) => {
+          toast.error('전송 실패: ' + (err.message || '알 수 없는 오류'));
+          setPendingUserMsg(null);
+          if (cid || conversationId) {
+            queryClient.invalidateQueries(['conversation', cid || conversationId]);
+          }
+        },
+      }
+    );
+    setNewMessage('');
+  };
 
   const saveMessageMutation = useMutation(
     ({ conversationJobId, messageIndex }) => textAPI.createGenerated({ conversationJobId, messageIndex }),
@@ -117,14 +128,21 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
     }
   );
 
+  // 스트리밍 중 자동 스크롤
+  useEffect(() => {
+    if (transcriptRef.current) {
+      transcriptRef.current.scrollTop = transcriptRef.current.scrollHeight;
+    }
+  }, [streamingText, pendingUserMsg]);
+
   const handleSend = (e) => {
     e?.preventDefault?.();
     const trimmed = newMessage.trim();
-    if (!trimmed) return;
-    sendMutation.mutate({ text: trimmed, settings: getValues(), cid: conversationId });
+    if (!trimmed || isStreaming) return;
+    doSend({ text: trimmed, settings: getValues(), cid: conversationId });
   };
 
-  const isSending = sendMutation.isLoading;
+  const isSending = isStreaming;
   const isLocked = !!conversationId; // 첫 전송 후 lock
 
   const renderSettingField = (field) => {
@@ -269,7 +287,7 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
           borderRadius: 1,
         }}
       >
-        {messages.length === 0 ? (
+        {messages.length === 0 && !pendingUserMsg && !isStreaming ? (
           <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center', py: 4 }}>
             아래 입력창에 메시지를 입력해 대화를 시작하세요.
           </Typography>
@@ -303,12 +321,37 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
                 )}
               </Box>
             ))}
+            {/* 낙관적 사용자 말풍선 — 보낸 직후 ~ 저장본 refetch 전까지 (#490) */}
+            {pendingUserMsg && (
+              <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
+                <Box sx={{ pt: 0.5 }}><PersonIcon fontSize="small" color="primary" /></Box>
+                <Box sx={{ flex: '1 1 0', minWidth: 0 }}>
+                  <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'uppercase', letterSpacing: 0.5 }}>
+                    user
+                  </Typography>
+                  <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', mt: 0.25 }}>
+                    {pendingUserMsg}
+                  </Typography>
+                </Box>
+              </Box>
+            )}
+            {/* 실시간 어시스턴트 말풍선 — 토큰 스트리밍 (#490) */}
+            {isStreaming && (
+              <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
+                <Box sx={{ pt: 0.5 }}><AssistantIcon fontSize="small" color="action" /></Box>
+                <Box sx={{ flex: '1 1 0', minWidth: 0 }}>
+                  <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'uppercase', letterSpacing: 0.5 }}>
+                    assistant
+                  </Typography>
+                  <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', mt: 0.25 }}>
+                    {streamingText}
+                    {!streamingText && <CircularProgress size={14} color="secondary" sx={{ ml: 0.5 }} />}
+                    {streamingText && <Box component="span" sx={{ opacity: 0.5 }}>▍</Box>}
+                  </Typography>
+                </Box>
+              </Box>
+            )}
           </Stack>
-        )}
-        {isSending && (
-          <Box display="flex" justifyContent="center" mt={2}>
-            <CircularProgress size={20} color="secondary" />
-          </Box>
         )}
         {conversation?.status === 'failed' && conversation?.error?.message && (
           <Alert severity="error" sx={{ mt: 2 }}>

--- a/frontend/src/hooks/useStreamingPrompt.js
+++ b/frontend/src/hooks/useStreamingPrompt.js
@@ -1,0 +1,40 @@
+import { useState, useRef, useCallback } from 'react';
+import { streamPrompt } from '../services/streamChat';
+
+// 텍스트 챗 스트리밍 공통 훅 (#490).
+// send(payload, { onDone, onError }) 호출 시:
+//  - 토큰이 올 때마다 streamingText 가 누적되어 컴포넌트가 실시간 렌더
+//  - 완료 시 onDone(info, fullText) 호출 후 streamingText 초기화
+//  - 에러 시 onError(error) 호출 후 streamingText 초기화
+// isStreaming 으로 입력 잠금/스피너 제어.
+export function useStreamingPrompt() {
+  const [streamingText, setStreamingText] = useState('');
+  const [isStreaming, setIsStreaming] = useState(false);
+  const accRef = useRef('');
+
+  const send = useCallback((payload, { onDone, onError } = {}) => {
+    accRef.current = '';
+    setStreamingText('');
+    setIsStreaming(true);
+
+    streamPrompt(payload, {
+      onToken: (delta) => {
+        accRef.current += delta;
+        setStreamingText(accRef.current);
+      },
+      onDone: (info) => {
+        const fullText = accRef.current;
+        setIsStreaming(false);
+        setStreamingText('');
+        onDone?.(info, fullText);
+      },
+      onError: (err) => {
+        setIsStreaming(false);
+        setStreamingText('');
+        onError?.(err);
+      },
+    });
+  }, []);
+
+  return { send, streamingText, isStreaming };
+}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 import Cookies from 'js-cookie';
 import toast from 'react-hot-toast';
 
-const API_BASE_URL = process.env.REACT_APP_API_URL || '/api';
+export const API_BASE_URL = process.env.REACT_APP_API_URL || '/api';
 
 const api = axios.create({
   baseURL: API_BASE_URL,

--- a/frontend/src/services/streamChat.js
+++ b/frontend/src/services/streamChat.js
@@ -1,0 +1,87 @@
+import Cookies from 'js-cookie';
+import { API_BASE_URL } from './api';
+
+// 텍스트 챗 SSE 스트리밍 클라이언트 (#490).
+// axios 는 브라우저에서 스트림 응답을 점진적으로 읽기 어려워 fetch + ReadableStream 사용.
+// 백엔드 /api/jobs/generate-prompt 가 보내는 SSE 이벤트:
+//   event: token  data: {"delta":"..."}   — 토큰 조각
+//   event: done   data: {conversationId, result, usage, costEstimate, model}
+//   event: error  data: {"message":"..."}
+//
+// callbacks: { onToken(delta), onDone(info), onError(error) }
+// 반환: abort 가능한 AbortController. 호출자가 언마운트 시 .abort() 가능(선택).
+export function streamPrompt(payload, { onToken, onDone, onError, signal } = {}) {
+  const token = Cookies.get('token');
+  const headers = {
+    'Content-Type': 'application/json',
+    Accept: 'text/event-stream',
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  (async () => {
+    let res;
+    try {
+      res = await fetch(`${API_BASE_URL}/jobs/generate-prompt`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(payload),
+        signal,
+      });
+    } catch (err) {
+      if (err?.name !== 'AbortError') onError?.(err);
+      return;
+    }
+
+    // 스트리밍 시작 전(검증 단계) 실패는 JSON 으로 옴
+    if (!res.ok || !res.body) {
+      let message = `요청 실패 (HTTP ${res.status})`;
+      try {
+        const j = await res.json();
+        message = j.message || message;
+      } catch (_) { /* JSON 아님 */ }
+      onError?.(new Error(message));
+      return;
+    }
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    try {
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+
+        // SSE 프레임은 빈 줄(\n\n)로 구분
+        let sep;
+        while ((sep = buffer.indexOf('\n\n')) !== -1) {
+          const frame = buffer.slice(0, sep);
+          buffer = buffer.slice(sep + 2);
+
+          let event = 'message';
+          let dataStr = '';
+          for (const rawLine of frame.split('\n')) {
+            const line = rawLine.trimEnd();
+            if (line.startsWith(':')) continue; // 코멘트(하트비트) 무시
+            if (line.startsWith('event:')) event = line.slice(6).trim();
+            else if (line.startsWith('data:')) dataStr += line.slice(5).trim();
+          }
+          if (!dataStr) continue;
+
+          let data;
+          try { data = JSON.parse(dataStr); } catch { data = dataStr; }
+
+          if (event === 'token') onToken?.(data.delta ?? '');
+          else if (event === 'done') onDone?.(data);
+          else if (event === 'error') onError?.(new Error(data.message || '생성 중 오류가 발생했습니다.'));
+        }
+      }
+    } catch (err) {
+      if (err?.name !== 'AbortError') onError?.(err);
+    }
+  })();
+
+  return signal;
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -28,6 +28,10 @@ server {
         # 텍스트 생성 (prompt-generate) 이 Bull queue 미사용으로 sync 응답 대기.
         proxy_read_timeout 300s;
         proxy_send_timeout 300s;
+        # SSE 스트리밍 (텍스트 챗, #490) — 버퍼링 끄지 않으면 nginx 가 응답을 모아
+        # 한 번에 내보내 스트리밍이 무력화된다. 토큰이 생성 즉시 클라이언트로 흐르도록 함.
+        proxy_buffering off;
+        proxy_cache off;
     }
 
     # Block direct access to uploads — all media served via signed URLs (/api/files/*)

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -427,6 +427,7 @@ router.post('/:id/cancel', requireAuth, async (req, res) => {
 });
 
 router.post('/generate-prompt', requireAuth, async (req, res) => {
+  let heartbeat = null; // SSE 하트비트 타이머 — 외부 catch 에서도 정리할 수 있도록 try 밖에 선언
   try {
     const { workboardId, inputData, conversationId, projectId, useWorldview, contextDocIds, systemPromptDocId } = req.body;
 
@@ -562,26 +563,77 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
       });
     }
 
-    // server.serverType 기반 chat 서비스 분기. Gemini 는 generateContent (텍스트 모드),
-    // 그 외 (OpenAI / OpenAI Compatible) 는 /v1/chat/completions.
-    const chatService = server.serverType === 'Gemini'
-      ? geminiService
-      : openAIChatService;
+    // ── 여기서부터 SSE 스트리밍 (#490) ──
+    // 위의 검증(400/403/404)은 모두 JSON 응답을 유지하고, 생성 단계부터 스트리밍한다.
+    // 첫 바이트를 즉시 흘려보내 Cloudflare Tunnel 등 앞단 프록시의 TTFB 타임아웃(100초)을 회피.
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream; charset=utf-8',
+      'Cache-Control': 'no-cache, no-transform',
+      'Connection': 'keep-alive',
+      'X-Accel-Buffering': 'no', // nginx 버퍼링 방지 (proxy_buffering off 와 병행)
+    });
+    if (typeof res.flushHeaders === 'function') res.flushHeaders();
+    // TTFB 즉시 확보용 SSE 코멘트
+    res.write(': open\n\n');
+
+    // 클라이언트가 중간에 나가도 LLM 스트림은 끝까지 받아 대화를 저장한다 (현재 sync 동작 보존).
+    // clientGone 이면 res 쓰기만 멈추고, 저장 로직은 그대로 진행.
+    let clientGone = false;
+    let finished = false;
+    res.on('close', () => { if (!finished) clientGone = true; });
+    const sse = (event, data) => {
+      if (clientGone || res.writableEnded) return;
+      try { res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`); } catch (_) { /* socket 닫힘 */ }
+    };
+
+    // 하트비트 — 첫 토큰까지 오래 걸리는(느린 로컬 LLM) 동안 SSE 코멘트를 주기적으로 흘려
+    // 앞단 프록시(Cloudflare 등)의 idle 타임아웃을 회피. 클라이언트는 코멘트(:)를 무시.
+    heartbeat = setInterval(() => {
+      if (clientGone || res.writableEnded) return;
+      try { res.write(': ping\n\n'); } catch (_) {}
+    }, 15000);
 
     let result, usage;
     try {
-      ({ content: result, usage } = await chatService.complete(
-        server.serverUrl,
-        server.configuration?.apiKey,
-        messages,
-        { model, temperature, timeout: server.configuration?.timeout || 60000 }
-      ));
+      if (server.serverType === 'Gemini') {
+        // Gemini 는 스트리밍 미구현 — 헤더는 이미 flush 됐으니 TTFB 는 확보됨.
+        // 결과를 단일 token 이벤트로 전송해 프론트 SSE 처리 경로를 통일.
+        ({ content: result, usage } = await geminiService.complete(
+          server.serverUrl,
+          server.configuration?.apiKey,
+          messages,
+          { model, temperature, timeout: server.configuration?.timeout || 60000 }
+        ));
+        if (result) sse('token', { delta: result });
+      } else {
+        ({ content: result, usage } = await openAIChatService.completeStream(
+          server.serverUrl,
+          server.configuration?.apiKey,
+          messages,
+          { model, temperature, timeout: server.configuration?.timeout || 60000 },
+          (delta) => sse('token', { delta })
+        ));
+      }
     } catch (chatError) {
+      clearInterval(heartbeat);
       conversation.status = 'failed';
       conversation.error = { message: chatError.message };
       conversation.completedAt = new Date();
       await conversation.save();
-      throw chatError;
+      sse('error', { message: chatError.message });
+      finished = true;
+      return res.end();
+    }
+
+    if (!result || !String(result).trim()) {
+      clearInterval(heartbeat);
+      conversation.status = 'failed';
+      conversation.error = { message: 'LLM 서버에서 빈 응답을 반환했습니다.' };
+      conversation.completedAt = new Date();
+      await conversation.save();
+      sse('error', { message: 'LLM 서버에서 빈 응답을 반환했습니다.' });
+      finished = true;
+      return res.end();
     }
 
     // assistant 응답 + usage + 비용 추정 (#377). usage 누적 (멀티턴 시 직전 턴 토큰 합산).
@@ -615,16 +667,25 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
 
     await workboard.incrementUsage();
 
-    res.json({
-      success: true,
+    clearInterval(heartbeat);
+    // 완료 이벤트 — 프론트는 여기서 conversationId 확보 + 저장된 메시지 refetch
+    sse('done', {
       conversationId: conversation._id,
       result,
       usage: turnUsage,
       costEstimate: conversation.costEstimate || null,
-      model
+      model,
     });
+    finished = true;
+    res.end();
   } catch (error) {
     console.error('Prompt generation error:', error);
+    if (heartbeat) clearInterval(heartbeat);
+    // 헤더가 이미 나갔으면(스트리밍 시작 후) error 이벤트로, 아니면 JSON 으로.
+    if (res.headersSent) {
+      try { res.write(`event: error\ndata: ${JSON.stringify({ message: error.message })}\n\n`); } catch (_) {}
+      return res.end();
+    }
     res.status(502).json({ message: error.message });
   }
 });

--- a/src/services/openAIChatService.js
+++ b/src/services/openAIChatService.js
@@ -71,4 +71,90 @@ const complete = async (serverUrl, apiKey, messages, options = {}) => {
   return { content, usage, model };
 };
 
-module.exports = { complete };
+// 스트리밍 버전 — `stream: true` 로 /v1/chat/completions 호출 후 토큰 delta 를 onToken 으로 흘려보낸다.
+// 첫 토큰이 즉시 나가므로 Cloudflare 등 앞단 프록시의 TTFB 타임아웃(예: 100초)을 회피한다 (#490).
+// 반환값은 비스트리밍 complete() 와 동일한 { content, usage } — 호출자가 누적/비용 계산에 사용.
+const completeStream = async (serverUrl, apiKey, messages, options = {}, onToken) => {
+  const resolvedServerUrl = (serverUrl || '').replace(/\/+$/, '');
+  if (!resolvedServerUrl) {
+    throw new Error('OpenAI Chat: serverUrl is required');
+  }
+
+  const model = extractValue(options.model);
+  if (!model) {
+    throw new Error('OpenAI Chat: model is required');
+  }
+
+  const requestBody = {
+    model,
+    messages,
+    stream: true,
+    // usage 를 마지막 청크에 포함하도록 요청 (지원하는 서버 한정 — 미지원 시 usage 0 으로 degrade)
+    stream_options: { include_usage: true },
+  };
+
+  const headers = { 'Content-Type': 'application/json' };
+  if (apiKey) {
+    headers['Authorization'] = `Bearer ${apiKey}`;
+  }
+
+  let response;
+  try {
+    response = await axios.post(
+      `${resolvedServerUrl}/v1/chat/completions`,
+      requestBody,
+      { headers, timeout: options.timeout || 60000, responseType: 'stream' }
+    );
+  } catch (err) {
+    // 스트림 요청 실패 시 에러 본문이 stream 으로 올 수 있어 한 번 모아 파싱 시도
+    const apiMessage = err.response?.data?.error?.message;
+    if (apiMessage && /organization must be verified/i.test(apiMessage)) {
+      throw new Error(
+        `${model} 모델 사용에는 OpenAI 조직 인증(Verify Organization)이 필요합니다. https://platform.openai.com/settings/organization/general 에서 인증 후 약 15분 대기하세요.`
+      );
+    }
+    if (apiMessage) throw new Error(`OpenAI: ${apiMessage}`);
+    throw err;
+  }
+
+  let content = '';
+  let usage = null;
+  let buffer = '';
+
+  await new Promise((resolve, reject) => {
+    response.data.on('data', (chunk) => {
+      buffer += chunk.toString('utf8');
+      let nl;
+      // SSE 는 줄 단위(`data: {...}`) — 청크 경계에서 잘린 줄은 buffer 에 남겨 다음 청크와 합친다.
+      while ((nl = buffer.indexOf('\n')) !== -1) {
+        const line = buffer.slice(0, nl).trim();
+        buffer = buffer.slice(nl + 1);
+        if (!line || !line.startsWith('data:')) continue;
+        const data = line.slice(5).trim();
+        if (data === '[DONE]') continue;
+        let json;
+        try { json = JSON.parse(data); } catch { continue; }
+        const delta = json.choices?.[0]?.delta?.content;
+        if (delta) {
+          content += delta;
+          if (typeof onToken === 'function') onToken(delta);
+        }
+        if (json.usage) usage = json.usage;
+      }
+    });
+    response.data.on('end', resolve);
+    response.data.on('error', reject);
+  });
+
+  const normalizedUsage = usage
+    ? {
+        promptTokens: usage.prompt_tokens || 0,
+        completionTokens: usage.completion_tokens || 0,
+        totalTokens: usage.total_tokens || 0,
+      }
+    : { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+
+  return { content, usage: normalizedUsage };
+};
+
+module.exports = { complete, completeStream };


### PR DESCRIPTION
## 문제
OpenAI Compatible(로컬 LLM) 챗이 100초를 넘기면 Cloudflare Tunnel 의 origin TTFB 100초 제한에 걸려 524 로 끊김(백엔드는 완료·저장되지만 사용자는 끊긴 것처럼 보임). 텍스트 챗이 동기 응답이라 생성이 다 끝나야 첫 바이트가 나가는 게 원인.

## 해결
`/api/jobs/generate-prompt` 를 SSE 스트리밍으로 전환 — 첫 바이트(`: open`)를 즉시 흘려보내 TTFB 충족 + 토큰 실시간 전송. 덤으로 실시간 타이핑 UX.

### 백엔드
- `openAIChatService.completeStream` — `stream:true` + SSE 청크 파싱(부분 프레임 버퍼링), onToken 콜백, `stream_options.include_usage` 로 usage 수집
- `/generate-prompt` SSE 전환 — `token`/`done`/`error` 이벤트, 헤더 즉시 flush, **15초 하트비트**(느린 첫 토큰 시 idle 타임아웃 방지), **클라이언트 disconnect 시에도 LLM 끝까지 받아 대화 저장**(기존 sync 동작 보존 — 나가도 결과 저장)
- Gemini 는 헤더 flush 후 결과를 단일 token 이벤트로 전송(프론트 경로 통일)
- nginx `/api`: `proxy_buffering off` (없으면 nginx 가 모아서 스트리밍 무력화)

### 프론트
- `streamChat` — fetch + ReadableStream SSE 수신, 코멘트(하트비트 `:`) 무시
- `useStreamingPrompt` 훅 — `streamingText`/`isStreaming` 상태
- 챗 3컴포넌트(시작/이어가기/다시보기) 스트리밍 적용 + 생성 중 입력 잠금

파이프라인은 Bull 백그라운드 큐라 영향 없어 미변경.

## 검증 (실 로컬 MLX 서버 M4Max-oMLX)
- curl: `: open` 즉시 도달(TTFB 확보) → token delta 실시간 → done(conversationId/usage). nginx(8136) 경유도 버퍼링 없이 흐름 확인
- Playwright: 작업판 챗 UI 실시간 렌더 + 최종 메시지 저장, 콘솔 에러 0
- DB: 스트리밍 대화 모두 completed 저장 확인
- 최종 524 회피는 사용자 Cloudflare 터널 경유로 확인 필요

closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)