### PR TITLE
fix: 작업 취소를 Bull 큐와 worker 에 전파 (#521)

### DIFF
--- a/src/models/ImageGenerationJob.js
+++ b/src/models/ImageGenerationJob.js
@@ -53,6 +53,8 @@ const imageGenerationJobSchema = new mongoose.Schema({
     required: false
   },
   comfyJobId: String,
+  // Bull 큐 잡 ID — 취소 시 큐에서 제거하기 위해 보존 (#521)
+  queueJobId: String,
   progress: {
     type: Number,
     min: 0,
@@ -108,8 +110,13 @@ const imageGenerationJobSchema = new mongoose.Schema({
 });
 
 imageGenerationJobSchema.methods.updateStatus = function(status, data = {}) {
+  // cancelled 는 종결 상태 — worker 의 active/completed/failed 이벤트가 덮어쓰지 않음 (#521)
+  if (this.status === 'cancelled' && status !== 'cancelled') {
+    return this;
+  }
+
   this.status = status;
-  
+
   if (status === 'processing') {
     this.startedAt = new Date();
   } else if (status === 'completed' || status === 'failed') {
@@ -130,7 +137,11 @@ imageGenerationJobSchema.methods.updateStatus = function(status, data = {}) {
   if (data.comfyJobId) {
     this.comfyJobId = data.comfyJobId;
   }
-  
+
+  if (data.queueJobId) {
+    this.queueJobId = String(data.queueJobId);
+  }
+
   if (data.resultImages) {
     this.resultImages = data.resultImages;
   }

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const { requireAuth, userHasWorkboardAccess } = require('../middleware/auth');
-const { addImageGenerationJob, getQueueStats } = require('../services/queueService');
+const { addImageGenerationJob, getQueueStats, cancelQueueJob } = require('../services/queueService');
 const openAIChatService = require('../services/openAIChatService');
 const geminiService = require('../services/geminiService');
 const { deleteFile } = require('../utils/fileUpload');
@@ -418,10 +418,15 @@ router.post('/:id/cancel', requireAuth, async (req, res) => {
     if (!['pending', 'processing'].includes(job.status)) {
       return res.status(400).json({ message: 'Job cannot be cancelled' });
     }
-    
+
+    // DB 상태를 먼저 cancelled 로 — active 잡은 worker 체크포인트가 이 상태를 보고 중단 (#521)
     await job.updateStatus('cancelled');
-    
-    res.json({ message: 'Job cancelled successfully' });
+
+    // 큐에서 제거 (waiting/delayed 면 실행 자체를 차단)
+    const { removed, state } = await cancelQueueJob(job.queueJobId);
+    console.log(`🚫 Job ${job._id} cancelled (queue: ${removed ? 'removed' : state || 'not found'})`);
+
+    res.json({ message: 'Job cancelled successfully', queueRemoved: removed });
   } catch (error) {
     res.status(500).json({ message: error.message });
   }

--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -89,6 +89,11 @@ const initializeQueues = async () => {
     });
 
     imageGenerationQueue.on('completed', async (job, result) => {
+      // 취소된 잡은 체크포인트가 빈 결과를 반환 — 상태를 덮어쓰지 않음 (#521)
+      if (result?.cancelled) {
+        console.log(`🚫 Job ${job.id} finished as cancelled — keeping cancelled status`);
+        return;
+      }
       console.log(`Job ${job.id} completed successfully`);
       console.log(`ComfyUI result:`, JSON.stringify(result, null, 2));
       console.log(`Result images count: ${result?.images?.length || 0}`);
@@ -291,11 +296,28 @@ async function handleComfyUIWorkflow({ workboardData, inputData, job, jobId }) {
   return { ...result, seed: actualSeed };
 }
 
+// 취소 여부 확인 — worker 체크포인트용 (#521)
+const isJobCancelled = async (jobId) => {
+  try {
+    const doc = await ImageGenerationJob.findById(jobId).select('status').lean();
+    return doc?.status === 'cancelled';
+  } catch (error) {
+    console.error(`Error checking cancel state for ${jobId}:`, error.message);
+    return false;
+  }
+};
+
 const processImageGeneration = async (job) => {
   const { jobId, workboardData, inputData } = job.data;
 
   try {
     job.progress(5);
+
+    // 취소 체크포인트 1 — 생성 시작 전. throw 하지 않음 (throw 시 Bull attempts 재시도가 발동) (#521)
+    if (await isJobCancelled(jobId)) {
+      console.log(`🚫 Job ${jobId} cancelled — skipping generation`);
+      return { cancelled: true };
+    }
 
     const { key, serverType, outputFormat } = resolveServiceKey(workboardData);
     const handler = SERVICE_MAP[key];
@@ -307,6 +329,13 @@ const processImageGeneration = async (job) => {
     console.log(`[dispatch] job ${jobId} → ${key}`);
 
     const generationResult = await handler({ workboardData, inputData, job, jobId });
+
+    // 취소 체크포인트 2 — 결과 저장 전. 생성은 이미 끝났지만 취소된 잡의 결과는 버린다 (#521)
+    if (await isJobCancelled(jobId)) {
+      console.log(`🚫 Job ${jobId} cancelled during generation — discarding results`);
+      return { cancelled: true };
+    }
+
     const enhancedInputData = generationResult.seed != null
       ? { ...inputData, seed: generationResult.seed }
       : inputData;
@@ -1041,6 +1070,30 @@ const getQueueStats = async () => {
   }
 };
 
+// 취소된 잡을 Bull 큐에서 제거 (#521)
+// waiting/delayed/paused 면 실행 자체를 차단. active 면 worker 체크포인트가 처리.
+const cancelQueueJob = async (queueJobId) => {
+  if (!imageGenerationQueue || !queueJobId) {
+    return { removed: false, state: null };
+  }
+  try {
+    const queueJob = await imageGenerationQueue.getJob(queueJobId);
+    if (!queueJob) {
+      return { removed: false, state: null };
+    }
+    const state = await queueJob.getState();
+    if (['waiting', 'delayed', 'paused'].includes(state)) {
+      await queueJob.remove();
+      console.log(`🚫 Queue job ${queueJobId} removed (state: ${state})`);
+      return { removed: true, state };
+    }
+    return { removed: false, state };
+  } catch (error) {
+    console.error(`Error removing queue job ${queueJobId}:`, error.message);
+    return { removed: false, state: 'error' };
+  }
+};
+
 // 종료 시 큐 정리 — active 잡 완료를 기다리지 않음 (잡이 매우 길 수 있어 빠른 종료 우선, #523)
 const closeQueues = async () => {
   if (!imageGenerationQueue) return;
@@ -1052,6 +1105,7 @@ module.exports = {
   initializeQueues,
   addImageGenerationJob,
   getQueueStats,
+  cancelQueueJob,
   closeQueues,
   imageGenerationQueue
 };

--- a/src/tests/jobStatusTransition.test.js
+++ b/src/tests/jobStatusTransition.test.js
@@ -1,0 +1,71 @@
+const mongoose = require('mongoose');
+const ImageGenerationJob = require('../models/ImageGenerationJob');
+
+/**
+ * #521 작업 취소 상태 전이 가드 회귀 테스트
+ *
+ * cancelled 는 종결 상태 — Bull worker 의 active('processing')/completed/failed 이벤트가
+ * 취소된 잡의 상태를 덮어쓰면 안 된다. DB 연결 없이 save 를 스텁해 전이 로직만 검증.
+ */
+
+function makeJob(status = 'pending') {
+  const job = new ImageGenerationJob({
+    userId: new mongoose.Types.ObjectId(),
+    workboardId: new mongoose.Types.ObjectId(),
+    inputData: { prompt: 'test prompt' }
+  });
+  job.status = status;
+  job.save = jest.fn(async () => job); // DB 미연결 — 저장 호출 여부만 추적
+  return job;
+}
+
+describe('ImageGenerationJob.updateStatus 전이 가드 (#521)', () => {
+  test('cancelled → processing 덮어쓰기 차단 (worker active 이벤트)', async () => {
+    const job = makeJob('cancelled');
+    await job.updateStatus('processing');
+    expect(job.status).toBe('cancelled');
+    expect(job.save).not.toHaveBeenCalled();
+  });
+
+  test('cancelled → completed 덮어쓰기 차단 (worker completed 이벤트)', async () => {
+    const job = makeJob('cancelled');
+    await job.updateStatus('completed', { resultImages: [new mongoose.Types.ObjectId()] });
+    expect(job.status).toBe('cancelled');
+    expect(job.resultImages).toHaveLength(0);
+    expect(job.save).not.toHaveBeenCalled();
+  });
+
+  test('cancelled → failed 덮어쓰기 차단', async () => {
+    const job = makeJob('cancelled');
+    await job.updateStatus('failed', { error: { message: 'x' } });
+    expect(job.status).toBe('cancelled');
+    expect(job.save).not.toHaveBeenCalled();
+  });
+
+  test('정상 전이는 그대로 동작 (pending → processing → completed)', async () => {
+    const job = makeJob('pending');
+    await job.updateStatus('processing');
+    expect(job.status).toBe('processing');
+    expect(job.startedAt).toBeInstanceOf(Date);
+
+    await job.updateStatus('completed');
+    expect(job.status).toBe('completed');
+    expect(job.completedAt).toBeInstanceOf(Date);
+    expect(job.save).toHaveBeenCalledTimes(2);
+  });
+
+  test('processing → cancelled 전이는 허용 (사용자 취소)', async () => {
+    const job = makeJob('processing');
+    await job.updateStatus('cancelled');
+    expect(job.status).toBe('cancelled');
+    expect(job.save).toHaveBeenCalled();
+  });
+
+  test('queueJobId 가 스키마에 저장됨 (strict strip 회귀 방지)', async () => {
+    const job = makeJob('pending');
+    await job.updateStatus('pending', { queueJobId: 12345 });
+    expect(job.queueJobId).toBe('12345');
+    // 스키마에 정의되어 있어야 toObject 에서 살아남음
+    expect(job.toObject().queueJobId).toBe('12345');
+  });
+});


### PR DESCRIPTION
## 문제

`/jobs/:id/cancel` 이 Mongo status 만 바꾸고 Bull 잡을 건드리지 않아, 취소한 작업이 그대로 실행되고 worker 이벤트가 상태를 processing→completed 로 덮어썼습니다. 유료 API(Gemini/GPT) 비용도 그대로 발생.

추가 발견: `addImageGenerationJob` 이 `queueJobId` 를 저장하려 했지만 **스키마에 필드가 없어 strict mode 가 조용히 strip** — Bull 잡 ID 자체가 유실되고 있었습니다 (v2.0.0 strict-strip 사고와 동일 패턴).

## 변경사항

1. **스키마**: `queueJobId: String` 추가 + `updateStatus` 에서 보존
2. **종결 가드**: `updateStatus` 에서 `cancelled → (processing|completed|failed)` 전이 차단
3. **cancel 라우트**: cancelled 마킹 → `cancelQueueJob()` 으로 waiting/delayed 잡 큐에서 제거 (응답에 `queueRemoved` 포함)
4. **worker 체크포인트 2곳**:
   - 생성 시작 전 — 취소면 외부 API 호출 자체를 건너뜀
   - 결과 저장 전 — 생성 중 취소된 잡의 결과 폐기 (파일/DB 미저장)
   - `{ cancelled: true }` 반환 방식 — throw 하면 Bull attempts:3 재시도가 발동하므로
5. ComfyUI `interruptExecution` 은 **호출하지 않음** — 재연결 후 재매칭 운영 플로우 보존 (triage 결정). active ComfyUI 잡은 서버에서 계속 돌지만 결과는 폐기되고 상태는 cancelled 유지.

## 한계 (인지)

- completed 이벤트의 findById→save 사이 ms 단위 race 윈도우는 남음 (전면 원자 업데이트 전환은 검토 리포트 M4 — 별도)
- 기존 잡들은 queueJobId 가 없어 큐 제거가 안 됨 (worker 체크포인트로는 보호됨)

## 검증

- 신규 단위 테스트 6건 (상태 전이 가드 + queueJobId strict-strip 회귀 방지) 통과
- 전체 jest 기준선 +6 (93 pass / 24 fail — 24건은 #535 기존 문제)
- 머지 후 alpha 에서 실제 취소 시나리오 확인 예정

closes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)