### PR TITLE
feat: 텍스트 작업판 이미지 첨부 — 비전 LLM 프롬프트 추출 (#517)

### DIFF
--- a/frontend/src/components/PromptGeneratorPanel.js
+++ b/frontend/src/components/PromptGeneratorPanel.js
@@ -146,6 +146,7 @@ function PromptGeneratorPanel({
   const [isGenerating, setIsGenerating] = useState(false);
   const [generatedResult, setGeneratedResult] = useState(null);
   const [referenceImages, setReferenceImages] = useState({});
+  const [attachImages, setAttachImages] = useState([]); // 비전 첨부 (#517)
   const { send: streamSend, streamingText, isStreaming } = useStreamingPrompt();
 
   const { control, handleSubmit, setValue, formState: { errors } } = useForm({
@@ -191,6 +192,7 @@ function PromptGeneratorPanel({
     setGeneratedResult(null);
 
     let uploadedImages = {};
+    let attachedImageIds = [];
     try {
       for (const [fieldName, images] of Object.entries(referenceImages)) {
         if (images && images.length > 0) {
@@ -209,6 +211,18 @@ function PromptGeneratorPanel({
           uploadedImages[fieldName] = imageIds;
         }
       }
+      // 비전 첨부 이미지 업로드 (#517)
+      for (const img of attachImages) {
+        if (img.file) {
+          const uploadData = new FormData();
+          uploadData.append('image', img.file);
+          uploadData.append('imageType', 'reference');
+          const response = await imageAPI.upload(uploadData);
+          attachedImageIds.push(response.data.image._id);
+        } else if (img._id) {
+          attachedImageIds.push(img._id);
+        }
+      }
     } catch (error) {
       toast.error('이미지 업로드 실패: ' + (error.response?.data?.message || error.message));
       setIsGenerating(false);
@@ -225,6 +239,7 @@ function PromptGeneratorPanel({
           model: formData.model,
           userPrompt: formData.userPrompt,
           ...uploadedImages,
+          ...(attachedImageIds.length > 0 ? { attachedImages: attachedImageIds } : {}),
           ...Object.fromEntries(
             Object.entries(formData).filter(([key]) =>
               !['model', 'userPrompt'].includes(key)
@@ -237,6 +252,7 @@ function PromptGeneratorPanel({
           setGeneratedResult({ ...info, result: info.result ?? fullText });
           toast.success('프롬프트가 생성되었습니다!');
           setIsGenerating(false);
+          setAttachImages([]); // 첨부 초기화 — 재생성 시 중복 업로드 방지 (#517)
         },
         onError: (error) => {
           toast.error('생성 실패: ' + (error.message || '알 수 없는 오류'));
@@ -375,6 +391,19 @@ function PromptGeneratorPanel({
                   />
                 )}
               />
+
+              {/* 비전 이미지 첨부 (#517) — 작업판이 이미지 입력 허용 시에만 */}
+              {workboard.allowImageInput && (
+                <Box sx={{ mt: 2 }}>
+                  <ImageUploadField
+                    label="이미지 첨부 (선택)"
+                    description="이미지를 첨부하면 모델이 분석에 참고합니다. 최대 4장. (비전 모델 전용)"
+                    images={attachImages}
+                    onImagesChange={setAttachImages}
+                    maxImages={4}
+                  />
+                </Box>
+              )}
 
               <Button
                 type="submit"

--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -747,6 +747,7 @@ export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage
       loraExposurePolicy: 'full',
       loraWhitelist: [],
       llmExtraParams: '',
+      allowImageInput: false,
       isActive: true,
       additionalCustomFields: []
     }
@@ -854,6 +855,7 @@ export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage
             llmExtraParams: fullData.llmExtraParams && Object.keys(fullData.llmExtraParams).length > 0
               ? JSON.stringify(fullData.llmExtraParams, null, 2)
               : '',
+            allowImageInput: !!fullData.allowImageInput,
             isActive: fullData.isActive ?? true,
             // 커스텀 필드 — 모든 additionalInputFields 를 단일 generic 편집기에 노출.
             // defaultValue / description / placeholder 도 form 에 같이 싣어 admin 이 편집 가능 (#391)
@@ -978,6 +980,7 @@ export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage
       loraExposurePolicy: isComfyUIServer && data.loraExposurePolicy === 'whitelist' ? 'whitelist' : 'full',
       loraWhitelist: isComfyUIServer && Array.isArray(data.loraWhitelist) ? data.loraWhitelist : [],
       llmExtraParams: parsedLlmExtraParams,
+      allowImageInput: !!data.allowImageInput,
       isActive: Boolean(data.isActive),
       // F3: baseInputFields 편집 제거 — 신규/기존 모두 빈 상태로 저장.
       // 스키마의 required: true (aiModel) 통과 위해 빈 배열 명시.
@@ -1490,6 +1493,22 @@ export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage
           {/* LLM 파라미터 탭 - 텍스트(LLM) 작업판만 (#495). ComfyUI 워크플로우 탭과 동일 위치(index 3) */}
           {outputFormat === 'text' && tabValue === 3 && (
             <Box>
+              {/* 이미지 입력 허용 (#517) — 비전 모델일 때만 켤 것 */}
+              <Controller
+                name="allowImageInput"
+                control={control}
+                render={({ field }) => (
+                  <FormControlLabel
+                    sx={{ mb: 1 }}
+                    control={<Switch checked={!!field.value} onChange={(e) => field.onChange(e.target.checked)} />}
+                    label="이미지 입력 허용 (비전 모델)"
+                  />
+                )}
+              />
+              <Typography variant="caption" color="textSecondary" display="block" sx={{ mb: 2 }}>
+                켜면 실행 화면에서 사용자가 이미지를 첨부할 수 있고, 첨부 이미지는 모델에 비전 입력으로 전달됩니다.
+                선택한 베이스 모델이 비전(멀티모달)을 지원해야 정상 동작합니다.
+              </Typography>
               <Typography variant="body2" color="textSecondary" paragraph>
                 LLM 요청에 추가로 전달할 파라미터를 JSON 으로 지정합니다. 모델/서버별 thinking 비활성화나
                 창작용 temperature 등을 작업판마다 다르게 설정할 수 있습니다. 비워두면 모델 기본값으로 동작합니다.

--- a/frontend/src/components/common/ConversationChatPanel.js
+++ b/frontend/src/components/common/ConversationChatPanel.js
@@ -184,6 +184,15 @@ function ConversationChatPanel({ workboard, conversationId }) {
                 <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', mt: 0.25 }}>
                   {msg.content}
                 </Typography>
+                {/* 첨부 이미지 썸네일 (#517) */}
+                {msg.attachments?.length > 0 && (
+                  <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap', mt: 0.75 }}>
+                    {msg.attachments.map((a, ai) => (
+                      <Box key={ai} component="img" src={a.url} alt="첨부 이미지"
+                        sx={{ width: 72, height: 72, objectFit: 'cover', borderRadius: 1, border: '1px solid', borderColor: 'divider' }} />
+                    ))}
+                  </Box>
+                )}
               </Box>
               {msg.role === 'assistant' && (
                 <Tooltip title="이 응답을 텍스트 컨텐츠로 저장">

--- a/frontend/src/components/common/ConversationChatPanel.js
+++ b/frontend/src/components/common/ConversationChatPanel.js
@@ -22,8 +22,9 @@ import {
 } from '@mui/icons-material';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import toast from 'react-hot-toast';
-import { conversationAPI, textAPI } from '../../services/api';
+import { conversationAPI, textAPI, imageAPI } from '../../services/api';
 import { useStreamingPrompt } from '../../hooks/useStreamingPrompt';
+import ImageUploadField from './ImageUploadField';
 
 // 멀티턴 대화 모드 패널 (#375).
 // `conversationId` 가 주어졌을 때 PromptGeneration 페이지에서 PromptGeneratorPanel 대신 렌더.
@@ -62,6 +63,7 @@ function ConversationChatPanel({ workboard, conversationId }) {
   // 스트리밍 전송 (#490)
   const { send: streamSend, streamingText, isStreaming } = useStreamingPrompt();
   const [pendingUserMsg, setPendingUserMsg] = useState(null);
+  const [attachImages, setAttachImages] = useState([]); // 비전 첨부 (#517)
 
   // 스트리밍 중 자동 스크롤
   useEffect(() => {
@@ -70,17 +72,40 @@ function ConversationChatPanel({ workboard, conversationId }) {
     }
   }, [streamingText, pendingUserMsg]);
 
-  const handleSend = (e) => {
+  const handleSend = async (e) => {
     e.preventDefault();
     const trimmed = newMessage.trim();
     if (!trimmed || isStreaming) return;
     setPendingUserMsg(trimmed);
     setNewMessage('');
+
+    // 비전 첨부 이미지 업로드 (#517)
+    let attachedImageIds = [];
+    if (workboard.allowImageInput && attachImages.length > 0) {
+      try {
+        for (const img of attachImages) {
+          if (img.file) {
+            const fd = new FormData();
+            fd.append('image', img.file);
+            fd.append('imageType', 'reference');
+            const resp = await imageAPI.upload(fd);
+            attachedImageIds.push(resp.data.image._id);
+          } else if (img._id) {
+            attachedImageIds.push(img._id);
+          }
+        }
+      } catch (err) {
+        toast.error('이미지 업로드 실패: ' + (err.response?.data?.message || err.message));
+        setPendingUserMsg(null);
+        return;
+      }
+    }
+
     streamSend(
       {
         workboardId: workboard._id,
         conversationId,
-        inputData: { userPrompt: trimmed },
+        inputData: { userPrompt: trimmed, ...(attachedImageIds.length ? { attachedImages: attachedImageIds } : {}) },
       },
       {
         onDone: () => {
@@ -95,6 +120,7 @@ function ConversationChatPanel({ workboard, conversationId }) {
         },
       }
     );
+    setAttachImages([]);
   };
 
   if (isLoading) {
@@ -213,6 +239,19 @@ function ConversationChatPanel({ workboard, conversationId }) {
           </Alert>
         )}
       </Box>
+
+      {/* 비전 이미지 첨부 (#517) — 작업판이 이미지 입력 허용 시 */}
+      {workboard.allowImageInput && (
+        <Box sx={{ mb: 1.5 }}>
+          <ImageUploadField
+            description="이미지를 첨부하면 모델이 분석에 참고합니다. 최대 4장. (비전 모델 전용)"
+            images={attachImages}
+            onImagesChange={setAttachImages}
+            maxImages={4}
+            disabled={isSending}
+          />
+        </Box>
+      )}
 
       <form onSubmit={handleSend}>
         {/* 전송 버튼을 입력창 높이만큼 채워 상단 정렬 맞춤 (#503) */}

--- a/frontend/src/components/common/ImageUploadField.js
+++ b/frontend/src/components/common/ImageUploadField.js
@@ -1,0 +1,87 @@
+import React, { useCallback } from 'react';
+import { Box, Typography, Card, CardMedia, IconButton } from '@mui/material';
+import { Delete, Add } from '@mui/icons-material';
+import { useDropzone } from 'react-dropzone';
+import toast from 'react-hot-toast';
+
+// 이미지 선택/미리보기/삭제 공용 필드 (#517). 비전 첨부·참조 이미지 등에서 재사용.
+// images: [{ file, preview } | { _id, url }] 형태. onImagesChange 로 상위가 상태 관리.
+// 업로드(서버 전송)는 호출하는 쪽에서 수행한다(여기선 선택만).
+function ImageUploadField({ label, description, images, onImagesChange, maxImages = 1, disabled = false }) {
+  const onDrop = useCallback((acceptedFiles) => {
+    if (images.length >= maxImages) {
+      toast.error(`최대 ${maxImages}개의 이미지만 첨부할 수 있습니다.`);
+      return;
+    }
+    const remainingSlots = maxImages - images.length;
+    const filesToAdd = acceptedFiles.slice(0, remainingSlots);
+    const newImages = filesToAdd.map((file) => ({ file, preview: URL.createObjectURL(file) }));
+    onImagesChange([...images, ...newImages]);
+  }, [images, maxImages, onImagesChange]);
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop,
+    accept: { 'image/*': ['.jpeg', '.jpg', '.png', '.webp'] },
+    maxSize: 10 * 1024 * 1024,
+    disabled: disabled || images.length >= maxImages,
+  });
+
+  const removeImage = (index) => {
+    const next = [...images];
+    if (next[index].preview) URL.revokeObjectURL(next[index].preview);
+    next.splice(index, 1);
+    onImagesChange(next);
+  };
+
+  return (
+    <Box>
+      {label && (
+        <Typography variant="subtitle2" gutterBottom>{label}</Typography>
+      )}
+      {description && (
+        <Typography variant="caption" color="textSecondary" display="block" mb={1}>
+          {description}
+        </Typography>
+      )}
+      <Box display="flex" gap={1} flexWrap="wrap" mb={1}>
+        {images.map((img, index) => (
+          <Box key={index} position="relative">
+            <Card sx={{ width: 72, height: 72 }}>
+              <CardMedia component="img" image={img.preview || img.url} sx={{ width: 72, height: 72, objectFit: 'cover' }} />
+            </Card>
+            {!disabled && (
+              <IconButton
+                size="small"
+                onClick={() => removeImage(index)}
+                sx={{
+                  position: 'absolute', top: -8, right: -8,
+                  bgcolor: 'error.main', color: 'white',
+                  '&:hover': { bgcolor: 'error.dark' }, width: 20, height: 20,
+                }}
+              >
+                <Delete sx={{ fontSize: 14 }} />
+              </IconButton>
+            )}
+          </Box>
+        ))}
+        {!disabled && images.length < maxImages && (
+          <Box
+            {...getRootProps()}
+            sx={{
+              width: 72, height: 72, border: '2px dashed',
+              borderColor: isDragActive ? 'secondary.main' : 'grey.300',
+              borderRadius: 1, display: 'flex', alignItems: 'center', justifyContent: 'center',
+              cursor: 'pointer', bgcolor: isDragActive ? 'action.hover' : 'transparent',
+              '&:hover': { borderColor: 'secondary.main', bgcolor: 'action.hover' },
+            }}
+          >
+            <input {...getInputProps()} />
+            <Add color="action" />
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+export default ImageUploadField;

--- a/frontend/src/components/common/WorkboardChatPanel.js
+++ b/frontend/src/components/common/WorkboardChatPanel.js
@@ -333,6 +333,15 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
                   <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', mt: 0.25 }}>
                     {msg.content}
                   </Typography>
+                  {/* 첨부 이미지 썸네일 (#517) */}
+                  {msg.attachments?.length > 0 && (
+                    <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap', mt: 0.75 }}>
+                      {msg.attachments.map((a, ai) => (
+                        <Box key={ai} component="img" src={a.url} alt="첨부 이미지"
+                          sx={{ width: 72, height: 72, objectFit: 'cover', borderRadius: 1, border: '1px solid', borderColor: 'divider' }} />
+                      ))}
+                    </Box>
+                  )}
                 </Box>
                 {msg.role === 'assistant' && (
                   <Tooltip title="이 응답을 텍스트 컨텐츠로 저장">

--- a/frontend/src/components/common/WorkboardChatPanel.js
+++ b/frontend/src/components/common/WorkboardChatPanel.js
@@ -30,9 +30,10 @@ import {
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { Controller, useForm } from 'react-hook-form';
 import toast from 'react-hot-toast';
-import { conversationAPI, textAPI } from '../../services/api';
+import { conversationAPI, textAPI, imageAPI } from '../../services/api';
 import { useStreamingPrompt } from '../../hooks/useStreamingPrompt';
 import MetadataFieldInput from './MetadataFieldInput';
+import ImageUploadField from './ImageUploadField';
 
 // 텍스트 작업판의 멀티턴 대화 모드 패널 (#391).
 // PromptGeneration 페이지에서 workboard.conversation_mode = true 일 때 PromptGeneratorPanel 대신 렌더.
@@ -81,9 +82,34 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
   // 완료되면 저장된 메시지를 refetch 하고 낙관적 상태를 정리.
   const { send: streamSend, streamingText, isStreaming } = useStreamingPrompt();
   const [pendingUserMsg, setPendingUserMsg] = useState(null);
+  const [attachImages, setAttachImages] = useState([]); // 비전 첨부 (#517)
 
-  const doSend = ({ text, settings, cid }) => {
+  const doSend = async ({ text, settings, cid }) => {
     setPendingUserMsg(text);
+    setNewMessage('');
+
+    // 비전 첨부 이미지 업로드 (#517)
+    let attachedImageIds = [];
+    if (workboard.allowImageInput && attachImages.length > 0) {
+      try {
+        for (const img of attachImages) {
+          if (img.file) {
+            const fd = new FormData();
+            fd.append('image', img.file);
+            fd.append('imageType', 'reference');
+            const resp = await imageAPI.upload(fd);
+            attachedImageIds.push(resp.data.image._id);
+          } else if (img._id) {
+            attachedImageIds.push(img._id);
+          }
+        }
+      } catch (e) {
+        toast.error('이미지 업로드 실패: ' + (e.response?.data?.message || e.message));
+        setPendingUserMsg(null);
+        return;
+      }
+    }
+
     streamSend(
       {
         workboardId: workboard._id,
@@ -92,7 +118,7 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
         // 이어가는 메시지엔 이미 첫 턴의 system 메시지가 보존되어 있음.
         projectId: cid ? undefined : (projectId || undefined),
         useWorldview: cid ? undefined : !!useWorldview,
-        inputData: { ...settings, userPrompt: text },
+        inputData: { ...settings, userPrompt: text, ...(attachedImageIds.length ? { attachedImages: attachedImageIds } : {}) },
       },
       {
         onDone: (info) => {
@@ -114,7 +140,7 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
         },
       }
     );
-    setNewMessage('');
+    setAttachImages([]);
   };
 
   const saveMessageMutation = useMutation(
@@ -359,6 +385,19 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
           </Alert>
         )}
       </Box>
+
+      {/* 비전 이미지 첨부 (#517) — 작업판이 이미지 입력 허용 시 */}
+      {workboard.allowImageInput && (
+        <Box sx={{ mb: 1.5 }}>
+          <ImageUploadField
+            description="이미지를 첨부하면 모델이 분석에 참고합니다. 최대 4장. (비전 모델 전용)"
+            images={attachImages}
+            onImagesChange={setAttachImages}
+            maxImages={4}
+            disabled={isSending}
+          />
+        </Box>
+      )}
 
       <form onSubmit={handleSend}>
         {/* 전송 버튼을 입력창 높이만큼 위아래 꽉 채워 상단 정렬 맞춤 (#503).

--- a/src/models/ConversationJob.js
+++ b/src/models/ConversationJob.js
@@ -13,6 +13,12 @@ const conversationMessageSchema = new mongoose.Schema({
     type: String,
     default: '',
   },
+  // 비전 LLM 첨부 이미지 (#517). imageId 참조 + 표시용 url 스냅샷.
+  // LLM 호출 시엔 imageId 로 원본을 읽어 base64 로 변환해 전송, 다시보기는 url 로 표시.
+  attachments: [new mongoose.Schema({
+    imageId: { type: mongoose.Schema.Types.ObjectId, ref: 'UploadedImage' },
+    url: String,
+  }, { _id: false })],
   createdAt: {
     type: Date,
     default: Date.now,

--- a/src/models/Workboard.js
+++ b/src/models/Workboard.js
@@ -110,6 +110,12 @@ const workboardSchema = new mongoose.Schema({
     type: mongoose.Schema.Types.Mixed,
     default: undefined
   },
+  // 텍스트(LLM) 작업판에서 이미지 첨부 허용 여부 (#517). 비전 모델일 때 admin 이 켠다.
+  // 켜면 실행 화면에 이미지 첨부 UI 가 노출되고, 첨부 이미지는 비전 콘텐츠로 LLM 에 전달.
+  allowImageInput: {
+    type: Boolean,
+    default: false
+  },
   // 이 작업판에 접근 가능한 사용자 그룹 (#198). 빈 배열이면 admin 외 접근 불가.
   // admin 은 implicit all-access (이 필드 무관). 마이그레이션 시 기본 그룹 1개 자동 할당.
   allowedGroupIds: [{

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -18,6 +18,7 @@ const { computeOpenAITextCost, computeGeminiTextCost } = require('../utils/prici
 const Project = require('../models/Project');
 const Tag = require('../models/Tag');
 const UploadedText = require('../models/UploadedText');
+const { loadVisionImages } = require('../utils/visionImages');
 
 // 세계관 (사전 컨텍스트) + 작업 지침 → 단일 system 메시지로 합성 (#396).
 // system prompt = LLM 의 역할 / 작업 방침 (작업판 admin 정의)
@@ -480,6 +481,16 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
       isContinuation: !!conversationId,
     });
 
+    // 비전 첨부 (#517): 작업판이 이미지 입력 허용 시 이번 턴의 첨부 이미지를 로드.
+    // turnImages = LLM 전송용 base64, turnAttachments = 대화 저장용 imageId/url 참조.
+    let turnImages = [];
+    let turnAttachments = [];
+    if (workboard.allowImageInput && Array.isArray(inputData.attachedImages) && inputData.attachedImages.length > 0) {
+      const loaded = await loadVisionImages(inputData.attachedImages, req.user._id);
+      turnImages = loaded.map((v) => ({ base64: v.base64, mimeType: v.mimeType }));
+      turnAttachments = loaded.map((v) => ({ imageId: v.imageId, url: v.url }));
+    }
+
     // 멀티턴 (#375): conversationId 가 있으면 기존 대화 로드 후 append.
     // 없으면 신규 대화 생성 (#373 Phase 1 동일 흐름).
     let conversation;
@@ -502,13 +513,21 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
       conversation.messages.push({
         role: 'user',
         content: inputData.userPrompt,
+        attachments: turnAttachments,
         createdAt: new Date(),
       });
       conversation.status = 'processing';
       conversation.error = undefined;
       await conversation.save();
-      // LLM 에는 전체 시퀀스 전달
-      messages = conversation.messages.map((m) => ({ role: m.role, content: m.content }));
+      // LLM 에는 전체 시퀀스 전달. 첨부 있는 메시지는 base64 로 로드해 비전 콘텐츠로 전송 (#517).
+      messages = await Promise.all(conversation.messages.map(async (m) => {
+        const base = { role: m.role, content: m.content };
+        if (m.attachments && m.attachments.length > 0) {
+          const imgs = await loadVisionImages(m.attachments.map((a) => a.imageId), conversation.userId);
+          if (imgs.length > 0) base.images = imgs.map((v) => ({ base64: v.base64, mimeType: v.mimeType }));
+        }
+        return base;
+      }));
     } else {
       // 신규 대화 — 세계관 / 사전 컨텍스트 / 시스템 프롬프트 문서 주입 (#396, #401).
       // 우선순위:
@@ -542,7 +561,14 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
       if (composedSystem) {
         messages.push({ role: 'system', content: composedSystem });
       }
-      messages.push({ role: 'user', content: inputData.userPrompt });
+      // 단발: 사용자 메시지에 첨부 이미지 동봉 (#517). attachments 는 영속(스키마), images 는
+      // LLM 전송용이라 ConversationJob.create 시 mongoose strict 가 떨궈낸다(스키마 미정의).
+      messages.push({
+        role: 'user',
+        content: inputData.userPrompt,
+        attachments: turnAttachments,
+        images: turnImages,
+      });
       // 프로젝트 작업 시 자동으로 프로젝트 태그 주입 (이미지 작업과 통일된 필터 메커니즘, #397 후속)
       let projectTagIds = [];
       if (projectId) {

--- a/src/routes/workboards.js
+++ b/src/routes/workboards.js
@@ -281,7 +281,8 @@ router.post('/', requireAdmin, async (req, res) => {
       modelWhitelist,
       loraExposurePolicy,
       loraWhitelist,
-      llmExtraParams
+      llmExtraParams,
+      allowImageInput
     } = req.body;
 
     const resolvedOutputFormat = outputFormat || (workboardType === 'prompt' ? 'text' : 'image');
@@ -341,6 +342,7 @@ router.post('/', requireAdmin, async (req, res) => {
       loraExposurePolicy: isComfyUI && loraExposurePolicy === 'whitelist' ? 'whitelist' : 'full',
       loraWhitelist: isComfyUI && Array.isArray(loraWhitelist) ? loraWhitelist : [],
       llmExtraParams: (llmExtraParams && Object.keys(llmExtraParams).length > 0) ? llmExtraParams : undefined,
+      allowImageInput: !!allowImageInput,
       createdBy: req.user._id
     });
 
@@ -380,6 +382,7 @@ router.put('/:id', requireAdmin, async (req, res) => {
       loraExposurePolicy,
       loraWhitelist,
       llmExtraParams,
+      allowImageInput,
       isActive
     } = req.body;
 
@@ -466,6 +469,9 @@ router.put('/:id', requireAdmin, async (req, res) => {
     if (llmExtraParams !== undefined) {
       workboard.llmExtraParams = (llmExtraParams && Object.keys(llmExtraParams).length > 0) ? llmExtraParams : undefined;
       workboard.markModified('llmExtraParams');
+    }
+    if (allowImageInput !== undefined) {
+      workboard.allowImageInput = !!allowImageInput;
     }
 
     console.log('Before save:', workboard.toObject());
@@ -579,6 +585,7 @@ router.post('/:id/duplicate', requireAdmin, async (req, res) => {
       loraExposurePolicy: originalWorkboard.loraExposurePolicy || 'full',
       loraWhitelist: originalWorkboard.loraWhitelist || [],
       llmExtraParams: originalWorkboard.llmExtraParams,
+      allowImageInput: originalWorkboard.allowImageInput,
       createdBy: req.user._id
     });
     

--- a/src/services/geminiService.js
+++ b/src/services/geminiService.js
@@ -124,9 +124,15 @@ const complete = async (serverUrl, apiKey, messages, options = {}) => {
   if (!model) throw new Error('Gemini Chat: model is required');
   if (!apiKey) throw new Error('Gemini Chat: api key is required');
 
+  // 비전 첨부(#517): 메시지에 images([{base64, mimeType}]) 가 있으면 inline_data 파트로 추가.
   const contents = (Array.isArray(messages) ? messages : []).map((m) => ({
     role: m.role === 'assistant' ? 'model' : 'user',
-    parts: [{ text: m.content || '' }],
+    parts: [
+      ...(m.content ? [{ text: m.content }] : []),
+      ...(Array.isArray(m.images)
+        ? m.images.map((img) => ({ inline_data: { mime_type: img.mimeType || 'image/jpeg', data: img.base64 } }))
+        : []),
+    ],
   }));
   if (contents.length === 0) {
     throw new Error('Gemini Chat: messages is empty');

--- a/src/services/openAIChatService.js
+++ b/src/services/openAIChatService.js
@@ -7,6 +7,25 @@ const extractValue = (input) => {
   return input;
 };
 
+// 비전 첨부(#517) 직렬화 — 메시지에 images([{base64, mimeType}]) 가 있으면 OpenAI vision 포맷으로.
+// content 를 텍스트 + image_url(data URL) 배열로 구성. 이미지 없으면 기존 문자열 content 그대로.
+// images 같은 내부 필드는 제거하고 OpenAI 가 받는 {role, content} 만 남긴다.
+const toOpenAIMessages = (messages) => (messages || []).map((m) => {
+  if (Array.isArray(m.images) && m.images.length > 0) {
+    return {
+      role: m.role,
+      content: [
+        ...(m.content ? [{ type: 'text', text: m.content }] : []),
+        ...m.images.map((img) => ({
+          type: 'image_url',
+          image_url: { url: `data:${img.mimeType || 'image/jpeg'};base64,${img.base64}` },
+        })),
+      ],
+    };
+  }
+  return { role: m.role, content: m.content || '' };
+});
+
 
 // OpenAI 호환 `/v1/chat/completions` 호출 — OpenAI 공식 / Local LLM (Ollama, LiteLLM, vLLM 등) 공통.
 // 응답에서 첫 번째 choice 의 메시지 본문 + usage 를 추출해 반환.
@@ -28,7 +47,7 @@ const complete = async (serverUrl, apiKey, messages, options = {}) => {
   const requestBody = {
     ...(options.extraParams || {}),
     model,
-    messages,
+    messages: toOpenAIMessages(messages),
   };
 
   const headers = { 'Content-Type': 'application/json' };
@@ -91,7 +110,7 @@ const completeStream = async (serverUrl, apiKey, messages, options = {}, onToken
     // 작업판별 추가 파라미터 passthrough (#493) — 필수/스트림 키가 뒤에서 항상 이김
     ...(options.extraParams || {}),
     model,
-    messages,
+    messages: toOpenAIMessages(messages),
     stream: true,
     // usage 를 마지막 청크에 포함하도록 요청 (지원하는 서버 한정 — 미지원 시 usage 0 으로 degrade)
     stream_options: { include_usage: true },

--- a/src/utils/visionImages.js
+++ b/src/utils/visionImages.js
@@ -1,0 +1,45 @@
+const sharp = require('sharp');
+const UploadedImage = require('../models/UploadedImage');
+
+// 비전 LLM 첨부 이미지 처리 (#517).
+// imageId 배열 → 비전 콘텐츠용 base64 이미지 배열로 변환한다.
+// - 사용자 소유 이미지만 로드(권한)
+// - 장변 MAX_DIM 으로 리사이즈 + jpeg 인코딩 (토큰/용량/비용 절감, 로컬 서버 한계 회피)
+// - 입력 순서 보존
+// 반환: [{ imageId, url, base64, mimeType }]  (LLM 호출엔 base64/mimeType, 영속/표시엔 imageId/url)
+
+const MAX_DIM = 1536;   // 장변 최대 픽셀
+const MAX_IMAGES = 4;   // 첨부 최대 장수
+
+async function loadVisionImages(imageIds, userId) {
+  if (!Array.isArray(imageIds) || imageIds.length === 0) return [];
+  const ids = imageIds.filter(Boolean).slice(0, MAX_IMAGES);
+  if (ids.length === 0) return [];
+
+  const docs = await UploadedImage.find({ _id: { $in: ids }, userId });
+  const byId = new Map(docs.map((d) => [String(d._id), d]));
+
+  const out = [];
+  for (const id of ids) {
+    const doc = byId.get(String(id));
+    if (!doc?.path) continue;
+    try {
+      const buf = await sharp(doc.path)
+        .rotate() // EXIF orientation 반영
+        .resize(MAX_DIM, MAX_DIM, { fit: 'inside', withoutEnlargement: true })
+        .jpeg({ quality: 85 })
+        .toBuffer();
+      out.push({
+        imageId: doc._id,
+        url: doc.url,
+        base64: buf.toString('base64'),
+        mimeType: 'image/jpeg',
+      });
+    } catch (e) {
+      console.error('[visionImages] 이미지 로드/변환 실패:', String(id), e.message);
+    }
+  }
+  return out;
+}
+
+module.exports = { loadVisionImages, MAX_IMAGES, MAX_DIM };


### PR DESCRIPTION
비전 LLM 에 이미지를 첨부해 분석 → 프롬프트 추출. 단발/멀티턴/이어가기 전부 지원.

## 흐름
업로드(imageId) → 백엔드가 base64(장변 1536 리사이즈, jpeg)로 읽어 LLM 메시지에 비전 콘텐츠 주입 (OpenAI `image_url` / Gemini `inline_data`) → 분석 결과 스트리밍.

## Phase 1 — 백엔드
- `Workboard.allowImageInput`(admin 토글), `ConversationJob` 메시지 `attachments`(imageId/url 참조)
- `utils/visionImages`: imageId → base64 (사용자 소유만, 리사이즈)
- openAIChatService(complete/completeStream)·geminiService: 메시지 `images` 를 각 vision 포맷으로 직렬화
- `/generate-prompt`: allowImageInput 게이트 하 `inputData.attachedImages` 처리, 단발·멀티턴 메시지 enrich + 첨부 저장
- workboards POST/PUT/duplicate: allowImageInput 영속

## Phase 2 — 프론트
- 공용 `ImageUploadField`(선택/미리보기/삭제). 세 패널 공유
- PromptGeneratorPanel·WorkboardChatPanel·ConversationChatPanel: allowImageInput 시 첨부 UI + 업로드 후 attachedImages 동봉
- 작업판 편집기 LLM 파라미터 탭에 '이미지 입력 허용(비전 모델)' 토글

## Phase 3 — 다시보기
- 대화 말풍선에 첨부 이미지 썸네일(서명 URL) 표시

## 검증 (실 M4Max 멀티모달)
- 백엔드 API: 첨부 이미지(빨간원/파란삼각형/'VCC TEST') 정확 분석, 첨부 영속, allowImageInput=false 게이트
- **실 채팅 UI E2E: 첨부→전송→"a red circle, a blue triangle, and a white rectangle with green border containing text 'VCC TEST'" 정확 분석 + 썸네일 표시**

closes #517

🤖 Generated with [Claude Code](https://claude.com/claude-code)