### PR TITLE
fix: 작업판 실행 화면(단발 텍스트) 베이스 모델 기본값 미적용 (#500)

### DIFF
--- a/frontend/src/components/PromptGeneratorPanel.js
+++ b/frontend/src/components/PromptGeneratorPanel.js
@@ -163,7 +163,21 @@ function PromptGeneratorPanel({
 
   const workboard = externalWorkboard || workboardData?.data?.workboard;
 
-  // F2: baseInputFields.aiModel 기반 기본값 제거 — customField 의 defaultValue 만 사용
+  // F2: baseInputFields.aiModel 기반 기본값 제거 — customField 의 defaultValue 만 사용.
+  // 작업판 로드 시 customField(베이스 모델/시스템 프롬프트 등)의 defaultValue 를 폼에 적용한다.
+  // 이게 없으면 실행 화면에서 베이스 모델 기본값이 빈 채로 떠 사용자가 매번 다시 골라야 했다 (#498 후속 버그).
+  // workboard._id 키로 1회 적용 — 캐시 refetch 로 객체 참조가 바뀌어도 사용자 입력을 덮어쓰지 않음.
+  useEffect(() => {
+    if (!workboard?.additionalInputFields) return;
+    workboard.additionalInputFields
+      .filter((f) => f.name !== 'conversation_mode')
+      .forEach((f) => {
+        if (f.defaultValue !== undefined && f.defaultValue !== null && f.defaultValue !== '') {
+          setValue(f.name, f.defaultValue);
+        }
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workboard?._id, setValue]);
 
   useEffect(() => {
     if (onResultChange) {


### PR DESCRIPTION
## 증상
작업판 실 사용 화면에서 관리자가 설정한 베이스 모델 기본값이 비어 있어 매번 다시 골라야 함(관리 화면은 정상). 이전부터 꾸준히 재현.

## 원인
단발 텍스트 실행 패널 `PromptGeneratorPanel` 이 customField(base_model 등)의 `defaultValue` 를 폼에 적용하는 로직 누락(`setValue` import 됐으나 미사용). WorkboardChatPanel·ImageGeneration 은 reset/setValue 로 적용해 정상인데 단발 텍스트 패널만 빠져 있었음.

## 수정
작업판 로드 시 `additionalInputFields` 의 `defaultValue` 를 `setValue` 로 적용하는 useEffect 추가. `workboard._id` 키로 1회 적용 → refetch 시 사용자 입력 미덮어씀.

## 검증
`/prompt-generate/:id` 베이스 모델 필드: 수정 전 value="" → 수정 후 value="Qwen3.6-...-8Bit"(헤드리스 확인).

closes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)