### PR TITLE
fix: ComfyUI 실행 타임아웃에 서버 설정 timeout 적용 (#530)

### DIFF
--- a/src/services/comfyUIService.js
+++ b/src/services/comfyUIService.js
@@ -169,7 +169,7 @@ const processHistoryResult = async (serverUrl, history) => {
   return { images, videos };
 };
 
-const submitWorkflow = async (serverUrl, workflowJson, progressCallback) => {
+const submitWorkflow = async (serverUrl, workflowJson, progressCallback, executionTimeout = 300000) => {
   const clientId = uuidv4();
 
   console.log(`🔗 ComfyUI Service: Connecting to ${serverUrl}`);
@@ -215,10 +215,12 @@ const submitWorkflow = async (serverUrl, workflowJson, progressCallback) => {
     //    executing { node: null }은 히스토리 저장 후 전송되므로 가장 안전한 완료 신호
     return new Promise((resolve, reject) => {
       let currentProgress = 0;
+      // 서버 설정 (Server.configuration.timeout) 적용 — 스키마 기본값도 300000 이라 미설정 시 기존과 동일 (#530)
+      // 타임아웃 시 interrupt 는 호출하지 않음 — 재연결 후 타임아웃 작업 재매칭 운영 플로우 보존
       const timeout = setTimeout(() => {
         ws.close();
-        reject(new Error('Workflow execution timeout'));
-      }, 300000); // 5 minutes timeout
+        reject(new Error(`Workflow execution timeout (${Math.round(executionTimeout / 1000)}s)`));
+      }, executionTimeout);
 
       ws.on('message', async (data, isBinary) => {
         // ComfyUI sends binary messages (image previews, etc.) — skip them

--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -274,7 +274,8 @@ async function handleComfyUIWorkflow({ workboardData, inputData, job, jobId }) {
   const result = await comfyUIService.submitWorkflow(
     workboardData.serverUrl,
     workflowJson,
-    (progress) => job.progress(20 + (progress * 0.7))
+    (progress) => job.progress(20 + (progress * 0.7)),
+    workboardData.timeout || 300000
   );
   job.progress(90);
 


### PR DESCRIPTION
## 변경사항

- `comfyUIService.submitWorkflow` 에 `executionTimeout` 파라미터 추가 — 실행 대기 setTimeout 의 300초 하드코딩 제거
- queueService ComfyUI 핸들러에서 `workboardData.timeout || 300000` 전달 — 관리자 페이지에서 서버별로 설정한 timeout 이 ComfyUI 워크플로우에도 적용됨 (기존엔 Gemini/GPT 경로만 적용)
- `Server.configuration.timeout` 스키마 기본값이 300000 이라 **timeout 을 별도 설정하지 않은 서버는 동작 변화 없음**
- 타임아웃 시 `interruptExecution` 은 호출하지 않음 — 재연결 후 타임아웃 작업 재매칭 운영 플로우 보존 (triage 결정)

## 검증
- submitWorkflow 호출처는 queueService 1곳뿐임을 확인
- 기존 jest 테스트 영향 없음 (`queueService.test.js` 의 suite 로드 실패는 dev 에 이미 존재하는 중복 선언 문제 — #525 에서 처리 예정)

closes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)