### PR TITLE
fix: 멀티턴 채팅 전송 버튼 정렬 — 입력창과 상단 정렬 (#503)

### DIFF
--- a/frontend/src/components/common/ConversationChatPanel.js
+++ b/frontend/src/components/common/ConversationChatPanel.js
@@ -215,7 +215,8 @@ function ConversationChatPanel({ workboard, conversationId }) {
       </Box>
 
       <form onSubmit={handleSend}>
-        <Stack direction="row" spacing={1} alignItems="flex-end">
+        {/* 전송 버튼을 입력창 높이만큼 채워 상단 정렬 맞춤 (#503) */}
+        <Stack direction="row" spacing={1} alignItems="flex-start">
           <TextField
             fullWidth
             multiline
@@ -229,7 +230,6 @@ function ConversationChatPanel({ workboard, conversationId }) {
                 handleSend(e);
               }
             }}
-            helperText="⌘/Ctrl + Enter 로 전송"
           />
           <Button
             type="submit"
@@ -242,6 +242,9 @@ function ConversationChatPanel({ workboard, conversationId }) {
             전송
           </Button>
         </Stack>
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+          ⌘/Ctrl + Enter 로 전송
+        </Typography>
       </form>
     </Paper>
   );

--- a/frontend/src/components/common/WorkboardChatPanel.js
+++ b/frontend/src/components/common/WorkboardChatPanel.js
@@ -361,7 +361,9 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
       </Box>
 
       <form onSubmit={handleSend}>
-        <Stack direction="row" spacing={1} alignItems="flex-end">
+        {/* 전송 버튼을 입력창 높이만큼 위아래 꽉 채워 상단 정렬 맞춤 (#503).
+            ⌘/Ctrl+Enter 안내는 정렬을 흐트러뜨리지 않도록 폼 아래 caption 으로 분리. */}
+        <Stack direction="row" spacing={1} alignItems="flex-start">
           <TextField
             fullWidth
             multiline
@@ -375,7 +377,6 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
                 handleSend(e);
               }
             }}
-            helperText="⌘/Ctrl + Enter 로 전송"
           />
           <Button
             type="submit"
@@ -388,6 +389,9 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
             전송
           </Button>
         </Stack>
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+          ⌘/Ctrl + Enter 로 전송
+        </Typography>
       </form>
     </Paper>
   );


### PR DESCRIPTION
## 증상
텍스트 작업판 멀티턴/이어가기 채팅에서 전송 버튼이 텍스트 입력창과 상단 정렬이 안 맞음. `alignItems="flex-end"` + TextField helperText(⌘/Ctrl+Enter) 때문에 버튼이 입력창이 아니라 helperText 아래선에 맞춰져 어색.

## 수정
- `alignItems="flex-start"` 로 상단 정렬, 버튼 높이를 2행 입력창에 맞춰(`height: 56`) 위아래 채움
- ⌘/Ctrl+Enter 안내를 TextField helperText → 폼 아래 caption 으로 이동(정렬 방해 제거)
- WorkboardChatPanel·ConversationChatPanel 동일 적용

## 검증 (헤드리스 측정)
버튼 top == 입력창 top (0px 차이), 버튼 높이 56 ≈ 입력창 55px.

closes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)