### PR TITLE
fix: 칩/태그 캡슐 패딩 보강 (#556)

### DIFF
--- a/frontend/src/components/common/ToneChip.js
+++ b/frontend/src/components/common/ToneChip.js
@@ -20,9 +20,9 @@ export function ToneChip({ tone, label, mono, sx }) {
       variant="filled"
       label={label}
       sx={{
-        height: 22, fontSize: '11.5px', fontWeight: 500, border: 0,
+        height: 24, fontSize: '11.5px', fontWeight: 600, border: 0,
         ...(mono && { fontFamily: MONO, fontSize: '11px' }),
-        '& .MuiChip-label': { px: '9px' },
+        '& .MuiChip-label': { px: '11px' },
         ...ts, ...sx,
       }}
     />

--- a/frontend/src/components/common/WorkboardCatalog.js
+++ b/frontend/src/components/common/WorkboardCatalog.js
@@ -68,10 +68,10 @@ export function TagChip({ label, mono, sx }) {
       variant="outlined"
       label={label}
       sx={{
-        height: 22, fontSize: mono ? '10.5px' : '11.5px', bgcolor: 'transparent',
+        height: 24, fontSize: mono ? '10.5px' : '11.5px', bgcolor: 'transparent',
         borderColor: 'divider', color: 'grey.600',
         ...(mono && { fontFamily: MONO }),
-        '& .MuiChip-label': { px: '9px' }, ...sx,
+        '& .MuiChip-label': { px: '11px' }, ...sx,
       }}
     />
   );

--- a/frontend/src/pages/ProjectList.js
+++ b/frontend/src/pages/ProjectList.js
@@ -46,7 +46,7 @@ function TagPill({ tag }) {
   if (!tag?.name) return null;
   return (
     <Box component="span" sx={{
-      display: 'inline-flex', alignItems: 'center', height: 18, px: '7px', borderRadius: 999,
+      display: 'inline-flex', alignItems: 'center', height: 21, px: '10px', borderRadius: 999,
       fontSize: 10.5, fontWeight: 600, color: '#fff', bgcolor: tag.color || '#7c4dff', whiteSpace: 'nowrap',
     }}>
       {tag.name}

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -107,7 +107,11 @@ export function buildVccTheme(mode = 'light') {
       },
       MuiChip: {
         defaultProps: { size: 'small', variant: 'outlined' },
-        styleOverrides: { root: { borderRadius: 999, fontWeight: 600, fontSize: 11.5 } },
+        styleOverrides: {
+          root: { borderRadius: 999, fontWeight: 600, fontSize: 11.5 },
+          sizeSmall: { height: 25 },
+          label: { paddingInline: 11 }, // 텍스트 주변 여유 (#556)
+        },
       },
       MuiPaper: {
         styleOverrides: {


### PR DESCRIPTION
토큰 레벨 피드백 반영 — 태그 캡슐이 텍스트 주변으로 너무 타이트하던 것을 theme(MuiChip label paddingInline 11 + height 25)과 커스텀 칩 3종(ToneChip/TagChip/TagPill)에서 일괄 보강.

closes #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)