### PR TITLE
feat: 공용 UI 컴포넌트 단일화 — PageHeader/SegmentTabs/EmptyState/ToneChip (#548)

### DIFF
--- a/frontend/src/components/admin/ServerManagement.js
+++ b/frontend/src/components/admin/ServerManagement.js
@@ -47,6 +47,8 @@ import { serverAPI, jobAPI } from '../../services/api';
 import { getServerTypeColor } from '../../templates/capabilities';
 import { ToneChip, TagChip } from '../common/WorkboardCatalog';
 import { MONO } from '../../theme';
+import PageHeader from '../common/PageHeader';
+import EmptyState from '../common/EmptyState';
 
 // 공식 base URL 이 알려진 provider — 서버 추가 시 자동 입력 (사용자 입력 우선)
 const KNOWN_SERVER_URLS = {
@@ -719,18 +721,17 @@ function ServerManagement() {
 
   return (
     <Box>
-      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 3, flexWrap: 'wrap', mb: 4 }}>
-        <Box sx={{ flex: 1, minWidth: 0 }}>
-          <Typography variant="h1">서버 관리</Typography>
-          <Typography variant="body1" color="text.secondary" sx={{ textWrap: 'pretty', mt: 0.5 }}>
-            ComfyUI / OpenAI / Gemini / Compatible 백엔드 등록 및 모델 동기화.
-          </Typography>
-        </Box>
-        <Box sx={{ display: 'flex', gap: 0.75 }}>
-          <Button variant="outlined" startIcon={<Refresh />} onClick={handleAllHealthCheck} disabled={allHealthCheckMutation.isLoading}>전체 헬스체크</Button>
-          <Button variant="contained" startIcon={<Add />} onClick={handleAddServer}>서버 추가</Button>
-        </Box>
-      </Box>
+      <PageHeader
+        title="서버 관리"
+        description="ComfyUI / OpenAI / Gemini / Compatible 백엔드 등록 및 모델 동기화."
+        sx={{ mb: 4 }}
+        actions={(
+          <>
+            <Button variant="outlined" startIcon={<Refresh />} onClick={handleAllHealthCheck} disabled={allHealthCheckMutation.isLoading}>전체 헬스체크</Button>
+            <Button variant="contained" startIcon={<Add />} onClick={handleAddServer}>서버 추가</Button>
+          </>
+        )}
+      />
 
       {/* 요약 */}
       <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 3, mb: 4.5 }}>
@@ -749,9 +750,7 @@ function ServerManagement() {
       </Box>
 
       {servers.length === 0 ? (
-        <Box sx={{ p: 5, textAlign: 'center', border: '1px dashed', borderColor: 'divider', borderRadius: 2 }}>
-          <Typography variant="body2" color="text.secondary">등록된 서버가 없습니다. 서버를 추가해주세요.</Typography>
-        </Box>
+        <EmptyState description="등록된 서버가 없습니다. 서버를 추가해주세요." />
       ) : (
         <Stack spacing={2.5}>
           {servers.map((server) => (

--- a/frontend/src/components/common/EmptyState.js
+++ b/frontend/src/components/common/EmptyState.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+
+/**
+ * 빈 상태 — 1px dashed 패턴 (#548 공용화, 디자인 시스템 v1)
+ *
+ * 페이지마다 갈리던 빈 상태(2px dashed / Alert / 맨 텍스트)의 표준형.
+ * - icon: 상단 아이콘 엘리먼트 (선택)
+ * - title / description / action
+ */
+export default function EmptyState({ icon, title, description, action, sx }) {
+  return (
+    <Box sx={{ p: 5, textAlign: 'center', border: '1px dashed', borderColor: 'divider', borderRadius: 2, ...sx }}>
+      {icon && (
+        <Box sx={{ color: 'text.disabled', mb: 1.5, '& svg': { fontSize: 32 } }}>{icon}</Box>
+      )}
+      {title && <Typography sx={{ fontWeight: 600, mb: 0.5 }}>{title}</Typography>}
+      {description && (
+        <Typography variant="body2" color="text.secondary" sx={{ mb: action ? 2 : 0 }}>
+          {description}
+        </Typography>
+      )}
+      {action}
+    </Box>
+  );
+}

--- a/frontend/src/components/common/PageHeader.js
+++ b/frontend/src/components/common/PageHeader.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+
+/**
+ * 페이지 헤더 — h1 타이틀 + 설명 + 우측 액션 (#548 공용화, 디자인 시스템 v1)
+ *
+ * 기존에 신규 페이지들이 각자 hand-roll 하던 패턴의 단일화.
+ * - title: 페이지 제목 (h1, 28px)
+ * - description: 보조 설명 (body1 · text.secondary · text-wrap pretty)
+ * - actions: 우측 액션 버튼 영역 (없으면 미렌더)
+ * - children: 설명 아래 부가 요소 (프로젝트 컨텍스트 칩 등)
+ */
+export default function PageHeader({ title, description, actions, children, sx }) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 3, flexWrap: 'wrap', mb: 4.5, ...sx }}>
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Typography variant="h1">{title}</Typography>
+        {description && (
+          <Typography variant="body1" color="text.secondary" sx={{ textWrap: 'pretty', mt: 0.5 }}>
+            {description}
+          </Typography>
+        )}
+        {children}
+      </Box>
+      {actions && (
+        <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap', alignItems: 'center' }}>
+          {actions}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/frontend/src/components/common/SegmentTabs.js
+++ b/frontend/src/components/common/SegmentTabs.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Box, Tabs, Tab } from '@mui/material';
+import { MONO } from '../../theme';
+
+/**
+ * 세그먼트 컨트롤 — 언더라인 탭 + 카운트 (#548 공용화, 디자인 목업 27/28 기준)
+ *
+ * MyImages 의 ContentTabLabel 패턴을 일반화. 필 버튼/칩 등 페이지별로 갈리던
+ * 세그먼트 구현을 단일화한다.
+ * - items: [{ value, label, count?, icon? }]
+ * - value/onChange: 선택 값 제어 (onChange 는 value 만 받음)
+ */
+export function SegmentTabLabel({ label, count }) {
+  return (
+    <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.75 }}>
+      {label}
+      {count !== undefined && count !== null && (
+        <Box component="span" sx={{ fontFamily: MONO, fontSize: 11, color: 'text.tertiary' }}>
+          {count}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+export default function SegmentTabs({ value, onChange, items, sx }) {
+  return (
+    <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 4.5, ...sx }}>
+      <Tabs
+        value={value}
+        onChange={(e, v) => onChange(v)}
+        variant="scrollable"
+        scrollButtons="auto"
+        allowScrollButtonsMobile
+      >
+        {items.map((it) => (
+          <Tab
+            key={it.value}
+            value={it.value}
+            disableRipple
+            icon={it.icon}
+            iconPosition={it.icon ? 'start' : undefined}
+            label={<SegmentTabLabel label={it.label} count={it.count} />}
+          />
+        ))}
+      </Tabs>
+    </Box>
+  );
+}

--- a/frontend/src/components/common/ToneChip.js
+++ b/frontend/src/components/common/ToneChip.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Chip } from '@mui/material';
+import { MONO } from '../../theme';
+
+// 상태/출력 등 의미 색이 있는 칩 — light/dark 양쪽 테마 토큰 기반 (#548 — WorkboardCatalog 내장에서 승격).
+// 같은 의미(완료/실패 등)는 모든 화면에서 이 컴포넌트로 표기한다 (MUI Chip color 직접 사용 금지).
+const TONE_SX = {
+  success: { bgcolor: 'success.light', color: 'success.main' },
+  info: { bgcolor: 'info.light', color: 'info.main' },
+  warning: { bgcolor: 'warning.light', color: 'warning.main' },
+  error: { bgcolor: 'error.light', color: 'error.main' },
+  accent: { bgcolor: (t) => (t.palette.mode === 'dark' ? 'rgba(118,118,224,0.22)' : 'rgba(91,91,214,0.12)'), color: 'primary.main' },
+  neutral: { bgcolor: 'grey.100', color: 'text.secondary' },
+};
+
+export function ToneChip({ tone, label, mono, sx }) {
+  const ts = TONE_SX[tone] || TONE_SX.neutral;
+  return (
+    <Chip
+      size="small"
+      variant="filled"
+      label={label}
+      sx={{
+        height: 22, fontSize: '11.5px', fontWeight: 500, border: 0,
+        ...(mono && { fontFamily: MONO, fontSize: '11px' }),
+        '& .MuiChip-label': { px: '9px' },
+        ...ts, ...sx,
+      }}
+    />
+  );
+}
+
+export default ToneChip;

--- a/frontend/src/components/common/WorkboardCatalog.js
+++ b/frontend/src/components/common/WorkboardCatalog.js
@@ -2,6 +2,7 @@ import React, { useState, useMemo } from 'react';
 import { usePersistedState } from '../../hooks/usePersistedState';
 import { Box, Paper, Typography, Chip, IconButton, Button, InputBase } from '@mui/material';
 import { MONO } from '../../theme';
+import { ToneChip } from './ToneChip';
 import {
   Search,
   Close,
@@ -57,31 +58,9 @@ export const SERVER_AXIS = [
 const OUT_TONE = { image: 'accent', video: 'warning', text: 'info' };
 
 // 원본 .chip--tag 톤 칩 — 은은한 틴트 배경 + 진한 글씨 (height 20, padding 0 7px, 11.5px).
-// 상태/출력 등 의미 색이 있는 칩에 사용. light/dark 양쪽 테마 토큰 기반.
-const TONE_SX = {
-  success: { bgcolor: 'success.light', color: 'success.main' },
-  info: { bgcolor: 'info.light', color: 'info.main' },
-  warning: { bgcolor: 'warning.light', color: 'warning.main' },
-  error: { bgcolor: 'error.light', color: 'error.main' },
-  accent: { bgcolor: (t) => (t.palette.mode === 'dark' ? 'rgba(118,118,224,0.22)' : 'rgba(91,91,214,0.12)'), color: 'primary.main' },
-  neutral: { bgcolor: 'grey.100', color: 'text.secondary' },
-};
-export function ToneChip({ tone, label, mono, sx }) {
-  const ts = TONE_SX[tone] || TONE_SX.neutral;
-  return (
-    <Chip
-      size="small"
-      variant="filled"
-      label={label}
-      sx={{
-        height: 22, fontSize: '11.5px', fontWeight: 500, border: 0,
-        ...(mono && { fontFamily: MONO, fontSize: '11px' }),
-        '& .MuiChip-label': { px: '9px' },
-        ...ts, ...sx,
-      }}
-    />
-  );
-}
+// ToneChip 은 common/ToneChip 으로 승격 (#548) — 기존 import 호환 재export
+export { ToneChip };
+
 // 의미 색 없는 태그 칩 — 투명 배경 + 옅은 테두리 + tertiary 글씨 (종류 라벨 등).
 export function TagChip({ label, mono, sx }) {
   return (

--- a/frontend/src/pages/JobHistory.js
+++ b/frontend/src/pages/JobHistory.js
@@ -50,6 +50,9 @@ import VideoViewerDialog from '../components/common/VideoViewerDialog';
 import WorkboardSelectDialog from '../components/common/WorkboardSelectDialog';
 import { SavePromptDialog, JobDetailDialog } from '../components/common/JobHistoryPanel';
 import { ToneChip, TagChip } from '../components/common/WorkboardCatalog';
+import PageHeader from '../components/common/PageHeader';
+import SegmentTabs from '../components/common/SegmentTabs';
+import EmptyState from '../components/common/EmptyState';
 import { MONO } from '../theme';
 import { relativeTime } from '../utils/relativeTime';
 
@@ -518,13 +521,10 @@ function JobHistory() {
 
   return (
     <Box>
-      {/* 헤더 */}
-      <Box sx={{ mb: 4.5 }}>
-        <Typography variant="h1">작업 히스토리</Typography>
-        <Typography variant="body1" color="text.secondary" sx={{ textWrap: 'pretty', mt: 0.5 }}>
-          파이프라인 · 이미지 · 영상 · 텍스트 생성 기록을 한 곳에서. 최신순.
-        </Typography>
-      </Box>
+      <PageHeader
+        title="작업 히스토리"
+        description="파이프라인 · 이미지 · 영상 · 텍스트 생성 기록을 한 곳에서. 최신순."
+      />
 
       {/* 검색 */}
       <TextField
@@ -536,39 +536,24 @@ function JobHistory() {
         InputProps={{ startAdornment: <InputAdornment position="start"><Search fontSize="small" /></InputAdornment> }}
       />
 
-      {/* 세그먼트 */}
-      <Stack direction="row" spacing={1} sx={{ mb: 4.5, overflowX: 'auto', pb: 0.5 }}>
-        {[
-          { k: 'all', l: '전체' },
-          { k: 'pipeline', l: '파이프라인' },
-          { k: 'image', l: '이미지' },
-          { k: 'video', l: '영상' },
-          { k: 'text', l: '텍스트' },
-        ].map((s) => (
-          <Button
-            key={s.k}
-            onClick={() => setSeg(s.k)}
-            variant={seg === s.k ? 'contained' : 'text'}
-            color={seg === s.k ? 'primary' : 'inherit'}
-            sx={{ flex: '0 0 auto', color: seg === s.k ? undefined : 'text.secondary' }}
-          >
-            {s.l}
-            <Box component="span" sx={{ ml: 0.75, fontFamily: MONO, fontSize: 11, opacity: 0.8 }}>
-              {counts[s.k]}
-            </Box>
-          </Button>
-        ))}
-      </Stack>
+      {/* 세그먼트 — 언더라인 탭 (목업 28, #548) */}
+      <SegmentTabs
+        value={seg}
+        onChange={setSeg}
+        items={[
+          { value: 'all', label: '전체', count: counts.all },
+          { value: 'pipeline', label: '파이프라인', count: counts.pipeline },
+          { value: 'image', label: '이미지', count: counts.image },
+          { value: 'video', label: '영상', count: counts.video },
+          { value: 'text', label: '텍스트', count: counts.text },
+        ]}
+      />
 
       {/* 피드 */}
       {loading && items.length === 0 ? (
         <Box display="flex" justifyContent="center" mt={8}><CircularProgress /></Box>
       ) : visible.length === 0 ? (
-        <Paper variant="outlined" sx={{ p: 5, textAlign: 'center' }}>
-          <Typography variant="body2" color="text.secondary">
-            {search ? '검색 결과가 없습니다.' : '아직 작업 기록이 없습니다.'}
-          </Typography>
-        </Paper>
+        <EmptyState description={search ? '검색 결과가 없습니다.' : '아직 작업 기록이 없습니다.'} />
       ) : (
         <Stack spacing={2}>
           {visible.map((item) => (

--- a/frontend/src/pages/MyImages.js
+++ b/frontend/src/pages/MyImages.js
@@ -35,6 +35,7 @@ import { imageAPI, userAPI, textAPI, projectAPI, tagAPI } from '../services/api'
 import TagInput from '../components/common/TagInput';
 import MediaGrid from '../components/common/MediaGrid';
 import TextContentPanel from '../components/common/TextContentPanel';
+import PageHeader from '../components/common/PageHeader';
 
 // 필터 레일 (5c 후속) — 좌측 sticky. 프로젝트 / 일반 태그 그룹.
 // 클릭으로 selectedTagIds 토글. backend 변경 없이 기존 ?tags=... CSV 로 필터.
@@ -568,20 +569,10 @@ function MyImages() {
 
   return (
     <Container maxWidth="xl" sx={{ mt: 4, mb: 4 }}>
-      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 4, mb: 4.5, flexWrap: 'wrap' }}>
-        <Box sx={{ flex: 1, minWidth: 0 }}>
-          <Typography
-            variant="h4"
-            component="h1"
-            sx={{ fontSize: { xs: '1.5rem', md: '2rem' }, fontWeight: 700, letterSpacing: '-0.01em' }}
-          >
-            내 컨텐츠
-          </Typography>
-          <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-            프로젝트에서 생성·업로드된 모든 자산. 탭으로 종류별 전환.
-          </Typography>
-        </Box>
-        {!bulkMode && !isTextTab && (
+      <PageHeader
+        title="내 컨텐츠"
+        description="프로젝트에서 생성·업로드된 모든 자산. 탭으로 종류별 전환."
+        actions={!bulkMode && !isTextTab && (
           <Box sx={{ display: 'flex', gap: 1.5, flexShrink: 0 }}>
             {tab === 1 && (
               <Button
@@ -602,7 +593,7 @@ function MyImages() {
             </Button>
           </Box>
         )}
-      </Box>
+      />
 
       {/* Bulk mode 툴바 */}
       {bulkMode && (

--- a/frontend/src/pages/ProjectList.js
+++ b/frontend/src/pages/ProjectList.js
@@ -38,6 +38,8 @@ import ProjectEditDialog from '../components/common/ProjectEditDialog';
 import { MONO } from '../theme';
 import { gradientForId } from '../utils/brandGradients';
 import { relativeTime } from '../utils/relativeTime';
+import PageHeader from '../components/common/PageHeader';
+import EmptyState from '../components/common/EmptyState';
 
 
 function TagPill({ tag }) {
@@ -244,19 +246,17 @@ function ProjectList() {
 
   return (
     <Box>
-      {/* 헤더 */}
-      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 3, flexWrap: 'wrap', mb: 5 }}>
-        <Box sx={{ flex: '1 1 360px', minWidth: 0 }}>
-          <Typography variant="h1">프로젝트</Typography>
-          <Typography variant="body1" color="text.secondary" sx={{ textWrap: 'pretty', mt: 0.5 }}>
-            세계관, 캠페인, 실험 모음을 프로젝트 단위로 묶어 관리합니다.
-          </Typography>
-        </Box>
-        <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap', alignItems: 'center' }}>
-          <ViewToggle view={view} setView={setView} />
-          <Button variant="contained" startIcon={<Add />} onClick={() => setCreateOpen(true)}>새 프로젝트</Button>
-        </Box>
-      </Box>
+      <PageHeader
+        title="프로젝트"
+        description="세계관, 캠페인, 실험 모음을 프로젝트 단위로 묶어 관리합니다."
+        sx={{ mb: 5 }}
+        actions={(
+          <>
+            <ViewToggle view={view} setView={setView} />
+            <Button variant="contained" startIcon={<Add />} onClick={() => setCreateOpen(true)}>새 프로젝트</Button>
+          </>
+        )}
+      />
 
       {/* 검색 / 필터 */}
       <Box sx={{ display: 'flex', gap: 2, mb: 4.5, alignItems: 'center', flexWrap: 'wrap' }}>
@@ -277,11 +277,11 @@ function ProjectList() {
       </Box>
 
       {projects.length === 0 ? (
-        <Box sx={{ p: 5, textAlign: 'center', border: '1px dashed', borderColor: 'divider', borderRadius: 2 }}>
-          <Typography sx={{ fontWeight: 600, mb: 0.5 }}>아직 프로젝트가 없습니다</Typography>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>첫 프로젝트를 만들어 보세요.</Typography>
-          <Button variant="contained" size="small" startIcon={<Add />} onClick={() => setCreateOpen(true)}>새 프로젝트</Button>
-        </Box>
+        <EmptyState
+          title="아직 프로젝트가 없습니다"
+          description="첫 프로젝트를 만들어 보세요."
+          action={<Button variant="contained" startIcon={<Add />} onClick={() => setCreateOpen(true)}>새 프로젝트</Button>}
+        />
       ) : view === 'list' ? (
         <Paper variant="outlined">
           {visible.map((p, i) => (

--- a/frontend/src/pages/WorkboardCatalogPage.js
+++ b/frontend/src/pages/WorkboardCatalogPage.js
@@ -46,6 +46,8 @@ import { copyToClipboard } from '../utils/clipboard';
 import { invalidateWorkboardQueries } from '../utils/queryInvalidation';
 import { usePersistedState } from '../hooks/usePersistedState';
 import { MONO } from '../theme';
+import PageHeader from '../components/common/PageHeader';
+import EmptyState from '../components/common/EmptyState';
 
 
 // ── 사용자: 작업판 선택(실행) ────────────────────────────────
@@ -207,25 +209,23 @@ function WorkboardCatalogPage({ admin = false }) {
   return (
     <Box>
       {/* 헤더 — admin 일 때만 관리 버튼 노출 */}
-      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 3, flexWrap: 'wrap', mb: 4 }}>
-        <Box sx={{ flex: 1, minWidth: 0 }}>
-          <Typography variant="h1">{admin ? '작업판 관리' : '작업판'}</Typography>
-          <Typography variant="body1" color="text.secondary" sx={{ textWrap: 'pretty', mt: 0.5 }}>
-            {admin
-              ? '작업판 정의 · 출력 형식 · 접근 권한 · 서버 매핑을 관리합니다.'
-              : '한 번의 호출로 실행하는 단위. 파이프라인의 단계로도 사용됩니다.'}
-          </Typography>
-          {projectContext && (
-            <Chip label={`프로젝트: ${projectContext.name}`} color="primary" variant="outlined" size="small" sx={{ mt: 1 }} />
-          )}
-        </Box>
-        {admin && (
-          <Box sx={{ display: 'flex', gap: 0.75 }}>
+      <PageHeader
+        title={admin ? '작업판 관리' : '작업판'}
+        description={admin
+          ? '작업판 정의 · 출력 형식 · 접근 권한 · 서버 매핑을 관리합니다.'
+          : '한 번의 호출로 실행하는 단위. 파이프라인의 단계로도 사용됩니다.'}
+        sx={{ mb: 4 }}
+        actions={admin && (
+          <>
             <Button variant="outlined" startIcon={<FileUpload />} onClick={() => setImportOpen(true)}>가져오기</Button>
             <Button variant="contained" startIcon={<Add />} onClick={handleCreate}>새 작업판</Button>
-          </Box>
+          </>
         )}
-      </Box>
+      >
+        {projectContext && (
+          <Chip label={`프로젝트: ${projectContext.name}`} color="primary" variant="outlined" size="small" sx={{ mt: 1 }} />
+        )}
+      </PageHeader>
 
       {/* 상태 필터 — admin 전용 축 */}
       {admin && (
@@ -261,16 +261,14 @@ function WorkboardCatalogPage({ admin = false }) {
       {isLoading ? (
         <Box display="flex" justifyContent="center" mt={8}><CircularProgress /></Box>
       ) : filtered.length === 0 ? (
-        <Box sx={{ p: 5, textAlign: 'center', border: '1px dashed', borderColor: 'divider', borderRadius: 2 }}>
-          <Inventory2 sx={{ fontSize: 32, color: 'text.disabled', mb: 1.5 }} />
-          <Typography sx={{ fontWeight: 600, mb: 0.5 }}>조건에 맞는 작업판이 없습니다</Typography>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: admin ? 2 : 0 }}>
-            {workboards.length === 0
-              ? (admin ? '새 작업판을 만들어 보세요.' : '사용 가능한 작업판이 없습니다.')
-              : '필터를 줄이거나 초기화해 보세요.'}
-          </Typography>
-          {admin && <Button variant="contained" size="small" startIcon={<Add />} onClick={handleCreate}>새 작업판</Button>}
-        </Box>
+        <EmptyState
+          icon={<Inventory2 />}
+          title="조건에 맞는 작업판이 없습니다"
+          description={workboards.length === 0
+            ? (admin ? '새 작업판을 만들어 보세요.' : '사용 가능한 작업판이 없습니다.')
+            : '필터를 줄이거나 초기화해 보세요.'}
+          action={admin ? <Button variant="contained" startIcon={<Add />} onClick={handleCreate}>새 작업판</Button> : undefined}
+        />
       ) : (
         <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: 'repeat(auto-fill, minmax(300px, 1fr))' }, gap: 3 }}>
           {filtered.map((wb) => (


### PR DESCRIPTION
## 변경사항 (UI R1)

같은 의미의 UI 가 페이지마다 다르게 구현되던 4가지 패턴을 공용 컴포넌트로 단일화:

| 컴포넌트 | 역할 | 기존 패턴 수 |
|---|---|---|
| `PageHeader` | h1 타이틀+설명+우측 액션 | 5페이지 hand-roll + h4 변형 |
| `SegmentTabs` | 언더라인 탭+카운트 (목업 27/28 기준, MyImages 패턴 일반화) | 필 버튼 / MUI Tabs / 칩 3종 |
| `EmptyState` | 1px dashed 표준형 (icon/title/description/action) | 4패턴 |
| `ToneChip` | 상태 칩 (common 으로 승격, 재export 로 기존 import 호환) | ToneChip vs MUI Chip 2패턴 |

적용 페이지: JobHistory(세그먼트가 디자인 목업 28 의 언더라인 탭으로 교체됨 — 시각 변화 있음), ProjectList, ServerManagement, WorkboardCatalogPage, MyImages(헤더 h4→h1 승급 — 타이틀이 다른 신식 페이지와 같은 크기로).

## 검증
- `docker compose build --no-cache frontend` 통과
- 머지 후 alpha 배포 + 주요 페이지 시각 점검 예정

closes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)