### PR TITLE
feat: 취소 시 진행 중 외부 API HTTP 호출 즉시 중단 (#539)

### DIFF
--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const { requireAuth, userHasWorkboardAccess } = require('../middleware/auth');
-const { addImageGenerationJob, getQueueStats, cancelQueueJob } = require('../services/queueService');
+const { addImageGenerationJob, getQueueStats, cancelQueueJob, abortActiveJob } = require('../services/queueService');
 const openAIChatService = require('../services/openAIChatService');
 const geminiService = require('../services/geminiService');
 const { deleteFile } = require('../utils/fileUpload');
@@ -424,9 +424,12 @@ router.post('/:id/cancel', requireAuth, async (req, res) => {
 
     // 큐에서 제거 (waiting/delayed 면 실행 자체를 차단)
     const { removed, state } = await cancelQueueJob(job.queueJobId);
-    console.log(`🚫 Job ${job._id} cancelled (queue: ${removed ? 'removed' : state || 'not found'})`);
 
-    res.json({ message: 'Job cancelled successfully', queueRemoved: removed });
+    // active 잡의 진행 중 외부 API HTTP 호출 즉시 중단 (Gemini/GPT — ComfyUI 는 비대상) (#539)
+    const aborted = abortActiveJob(job._id);
+    console.log(`🚫 Job ${job._id} cancelled (queue: ${removed ? 'removed' : state || 'not found'}, http aborted: ${aborted})`);
+
+    res.json({ message: 'Job cancelled successfully', queueRemoved: removed, httpAborted: aborted });
   } catch (error) {
     res.status(500).json({ message: error.message });
   }

--- a/src/services/geminiService.js
+++ b/src/services/geminiService.js
@@ -82,7 +82,8 @@ const generateImage = async (serverUrl, apiKey, prompt, options = {}) => {
       headers: {
         'Content-Type': 'application/json'
       },
-      timeout: options.timeout || 300000
+      timeout: options.timeout || 300000,
+      signal: options.signal
     }
   );
 

--- a/src/services/gptImageService.js
+++ b/src/services/gptImageService.js
@@ -47,7 +47,8 @@ const generateImage = async (serverUrl, apiKey, prompt, options = {}) => {
           'Authorization': `Bearer ${apiKey}`,
           'Content-Type': 'application/json'
         },
-        timeout: options.timeout || 300000
+        timeout: options.timeout || 300000,
+        signal: options.signal
       }
     );
   } catch (err) {

--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -144,7 +144,7 @@ const resolveServiceKey = (workboardData) => {
   return { key: `${serverType}:${outputFormat}`, serverType, outputFormat };
 };
 
-async function handleGeminiImage({ workboardData, inputData, job }) {
+async function handleGeminiImage({ workboardData, inputData, job, signal }) {
   const geminiImages = await loadImageInputs(
     workboardData.additionalInputFields || [],
     inputData
@@ -161,6 +161,7 @@ async function handleGeminiImage({ workboardData, inputData, job }) {
       resolution: extractOptionValue(inputData.additionalParams?.resolution),
       images: geminiImages,
       timeout: workboardData.timeout,
+      signal,
     }
   );
   job.progress(90);
@@ -188,7 +189,7 @@ async function handleGeminiImage({ workboardData, inputData, job }) {
   };
 }
 
-async function handleOpenAIImage({ workboardData, inputData, job }) {
+async function handleOpenAIImage({ workboardData, inputData, job, signal }) {
   const result = await gptImageService.generateImage(
     workboardData.serverUrl,
     workboardData.apiKey || process.env.OPENAI_IMAGE_API_KEY,
@@ -208,6 +209,7 @@ async function handleOpenAIImage({ workboardData, inputData, job }) {
       background: extractOptionValue(inputData.additionalParams?.background),
       outputCompression: extractOptionValue(inputData.additionalParams?.output_compression),
       timeout: workboardData.timeout,
+      signal,
     }
   );
   job.progress(90);
@@ -296,6 +298,20 @@ async function handleComfyUIWorkflow({ workboardData, inputData, job, jobId }) {
   return { ...result, seed: actualSeed };
 }
 
+// 진행 중 잡의 AbortController — 취소 시 외부 API HTTP 호출 즉시 중단용 (#539)
+// in-memory 라 단일 백엔드 인스턴스 전제. ComfyUI 경로는 재매칭 플로우 보존을 위해 제외.
+const activeJobAborters = new Map();
+
+const abortActiveJob = (jobId) => {
+  const aborter = activeJobAborters.get(String(jobId));
+  if (aborter) {
+    aborter.abort();
+    console.log(`🚫 Job ${jobId} — in-flight HTTP request aborted`);
+    return true;
+  }
+  return false;
+};
+
 // 취소 여부 확인 — worker 체크포인트용 (#521)
 const isJobCancelled = async (jobId) => {
   try {
@@ -309,6 +325,8 @@ const isJobCancelled = async (jobId) => {
 
 const processImageGeneration = async (job) => {
   const { jobId, workboardData, inputData } = job.data;
+  const aborter = new AbortController();
+  activeJobAborters.set(String(jobId), aborter);
 
   try {
     job.progress(5);
@@ -328,7 +346,7 @@ const processImageGeneration = async (job) => {
     }
     console.log(`[dispatch] job ${jobId} → ${key}`);
 
-    const generationResult = await handler({ workboardData, inputData, job, jobId });
+    const generationResult = await handler({ workboardData, inputData, job, jobId, signal: aborter.signal });
 
     // 취소 체크포인트 2 — 결과 저장 전. 생성은 이미 끝났지만 취소된 잡의 결과는 버린다 (#521)
     if (await isJobCancelled(jobId)) {
@@ -374,8 +392,15 @@ const processImageGeneration = async (job) => {
       costEstimate: generationResult.costEstimate,
     };
   } catch (error) {
+    // 취소로 인한 HTTP 중단 — 실패가 아니라 취소 종결 (Bull 재시도 방지) (#539)
+    if (aborter.signal.aborted || error.code === 'ERR_CANCELED' || error.name === 'CanceledError') {
+      console.log(`🚫 Job ${jobId} — generation aborted by cancel`);
+      return { cancelled: true };
+    }
     console.error(`Error processing job ${jobId}:`, error);
     throw error;
+  } finally {
+    activeJobAborters.delete(String(jobId));
   }
 };
 
@@ -1106,6 +1131,7 @@ module.exports = {
   addImageGenerationJob,
   getQueueStats,
   cancelQueueJob,
+  abortActiveJob,
   closeQueues,
   imageGenerationQueue
 };


### PR DESCRIPTION
## 변경사항

#521 의 취소 전파를 한 단계 강화 — 취소 시 Gemini/GPT 의 **진행 중 HTTP 요청을 AbortSignal 로 즉시 중단**합니다. 기존엔 응답(수십 초)을 기다렸다가 결과를 폐기했음 (2026-06-12 실과금 테스트로 확인).

- worker 가 잡별 `AbortController` 를 in-memory Map 에 등록, cancel 라우트가 `abortActiveJob(jobId)` 호출 (응답에 `httpAborted` 포함)
- axios `signal` 옵션 연결: gptImageService / geminiService 의 generateImage
- abort 발생 시 `{ cancelled: true }` 종결 — Bull attempts 재시도 미발동. gptImageService 가 에러를 재포장해도 `signal.aborted` 로 판정
- **ComfyUI 경로 비대상** — WS 대기 중단은 재매칭 운영 플로우와 충돌 (triage 결정 유지)

## 한계 (명시)

- in-memory 등록이라 **단일 백엔드 인스턴스 전제** (현 구성 일치)
- HTTP 를 끊어도 provider 서버측 생성이 이미 시작됐으면 과금될 수 있음 — 보장은 "즉시 중단 + worker 슬롯 즉시 반환"

## 검증
- 전체 jest 기준선 동일 (100 pass / 24 fail)
- 머지 후 alpha 에서 실호출 abort 시나리오 확인 예정

closes #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)