### PR TITLE
chore: .dockerignore 추가 — 빌드 컨텍스트에서 .env/node_modules/.git 제외 (#527)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,44 @@
+# 빌드 컨텍스트 제외 목록 (#527)
+# 주의: .dockerignore 패턴은 .gitignore 와 달리 컨텍스트 루트 기준 앵커링.
+#       'nginx.conf' 는 Dockerfile.frontend 가 COPY 하므로 제외 금지.
+
+# 의존성 / 빌드 산출물 (이미지 내부에서 설치/빌드)
+node_modules
+**/node_modules
+**/.pnpm-store
+frontend/build
+
+# VCS / OS
+.git
+.github
+.DS_Store
+**/.DS_Store
+
+# 시크릿 — 런타임 환경변수는 compose 가 주입.
+# frontend/.env 는 CRA "빌드타임" 설정이라 컨텍스트에 포함되어야 함 (루트 앵커링이라 자동 보존됨)
+.env
+.env.production
+
+# 테스트 / 개발 도구 (이미지에 불필요)
+e2e
+test-results
+playwright.config.js
+samples
+tools
+scripts
+claude
+mongo-init
+
+# 런타임 볼륨으로 마운트되는 디렉토리
+uploads
+backups
+
+# 문서 (updatelogs 는 backend 가 COPY — 재포함)
+docs/*
+!docs/updatelogs
+*.md
+
+# docker 메타파일 자신
+docker-compose*.yml
+Dockerfile*
+.dockerignore


### PR DESCRIPTION
## 변경사항

`.dockerignore` 신설. 빌드 컨텍스트(데몬으로 전송되는 파일 묶음)에서 `node_modules`(116M), `.git`(18M), `.env`(시크릿), frontend/build, e2e, uploads 등을 제외.

## 효과
- 컨텍스트 전송: ~140MB+ → backend 0.8MB / frontend 1.5MB (`--no-cache` 정책상 매 빌드 이득)
- 향후 `COPY . .` 추가 시 `.env` 가 이미지에 박히는 사고 경로 차단

## 보존 처리 (검증 포인트)
- `nginx.conf` — Dockerfile.frontend 가 COPY → 제외하지 않음
- `frontend/.env` — CRA 빌드타임 설정 → .dockerignore 는 루트 앵커링이라 루트 `.env` 만 제외되고 frontend/.env 는 자동 보존
- `docs/updatelogs` — backend 가 COPY → `docs/*` + `!docs/updatelogs` 재포함

## 검증
- 3개 이미지 모두 `docker compose build --no-cache` 성공

closes #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)