### PR TITLE
fix: backupLock allowlist 경로 매칭 버그 수정 + 선별 allowlist (#529)

### DIFF
--- a/src/middleware/backupLock.js
+++ b/src/middleware/backupLock.js
@@ -48,26 +48,29 @@ function blockDuringBackup(req, res, next) {
     return next();
   }
 
-  // 백업 관련 API는 허용 (상태 조회 등)
-  if (req.path.startsWith('/api/admin/backup')) {
+  if (!backupInProgress) {
     return next();
   }
 
-  // 인증 API는 허용
-  if (req.path.startsWith('/api/auth')) {
+  // NOTE: app.use('/api', ...) 로 마운트되므로 req.path 에는 '/api' prefix 가 없음 (#529)
+
+  // 로그인/로그아웃은 백업 중에도 허용 (관리자 진입 경로).
+  // signup / 비밀번호 재설정은 User 컬렉션 쓰기라 차단 유지.
+  if (req.path === '/auth/signin' || req.path === '/auth/logout') {
     return next();
   }
 
-  // 백업 진행 중이면 차단
-  if (backupInProgress) {
-    return res.status(503).json({
-      success: false,
-      message: '백업이 진행 중입니다. 잠시 후 다시 시도해주세요.',
-      backupJobId: currentBackupJobId
-    });
+  // 백업 제어 API 는 허용 (백업 시작은 핸들러 자체 가드로 중복 방지).
+  // 단 복원(restore)은 진행 중 백업과 동시 실행 금지.
+  if (req.path.startsWith('/admin/backup') && !req.path.startsWith('/admin/backup/restore')) {
+    return next();
   }
 
-  next();
+  return res.status(503).json({
+    success: false,
+    message: '백업이 진행 중입니다. 잠시 후 다시 시도해주세요.',
+    backupJobId: currentBackupJobId
+  });
 }
 
 module.exports = {

--- a/src/routes/backup.js
+++ b/src/routes/backup.js
@@ -291,6 +291,14 @@ router.post('/restore/validate', requireAdmin, upload.single('backup'), async (r
  */
 router.post('/restore', requireAdmin, async (req, res) => {
   try {
+    // 백업 진행 중 복원 금지 — blockDuringBackup allowlist 와 무관하게 핸들러에서도 가드 (#529)
+    if (isBackupInProgress()) {
+      return res.status(409).json({
+        success: false,
+        message: '백업이 진행 중입니다. 백업 완료 후 복원을 시작해주세요.'
+      });
+    }
+
     const { jobId, options = {} } = req.body;
 
     if (!jobId) {

--- a/src/tests/backupLock.test.js
+++ b/src/tests/backupLock.test.js
@@ -1,0 +1,79 @@
+const express = require('express');
+const request = require('supertest');
+
+/**
+ * #529 backupLock 미들웨어 경로 매칭 회귀 테스트
+ *
+ * app.use('/api', blockDuringBackup) 로 마운트되면 req.path 에서 '/api' prefix 가
+ * 제거된다. allowlist 가 '/api/...' 형태로 비교하면 절대 매치되지 않는 버그가 있었음.
+ * 실제 마운트 형태 그대로 supertest 로 검증한다.
+ */
+
+const {
+  startBackupLock,
+  endBackupLock,
+  blockDuringBackup
+} = require('../middleware/backupLock');
+
+function buildApp() {
+  const app = express();
+  app.use('/api', blockDuringBackup);
+  app.all('/api/*', (req, res) => res.status(200).json({ passed: true }));
+  return app;
+}
+
+describe('blockDuringBackup (마운트 경로 기준)', () => {
+  const app = buildApp();
+
+  afterEach(() => {
+    endBackupLock();
+  });
+
+  describe('백업 미진행 시', () => {
+    test('모든 쓰기 요청 통과', async () => {
+      await request(app).post('/api/images/bulk-delete').expect(200);
+      await request(app).post('/api/auth/signup').expect(200);
+      await request(app).post('/api/admin/backup/restore').expect(200);
+    });
+  });
+
+  describe('백업 진행 중', () => {
+    beforeEach(() => {
+      startBackupLock('test-backup-job');
+    });
+
+    test('읽기 요청 (GET) 은 항상 통과', async () => {
+      await request(app).get('/api/admin/backup/list').expect(200);
+      await request(app).get('/api/jobs/my').expect(200);
+    });
+
+    test('일반 쓰기 요청은 503 차단', async () => {
+      const res = await request(app).post('/api/images/bulk-delete').expect(503);
+      expect(res.body.backupJobId).toBe('test-backup-job');
+      await request(app).delete('/api/jobs/123').expect(503);
+      await request(app).put('/api/workboards/123').expect(503);
+    });
+
+    test('로그인/로그아웃은 허용 (관리자 진입 경로)', async () => {
+      await request(app).post('/api/auth/signin').expect(200);
+      await request(app).post('/api/auth/logout').expect(200);
+    });
+
+    test('signup / 비밀번호 재설정은 차단 (User 컬렉션 쓰기)', async () => {
+      await request(app).post('/api/auth/signup').expect(503);
+      await request(app).post('/api/auth/forgot-password').expect(503);
+      await request(app).post('/api/auth/reset-password').expect(503);
+    });
+
+    test('백업 제어 API 는 허용', async () => {
+      await request(app).post('/api/admin/backup').expect(200);
+      await request(app).post('/api/admin/backup/abc123/signed-url').expect(200);
+      await request(app).delete('/api/admin/backup/abc123').expect(200);
+    });
+
+    test('복원(restore) 은 백업 중 차단', async () => {
+      await request(app).post('/api/admin/backup/restore').expect(503);
+      await request(app).post('/api/admin/backup/restore/validate').expect(503);
+    });
+  });
+});


### PR DESCRIPTION
## 변경사항

`app.use('/api', ...)` 마운트 시 req.path 에서 '/api' prefix 가 제거되어 allowlist 가 절대 매치되지 않던 버그 수정. 백업 중 로그인까지 503 차단되던 동작이 의도된 allowlist 대로 복원됩니다.

### 선별 allowlist 구성 (이슈 #529 의 전수 조사 기반)

백업 진행 중 비-GET 요청에 대해:
- ✅ `POST /auth/signin`, `POST /auth/logout` — 관리자 진입 경로 (signin 의 lastLogin 갱신은 감수)
- ❌ `signup` / `forgot-password` / `reset-password` — User 컬렉션 쓰기라 차단 유지
- ✅ `/admin/backup` 하위 백업 제어 — 백업 시작 POST 는 핸들러 자체 중복 가드 있음
- ❌ `/admin/backup/restore*` — 백업-복원 동시 실행 금지
- GET/HEAD/OPTIONS 는 기존대로 항상 통과

### 방어 심층화
`POST /restore` 핸들러에도 `isBackupInProgress()` 가드 추가 (409) — 미들웨어 정책 변경과 무관하게 보호.

## 검증
- supertest 회귀 테스트 7건 추가, 전부 통과 (`src/tests/backupLock.test.js` — 실제 '/api' 마운트 형태로 검증)

closes #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)