### PR TITLE
feat: 작업판 LLM 추가 파라미터(JSON) passthrough + temperature 입력 제거 (#493)

### DIFF
--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -740,6 +740,7 @@ export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage
       modelWhitelist: [],
       loraExposurePolicy: 'full',
       loraWhitelist: [],
+      llmExtraParams: '',
       isActive: true,
       additionalCustomFields: []
     }
@@ -843,6 +844,10 @@ export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage
             modelWhitelist: fullData.modelWhitelist || [],
             loraExposurePolicy: fullData.loraExposurePolicy || 'full',
             loraWhitelist: fullData.loraWhitelist || [],
+            // LLM 추가 파라미터 (#493) — 편집용으로 JSON 문자열(보기 좋게 들여쓰기)로 hydrate
+            llmExtraParams: fullData.llmExtraParams && Object.keys(fullData.llmExtraParams).length > 0
+              ? JSON.stringify(fullData.llmExtraParams, null, 2)
+              : '',
             isActive: fullData.isActive ?? true,
             // 커스텀 필드 — 모든 additionalInputFields 를 단일 generic 편집기에 노출.
             // defaultValue / description / placeholder 도 form 에 같이 싣어 admin 이 편집 가능 (#391)
@@ -936,6 +941,21 @@ export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage
       });
     }
 
+    // LLM 추가 파라미터 (#493) — JSON 문자열을 파싱해 객체로. 비었으면 빈 객체.
+    let parsedLlmExtraParams = {};
+    const rawExtra = (data.llmExtraParams || '').trim();
+    if (rawExtra) {
+      try {
+        parsedLlmExtraParams = JSON.parse(rawExtra);
+        if (typeof parsedLlmExtraParams !== 'object' || Array.isArray(parsedLlmExtraParams)) {
+          throw new Error('객체(JSON object) 형태여야 합니다');
+        }
+      } catch (e) {
+        toast.error('추가 LLM 파라미터 JSON 형식 오류: ' + e.message);
+        return;
+      }
+    }
+
     const isComfyUIServer = data.serverType === 'ComfyUI';
     const normalizedOutputFormat = data.outputFormat || 'image';
     const updateData = {
@@ -951,6 +971,7 @@ export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage
       modelWhitelist: Array.isArray(data.modelWhitelist) ? data.modelWhitelist : [],
       loraExposurePolicy: isComfyUIServer && data.loraExposurePolicy === 'whitelist' ? 'whitelist' : 'full',
       loraWhitelist: isComfyUIServer && Array.isArray(data.loraWhitelist) ? data.loraWhitelist : [],
+      llmExtraParams: parsedLlmExtraParams,
       isActive: Boolean(data.isActive),
       // F3: baseInputFields 편집 제거 — 신규/기존 모두 빈 상태로 저장.
       // 스키마의 required: true (aiModel) 통과 위해 빈 배열 명시.
@@ -1036,14 +1057,40 @@ export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage
 
           {/* 기본 정보 탭 */}
           {tabValue === 0 && (
-            <WorkboardBasicInfoForm
-              control={control}
-              setValue={setValue}
-              errors={errors}
-              showActiveSwitch={true}
-              showTypeSelector={true}
-              isDialogOpen={isOpen}
-            />
+            <>
+              <WorkboardBasicInfoForm
+                control={control}
+                setValue={setValue}
+                errors={errors}
+                showActiveSwitch={true}
+                showTypeSelector={true}
+                isDialogOpen={isOpen}
+              />
+              {/* 추가 LLM 파라미터 (#493) — 텍스트(LLM) 작업판 한정 */}
+              {outputFormat === 'text' && (
+                <Box sx={{ mt: 3 }}>
+                  <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5 }}>
+                    추가 LLM 파라미터 (고급)
+                  </Typography>
+                  <Controller
+                    name="llmExtraParams"
+                    control={control}
+                    render={({ field }) => (
+                      <TextField
+                        {...field}
+                        fullWidth
+                        multiline
+                        minRows={3}
+                        label="추가 LLM 파라미터 (JSON)"
+                        placeholder={'{\n  "temperature": 1.0,\n  "chat_template_kwargs": { "enable_thinking": false }\n}'}
+                        helperText="LLM 요청에 그대로 전달됩니다. 모델/서버별 thinking 비활성화(enable_thinking)·창작 temperature 등을 지정하세요. 비워두면 모델 기본값 사용. (OpenAI 계열: 요청 본문 최상위 / Gemini: generationConfig 에 병합)"
+                        InputProps={{ sx: { fontFamily: 'monospace', fontSize: '0.85rem' } }}
+                      />
+                    )}
+                  />
+                </Box>
+              )}
+            </>
           )}
 
 

--- a/frontend/src/templates/Gemini-text.json
+++ b/frontend/src/templates/Gemini-text.json
@@ -16,14 +16,6 @@
       "placeholder": "AI 의 역할 / 컨텍스트를 정의..."
     },
     {
-      "name": "temperature",
-      "label": "Temperature",
-      "type": "number",
-      "required": false,
-      "defaultValue": 0.7,
-      "description": "0.0 ~ 1.0. 높을수록 창의적, 낮을수록 일관적."
-    },
-    {
       "name": "conversation_mode",
       "label": "멀티턴 대화 모드",
       "type": "boolean",

--- a/frontend/src/templates/OpenAI Compatible-text.json
+++ b/frontend/src/templates/OpenAI Compatible-text.json
@@ -16,13 +16,6 @@
       "placeholder": "AI 의 역할 / 컨텍스트를 정의..."
     },
     {
-      "name": "temperature",
-      "label": "Temperature",
-      "type": "number",
-      "required": false,
-      "defaultValue": 0.7
-    },
-    {
       "name": "conversation_mode",
       "label": "멀티턴 대화 모드",
       "type": "boolean",

--- a/frontend/src/templates/OpenAI-text.json
+++ b/frontend/src/templates/OpenAI-text.json
@@ -16,14 +16,6 @@
       "placeholder": "AI 의 역할 / 컨텍스트를 정의..."
     },
     {
-      "name": "temperature",
-      "label": "Temperature",
-      "type": "number",
-      "required": false,
-      "defaultValue": 0.7,
-      "description": "0.0 ~ 1.0. 높을수록 창의적, 낮을수록 일관적."
-    },
-    {
       "name": "conversation_mode",
       "label": "멀티턴 대화 모드",
       "type": "boolean",

--- a/src/models/Workboard.js
+++ b/src/models/Workboard.js
@@ -103,6 +103,13 @@ const workboardSchema = new mongoose.Schema({
     type: [String],
     default: []
   },
+  // 작업판 단위 LLM 추가 요청 파라미터 (#493). 텍스트 챗(OpenAI/Compatible/Gemini) 요청에
+  // 그대로 passthrough — temperature / top_p / chat_template_kwargs(enable_thinking) 등을
+  // 모델·서버별로 admin 이 직접 지정. 모델별 thinking 비활성화/창작 temperature 제어용.
+  llmExtraParams: {
+    type: mongoose.Schema.Types.Mixed,
+    default: undefined
+  },
   // 이 작업판에 접근 가능한 사용자 그룹 (#198). 빈 배열이면 admin 외 접근 불가.
   // admin 은 implicit all-access (이 필드 무관). 마이그레이션 시 기본 그룹 1개 자동 할당.
   allowedGroupIds: [{

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -602,7 +602,7 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
           server.serverUrl,
           server.configuration?.apiKey,
           messages,
-          { model, temperature, timeout: server.configuration?.timeout || 60000 }
+          { model, temperature, timeout: server.configuration?.timeout || 60000, extraParams: workboard.llmExtraParams }
         ));
         if (result) sse('token', { delta: result });
       } else {
@@ -610,7 +610,7 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
           server.serverUrl,
           server.configuration?.apiKey,
           messages,
-          { model, temperature, timeout: server.configuration?.timeout || 60000 },
+          { model, temperature, timeout: server.configuration?.timeout || 60000, extraParams: workboard.llmExtraParams },
           (delta) => sse('token', { delta })
         ));
       }

--- a/src/routes/workboards.js
+++ b/src/routes/workboards.js
@@ -280,7 +280,8 @@ router.post('/', requireAdmin, async (req, res) => {
       modelExposurePolicy,
       modelWhitelist,
       loraExposurePolicy,
-      loraWhitelist
+      loraWhitelist,
+      llmExtraParams
     } = req.body;
 
     const resolvedOutputFormat = outputFormat || (workboardType === 'prompt' ? 'text' : 'image');
@@ -339,6 +340,7 @@ router.post('/', requireAdmin, async (req, res) => {
       modelWhitelist: Array.isArray(modelWhitelist) ? modelWhitelist : [],
       loraExposurePolicy: isComfyUI && loraExposurePolicy === 'whitelist' ? 'whitelist' : 'full',
       loraWhitelist: isComfyUI && Array.isArray(loraWhitelist) ? loraWhitelist : [],
+      llmExtraParams: (llmExtraParams && Object.keys(llmExtraParams).length > 0) ? llmExtraParams : undefined,
       createdBy: req.user._id
     });
 
@@ -377,6 +379,7 @@ router.put('/:id', requireAdmin, async (req, res) => {
       modelWhitelist,
       loraExposurePolicy,
       loraWhitelist,
+      llmExtraParams,
       isActive
     } = req.body;
 
@@ -459,7 +462,12 @@ router.put('/:id', requireAdmin, async (req, res) => {
       workboard.loraWhitelist = wbServer?.serverType === 'ComfyUI' ? loraWhitelist : [];
     }
     if (isActive !== undefined) workboard.isActive = isActive;
-    
+    // LLM 추가 파라미터 (#493) — 빈 객체/null 이면 미설정 처리. Mixed 라 markModified 필요.
+    if (llmExtraParams !== undefined) {
+      workboard.llmExtraParams = (llmExtraParams && Object.keys(llmExtraParams).length > 0) ? llmExtraParams : undefined;
+      workboard.markModified('llmExtraParams');
+    }
+
     console.log('Before save:', workboard.toObject());
     await workboard.save();
     await workboard.populate('createdBy', 'nickname email');
@@ -570,6 +578,7 @@ router.post('/:id/duplicate', requireAdmin, async (req, res) => {
       modelWhitelist: originalWorkboard.modelWhitelist || [],
       loraExposurePolicy: originalWorkboard.loraExposurePolicy || 'full',
       loraWhitelist: originalWorkboard.loraWhitelist || [],
+      llmExtraParams: originalWorkboard.llmExtraParams,
       createdBy: req.user._id
     });
     

--- a/src/services/geminiService.js
+++ b/src/services/geminiService.js
@@ -133,9 +133,11 @@ const complete = async (serverUrl, apiKey, messages, options = {}) => {
   }
 
   // Gemini 3+ 는 temperature 를 기본(1.0) 으로 두는 것을 공식 권장 (looping/성능 저하 방지).
-  // maxOutputTokens 도 모델 기본값을 사용 — 두 옵션 모두 전송하지 않음.
+  // maxOutputTokens 도 모델 기본값을 사용 — 두 옵션 모두 기본 전송하지 않음.
+  // 작업판별 추가 파라미터(temperature/topP 등)는 extraParams 로 generationConfig 에 merge (#493).
   const generationConfig = {
     responseModalities: ['TEXT'],
+    ...(options.extraParams || {}),
   };
 
   const response = await axios.post(

--- a/src/services/openAIChatService.js
+++ b/src/services/openAIChatService.js
@@ -21,10 +21,12 @@ const complete = async (serverUrl, apiKey, messages, options = {}) => {
     throw new Error('OpenAI Chat: model is required');
   }
 
-  // max_tokens / max_completion_tokens / temperature 모두 모델 기본값 사용.
-  // gpt-5+ 등 reasoning 모델은 비기본 temperature 를 거부하고, 그 외 모델도
-  // 텍스트 워크보드에서는 사용자 미세조정 수요가 낮아 단순화함.
+  // max_tokens / max_completion_tokens / temperature 모두 기본은 모델 기본값 사용.
+  // gpt-5+ 등 reasoning 모델은 비기본 temperature 를 거부하므로 전역 전송은 안 함.
+  // 작업판별로 필요한 값(temperature/top_p/chat_template_kwargs 등)은 extraParams 로 passthrough (#493).
+  // extraParams 를 먼저 펼치고 필수 키(model/messages)를 뒤에 둬 덮어쓰기 방지.
   const requestBody = {
+    ...(options.extraParams || {}),
     model,
     messages,
   };
@@ -86,6 +88,8 @@ const completeStream = async (serverUrl, apiKey, messages, options = {}, onToken
   }
 
   const requestBody = {
+    // 작업판별 추가 파라미터 passthrough (#493) — 필수/스트림 키가 뒤에서 항상 이김
+    ...(options.extraParams || {}),
     model,
     messages,
     stream: true,

--- a/src/services/pipelineRunService.js
+++ b/src/services/pipelineRunService.js
@@ -166,7 +166,7 @@ async function runTextStep(userId, pipelineRun, step, pipelineStep, inputData, p
       server.serverUrl,
       server.configuration?.apiKey,
       messages,
-      { model: resolvedModel, temperature, timeout: server.configuration?.timeout || 60000 }
+      { model: resolvedModel, temperature, timeout: server.configuration?.timeout || 60000, extraParams: workboard.llmExtraParams }
     ));
   } catch (err) {
     conversation.status = 'failed';


### PR DESCRIPTION
## 배경
- `temperature` 는 reasoning 모델(gpt-5/o1/o3) 거부 회피로 이미 LLM 요청에 안 보내고 있어, 작업판 temperature 입력은 **수집되지만 무시되는 장식 상태**였음.
- thinking 비활성화는 모델/서버별 방식이 제각각(`enable_thinking`, `chat_template_kwargs`, `/no_think`, `reasoning_effort`)이라 하드코딩 불가.

## 해결
작업판별 **임의 LLM 파라미터(JSON) passthrough** 로 통합 — temperature(창작 1.0), thinking off 등을 작업판마다 admin 이 지정.

### 백엔드
- `Workboard.llmExtraParams` (Mixed)
- openAIChatService `complete`/`completeStream`: extraParams 를 요청 본문 top-level 에 merge (필수/스트림 키가 항상 우선)
- geminiService `complete`: generationConfig 에 merge
- `/generate-prompt`, pipelineRunService: `workboard.llmExtraParams` 전달
- workboards POST/PUT/duplicate: 영속화(Mixed `markModified`)

### 프론트
- 작업판 편집기 **기본 정보 탭**에 "추가 LLM 파라미터(JSON)" 입력 — 텍스트 작업판 한정, JSON 검증(잘못된 JSON 저장 차단)
- 기본 텍스트 템플릿 3종(OpenAI/OpenAI Compatible/Gemini)에서 `temperature` customField 제거(신규 작업판). 기존 작업판은 무시되던 값이라 영향 없음

## 검증 (실 MLX 서버 M4Max-oMLX)
- `max_tokens:8` → 응답이 정확히 8토큰으로 truncate → **passthrough 가 LLM 요청 본문에 실제 반영됨 증명**
- `chat_template_kwargs:{enable_thinking:false}` → **thinking 생략**, "Four"/"Blue" 등 1토큰 답변(기존 ~363토큰) → 응답 대폭 가속
- 편집기 저장(PUT) → DB 영속 → admin GET hydration → LLM 적용 전 구간 확인

closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)