### PR TITLE
feat: 디자인 토큰 기반 수리 — 누락 토큰 + 사본 공용화 + 다크 지뢰 (#542)

### DIFF
--- a/frontend/src/components/PromptGeneratorPanel.js
+++ b/frontend/src/components/PromptGeneratorPanel.js
@@ -32,6 +32,7 @@ import toast from 'react-hot-toast';
 import { workboardAPI, imageAPI } from '../services/api';
 import { useStreamingPrompt } from '../hooks/useStreamingPrompt';
 import MetadataFieldInput from './common/MetadataFieldInput';
+import { MONO } from '../theme';
 
 function ImageUploadField({ label, description, images, onImagesChange, maxImages = 1 }) {
   const onDrop = useCallback((acceptedFiles) => {
@@ -435,7 +436,7 @@ function PromptGeneratorPanel({
                       borderRadius: 1,
                       maxHeight: compact ? 200 : 500,
                       overflow: 'auto',
-                      fontFamily: 'monospace',
+                      fontFamily: MONO,
                       fontSize: compact ? '0.875rem' : '1rem'
                     }}
                   >

--- a/frontend/src/components/Sidebar.js
+++ b/frontend/src/components/Sidebar.js
@@ -203,7 +203,8 @@ function Sidebar({ mobileOpen, onMobileToggle }) {
           <Divider sx={{ borderColor: 'divider', my: 1 }} />
 
           <Box sx={{ px: 2, py: 1 }}>
-            <Typography variant="caption" sx={{ color: 'grey.500' }}>
+            {/* 관리자 구분은 색이 아닌 섹션 라벨로 (#542 — 빨강 일괄 적용 제거, 핸드오프 중립 스타일) */}
+            <Typography variant="overline" sx={{ color: 'grey.500', letterSpacing: '0.06em' }}>
               관리자 메뉴
             </Typography>
           </Box>
@@ -221,7 +222,7 @@ function Sidebar({ mobileOpen, onMobileToggle }) {
                     '&:hover': { bgcolor: 'navbar.light' },
                   }}
                 >
-                  <ListItemIcon sx={{ color: 'error.main', minWidth: 40 }}>
+                  <ListItemIcon sx={{ color: 'navbar.contrastText', minWidth: 40 }}>
                     {item.icon}
                   </ListItemIcon>
                   <ListItemText
@@ -230,7 +231,6 @@ function Sidebar({ mobileOpen, onMobileToggle }) {
                       '& .MuiListItemText-primary': {
                         fontSize: isMobile ? '1rem' : '0.9rem',
                         fontWeight: isMobile ? 500 : 400,
-                        color: 'error.main',
                       },
                     }}
                   />

--- a/frontend/src/components/admin/MetadataImageListItem.js
+++ b/frontend/src/components/admin/MetadataImageListItem.js
@@ -17,6 +17,7 @@ import {
 import MetadataMediaThumbnail from '../common/MetadataMediaThumbnail';
 import { getKindLabel } from '../../utils/metadataItem';
 import { getBaseModelColor } from '../common/MetadataItemCard';
+import { MONO } from '../../theme';
 
 // 한 줄 / 아이템 — 이미지 좌측, 정보 우측 (#344).
 // 좌: 썸네일 (90x90). 우: 모델명+버전 / chips / 트리거 워드 또는 파일명 / 액션 버튼.
@@ -135,7 +136,7 @@ function MetadataImageListItem({
             )}
           </Box>
         ) : (
-          <Typography variant="caption" color="text.secondary" noWrap title={item.filename} sx={{ mt: 0.5, fontFamily: 'monospace' }}>
+          <Typography variant="caption" color="text.secondary" noWrap title={item.filename} sx={{ mt: 0.5, fontFamily: MONO }}>
             {item.filename}
           </Typography>
         )}

--- a/frontend/src/components/admin/MetadataManagementBody.js
+++ b/frontend/src/components/admin/MetadataManagementBody.js
@@ -41,6 +41,7 @@ import MetadataDetailDialog from '../common/MetadataDetailDialog';
 import MetadataImageListItem from './MetadataImageListItem';
 import { normalizeLora, normalizeModel } from '../../utils/metadataItem';
 import { serverAPI } from '../../services/api';
+import { MONO } from '../../theme';
 
 const VIEW_MODE_KEY_PREFIX = 'vcc.metadataAdmin.viewMode.';
 const PAGE_SIZE = 24;
@@ -468,7 +469,7 @@ function MetadataManagementBody({ kind, selectedServerId, selectedServer, nsfwMo
                         </Typography>
                       )}
                     </Typography>
-                    <Typography variant="caption" color="text.secondary" noWrap title={item.filename} sx={{ fontFamily: 'monospace', display: 'block' }}>
+                    <Typography variant="caption" color="text.secondary" noWrap title={item.filename} sx={{ fontFamily: MONO, display: 'block' }}>
                       {item.filename}
                     </Typography>
                   </Box>

--- a/frontend/src/components/admin/ServerManagement.js
+++ b/frontend/src/components/admin/ServerManagement.js
@@ -46,6 +46,7 @@ import toast from 'react-hot-toast';
 import { serverAPI, jobAPI } from '../../services/api';
 import { getServerTypeColor } from '../../templates/capabilities';
 import { ToneChip, TagChip } from '../common/WorkboardCatalog';
+import { MONO } from '../../theme';
 
 // 공식 base URL 이 알려진 provider — 서버 추가 시 자동 입력 (사용자 입력 우선)
 const KNOWN_SERVER_URLS = {
@@ -136,7 +137,6 @@ function ServerCard({
     }
   };
 
-  const MONO = '"JetBrains Mono","SF Mono",Menlo,monospace';
   const statusKey = server.healthCheck?.status;
   const statusChip = statusKey === 'healthy'
     ? { tone: 'success', label: 'online' }

--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -60,6 +60,8 @@ import { workboardAPI, serverAPI, groupAPI } from '../../services/api';
 import WorkboardBasicInfoForm from './WorkboardBasicInfoForm';
 import MetadataPickerModal from '../common/MetadataPickerModal';
 import { BUILTIN_WORKFLOW_VARIABLES, WORKFLOW_VARIABLE_CATEGORIES, formatValueType } from '../../constants/workflowVariables';
+import { MONO } from '../../theme';
+import { BRAND_GRADIENTS } from '../../utils/brandGradients';
 import {
   getServerTypeLabel,
   getOutputFormatLabel,
@@ -207,7 +209,7 @@ function WorkboardCard({ workboard, onEdit, onDelete, onDuplicate, onExport, onV
         </Box>
 
         <Box display="flex" alignItems="center" gap={0.5} mb={2}>
-          <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+          <Typography variant="caption" color="text.secondary" sx={{ fontFamily: MONO }}>
             ID: {workboard._id}
           </Typography>
           <IconButton size="small" onClick={handleCopyWorkboardId} aria-label="작업판 ID 복사">
@@ -673,7 +675,7 @@ function PreviewField({ field }) {
       <Box>
         {label}
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, px: 1.5, py: 1, border: 1, borderColor: 'divider', borderRadius: 1, bgcolor: 'action.hover' }}>
-          <Box sx={{ width: 22, height: 22, borderRadius: 0.5, background: 'linear-gradient(135deg, #7B4DD8, #5B5BD6)', color: 'white', display: 'grid', placeItems: 'center', fontSize: 11 }}>
+          <Box sx={{ width: 22, height: 22, borderRadius: 0.5, background: BRAND_GRADIENTS[0], color: 'white', display: 'grid', placeItems: 'center', fontSize: 11 }}>
             M
           </Box>
           <Typography variant="caption" sx={{ flex: 1 }}>모델 선택…</Typography>
@@ -1036,7 +1038,7 @@ export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage
           ) : (
             <>
           <Box display="flex" alignItems="center" gap={0.5} mb={2}>
-            <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+            <Typography variant="caption" color="text.secondary" sx={{ fontFamily: MONO }}>
               작업판 ID: {workboard?._id}
             </Typography>
             <IconButton
@@ -1139,13 +1141,13 @@ export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage
                                 <Chip
                                   label={field.type}
                                   variant="outlined"
-                                  sx={{ fontFamily: '"JetBrains Mono", monospace', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.04em', fontWeight: 600 }}
+                                  sx={{ fontFamily: MONO, fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.04em', fontWeight: 600 }}
                                 />
                                 <Typography sx={{ fontWeight: selectedFieldIdx === index ? 600 : 500 }}>
                                   {field.label || `커스텀 필드 ${index + 1}`}
                                 </Typography>
                                 {field.name && (
-                                  <Typography variant="caption" color="text.secondary" sx={{ fontFamily: '"JetBrains Mono", monospace' }}>
+                                  <Typography variant="caption" color="text.secondary" sx={{ fontFamily: MONO }}>
                                     {field.name}
                                   </Typography>
                                 )}
@@ -1167,7 +1169,7 @@ export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage
                                   fullWidth
                                   label="필드명 (영문)"
                                   placeholder="예: customField1"
-                                  sx={{ fontFamily: 'monospace' }}
+                                  sx={{ fontFamily: MONO }}
                                 />
                               )}
                             />
@@ -1218,7 +1220,7 @@ export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage
                                   fullWidth
                                   label="Workflow 형식 문자열"
                                   placeholder={`예: {{##${field.name || 'field_name'}##}}`}
-                                  sx={{ fontFamily: 'monospace' }}
+                                  sx={{ fontFamily: MONO }}
                                 />
                               )}
                             />
@@ -1502,7 +1504,7 @@ export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage
                     label="추가 LLM 파라미터 (JSON)"
                     placeholder={'{\n  "temperature": 1.0,\n  "chat_template_kwargs": { "enable_thinking": false }\n}'}
                     helperText="OpenAI 계열은 요청 본문 최상위, Gemini 는 generationConfig 에 병합됩니다. thinking 끄는 방식은 모델/서버마다 달라 가이드 문서를 참고하세요."
-                    InputProps={{ sx: { fontFamily: 'monospace', fontSize: '0.85rem' } }}
+                    InputProps={{ sx: { fontFamily: MONO, fontSize: '0.85rem' } }}
                   />
                 )}
               />
@@ -1511,7 +1513,7 @@ export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage
                   <Typography variant="subtitle2" fontWeight="bold">자주 쓰는 예시</Typography>
                 </AccordionSummary>
                 <AccordionDetails>
-                  <Typography variant="caption" component="div" sx={{ fontFamily: 'monospace', whiteSpace: 'pre-wrap' }}>
+                  <Typography variant="caption" component="div" sx={{ fontFamily: MONO, whiteSpace: 'pre-wrap' }}>
                     {'// 창작용 — 무작위성 높이고 thinking 끄기 (서버에 따라 키가 다름)\n'}
                     {'{ "temperature": 1.0, "chat_template_kwargs": { "enable_thinking": false } }\n\n'}
                     {'// reasoning 모델(gpt-5/o1 등) — temperature 미지원이니 비워두기\n'}
@@ -1646,7 +1648,7 @@ export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage
                         label="ComfyUI Workflow JSON"
                         error={!!errors.workflowData}
                         helperText={errors.workflowData?.message || "위 변수 목록을 참고하여 워크플로우를 작성하세요"}
-                        sx={{ fontFamily: 'monospace' }}
+                        sx={{ fontFamily: MONO }}
                       />
                     )}
                   />

--- a/frontend/src/components/common/MediaGrid.js
+++ b/frontend/src/components/common/MediaGrid.js
@@ -90,24 +90,24 @@ function ImageDetailDialog({ image, open, onClose, type }) {
       onClose={onClose}
       maxWidth="lg"
       fullWidth
-      PaperProps={{ sx: { bgcolor: 'black', maxHeight: '90vh' } }}
+      PaperProps={{ sx: { bgcolor: 'common.black', maxHeight: '90vh' } }}
     >
-      <DialogTitle sx={{ color: 'white', pb: 1 }}>
+      <DialogTitle sx={{ color: 'common.white', pb: 1 }}>
         <Box display="flex" justifyContent="space-between" alignItems="center">
           <Typography variant="h6">이미지 상세보기</Typography>
           <Box>
-            <IconButton onClick={handleDownload} sx={{ color: 'white', mr: 1 }}><Download /></IconButton>
-            <IconButton onClick={onClose} sx={{ color: 'white' }}><Close /></IconButton>
+            <IconButton onClick={handleDownload} sx={{ color: 'common.white', mr: 1 }}><Download /></IconButton>
+            <IconButton onClick={onClose} sx={{ color: 'common.white' }}><Close /></IconButton>
           </Box>
         </Box>
       </DialogTitle>
-      <DialogContent sx={{ textAlign: 'center', p: 2, bgcolor: 'black' }}>
+      <DialogContent sx={{ textAlign: 'center', p: 2, bgcolor: 'common.black' }}>
         <img
           src={image.url}
           alt={image.originalName}
           style={{ maxWidth: '100%', maxHeight: '70vh', objectFit: 'contain', borderRadius: '8px' }}
         />
-        <Box mt={2} sx={{ color: 'white' }}>
+        <Box mt={2} sx={{ color: 'common.white' }}>
           <Typography variant="body2">{image.originalName}</Typography>
           {image.metadata && (
             <Typography variant="body2">크기: {image.metadata.width} x {image.metadata.height}</Typography>
@@ -270,7 +270,7 @@ function VideoCard({ video, onEdit, onDelete, onView, readOnly = false, showTags
       )}
       <Box
         sx={{
-          position: 'relative', height: 200, bgcolor: 'black',
+          position: 'relative', height: 200, bgcolor: 'common.black',
           display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer'
         }}
         onClick={() => bulkMode ? onBulkToggle?.(video._id) : onView(video)}
@@ -283,7 +283,7 @@ function VideoCard({ video, onEdit, onDelete, onView, readOnly = false, showTags
           onMouseLeave={(e) => { e.target.pause(); e.target.currentTime = 0; }}
         />
         <Box sx={{ position: 'absolute', top: 8, right: 8, bgcolor: 'rgba(0,0,0,0.6)', borderRadius: 1, px: 1, py: 0.5 }}>
-          <Videocam sx={{ color: 'white', fontSize: 20 }} />
+          <Videocam sx={{ color: 'common.white', fontSize: 20 }} />
         </Box>
       </Box>
       <CardContent sx={{ flexGrow: 1, pb: 1 }}>
@@ -478,7 +478,7 @@ function MediaGrid({
                         <CheckCircle
                           sx={{
                             position: 'absolute', top: 8, right: 8,
-                            color: 'primary.main', bgcolor: 'white', borderRadius: '50%', zIndex: 1
+                            color: 'primary.main', bgcolor: 'common.white', borderRadius: '50%', zIndex: 1
                           }}
                         />
                       )}

--- a/frontend/src/components/common/NotificationsPopover.js
+++ b/frontend/src/components/common/NotificationsPopover.js
@@ -20,6 +20,7 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { useQueryClient } from 'react-query';
 import { alpha } from '@mui/material/styles';
+import { MONO } from '../../theme';
 
 // 휘발성 알림 popover (Phase 6).
 // 영속 저장은 없음 — react-query 캐시에 있는 'pipelineRun' 데이터를 source 로 활용.
@@ -245,7 +246,7 @@ function NotifRow({ run, onClick, unread }) {
           <Typography variant="body2" sx={{ flex: 1, fontWeight: 600, textWrap: 'pretty' }}>
             {title}
           </Typography>
-          <Typography variant="caption" sx={{ fontFamily: '"JetBrains Mono", monospace', color: 'text.secondary', flexShrink: 0 }}>
+          <Typography variant="caption" sx={{ fontFamily: MONO, color: 'text.secondary', flexShrink: 0 }}>
             {formatRelative(time)}
           </Typography>
         </Box>

--- a/frontend/src/components/common/PipelinePanel.js
+++ b/frontend/src/components/common/PipelinePanel.js
@@ -51,6 +51,7 @@ import PromptDataPickerDialog from './PromptDataPickerDialog';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import toast from 'react-hot-toast';
 import { pipelineAPI, pipelineRunAPI, projectAPI, jobAPI, tagAPI, textAPI, workboardAPI, promptDataAPI } from '../../services/api';
+import { MONO } from '../../theme';
 
 // 파이프라인 step 의 이미지 결과 — 썸네일 그리드 + 클릭 시 큰 보기 (#409).
 // runStep.imageGenerationJobId 가 populate 되어 있어야 함 (백엔드 단일 GET 만 populate).
@@ -238,7 +239,7 @@ function PipelineCard({ pipeline, onRun, onEdit, onDelete }) {
               color="text.secondary"
               noWrap
               sx={{
-                fontFamily: '"JetBrains Mono", monospace',
+                fontFamily: MONO,
                 minWidth: 0,
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
@@ -306,7 +307,7 @@ function PipelineCard({ pipeline, onRun, onEdit, onDelete }) {
                     placeItems: 'center',
                     fontSize: 10,
                     fontWeight: 700,
-                    fontFamily: '"JetBrains Mono", monospace',
+                    fontFamily: MONO,
                     flexShrink: 0,
                   }}
                 >
@@ -317,7 +318,7 @@ function PipelineCard({ pipeline, onRun, onEdit, onDelete }) {
                     {s.workboardId?.name || '(삭제됨)'}
                   </Typography>
                   {s.workboardId?.outputFormat && (
-                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', fontSize: 10, fontFamily: '"JetBrains Mono", monospace' }}>
+                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', fontSize: 10, fontFamily: MONO }}>
                       out: {s.workboardId.outputFormat}
                     </Typography>
                   )}
@@ -478,7 +479,7 @@ function StepLaneCard({
             placeItems: 'center',
             fontSize: 12,
             fontWeight: 700,
-            fontFamily: '"JetBrains Mono", monospace',
+            fontFamily: MONO,
           }}
         >
           {index + 1}
@@ -487,7 +488,7 @@ function StepLaneCard({
           <Chip
             label={`out: ${step.workboard.outputFormat}`}
             variant="outlined"
-            sx={{ fontFamily: '"JetBrains Mono", monospace', letterSpacing: '0.04em', textTransform: 'uppercase', fontWeight: 600 }}
+            sx={{ fontFamily: MONO, letterSpacing: '0.04em', textTransform: 'uppercase', fontWeight: 600 }}
           />
         )}
         <Box sx={{ flex: 1 }} />
@@ -658,7 +659,7 @@ function LaneConnector({ isMobile, prevOutput, autoInject }) {
       {prevOutput && (
         <Typography
           variant="caption"
-          sx={{ fontFamily: '"JetBrains Mono", monospace', fontSize: 10, color: 'text.tertiary', textTransform: 'uppercase', letterSpacing: '0.04em' }}
+          sx={{ fontFamily: MONO, fontSize: 10, color: 'text.tertiary', textTransform: 'uppercase', letterSpacing: '0.04em' }}
         >
           {prevOutput}
         </Typography>
@@ -813,7 +814,7 @@ function PaletteDocList({ docs, selectedIds, disabled, onClickDoc, singleSelect 
               <Typography variant="body2" noWrap sx={{ fontWeight: active ? 600 : 500 }}>
                 {d.title || '(제목 없음)'}
               </Typography>
-              <Typography variant="caption" color="text.secondary" sx={{ fontFamily: '"JetBrains Mono", monospace', fontSize: 10, display: 'block' }}>
+              <Typography variant="caption" color="text.secondary" sx={{ fontFamily: MONO, fontSize: 10, display: 'block' }}>
                 {(d.content || '').length.toLocaleString()}자
               </Typography>
             </Box>
@@ -889,7 +890,7 @@ function PipelineDiagnosticStrip({ steps }) {
         <Typography
           variant="caption"
           sx={{
-            fontFamily: '"JetBrains Mono", monospace',
+            fontFamily: MONO,
             fontSize: 11,
             color: 'text.secondary',
             flexShrink: 0,
@@ -1740,7 +1741,7 @@ function PipelineRunner({ projectId, pipelineId, onClose }) {
           {run && (
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mt: 1.5, flexWrap: 'wrap', fontSize: 13, color: 'text.secondary' }}>
               <span>실행 ID</span>
-              <Box component="code" sx={{ px: 1, py: 0.25, bgcolor: 'action.hover', borderRadius: 0.5, fontFamily: '"JetBrains Mono", monospace', fontSize: 12, color: 'text.primary' }}>
+              <Box component="code" sx={{ px: 1, py: 0.25, bgcolor: 'action.hover', borderRadius: 0.5, fontFamily: MONO, fontSize: 12, color: 'text.primary' }}>
                 {String(run._id).slice(-8)}
               </Box>
               {run.startedAt && (
@@ -1832,7 +1833,7 @@ function PipelineRunner({ projectId, pipelineId, onClose }) {
                 sx={{ height: 6, borderRadius: 1 }}
               />
             </Box>
-            <Typography variant="caption" sx={{ fontFamily: '"JetBrains Mono", monospace', color: 'text.secondary', minWidth: 36, textAlign: 'right' }}>
+            <Typography variant="caption" sx={{ fontFamily: MONO, color: 'text.secondary', minWidth: 36, textAlign: 'right' }}>
               {progressPct}%
             </Typography>
           </Box>
@@ -1875,7 +1876,7 @@ function PipelineRunner({ projectId, pipelineId, onClose }) {
                     )}
                     {runStep.status === 'completed' && runStep.output && (
                       <Paper variant="outlined" sx={{ borderColor: (t) => alpha(t.palette.success.main, 0.35), bgcolor: (t) => alpha(t.palette.success.main, 0.06), overflow: 'hidden' }}>
-                        <Box sx={{ px: 1.5, py: 1, display: 'flex', alignItems: 'center', gap: 1, borderBottom: '1px dashed', borderColor: 'divider', fontSize: 11.5, color: 'text.secondary', fontFamily: '"JetBrains Mono", monospace' }}>
+                        <Box sx={{ px: 1.5, py: 1, display: 'flex', alignItems: 'center', gap: 1, borderBottom: '1px dashed', borderColor: 'divider', fontSize: 11.5, color: 'text.secondary', fontFamily: MONO }}>
                           결과 ({runStep.output.type})
                         </Box>
                         <Box sx={{ p: 1.5 }}>
@@ -1969,7 +1970,7 @@ function PipelineRunner({ projectId, pipelineId, onClose }) {
                         <Typography variant="body2" noWrap sx={{ flex: 1, fontWeight: isCurrent ? 600 : 500 }}>
                           {r.initialPrompt?.slice(0, 30) || '(빈 입력)'}
                         </Typography>
-                        <Typography variant="caption" sx={{ fontFamily: '"JetBrains Mono", monospace', color: 'text.secondary', flexShrink: 0 }}>
+                        <Typography variant="caption" sx={{ fontFamily: MONO, color: 'text.secondary', flexShrink: 0 }}>
                           {formatRunTime(r.createdAt)}
                         </Typography>
                       </Box>
@@ -2134,7 +2135,7 @@ export function PipelineHistoryPanel({ projectId }) {
               </StepLabel>
               <StepContent>
                 {runStep.status === 'completed' && runStep.output && (
-                  <Paper variant="outlined" sx={{ p: 1.5, bgcolor: 'rgba(76, 175, 80, 0.08)' }}>
+                  <Paper variant="outlined" sx={{ p: 1.5, bgcolor: 'success.light' }}>
                     <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
                       결과 ({runStep.output.type})
                     </Typography>
@@ -2218,7 +2219,7 @@ function PipelineRunCard({ run, onSelect, onDelete }) {
             <Chip label={`재시도 ${run.triggerCount - 1}회`} variant="outlined" />
           )}
           <Box sx={{ flex: 1 }} />
-          <Typography variant="caption" color="text.secondary" sx={{ fontFamily: '"JetBrains Mono", monospace' }}>
+          <Typography variant="caption" color="text.secondary" sx={{ fontFamily: MONO }}>
             {new Date(run.createdAt).toLocaleString('ko-KR')}
           </Typography>
         </Box>
@@ -2246,7 +2247,7 @@ function PipelineRunCard({ run, onSelect, onDelete }) {
               const isFail = s.status === 'failed';
               const isRunning = s.status === 'running';
               const bg = isDone ? 'success.main' : isFail ? 'error.main' : isRunning ? 'info.main' : 'transparent';
-              const fg = isDone || isFail || isRunning ? '#FFFFFF' : 'text.secondary';
+              const fg = isDone || isFail || isRunning ? 'common.white' : 'text.secondary';
               const border = isDone ? 'success.main' : isFail ? 'error.main' : isRunning ? 'info.main' : 'divider';
               return (
                 <Box
@@ -2263,7 +2264,7 @@ function PipelineRunCard({ run, onSelect, onDelete }) {
                     placeItems: 'center',
                     fontSize: 10,
                     fontWeight: 700,
-                    fontFamily: '"JetBrains Mono", monospace',
+                    fontFamily: MONO,
                   }}
                 >
                   {isDone ? <CheckCircleIcon sx={{ fontSize: 12 }} /> : idx + 1}
@@ -2278,7 +2279,7 @@ function PipelineRunCard({ run, onSelect, onDelete }) {
                 value={progressPct}
                 sx={{ height: 4, borderRadius: 1 }}
               />
-              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', textAlign: 'right', fontFamily: '"JetBrains Mono", monospace', fontSize: 10, mt: 0.25 }}>
+              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', textAlign: 'right', fontFamily: MONO, fontSize: 10, mt: 0.25 }}>
                 {progressPct}%
               </Typography>
             </Box>

--- a/frontend/src/components/common/WorkboardCatalog.js
+++ b/frontend/src/components/common/WorkboardCatalog.js
@@ -1,6 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import { usePersistedState } from '../../hooks/usePersistedState';
 import { Box, Paper, Typography, Chip, IconButton, Button, InputBase } from '@mui/material';
+import { MONO } from '../../theme';
 import {
   Search,
   Close,
@@ -15,7 +16,6 @@ import {
   Info,
 } from '@mui/icons-material';
 
-const MONO = '"JetBrains Mono","SF Mono",Menlo,monospace';
 
 // 작업판 종류(생성 엔진) — outputFormat + serverType 로 유도. 카드 좌측 아이콘.
 export const KIND_META = {

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -32,40 +32,10 @@ import {
 import { useAuth } from '../contexts/AuthContext';
 import config from '../config';
 import UpdateLogDialog from '../components/common/UpdateLogDialog';
+import { MONO } from '../theme';
+import { gradientForId } from '../utils/brandGradients';
+import { relativeTime } from '../utils/relativeTime';
 
-const MONO = '"JetBrains Mono","SF Mono",Menlo,monospace';
-
-// 프로젝트 아바타 그라데이션 — 디자인 핸드오프 팔레트에서 id 해시로 결정적 선택
-const GRADIENTS = [
-  'linear-gradient(135deg, #7B4DD8, #5B5BD6)',
-  'linear-gradient(135deg, #2F77E4, #4E8EE8)',
-  'linear-gradient(135deg, #BE7415, #D69021)',
-  'linear-gradient(135deg, #1F9D55, #2EBA6B)',
-  'linear-gradient(135deg, #5B616E, #8A8F9A)',
-];
-function gradientFor(id = '') {
-  let h = 0;
-  for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) >>> 0;
-  return GRADIENTS[h % GRADIENTS.length];
-}
-
-// 상대 시각 — "방금 / N분 전 / N시간 전 / 어제 / N일 전 / yy.M.d"
-function relativeTime(iso) {
-  if (!iso) return '';
-  const then = new Date(iso).getTime();
-  if (Number.isNaN(then)) return '';
-  const diff = Date.now() - then;
-  const min = Math.floor(diff / 60000);
-  if (min < 1) return '방금';
-  if (min < 60) return `${min}분 전`;
-  const hr = Math.floor(min / 60);
-  if (hr < 24) return `${hr}시간 전`;
-  const day = Math.floor(hr / 24);
-  if (day === 1) return '어제';
-  if (day < 7) return `${day}일 전`;
-  const d = new Date(then);
-  return `${String(d.getFullYear()).slice(2)}. ${d.getMonth() + 1}. ${d.getDate()}.`;
-}
 
 function dateHeroLine() {
   const now = new Date();
@@ -419,7 +389,7 @@ function Dashboard() {
                         width: 36,
                         height: 36,
                         borderRadius: 2,
-                        background: gradientFor(String(p._id)),
+                        background: gradientForId(String(p._id)),
                         color: '#fff',
                         fontWeight: 700,
                         fontSize: 16,

--- a/frontend/src/pages/ImageGeneration.js
+++ b/frontend/src/pages/ImageGeneration.js
@@ -53,6 +53,7 @@ import { extractLoraName, insertLoraTag, insertTriggerWordWithLora } from '../ut
 import Pagination from '../components/common/Pagination';
 import ImageSelectDialog from '../components/common/ImageSelectDialog';
 import PromptGeneratorDialog from '../components/PromptGeneratorDialog';
+import { MONO } from '../theme';
 
 function PromptDataSelectDialog({ open, onClose, onSelect }) {
   const [page, setPage] = useState(1);
@@ -835,7 +836,7 @@ function ImageGeneration() {
           </Typography>
         )}
         <Box display="flex" alignItems="center" gap={0.5} mb={1}>
-          <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+          <Typography variant="caption" color="text.secondary" sx={{ fontFamily: MONO }}>
             작업판 ID: {workboardData?._id}
           </Typography>
           <IconButton size="small" onClick={handleCopyWorkboardId} aria-label="작업판 ID 복사">

--- a/frontend/src/pages/JobHistory.js
+++ b/frontend/src/pages/JobHistory.js
@@ -50,8 +50,9 @@ import VideoViewerDialog from '../components/common/VideoViewerDialog';
 import WorkboardSelectDialog from '../components/common/WorkboardSelectDialog';
 import { SavePromptDialog, JobDetailDialog } from '../components/common/JobHistoryPanel';
 import { ToneChip, TagChip } from '../components/common/WorkboardCatalog';
+import { MONO } from '../theme';
+import { relativeTime } from '../utils/relativeTime';
 
-const MONO = '"JetBrains Mono","SF Mono",Menlo,monospace';
 const TYPE_LABEL = { pipeline: '파이프라인', image: '이미지', video: '영상', text: '텍스트' };
 
 // ---- 상태 매핑 ----------------------------------------------------------
@@ -98,18 +99,6 @@ function extractSize(job) {
 function projectFromTags(tags = []) {
   const t = tags.find((x) => typeof x === 'object' && x.name);
   return t?.name || '';
-}
-function relativeTime(time) {
-  const diff = Date.now() - time.getTime();
-  const min = Math.floor(diff / 60000);
-  if (min < 1) return '방금';
-  if (min < 60) return `${min}분 전`;
-  const hr = Math.floor(min / 60);
-  if (hr < 24) return `${hr}시간 전`;
-  const day = Math.floor(hr / 24);
-  if (day === 1) return '어제';
-  if (day < 7) return `${day}일 전`;
-  return `${String(time.getFullYear()).slice(2)}. ${time.getMonth() + 1}. ${time.getDate()}.`;
 }
 
 // ---- 정규화 -------------------------------------------------------------

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -13,6 +13,7 @@ import {
   IconButton,
   CircularProgress
 } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import {
   Google as GoogleIcon,
   Visibility,
@@ -28,6 +29,7 @@ import { authAPI } from '../services/api';
 import { useAuth } from '../contexts/AuthContext';
 
 function Login() {
+  const theme = useTheme();
   const [showPassword, setShowPassword] = useState(false);
   const navigate = useNavigate();
   const location = useLocation();
@@ -99,8 +101,8 @@ function Login() {
             duration: 6000,
             icon: '❌',
             style: {
-              background: '#ffebee',
-              color: '#c62828',
+              background: theme.palette.error.light,
+              color: theme.palette.error.main,
             },
           });
         } else {

--- a/frontend/src/pages/ProjectDetail.js
+++ b/frontend/src/pages/ProjectDetail.js
@@ -56,6 +56,7 @@ import WorkboardSelectDialog from '../components/common/WorkboardSelectDialog';
 import JobHistoryPanel from '../components/common/JobHistoryPanel';
 import TagInput from '../components/common/TagInput';
 import ProjectEditDialog from '../components/common/ProjectEditDialog';
+import { BRAND_GRADIENTS } from '../utils/brandGradients';
 
 // 이미지/비디오 편집 다이얼로그
 function ImageEditDialog({ image, open, onClose, isVideo = false, projectId }) {
@@ -801,7 +802,7 @@ function ProjectHero({ project, isMobile, onEdit, onDelete, onToggleFavorite, on
           overflow: 'hidden',
           backgroundImage: hasCover
             ? `url(${project.coverImage.url})`
-            : 'linear-gradient(135deg, #7B4DD8 0%, #5B5BD6 50%, #2F77E4 100%)',
+            : BRAND_GRADIENTS[0],
           backgroundSize: 'cover',
           backgroundPosition: 'center',
           boxShadow: 1,

--- a/frontend/src/pages/ProjectList.js
+++ b/frontend/src/pages/ProjectList.js
@@ -35,37 +35,10 @@ import { useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import { projectAPI } from '../services/api';
 import ProjectEditDialog from '../components/common/ProjectEditDialog';
+import { MONO } from '../theme';
+import { gradientForId } from '../utils/brandGradients';
+import { relativeTime } from '../utils/relativeTime';
 
-const MONO = '"JetBrains Mono","SF Mono",Menlo,monospace';
-
-const GRADIENTS = [
-  'linear-gradient(135deg, #7B4DD8 0%, #5B5BD6 50%, #2F77E4 100%)',
-  'linear-gradient(135deg, #2F77E4 0%, #4E8EE8 100%)',
-  'linear-gradient(135deg, #BE7415 0%, #D69021 100%)',
-  'linear-gradient(135deg, #1F9D55 0%, #2EBA6B 100%)',
-  'linear-gradient(135deg, #D5383E 0%, #BE7415 100%)',
-  'linear-gradient(135deg, #5B616E 0%, #8A8F9A 100%)',
-];
-function gradientFor(id = '') {
-  let h = 0;
-  for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) >>> 0;
-  return GRADIENTS[h % GRADIENTS.length];
-}
-function relativeTime(iso) {
-  if (!iso) return '';
-  const then = new Date(iso).getTime();
-  if (Number.isNaN(then)) return '';
-  const min = Math.floor((Date.now() - then) / 60000);
-  if (min < 1) return '방금';
-  if (min < 60) return `${min}분 전`;
-  const hr = Math.floor(min / 60);
-  if (hr < 24) return `${hr}시간 전`;
-  const day = Math.floor(hr / 24);
-  if (day === 1) return '어제';
-  if (day < 7) return `${day}일 전`;
-  const d = new Date(then);
-  return `${String(d.getFullYear()).slice(2)}. ${d.getMonth() + 1}. ${d.getDate()}.`;
-}
 
 function TagPill({ tag }) {
   if (!tag?.name) return null;
@@ -138,7 +111,7 @@ function ProjectGridCard({ project, isFav, onOpen, onToggleFav, onMenu }) {
       sx={{ p: 0, overflow: 'hidden', cursor: 'pointer', transition: 'all 150ms', height: '100%', display: 'flex', flexDirection: 'column',
         '&:hover': { borderColor: 'primary.main', boxShadow: 2 } }}>
       {/* cover — 설정된 커버 이미지가 있으면 그걸, 없으면 그라데이션 */}
-      <Box sx={{ position: 'relative', height: 120, background: gradientFor(String(project._id)), overflow: 'hidden' }}>
+      <Box sx={{ position: 'relative', height: 120, background: gradientForId(String(project._id)), overflow: 'hidden' }}>
         {project.coverImage?.url && (
           <Box component="img" src={project.coverImage.url} alt="" loading="lazy"
             sx={{ position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover' }} />
@@ -184,7 +157,7 @@ function ProjectListRow({ project, isFav, onOpen, onToggleFav, onMenu, first }) 
   return (
     <Box onClick={onOpen} sx={{ px: 3.5, py: 3, display: 'flex', alignItems: 'center', gap: 3, cursor: 'pointer',
       borderTop: first ? 'none' : '1px solid', borderColor: 'divider', '&:hover': { bgcolor: 'action.hover' } }}>
-      <Box sx={{ width: 36, height: 36, borderRadius: 1.5, flex: '0 0 auto', overflow: 'hidden', background: gradientFor(String(project._id)),
+      <Box sx={{ width: 36, height: 36, borderRadius: 1.5, flex: '0 0 auto', overflow: 'hidden', background: gradientForId(String(project._id)),
         color: '#fff', fontWeight: 700, display: 'grid', placeItems: 'center' }}>
         {project.coverImage?.url
           ? <Box component="img" src={project.coverImage.url} alt="" sx={{ width: '100%', height: '100%', objectFit: 'cover' }} />

--- a/frontend/src/pages/PromptGeneration.js
+++ b/frontend/src/pages/PromptGeneration.js
@@ -23,6 +23,7 @@ import ConversationChatPanel from '../components/common/ConversationChatPanel';
 import WorkboardChatPanel from '../components/common/WorkboardChatPanel';
 import ProjectContextSelector from '../components/common/ProjectContextSelector';
 import toast from 'react-hot-toast';
+import { MONO } from '../theme';
 
 function PromptGeneration() {
   const { workboardId } = useParams();
@@ -104,7 +105,7 @@ function PromptGeneration() {
       </Box>
 
       <Box display="flex" alignItems="center" gap={0.5} mb={2}>
-        <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+        <Typography variant="caption" color="text.secondary" sx={{ fontFamily: MONO }}>
           작업판 ID: {workboard._id}
         </Typography>
         <IconButton size="small" onClick={handleCopyWorkboardId} aria-label="작업판 ID 복사">

--- a/frontend/src/pages/WorkboardCatalogPage.js
+++ b/frontend/src/pages/WorkboardCatalogPage.js
@@ -45,8 +45,8 @@ import { WorkboardImportDialog } from '../components/admin/WorkboardManagement';
 import { copyToClipboard } from '../utils/clipboard';
 import { invalidateWorkboardQueries } from '../utils/queryInvalidation';
 import { usePersistedState } from '../hooks/usePersistedState';
+import { MONO } from '../theme';
 
-const MONO = '"JetBrains Mono","SF Mono",Menlo,monospace';
 
 // ── 사용자: 작업판 선택(실행) ────────────────────────────────
 function selectWorkboard(workboard, projectId, navigate) {

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -8,6 +8,9 @@
 //   - 신설 palette.navbar (사이드바/헤더 통합)
 //   - 한국어 letter-spacing -0.005em, font: Pretendard
 
+// 모노스페이스 폰트 토큰 — 시드/ID/메타 영역 공용 (tokens.css --font-mono, #542)
+export const MONO = '"JetBrains Mono","SF Mono","Menlo","Consolas",monospace';
+
 const LIGHT = {
   primary:   { main: '#5B5BD6', light: '#A6A8E6', dark: '#4040AD', contrastText: '#FFFFFF' },
   secondary: { main: '#7B4DD8', light: '#B69CEC', dark: '#5B2DBF', contrastText: '#FFFFFF' },
@@ -18,7 +21,7 @@ const LIGHT = {
   // 라이트모드에선 사이드바/헤더도 밝게 (#514). 흰 표면 + 어두운 텍스트, 활성/hover 는 옅은 primary 틴트.
   navbar:    { main: '#FFFFFF', light: '#ECEDF7', dark: '#F1F1ED', contrastText: '#16181D' },
   background:{ default: '#F7F7F4', paper: '#FFFFFF' },
-  text:      { primary: '#16181D', secondary: '#5B616E', disabled: '#B6BAC2' },
+  text:      { primary: '#16181D', secondary: '#5B616E', tertiary: '#8A8F9A', disabled: '#B6BAC2' },
   divider:   '#E2E2DC',
   grey: {
     50:  '#F7F7F4', 100: '#F1F1ED', 200: '#EBEAE5', 300: '#E2E2DC',
@@ -37,7 +40,7 @@ const DARK = {
   // 다크에선 사이드바가 컨텐츠보다 더 어둡게 (디자이너 권장)
   navbar:    { main: '#0A0C10', light: '#1A1E27', dark: '#05070A', contrastText: '#E4E5E9' },
   background:{ default: '#0E1015', paper: '#161A22' },
-  text:      { primary: '#E8E9EE', secondary: '#A0A4AF', disabled: '#4A4E58' },
+  text:      { primary: '#E8E9EE', secondary: '#A0A4AF', tertiary: '#717684', disabled: '#4A4E58' },
   divider:   '#2A2F3B',
   // 다크 grey 스케일 — bgcolor: 'grey.50/100/...' 가 다크모드에서 어두운 surface 로 동작하도록
   // 50~400 은 paper 주변의 다크 톤, 500~700 은 mid → light text/icon 톤, 800~900 은 near-white.
@@ -73,6 +76,7 @@ export function buildVccTheme(mode = 'light') {
     palette: { mode, ...palette },
     typography: {
       fontFamily: '"Pretendard","Pretendard Variable",-apple-system,BlinkMacSystemFont,"Noto Sans KR",Roboto,sans-serif',
+      fontFamilyMono: MONO,
       h1: { fontSize: 28, lineHeight: '36px', fontWeight: 700, letterSpacing: '-0.01em' },
       h2: { fontSize: 22, lineHeight: '30px', fontWeight: 700, letterSpacing: '-0.01em' },
       h3: { fontSize: 18, lineHeight: '26px', fontWeight: 700, letterSpacing: '-0.005em' },

--- a/frontend/src/utils/brandGradients.js
+++ b/frontend/src/utils/brandGradients.js
@@ -1,0 +1,17 @@
+// 브랜드 그라데이션 — 디자인 핸드오프 팔레트 기반. 단일 소스 (#542).
+// 과거 페이지별 사본(6종 vs 5종)이 달라 같은 id 가 화면마다 다른 색이 되던 문제를 통합.
+export const BRAND_GRADIENTS = [
+  'linear-gradient(135deg, #7B4DD8 0%, #5B5BD6 50%, #2F77E4 100%)',
+  'linear-gradient(135deg, #2F77E4 0%, #4E8EE8 100%)',
+  'linear-gradient(135deg, #BE7415 0%, #D69021 100%)',
+  'linear-gradient(135deg, #1F9D55 0%, #2EBA6B 100%)',
+  'linear-gradient(135deg, #D5383E 0%, #BE7415 100%)',
+  'linear-gradient(135deg, #5B616E 0%, #8A8F9A 100%)',
+];
+
+// id(문자열) 해시로 결정적 선택 — 모든 화면에서 동일 id = 동일 그라데이션 보장
+export function gradientForId(id = '') {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) >>> 0;
+  return BRAND_GRADIENTS[h % BRAND_GRADIENTS.length];
+}

--- a/frontend/src/utils/relativeTime.js
+++ b/frontend/src/utils/relativeTime.js
@@ -1,0 +1,17 @@
+// 상대 시각 표기 — "방금 / N분 전 / N시간 전 / 어제 / N일 전 / yy. M. d." (#542 공용화)
+// Date 객체와 ISO 문자열 모두 허용 (기존 3중복 구현의 superset).
+export function relativeTime(input) {
+  if (!input) return '';
+  const then = input instanceof Date ? input.getTime() : new Date(input).getTime();
+  if (Number.isNaN(then)) return '';
+  const min = Math.floor((Date.now() - then) / 60000);
+  if (min < 1) return '방금';
+  if (min < 60) return `${min}분 전`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}시간 전`;
+  const day = Math.floor(hr / 24);
+  if (day === 1) return '어제';
+  if (day < 7) return `${day}일 전`;
+  const d = new Date(then);
+  return `${String(d.getFullYear()).slice(2)}. ${d.getMonth() + 1}. ${d.getDate()}.`;
+}


### PR DESCRIPTION
## 변경사항 (UI R0 ❶)

### theme.js 누락 토큰 보충
- `text.tertiary` (light `#8A8F9A` / dark `#717684`, tokens.css 값) — **이미 5곳이 참조 중이었는데 silent fail 하던 것 복구** (CommandPalette ×2, PipelinePanel ×2, WorkboardManagement ×1)
- `typography.fontFamilyMono` + `MONO` named export

### 스타일 사본 공용화
- `utils/brandGradients.js` — 그라데이션 4중 사본(6종 vs 5종으로 어긋나 같은 프로젝트가 페이지마다 다른 색 아바타) → 단일 모듈. 6종+% stop 확정, 해시 동일
- `utils/relativeTime.js` — 3중복 통합 (Date 객체/ISO 문자열 모두 허용)
- MONO: 상수 6중복 + inline `"JetBrains Mono", monospace` 18곳 + legacy `'monospace'` 6곳 → 전부 토큰 참조

### 결정 반영
- **관리자 메뉴 중립화** (triage: "직접 판단, 구분만 잘 되게") — error.main 빨강 일괄 적용 제거, 핸드오프의 중립 스타일 + overline 섹션 라벨로 구분. 다크모드에서도 자연스러움

### 다크모드 지뢰
- PipelinePanel `rgba(76,175,80,.08)`(구 MUI green) → `success.light` (다크에선 rgba 틴트로 자동 전환)
- Login 가입거절 토스트 `#ffebee/#c62828` → error 팔레트 (useTheme)
- MediaGrid black/white → `common.*` 토큰 (시네마 viewer 의도는 유지 — 시맨틱만 명시)

### 조사 후 범위 제외 (이유 명시)
- **capabilities.js 서버색** — OpenAI teal/Google blue 등 의도된 브랜드 컬러 (주석 명시 확인) → 유지, #543 Deviations 에 기록
- **태그 기본색 `#1976d2` / builtinTags** — 백엔드 `src/constants/builtinTags.js` 미러 + Tag 스키마 default + ensureWorldviewTag 마이그레이션이 얽힌 full-stack 변경 → 별도 이슈 분리 (프론트만 바꾸면 미러 어긋남)

## 검증
- `docker compose build --no-cache frontend` 통과
- 사본 잔존 0건 grep 확인 (`const GRADIENTS`/`function relativeTime`/`const MONO`)

closes #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)