### PR TITLE
fix: 채팅 전송 버튼 높이 일치 + 간격 확대 (#503 후속)

### DIFF
--- a/frontend/src/components/common/ConversationChatPanel.js
+++ b/frontend/src/components/common/ConversationChatPanel.js
@@ -216,7 +216,7 @@ function ConversationChatPanel({ workboard, conversationId }) {
 
       <form onSubmit={handleSend}>
         {/* 전송 버튼을 입력창 높이만큼 채워 상단 정렬 맞춤 (#503) */}
-        <Stack direction="row" spacing={1} alignItems="flex-start">
+        <Stack direction="row" spacing={3} alignItems="flex-start">
           <TextField
             fullWidth
             multiline
@@ -237,7 +237,9 @@ function ConversationChatPanel({ workboard, conversationId }) {
             color="secondary"
             disabled={isSending || !newMessage.trim()}
             startIcon={isSending ? <CircularProgress size={18} color="inherit" /> : <Send />}
-            sx={{ minWidth: 100, height: 56 }}
+            // 입력창(size small, 2행)과 외곽 높이 정확히 맞춤 + elevation 제거 (#503)
+            disableElevation
+            sx={{ minWidth: 100, height: 55 }}
           >
             전송
           </Button>

--- a/frontend/src/components/common/WorkboardChatPanel.js
+++ b/frontend/src/components/common/WorkboardChatPanel.js
@@ -363,7 +363,7 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
       <form onSubmit={handleSend}>
         {/* 전송 버튼을 입력창 높이만큼 위아래 꽉 채워 상단 정렬 맞춤 (#503).
             ⌘/Ctrl+Enter 안내는 정렬을 흐트러뜨리지 않도록 폼 아래 caption 으로 분리. */}
-        <Stack direction="row" spacing={1} alignItems="flex-start">
+        <Stack direction="row" spacing={3} alignItems="flex-start">
           <TextField
             fullWidth
             multiline
@@ -384,7 +384,9 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
             color="secondary"
             disabled={isSending || !newMessage.trim()}
             startIcon={isSending ? <CircularProgress size={18} color="inherit" /> : <Send />}
-            sx={{ minWidth: 100, height: 56 }}
+            // 입력창(size small, 2행)과 외곽 높이를 정확히 맞춤. elevation 제거로 시각적 두께도 통일 (#503)
+            disableElevation
+            sx={{ minWidth: 100, height: 55 }}
           >
             전송
           </Button>


### PR DESCRIPTION
전송 버튼 높이를 입력창과 정확히 일치(55px, disableElevation 으로 그림자 두께도 제거), 입력창↔버튼 간격 4px→12px 확대. WorkboardChatPanel·ConversationChatPanel 동일. 검증: 입력창 55==버튼 55, top 0px, 간격 12px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)