### PR TITLE
fix: docker-compose 로그 로테이션 추가 — json-file 10m × 3 (#522)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,8 +1,16 @@
+# 컨테이너 로그 로테이션 — 무제한 누적으로 인한 디스크 고갈 방지 (#522)
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "3"
+
 services:
   mongodb:
     image: mongo:7.0
     container_name: vcc-mongodb
     restart: unless-stopped
+    logging: *default-logging
     environment:
       MONGO_INITDB_ROOT_USERNAME: ${MONGO_ROOT_USER:?MONGO_ROOT_USER is required}
       MONGO_INITDB_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD:?MONGO_ROOT_PASSWORD is required}
@@ -20,6 +28,7 @@ services:
     image: redis:7.2-alpine
     container_name: vcc-redis
     restart: unless-stopped
+    logging: *default-logging
     command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD:?REDIS_PASSWORD is required}
     # 🔒 포트 노출 제거 (내부 네트워크에서만 접근 가능)
     # ports:
@@ -35,6 +44,7 @@ services:
       dockerfile: Dockerfile.backend
     container_name: vcc-backend
     restart: unless-stopped
+    logging: *default-logging
     healthcheck:
       test: ["CMD", "node", "-e", "require('http').get('http://localhost:3000/health', (res) => process.exit(res.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"]
       interval: 30s
@@ -88,6 +98,7 @@ services:
         REACT_APP_API_URL: ${REACT_APP_API_URL:-/api}
     container_name: vcc-frontend
     restart: unless-stopped
+    logging: *default-logging
     ports:
       - "${FRONTEND_PORT:-8136}:80"
     depends_on:
@@ -101,6 +112,7 @@ services:
       dockerfile: Dockerfile.mcp
     container_name: vcc-mcp-server
     restart: unless-stopped
+    logging: *default-logging
     healthcheck:
       test: ["CMD", "node", "-e", "require('http').get('http://localhost:3100/health', (res) => process.exit(res.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"]
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,17 @@
 
+# 컨테이너 로그 로테이션 — 무제한 누적으로 인한 디스크 고갈 방지 (#522)
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "3"
+
 services:
   mongodb:
     image: mongo:7.0
     container_name: vcc-mongodb
     restart: unless-stopped
+    logging: *default-logging
     environment:
       MONGO_INITDB_ROOT_USERNAME: ${MONGO_ROOT_USER:-admin}
       MONGO_INITDB_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD:-password}
@@ -21,6 +29,7 @@ services:
     image: redis:7.2-alpine
     container_name: vcc-redis
     restart: unless-stopped
+    logging: *default-logging
     command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD:-redispassword}
     # 보안상 Redis 포트는 개발환경에서만 노출 (프로덕션에서는 docker-compose.prod.yml 사용 권장)
     ports:
@@ -36,6 +45,7 @@ services:
       dockerfile: Dockerfile.backend
     container_name: vcc-backend
     restart: unless-stopped
+    logging: *default-logging
     environment:
       NODE_ENV: production
       PORT: 3000
@@ -84,6 +94,7 @@ services:
       dockerfile: Dockerfile.frontend
     container_name: vcc-frontend
     restart: unless-stopped
+    logging: *default-logging
     ports:
       - "${FRONTEND_PORT:-8136}:80"
     depends_on:
@@ -97,6 +108,7 @@ services:
       dockerfile: Dockerfile.mcp
     container_name: vcc-mcp-server
     restart: unless-stopped
+    logging: *default-logging
     environment:
       MCP_TRANSPORT: http
       MCP_PORT: 3100


### PR DESCRIPTION
## 변경사항

dev/prod compose 전 서비스(mongodb/redis/backend/frontend/mcp-server)에 `x-logging` anchor 로 로그 로테이션 적용:

```yaml
logging:
  driver: json-file
  options:
    max-size: "10m"
    max-file: "3"
```

서비스당 최대 30MB — 과거 디스크 고갈 → MongoDB silent crash 사고의 재발 경로(컨테이너 로그 무제한 누적) 차단. 사용자 생성물/백업 데이터는 범위 아님 (로그만).

※ 적용은 컨테이너 **재생성** 시점부터 (restart 만으로는 미적용 — `docker compose up -d` 로 재생성 필요)

## 검증
- `docker compose config` 양쪽 모두 유효
- compose 정책 테스트 8건 통과 (prodComposeSecrets, secretFailFast)

closes #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)