### PR TITLE
fix: 라이트모드에서 사이드바/헤더 밝게 (#514)

### DIFF
--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -117,7 +117,7 @@ function Header({ onMobileToggle, onOpenPalette }) {
                 label="Admin"
                 color="secondary"
                 variant="outlined"
-                sx={{ color: 'white', borderColor: 'white' }}
+                sx={{ color: 'navbar.contrastText', borderColor: 'navbar.contrastText' }}
               />
             )}
 

--- a/frontend/src/components/Sidebar.js
+++ b/frontend/src/components/Sidebar.js
@@ -166,7 +166,7 @@ function Sidebar({ mobileOpen, onMobileToggle }) {
         </Typography>
       </Box>
 
-      <Divider sx={{ borderColor: 'rgba(255,255,255,0.08)' }} />
+      <Divider sx={{ borderColor: 'divider' }} />
 
       <List sx={{ px: 1 }}>
         {menuItems.map((item) => (
@@ -200,7 +200,7 @@ function Sidebar({ mobileOpen, onMobileToggle }) {
 
       {isAdmin && (
         <>
-          <Divider sx={{ borderColor: 'rgba(255,255,255,0.08)', my: 1 }} />
+          <Divider sx={{ borderColor: 'divider', my: 1 }} />
 
           <Box sx={{ px: 2, py: 1 }}>
             <Typography variant="caption" sx={{ color: 'grey.500' }}>

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -15,7 +15,8 @@ const LIGHT = {
   warning:   { main: '#BE7415', light: '#FAEBC8', dark: '#95580B', contrastText: '#FFFFFF' },
   error:     { main: '#D5383E', light: '#FBE0E0', dark: '#A8222A', contrastText: '#FFFFFF' },
   info:      { main: '#2F77E4', light: '#DCEBFC', dark: '#1955B0', contrastText: '#FFFFFF' },
-  navbar:    { main: '#161A22', light: '#262C39', dark: '#0F1218', contrastText: '#E4E5E9' },
+  // 라이트모드에선 사이드바/헤더도 밝게 (#514). 흰 표면 + 어두운 텍스트, 활성/hover 는 옅은 primary 틴트.
+  navbar:    { main: '#FFFFFF', light: '#ECEDF7', dark: '#F1F1ED', contrastText: '#16181D' },
   background:{ default: '#F7F7F4', paper: '#FFFFFF' },
   text:      { primary: '#16181D', secondary: '#5B616E', disabled: '#B6BAC2' },
   divider:   '#E2E2DC',


### PR DESCRIPTION
LIGHT.navbar 팔레트가 어두운 색이라 라이트모드에서도 사이드바·헤더가 항상 어두웠음 → 흰 표면+어두운 텍스트로 변경. 사이드바 하드코딩 흰색 구분선·헤더 Admin 칩 흰색도 테마 적응형으로 수정. 다크모드 불변.

검증: light bg #FFF/텍스트 어두움, dark bg #0A0C10/텍스트 밝음.

closes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)