### PR TITLE
fix: 작업판 CRUD 캐시 미반영 근본 수정 + 기본값 표시 강화 (#498)

### DIFF
--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -82,14 +82,26 @@ function ServerMetadataDefaultValueInput({ serverId, type, value, onChange, labe
   );
   const items = data?.data?.data?.items
     || data?.data?.data?.models
+    || data?.data?.data?.loraModels
     || data?.data?.data?.loras
     || data?.data?.models
+    || data?.data?.loraModels
     || data?.data?.loras
     || [];
 
+  const keyOf = (m) => (typeof m === 'string' ? m : (m?.filename || m?.fileName || m?.name || ''));
+
+  // 저장된 기본값(문자열)을 항상 표시한다 (#498). 모델 목록이 로딩 중이거나 stale/누락이어도
+  // 선택값이 비어 보이지 않도록, 목록에 없으면 합성 옵션을 만들어 value/options 를 객체로 일치시킨다.
+  const matched = typeof value === 'string' ? items.find((m) => keyOf(m) === value) : value;
+  const selectedValue = matched || (typeof value === 'string' && value ? { filename: value } : (value || null));
+  const options = (selectedValue && !items.some((m) => keyOf(m) === keyOf(selectedValue)))
+    ? [selectedValue, ...items]
+    : items;
+
   return (
     <Autocomplete
-      options={items}
+      options={options}
       getOptionLabel={(opt) => {
         if (!opt) return '';
         if (typeof opt === 'string') return opt;
@@ -97,14 +109,8 @@ function ServerMetadataDefaultValueInput({ serverId, type, value, onChange, labe
           ? `${opt.civitai.model.name} (${opt.filename || opt.fileName})`
           : (opt.filename || opt.fileName || opt.name || '');
       }}
-      isOptionEqualToValue={(opt, val) => {
-        const optKey = typeof opt === 'string' ? opt : (opt.filename || opt.fileName || opt.name);
-        const valKey = typeof val === 'string' ? val : (val?.filename || val?.fileName || val?.name);
-        return optKey === valKey;
-      }}
-      value={typeof value === 'string'
-        ? (items.find((m) => (m.filename || m.fileName) === value) || (value ? value : null))
-        : (value || null)}
+      isOptionEqualToValue={(opt, val) => keyOf(opt) === keyOf(val)}
+      value={selectedValue}
       onChange={(_, picked) => {
         if (!picked) return onChange('');
         const key = typeof picked === 'string' ? picked : (picked.filename || picked.fileName || picked.name || '');

--- a/frontend/src/pages/WorkboardCatalogPage.js
+++ b/frontend/src/pages/WorkboardCatalogPage.js
@@ -43,6 +43,7 @@ import {
 } from '../components/common/WorkboardCatalog';
 import { WorkboardImportDialog } from '../components/admin/WorkboardManagement';
 import { copyToClipboard } from '../utils/clipboard';
+import { invalidateWorkboardQueries } from '../utils/queryInvalidation';
 
 const MONO = '"JetBrains Mono","SF Mono",Menlo,monospace';
 
@@ -149,7 +150,8 @@ function WorkboardCatalogPage({ admin = false }) {
   const { q, setQ, outSel, svcSel, toggleOut, toggleSvc, clear, counts, filtered } = useWorkboardFilter(baseList);
 
   // ── admin mutations ──
-  const invalidate = () => queryClient.invalidateQueries(['workboardCatalog', true]);
+  // 작업판 관련 캐시 전체 무효화 (#498) — 목록/상세/실행화면/대시보드 일괄 갱신
+  const invalidate = () => invalidateWorkboardQueries(queryClient);
   const deleteMutation = useMutation(workboardAPI.delete, {
     onSuccess: () => { toast.success('작업판이 삭제되었습니다'); invalidate(); },
     onError: (e) => toast.error('삭제 실패: ' + e.message),

--- a/frontend/src/pages/admin/WorkboardCreatePage.js
+++ b/frontend/src/pages/admin/WorkboardCreatePage.js
@@ -6,6 +6,7 @@ import toast from 'react-hot-toast';
 import { workboardAPI } from '../../services/api';
 import { getWorkboardTemplate } from '../../templates';
 import { WorkboardCreateDialog } from '../../components/admin/WorkboardManagement';
+import { invalidateWorkboardQueries } from '../../utils/queryInvalidation';
 
 // #437 Phase A — WorkboardCreateDialog 를 페이지로. 생성 성공 시 편집 페이지로 이동.
 function WorkboardCreatePage() {
@@ -17,7 +18,7 @@ function WorkboardCreatePage() {
     {
       onSuccess: (response) => {
         toast.success('작업판이 생성되었습니다');
-        queryClient.invalidateQueries('adminWorkboards');
+        invalidateWorkboardQueries(queryClient);
         const newId = response?.data?.workboard?._id;
         if (newId) {
           navigate(`/admin/workboards/${newId}/edit`, { replace: true });

--- a/frontend/src/pages/admin/WorkboardEditorPage.js
+++ b/frontend/src/pages/admin/WorkboardEditorPage.js
@@ -5,6 +5,7 @@ import { Container, Box, CircularProgress, Alert } from '@mui/material';
 import toast from 'react-hot-toast';
 import { workboardAPI } from '../../services/api';
 import { WorkboardDetailDialog } from '../../components/admin/WorkboardManagement';
+import { invalidateWorkboardQueries } from '../../utils/queryInvalidation';
 
 // #437 Phase A — 기존 WorkboardDetailDialog 를 페이지 안에 그대로 렌더 (asPage prop).
 // 데이터 fetch / update mutation / unsaved 경고는 본 페이지가 소유.
@@ -29,8 +30,7 @@ function WorkboardEditorPage() {
     {
       onSuccess: () => {
         toast.success('작업판이 수정되었습니다');
-        queryClient.invalidateQueries('adminWorkboards');
-        queryClient.invalidateQueries(['adminWorkboard', id]);
+        invalidateWorkboardQueries(queryClient);
         navigate('/admin/workboards');
       },
       onError: (err) => {

--- a/frontend/src/utils/queryInvalidation.js
+++ b/frontend/src/utils/queryInvalidation.js
@@ -1,0 +1,28 @@
+// 작업판 관련 React Query 캐시 일괄 무효화 (#498).
+//
+// 배경: 작업판 목록/상세가 여러 화면에서 서로 다른 쿼리 키로 캐시된다
+// (admin 목록 ['workboardCatalog', true], 사용자 목록 ['workboardCatalog', false],
+//  편집기 상세 ['adminWorkboard', id], 실행화면 ['workboard', id], 대시보드 위젯 등).
+// 과거에 각 뮤테이션이 제각각의 키만 무효화해(또는 #465 이전의 죽은 키 'adminWorkboards' 만)
+// CRUD 후 다른 화면에 이전 정보가 남는 stale 문제가 반복됐다.
+//
+// 해결: 작업판을 변경하는 모든 뮤테이션(생성/수정/삭제/복제/활성토글/가져오기)은
+// 이 헬퍼 하나만 호출한다. 새 목록 쿼리가 생겨도 아래 배열에만 키를 추가하면 된다.
+//
+// React Query v3 의 invalidateQueries 는 문자열/배열 prefix 로 부분 매칭한다.
+// 예: 'workboard' → ['workboard', id] 매칭, 'workboardCatalog' → ['workboardCatalog', true|false] 매칭.
+const WORKBOARD_QUERY_ROOTS = [
+  'workboardCatalog',          // admin/사용자 작업판 목록 (catalog 페이지)
+  'adminWorkboards',           // 레거시 admin 목록 (일부 잔존 경로 호환)
+  'adminWorkboard',            // 편집기 단일 상세
+  'workboard',                 // 실행/프롬프트 화면의 단일 작업판
+  'workboards',                // 작업판 선택 다이얼로그 등
+  'promptWorkboards',          // 레거시 프롬프트 작업판
+  'projectWorkboards',         // 프로젝트별 작업판 연결
+  'dashboardWorkboardUsage',   // 대시보드 "자주 쓰는 작업판" 위젯
+  'adminDefaultValueMetadata', // 편집기 baseModel/lora 기본값 autocomplete 의 모델 목록
+];
+
+export function invalidateWorkboardQueries(queryClient) {
+  WORKBOARD_QUERY_ROOTS.forEach((key) => queryClient.invalidateQueries(key));
+}


### PR DESCRIPTION
## 증상
관리자 메뉴에서 작업판 생성/수정 후 목록·상세에 이전 정보가 남는 stale 현상이 반복.

## 원인 (React Query v3 invalidation 키 불일치)
#465 에서 admin 목록이 `['workboardCatalog', true]` 로 통합됐는데, 생성/수정 뮤테이션은 그 이전의 **죽은 키 `'adminWorkboards'`** 만 무효화 → 실제 목록 캐시 미갱신. 사용자 목록(`['workboardCatalog', false]`)·실행화면(`['workboard', id]`)·대시보드 위젯도 무효화 누락. 키가 페이지마다 흩어져 있어 재발.

## 수정
- 공용 헬퍼 `invalidateWorkboardQueries(queryClient)` — 작업판 관련 쿼리 루트 전체 일괄 무효화
- 모든 live 뮤테이션(생성/수정/삭제/복제/활성토글/가져오기)이 이 헬퍼만 호출 → 키 변경/추가 시 한 곳만 관리(재발 방지)
- 부수: `ServerMetadataDefaultValueInput` 의 저장된 기본값(베이스 모델/LoRA)을 목록이 로딩/누락/stale 이어도 항상 표시(value/options 객체 일치 + 합성 옵션), LoRA 추출 키(`.loraModels`) 보강

## 검증 (헤드리스)
- 작업판 이름 수정 → 저장 → 목록 페이지가 **즉시 새 이름 반영**(수동 새로고침 없이) 확인
- 베이스 모델 기본값 표시 회귀 없음(`13개 중 선택` 유지), 콘솔 에러 0

closes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)