### PR TITLE
fix: 채팅 전송 버튼 높이 하향 + 간격 8px (#503 후속2)

### DIFF
--- a/frontend/src/components/common/ConversationChatPanel.js
+++ b/frontend/src/components/common/ConversationChatPanel.js
@@ -216,7 +216,7 @@ function ConversationChatPanel({ workboard, conversationId }) {
 
       <form onSubmit={handleSend}>
         {/* 전송 버튼을 입력창 높이만큼 채워 상단 정렬 맞춤 (#503) */}
-        <Stack direction="row" spacing={3} alignItems="flex-start">
+        <Stack direction="row" spacing={2} alignItems="flex-start">
           <TextField
             fullWidth
             multiline
@@ -239,7 +239,7 @@ function ConversationChatPanel({ workboard, conversationId }) {
             startIcon={isSending ? <CircularProgress size={18} color="inherit" /> : <Send />}
             // 입력창(size small, 2행)과 외곽 높이 정확히 맞춤 + elevation 제거 (#503)
             disableElevation
-            sx={{ minWidth: 100, height: 55 }}
+            sx={{ minWidth: 100, height: 52 }}
           >
             전송
           </Button>

--- a/frontend/src/components/common/WorkboardChatPanel.js
+++ b/frontend/src/components/common/WorkboardChatPanel.js
@@ -363,7 +363,7 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
       <form onSubmit={handleSend}>
         {/* 전송 버튼을 입력창 높이만큼 위아래 꽉 채워 상단 정렬 맞춤 (#503).
             ⌘/Ctrl+Enter 안내는 정렬을 흐트러뜨리지 않도록 폼 아래 caption 으로 분리. */}
-        <Stack direction="row" spacing={3} alignItems="flex-start">
+        <Stack direction="row" spacing={2} alignItems="flex-start">
           <TextField
             fullWidth
             multiline
@@ -386,7 +386,7 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
             startIcon={isSending ? <CircularProgress size={18} color="inherit" /> : <Send />}
             // 입력창(size small, 2행)과 외곽 높이를 정확히 맞춤. elevation 제거로 시각적 두께도 통일 (#503)
             disableElevation
-            sx={{ minWidth: 100, height: 55 }}
+            sx={{ minWidth: 100, height: 52 }}
           >
             전송
           </Button>


### PR DESCRIPTION
버튼이 입력창과 외곽 같아도 solid fill 이라 더 높아 보인다는 피드백 → 버튼 높이 55→52(입력창보다 살짝 낮게). 간격 12→8px. 검증: 입력창55/버튼52, top 0px, 간격 8px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)