### PR TITLE
refactor: 이미지 첨부를 image customField 로 통합 (#519)

### DIFF
--- a/frontend/src/components/PromptGeneratorPanel.js
+++ b/frontend/src/components/PromptGeneratorPanel.js
@@ -146,7 +146,6 @@ function PromptGeneratorPanel({
   const [isGenerating, setIsGenerating] = useState(false);
   const [generatedResult, setGeneratedResult] = useState(null);
   const [referenceImages, setReferenceImages] = useState({});
-  const [attachImages, setAttachImages] = useState([]); // 비전 첨부 (#517)
   const { send: streamSend, streamingText, isStreaming } = useStreamingPrompt();
 
   const { control, handleSubmit, setValue, formState: { errors } } = useForm({
@@ -192,7 +191,6 @@ function PromptGeneratorPanel({
     setGeneratedResult(null);
 
     let uploadedImages = {};
-    let attachedImageIds = [];
     try {
       for (const [fieldName, images] of Object.entries(referenceImages)) {
         if (images && images.length > 0) {
@@ -211,18 +209,6 @@ function PromptGeneratorPanel({
           uploadedImages[fieldName] = imageIds;
         }
       }
-      // 비전 첨부 이미지 업로드 (#517)
-      for (const img of attachImages) {
-        if (img.file) {
-          const uploadData = new FormData();
-          uploadData.append('image', img.file);
-          uploadData.append('imageType', 'reference');
-          const response = await imageAPI.upload(uploadData);
-          attachedImageIds.push(response.data.image._id);
-        } else if (img._id) {
-          attachedImageIds.push(img._id);
-        }
-      }
     } catch (error) {
       toast.error('이미지 업로드 실패: ' + (error.response?.data?.message || error.message));
       setIsGenerating(false);
@@ -239,7 +225,6 @@ function PromptGeneratorPanel({
           model: formData.model,
           userPrompt: formData.userPrompt,
           ...uploadedImages,
-          ...(attachedImageIds.length > 0 ? { attachedImages: attachedImageIds } : {}),
           ...Object.fromEntries(
             Object.entries(formData).filter(([key]) =>
               !['model', 'userPrompt'].includes(key)
@@ -252,7 +237,7 @@ function PromptGeneratorPanel({
           setGeneratedResult({ ...info, result: info.result ?? fullText });
           toast.success('프롬프트가 생성되었습니다!');
           setIsGenerating(false);
-          setAttachImages([]); // 첨부 초기화 — 재생성 시 중복 업로드 방지 (#517)
+          setReferenceImages({}); // 첨부 초기화 — 재생성 시 중복 업로드 방지 (#519)
         },
         onError: (error) => {
           toast.error('생성 실패: ' + (error.message || '알 수 없는 오류'));
@@ -370,6 +355,16 @@ function PromptGeneratorPanel({
                       )}
                     />
                   )}
+                  {/* 이미지 입력 (#519) — image 타입 필드. 첨부 시 비전 입력으로 사용 */}
+                  {field.type === 'image' && (
+                    <ImageUploadField
+                      label={field.label}
+                      description={field.description || '이미지를 첨부하면 모델이 분석에 참고합니다. (비전 모델 전용)'}
+                      images={referenceImages[field.name] || []}
+                      onImagesChange={(imgs) => setReferenceImages((prev) => ({ ...prev, [field.name]: imgs }))}
+                      maxImages={field.imageConfig?.maxImages || 4}
+                    />
+                  )}
                 </Box>
               ))}
 
@@ -391,19 +386,6 @@ function PromptGeneratorPanel({
                   />
                 )}
               />
-
-              {/* 비전 이미지 첨부 (#517) — 작업판이 이미지 입력 허용 시에만 */}
-              {workboard.allowImageInput && (
-                <Box sx={{ mt: 2 }}>
-                  <ImageUploadField
-                    label="이미지 첨부 (선택)"
-                    description="이미지를 첨부하면 모델이 분석에 참고합니다. 최대 4장. (비전 모델 전용)"
-                    images={attachImages}
-                    onImagesChange={setAttachImages}
-                    maxImages={4}
-                  />
-                </Box>
-              )}
 
               <Button
                 type="submit"

--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -747,7 +747,6 @@ export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage
       loraExposurePolicy: 'full',
       loraWhitelist: [],
       llmExtraParams: '',
-      allowImageInput: false,
       isActive: true,
       additionalCustomFields: []
     }
@@ -855,7 +854,6 @@ export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage
             llmExtraParams: fullData.llmExtraParams && Object.keys(fullData.llmExtraParams).length > 0
               ? JSON.stringify(fullData.llmExtraParams, null, 2)
               : '',
-            allowImageInput: !!fullData.allowImageInput,
             isActive: fullData.isActive ?? true,
             // 커스텀 필드 — 모든 additionalInputFields 를 단일 generic 편집기에 노출.
             // defaultValue / description / placeholder 도 form 에 같이 싣어 admin 이 편집 가능 (#391)
@@ -980,7 +978,6 @@ export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage
       loraExposurePolicy: isComfyUIServer && data.loraExposurePolicy === 'whitelist' ? 'whitelist' : 'full',
       loraWhitelist: isComfyUIServer && Array.isArray(data.loraWhitelist) ? data.loraWhitelist : [],
       llmExtraParams: parsedLlmExtraParams,
-      allowImageInput: !!data.allowImageInput,
       isActive: Boolean(data.isActive),
       // F3: baseInputFields 편집 제거 — 신규/기존 모두 빈 상태로 저장.
       // 스키마의 required: true (aiModel) 통과 위해 빈 배열 명시.
@@ -1493,22 +1490,8 @@ export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage
           {/* LLM 파라미터 탭 - 텍스트(LLM) 작업판만 (#495). ComfyUI 워크플로우 탭과 동일 위치(index 3) */}
           {outputFormat === 'text' && tabValue === 3 && (
             <Box>
-              {/* 이미지 입력 허용 (#517) — 비전 모델일 때만 켤 것 */}
-              <Controller
-                name="allowImageInput"
-                control={control}
-                render={({ field }) => (
-                  <FormControlLabel
-                    sx={{ mb: 1 }}
-                    control={<Switch checked={!!field.value} onChange={(e) => field.onChange(e.target.checked)} />}
-                    label="이미지 입력 허용 (비전 모델)"
-                  />
-                )}
-              />
-              <Typography variant="caption" color="textSecondary" display="block" sx={{ mb: 2 }}>
-                켜면 실행 화면에서 사용자가 이미지를 첨부할 수 있고, 첨부 이미지는 모델에 비전 입력으로 전달됩니다.
-                선택한 베이스 모델이 비전(멀티모달)을 지원해야 정상 동작합니다.
-              </Typography>
+              {/* 이미지 입력은 입력 양식 탭에서 'image' 타입 필드를 추가하면 자동 활성화됩니다 (#519).
+                  비전(멀티모달) 모델을 베이스 모델로 선택해야 분석됩니다. */}
               <Typography variant="body2" color="textSecondary" paragraph>
                 LLM 요청에 추가로 전달할 파라미터를 JSON 으로 지정합니다. 모델/서버별 thinking 비활성화나
                 창작용 temperature 등을 작업판마다 다르게 설정할 수 있습니다. 비워두면 모델 기본값으로 동작합니다.

--- a/frontend/src/components/common/ConversationChatPanel.js
+++ b/frontend/src/components/common/ConversationChatPanel.js
@@ -63,7 +63,8 @@ function ConversationChatPanel({ workboard, conversationId }) {
   // 스트리밍 전송 (#490)
   const { send: streamSend, streamingText, isStreaming } = useStreamingPrompt();
   const [pendingUserMsg, setPendingUserMsg] = useState(null);
-  const [attachImages, setAttachImages] = useState([]); // 비전 첨부 (#517)
+  const [attachImages, setAttachImages] = useState([]); // 비전 첨부 (#519)
+  const imageField = (workboard.additionalInputFields || []).find((f) => f.type === 'image');
 
   // 스트리밍 중 자동 스크롤
   useEffect(() => {
@@ -79,9 +80,9 @@ function ConversationChatPanel({ workboard, conversationId }) {
     setPendingUserMsg(trimmed);
     setNewMessage('');
 
-    // 비전 첨부 이미지 업로드 (#517)
+    // 비전 첨부 이미지 업로드 (#519) — image 필드가 있을 때만
     let attachedImageIds = [];
-    if (workboard.allowImageInput && attachImages.length > 0) {
+    if (imageField && attachImages.length > 0) {
       try {
         for (const img of attachImages) {
           if (img.file) {
@@ -105,7 +106,7 @@ function ConversationChatPanel({ workboard, conversationId }) {
       {
         workboardId: workboard._id,
         conversationId,
-        inputData: { userPrompt: trimmed, ...(attachedImageIds.length ? { attachedImages: attachedImageIds } : {}) },
+        inputData: { userPrompt: trimmed, ...(attachedImageIds.length && imageField ? { [imageField.name]: attachedImageIds } : {}) },
       },
       {
         onDone: () => {
@@ -249,14 +250,15 @@ function ConversationChatPanel({ workboard, conversationId }) {
         )}
       </Box>
 
-      {/* 비전 이미지 첨부 (#517) — 작업판이 이미지 입력 허용 시 */}
-      {workboard.allowImageInput && (
+      {/* 비전 이미지 첨부 (#519) — image 필드가 있을 때 턴별 첨부 */}
+      {imageField && (
         <Box sx={{ mb: 1.5 }}>
           <ImageUploadField
-            description="이미지를 첨부하면 모델이 분석에 참고합니다. 최대 4장. (비전 모델 전용)"
+            label={imageField.label}
+            description={imageField.description || '이미지를 첨부하면 모델이 분석에 참고합니다. (비전 모델 전용)'}
             images={attachImages}
             onImagesChange={setAttachImages}
-            maxImages={4}
+            maxImages={imageField.imageConfig?.maxImages || 4}
             disabled={isSending}
           />
         </Box>

--- a/frontend/src/components/common/WorkboardChatPanel.js
+++ b/frontend/src/components/common/WorkboardChatPanel.js
@@ -46,9 +46,15 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
   const transcriptRef = useRef(null);
   const queryClient = useQueryClient();
 
-  // admin 이 설정하는 conversation_mode 외 customField 를 settings 폼으로 노출
+  // 비전 이미지 입력 필드 (#519) — image 타입은 "설정"이 아니라 턴별 첨부로 다룬다(잠금 분리).
+  const imageField = useMemo(
+    () => (workboard.additionalInputFields || []).find((f) => f.type === 'image'),
+    [workboard]
+  );
+
+  // admin 이 설정하는 conversation_mode / image 외 customField 를 settings 폼으로 노출
   const settingsFields = useMemo(
-    () => (workboard.additionalInputFields || []).filter((f) => f.name !== 'conversation_mode'),
+    () => (workboard.additionalInputFields || []).filter((f) => f.name !== 'conversation_mode' && f.type !== 'image'),
     [workboard]
   );
 
@@ -88,9 +94,9 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
     setPendingUserMsg(text);
     setNewMessage('');
 
-    // 비전 첨부 이미지 업로드 (#517)
+    // 비전 첨부 이미지 업로드 (#519) — image 필드가 있을 때만
     let attachedImageIds = [];
-    if (workboard.allowImageInput && attachImages.length > 0) {
+    if (imageField && attachImages.length > 0) {
       try {
         for (const img of attachImages) {
           if (img.file) {
@@ -118,7 +124,7 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
         // 이어가는 메시지엔 이미 첫 턴의 system 메시지가 보존되어 있음.
         projectId: cid ? undefined : (projectId || undefined),
         useWorldview: cid ? undefined : !!useWorldview,
-        inputData: { ...settings, userPrompt: text, ...(attachedImageIds.length ? { attachedImages: attachedImageIds } : {}) },
+        inputData: { ...settings, userPrompt: text, ...(attachedImageIds.length && imageField ? { [imageField.name]: attachedImageIds } : {}) },
       },
       {
         onDone: (info) => {
@@ -395,14 +401,15 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
         )}
       </Box>
 
-      {/* 비전 이미지 첨부 (#517) — 작업판이 이미지 입력 허용 시 */}
-      {workboard.allowImageInput && (
+      {/* 비전 이미지 첨부 (#519) — image 필드가 있을 때 턴별 첨부 */}
+      {imageField && (
         <Box sx={{ mb: 1.5 }}>
           <ImageUploadField
-            description="이미지를 첨부하면 모델이 분석에 참고합니다. 최대 4장. (비전 모델 전용)"
+            label={imageField.label}
+            description={imageField.description || '이미지를 첨부하면 모델이 분석에 참고합니다. (비전 모델 전용)'}
             images={attachImages}
             onImagesChange={setAttachImages}
-            maxImages={4}
+            maxImages={imageField.imageConfig?.maxImages || 4}
             disabled={isSending}
           />
         </Box>

--- a/src/models/Workboard.js
+++ b/src/models/Workboard.js
@@ -110,12 +110,6 @@ const workboardSchema = new mongoose.Schema({
     type: mongoose.Schema.Types.Mixed,
     default: undefined
   },
-  // 텍스트(LLM) 작업판에서 이미지 첨부 허용 여부 (#517). 비전 모델일 때 admin 이 켠다.
-  // 켜면 실행 화면에 이미지 첨부 UI 가 노출되고, 첨부 이미지는 비전 콘텐츠로 LLM 에 전달.
-  allowImageInput: {
-    type: Boolean,
-    default: false
-  },
   // 이 작업판에 접근 가능한 사용자 그룹 (#198). 빈 배열이면 admin 외 접근 불가.
   // admin 은 implicit all-access (이 필드 무관). 마이그레이션 시 기본 그룹 1개 자동 할당.
   allowedGroupIds: [{

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -481,12 +481,22 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
       isContinuation: !!conversationId,
     });
 
-    // 비전 첨부 (#517): 작업판이 이미지 입력 허용 시 이번 턴의 첨부 이미지를 로드.
+    // 비전 첨부 (#517 → #519 통합): 작업판의 image 타입 customField 값(imageId)을 비전 입력으로.
+    // 별도 토글 없이 image 필드가 있으면 동작하고, 첨부가 없으면 그냥 일반 채팅으로 진행.
     // turnImages = LLM 전송용 base64, turnAttachments = 대화 저장용 imageId/url 참조.
     let turnImages = [];
     let turnAttachments = [];
-    if (workboard.allowImageInput && Array.isArray(inputData.attachedImages) && inputData.attachedImages.length > 0) {
-      const loaded = await loadVisionImages(inputData.attachedImages, req.user._id);
+    const imageFieldNames = (workboard.additionalInputFields || [])
+      .filter((f) => f.type === 'image')
+      .map((f) => f.name);
+    const collectedImageIds = [];
+    for (const fname of imageFieldNames) {
+      const v = inputData[fname];
+      if (Array.isArray(v)) collectedImageIds.push(...v.filter(Boolean));
+      else if (v) collectedImageIds.push(v);
+    }
+    if (collectedImageIds.length > 0) {
+      const loaded = await loadVisionImages(collectedImageIds, req.user._id);
       turnImages = loaded.map((v) => ({ base64: v.base64, mimeType: v.mimeType }));
       turnAttachments = loaded.map((v) => ({ imageId: v.imageId, url: v.url }));
     }

--- a/src/routes/workboards.js
+++ b/src/routes/workboards.js
@@ -281,8 +281,7 @@ router.post('/', requireAdmin, async (req, res) => {
       modelWhitelist,
       loraExposurePolicy,
       loraWhitelist,
-      llmExtraParams,
-      allowImageInput
+      llmExtraParams
     } = req.body;
 
     const resolvedOutputFormat = outputFormat || (workboardType === 'prompt' ? 'text' : 'image');
@@ -342,7 +341,6 @@ router.post('/', requireAdmin, async (req, res) => {
       loraExposurePolicy: isComfyUI && loraExposurePolicy === 'whitelist' ? 'whitelist' : 'full',
       loraWhitelist: isComfyUI && Array.isArray(loraWhitelist) ? loraWhitelist : [],
       llmExtraParams: (llmExtraParams && Object.keys(llmExtraParams).length > 0) ? llmExtraParams : undefined,
-      allowImageInput: !!allowImageInput,
       createdBy: req.user._id
     });
 
@@ -382,7 +380,6 @@ router.put('/:id', requireAdmin, async (req, res) => {
       loraExposurePolicy,
       loraWhitelist,
       llmExtraParams,
-      allowImageInput,
       isActive
     } = req.body;
 
@@ -469,9 +466,6 @@ router.put('/:id', requireAdmin, async (req, res) => {
     if (llmExtraParams !== undefined) {
       workboard.llmExtraParams = (llmExtraParams && Object.keys(llmExtraParams).length > 0) ? llmExtraParams : undefined;
       workboard.markModified('llmExtraParams');
-    }
-    if (allowImageInput !== undefined) {
-      workboard.allowImageInput = !!allowImageInput;
     }
 
     console.log('Before save:', workboard.toObject());
@@ -585,7 +579,6 @@ router.post('/:id/duplicate', requireAdmin, async (req, res) => {
       loraExposurePolicy: originalWorkboard.loraExposurePolicy || 'full',
       loraWhitelist: originalWorkboard.loraWhitelist || [],
       llmExtraParams: originalWorkboard.llmExtraParams,
-      allowImageInput: originalWorkboard.allowImageInput,
       createdBy: req.user._id
     });
     


### PR DESCRIPTION
#517 후속. 별도 'allowImageInput' 토글 대신 작업판에 **image 타입 customField** 가 있으면 비전 입력으로 사용. 필드 required on/off 로 필수/선택 제어, 첨부 없으면 일반 채팅(단발/멀티턴 동일).

- 백엔드 `/generate-prompt`: image 타입 필드 값(imageId)을 비전 콘텐츠로 (attachedImages 대체), allowImageInput 게이트 제거
- `Workboard.allowImageInput` 스키마/라우트/편집기 토글 제거
- 단발(PromptGeneratorPanel): customField 루프에 image 타입 렌더(referenceImages 경유)
- 멀티턴/이어가기: image 필드를 settings 잠금에서 분리 → 입력창 위 턴별 첨부로 렌더, 필드명으로 업로드
- 다시보기 썸네일 유지

검증(실 M4Max multimodal): image 필드 추가 → 채팅 첨부 → 정확 분석 + 썸네일. 콘솔 에러 0.

closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)