### PR TITLE
fix: 로그인/회원가입 '또는' 구분선 모바일 줄바꿈 (#512)

### DIFF
--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -239,7 +239,7 @@ function Login() {
           </form>
 
           <Divider sx={{ my: 3 }}>
-            <Typography variant="body2" color="textSecondary">
+            <Typography variant="body2" color="textSecondary" sx={{ whiteSpace: 'nowrap' }}>
               또는
             </Typography>
           </Divider>

--- a/frontend/src/pages/Signup.js
+++ b/frontend/src/pages/Signup.js
@@ -392,7 +392,7 @@ function Signup() {
           </form>
 
           <Divider sx={{ my: 3 }}>
-            <Typography variant="body2" color="textSecondary">
+            <Typography variant="body2" color="textSecondary" sx={{ whiteSpace: 'nowrap' }}>
               또는
             </Typography>
           </Divider>


### PR DESCRIPTION
모바일 좁은 폭에서 '또는'이 글자 단위 줄바꿈되던 것 whiteSpace: nowrap 으로 고정. Login·Signup 동일. 검증: 360px 단일 라인.

closes #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)