### PR TITLE
feat: 작업판 목록 필터 유지 + 언어모델 카드 아이콘 (#510)

### DIFF
--- a/frontend/src/components/common/MetadataItemCard.js
+++ b/frontend/src/components/common/MetadataItemCard.js
@@ -16,7 +16,10 @@ import {
   InfoOutlined as InfoOutlinedIcon,
   OpenInNew as OpenInNewIcon,
   CheckCircle as CheckCircleIcon,
-  Add as AddIcon
+  Add as AddIcon,
+  Psychology as PsychologyIcon,
+  ImageOutlined as ImageOutlinedIcon,
+  HideImageOutlined as HideImageOutlinedIcon
 } from '@mui/icons-material';
 import MetadataMediaThumbnail from './MetadataMediaThumbnail';
 import { getKindLabel } from '../../utils/metadataItem';
@@ -71,6 +74,20 @@ const MetadataItemCard = React.memo(function MetadataItemCard({
 
   const handleCardClick = cardClickable && onPrimary ? () => onPrimary(item) : undefined;
 
+  // 썸네일이 없을 때의 placeholder (#510). 언어(LLM)/이미지 API 모델은 썸네일이 없는 게 정상이라
+  // 텍스트 대신 종류에 맞는 아이콘을 보여준다. (provider-model 의 outputFormats 로 언어/이미지 구분)
+  const noImagePlaceholder = (() => {
+    if (item.kind === 'provider-model') {
+      const fmts = item.outputFormats || [];
+      // 이미지 전용으로 분류된 모델(DALL-E/Imagen 등)만 이미지 아이콘.
+      // 그 외(텍스트 또는 미분류 — 로컬 LLM 은 분류 불가라 outputFormats 가 비는 경우가 많음)는
+      // 언어 모델로 본다.
+      if (fmts.includes('image') && !fmts.includes('text')) return { Icon: ImageOutlinedIcon, label: '이미지 모델' };
+      return { Icon: PsychologyIcon, label: '언어 모델' };
+    }
+    return { Icon: HideImageOutlinedIcon, label: '미리보기 없음' };
+  })();
+
   // multi-add 모드에서 이미 선택된 항목은 토글로 \"제거\" 표시 (#277)
   const resolvedPrimaryLabel = primaryLabel || (
     primaryVariant === 'insert' ? '프롬프트에 추가'
@@ -94,7 +111,7 @@ const MetadataItemCard = React.memo(function MetadataItemCard({
         '&:hover': { borderColor: 'primary.main' }
       }}
     >
-      {/* 미리보기 */}
+      {/* 미리보기 — 썸네일 없으면 종류별 아이콘 placeholder (#510) */}
       {previewImage?.url ? (
         <MetadataMediaThumbnail image={previewImage} alt={item.displayName} />
       ) : (
@@ -102,13 +119,17 @@ const MetadataItemCard = React.memo(function MetadataItemCard({
           sx={{
             height: 140,
             display: 'flex',
+            flexDirection: 'column',
+            gap: 0.75,
             alignItems: 'center',
             justifyContent: 'center',
-            bgcolor: 'action.hover'
+            bgcolor: 'action.hover',
+            color: 'text.disabled'
           }}
         >
-          <Typography variant="body2" color="text.secondary">
-            미리보기 없음
+          <noImagePlaceholder.Icon sx={{ fontSize: 44 }} />
+          <Typography variant="caption" color="text.secondary">
+            {noImagePlaceholder.label}
           </Typography>
         </Box>
       )}

--- a/frontend/src/components/common/WorkboardCatalog.js
+++ b/frontend/src/components/common/WorkboardCatalog.js
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from 'react';
+import { usePersistedState } from '../../hooks/usePersistedState';
 import { Box, Paper, Typography, Chip, IconButton, Button, InputBase } from '@mui/material';
 import {
   Search,
@@ -99,10 +100,11 @@ export function TagChip({ label, mono, sx }) {
 }
 
 // ── 필터 로직 훅 ─────────────────────────────────────────────
-export function useWorkboardFilter(workboards) {
-  const [q, setQ] = useState('');
-  const [outSel, setOutSel] = useState([]);
-  const [svcSel, setSvcSel] = useState([]);
+// persistKey 를 주면 검색어·필터 선택을 localStorage 에 유지한다 (#510) — 작업판에 들어갔다 나와도 보존.
+export function useWorkboardFilter(workboards, persistKey) {
+  const [q, setQ] = usePersistedState(persistKey ? `${persistKey}.q` : null, '');
+  const [outSel, setOutSel] = usePersistedState(persistKey ? `${persistKey}.out` : null, []);
+  const [svcSel, setSvcSel] = usePersistedState(persistKey ? `${persistKey}.svc` : null, []);
 
   const toggleOut = (k) => setOutSel((s) => (s.includes(k) ? s.filter((x) => x !== k) : [...s, k]));
   const toggleSvc = (k) => setSvcSel((s) => (s.includes(k) ? s.filter((x) => x !== k) : [...s, k]));

--- a/frontend/src/hooks/usePersistedState.js
+++ b/frontend/src/hooks/usePersistedState.js
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react';
+
+// useState 와 동일하지만 값을 localStorage 에 영속화한다 (#510).
+// 화면을 떠났다가 돌아와도(언마운트→리마운트) 마지막 값이 복원된다 — 작업판 목록 필터 유지 등.
+// key 가 falsy 면 영속화 없이 일반 useState 처럼 동작.
+export function usePersistedState(key, initial) {
+  const [value, setValue] = useState(() => {
+    if (!key) return initial;
+    try {
+      const stored = localStorage.getItem(key);
+      return stored != null ? JSON.parse(stored) : initial;
+    } catch {
+      return initial;
+    }
+  });
+
+  useEffect(() => {
+    if (!key) return;
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      /* 용량 초과 등 무시 */
+    }
+  }, [key, value]);
+
+  return [value, setValue];
+}

--- a/frontend/src/pages/WorkboardCatalogPage.js
+++ b/frontend/src/pages/WorkboardCatalogPage.js
@@ -44,6 +44,7 @@ import {
 import { WorkboardImportDialog } from '../components/admin/WorkboardManagement';
 import { copyToClipboard } from '../utils/clipboard';
 import { invalidateWorkboardQueries } from '../utils/queryInvalidation';
+import { usePersistedState } from '../hooks/usePersistedState';
 
 const MONO = '"JetBrains Mono","SF Mono",Menlo,monospace';
 
@@ -113,10 +114,13 @@ function WorkboardCatalogPage({ admin = false }) {
   const [searchParams] = useSearchParams();
   const projectId = admin ? null : searchParams.get('projectId');
 
+  // 필터 영속 키 — admin/user 컨텍스트별 분리 (#510). 작업판에 들어갔다 나와도 필터 유지.
+  const persistKey = `vcc.wbCatalog.${admin ? 'admin' : 'user'}`;
+
   // user-only
   const [detailWb, setDetailWb] = useState(null);
   // admin-only
-  const [status, setStatus] = useState('all'); // all | active | inactive
+  const [status, setStatus] = usePersistedState(`${persistKey}.status`, 'all'); // all | active | inactive
   const [menuAnchor, setMenuAnchor] = useState(null);
   const [menuWb, setMenuWb] = useState(null);
   const [importOpen, setImportOpen] = useState(false);
@@ -147,7 +151,7 @@ function WorkboardCatalogPage({ admin = false }) {
     ? workboards
     : workboards.filter((w) => (status === 'active' ? w.isActive : !w.isActive));
 
-  const { q, setQ, outSel, svcSel, toggleOut, toggleSvc, clear, counts, filtered } = useWorkboardFilter(baseList);
+  const { q, setQ, outSel, svcSel, toggleOut, toggleSvc, clear, counts, filtered } = useWorkboardFilter(baseList, persistKey);
 
   // ── admin mutations ──
   // 작업판 관련 캐시 전체 무효화 (#498) — 목록/상세/실행화면/대시보드 일괄 갱신

--- a/frontend/src/utils/metadataItem.js
+++ b/frontend/src/utils/metadataItem.js
@@ -116,6 +116,7 @@ export function normalizeModel(raw, { serverType } = {}) {
     baseModel: civ.baseModel || null,
     trainedWords: civ.trainedWords || [],
     capabilities: prov.capabilities || [],
+    outputFormats: prov.outputFormats || [],
     contextWindow: prov.contextWindow || null,
     hash: raw.hash || null,
     hashError: raw.hashError || null,


### PR DESCRIPTION
1. **작업판 목록 필터 유지** — 상태/출력×서버/검색을 localStorage 영속(usePersistedState, admin·user 키 분리). 작업판 진입 후 복귀해도 유지.
2. **언어모델 아이콘** — 썸네일 없는 모델 카드의 '미리보기 없음' 을 종류별 아이콘으로. provider-model=언어 모델(Psychology), 이미지전용만 이미지 아이콘. 로컬 LLM(outputFormats 빈값)은 기본 언어 모델.

검증(헤드리스): 게시됨 필터 선택→이탈→복귀 유지(localStorage active), picker 카드 '언어 모델' 표시.

closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)