### PR TITLE
feat: 셸 v2 — 사이드바·탑바 리디자인 (#558)

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -133,11 +133,12 @@ function MainLayout() {
   };
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
-      <Header onMobileToggle={handleMobileToggle} onOpenPalette={() => setPaletteOpen(true)} />
+    // v2 셸 (#558): 사이드바 전고(全高) — 로고가 좌상단 앵커, 헤더는 콘텐츠 컬럼 폭만 차지
+    <Box sx={{ display: 'flex', minHeight: '100vh' }}>
+      <Sidebar mobileOpen={mobileOpen} onMobileToggle={handleMobileToggle} />
       <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
-      <Box sx={{ display: 'flex', flex: 1 }}>
-        <Sidebar mobileOpen={mobileOpen} onMobileToggle={handleMobileToggle} />
+      <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minWidth: 0 }}>
+        <Header onMobileToggle={handleMobileToggle} onOpenPalette={() => setPaletteOpen(true)} />
         <Box component="main" sx={{
           flexGrow: 1,
           minWidth: 0, // flex item 이 content intrinsic width 로 늘어나 body 가로 스크롤 유발하는 것 방지 (#383)

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -8,7 +8,7 @@ import {
   MenuItem,
   IconButton,
   Box,
-  Chip,
+  ButtonBase,
   ListItemIcon,
   ListItemText,
   Divider,
@@ -26,12 +26,66 @@ import {
   LightMode as LightModeIcon,
   DarkMode as DarkModeIcon,
   BrightnessAuto as SystemModeIcon,
-  Check as CheckIcon
+  Check as CheckIcon,
+  Dns as DnsIcon
 } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
+import { useQuery } from 'react-query';
 import { useAuth } from '../contexts/AuthContext';
 import { useColorScheme } from '../contexts/ColorSchemeContext';
+import { serverAPI } from '../services/api';
+import { MONO } from '../theme';
+import { BRAND_GRADIENTS } from '../utils/brandGradients';
 import NotificationsPopover from './common/NotificationsPopover';
+
+// 탑바 필 공통 스타일 — v2 셸 (#558)
+const pillSx = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 2,
+  bgcolor: 'background.paper',
+  border: 1,
+  borderColor: 'divider',
+  borderRadius: 999,
+  boxShadow: 1,
+};
+
+// 서버 상태 필 — GET /servers (일반 사용자 접근 가능) 실데이터
+function ServerStatusPill({ isAdmin }) {
+  const navigate = useNavigate();
+  const { data } = useQuery('servers', () => serverAPI.getServers(), {
+    staleTime: 30000,
+    refetchInterval: 60000,
+  });
+  const servers = data?.data?.data?.servers || [];
+  if (!servers.length) return null;
+
+  const healthy = servers.filter((s) => s.healthCheck?.status === 'healthy').length;
+  const allOk = healthy === servers.length;
+
+  return (
+    <ButtonBase
+      onClick={isAdmin ? () => navigate('/admin/servers') : undefined}
+      disabled={!isAdmin}
+      sx={{
+        ...pillSx,
+        gap: 1.5,
+        px: 3,
+        py: 1.25,
+        bgcolor: allOk ? 'success.light' : 'warning.light',
+        borderColor: 'transparent',
+        boxShadow: 'none',
+        display: { xs: 'none', sm: 'flex' },
+      }}
+      title={isAdmin ? '서버 관리로 이동' : undefined}
+    >
+      <DnsIcon sx={{ fontSize: 13, color: allOk ? 'success.main' : 'warning.main' }} />
+      <Typography sx={{ fontSize: 11.5, fontWeight: 700, color: allOk ? 'success.main' : 'warning.main' }}>
+        서버 {healthy}/{servers.length} {allOk ? '정상' : '점검 필요'}
+      </Typography>
+    </ButtonBase>
+  );
+}
 
 function Header({ onMobileToggle, onOpenPalette }) {
   const { user, logout, isAdmin } = useAuth();
@@ -73,68 +127,81 @@ function Header({ onMobileToggle, onOpenPalette }) {
 
   return (
     <AppBar position="static" sx={{ bgcolor: 'navbar.main' }}>
-      <Toolbar>
-        {/* 모바일 메뉴 버튼 */}
-        {isMobile && onMobileToggle && (
-          <IconButton
-            color="inherit"
-            aria-label="open drawer"
-            edge="start"
-            onClick={onMobileToggle}
-            sx={{ mr: 2 }}
-          >
-            <MenuIcon />
-          </IconButton>
+      <Toolbar sx={{ gap: 3 }}>
+        {/* 모바일 메뉴 버튼 + 로고 (데스크탑 로고는 사이드바로 이동, #558) */}
+        {isMobile && (
+          <>
+            {onMobileToggle && (
+              <IconButton color="inherit" aria-label="open drawer" edge="start" onClick={onMobileToggle}>
+                <MenuIcon />
+              </IconButton>
+            )}
+            <Typography
+              variant="h6"
+              component="div"
+              sx={{ cursor: 'pointer', fontWeight: 800 }}
+              onClick={() => navigate('/dashboard')}
+            >
+              VCCM
+            </Typography>
+          </>
         )}
-        
-        <Typography 
-          variant="h6" 
-          component="div" 
-          sx={{ flexGrow: 1, cursor: 'pointer' }}
-          onClick={() => navigate('/dashboard')}
-        >
-          {isMobile ? 'VCCM' : 'Visual Content Creator'}
-        </Typography>
-        
+
         {user && (
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-            {/* ⌘K 명령 팔레트 트리거 */}
-            {onOpenPalette && (
-              <IconButton
-                color="inherit"
-                onClick={onOpenPalette}
-                title="검색 (⌘K)"
-              >
-                <SearchIcon />
-              </IconButton>
+          <>
+            {/* 검색 필 — 기존 ⌘K 명령 팔레트의 가시화 (프로젝트·작업판 검색 + 페이지 이동) */}
+            {onOpenPalette && !isMobile && (
+              <ButtonBase onClick={onOpenPalette} sx={{ ...pillSx, flexBasis: 320, px: 4, py: 1.75, justifyContent: 'flex-start' }}>
+                <SearchIcon sx={{ fontSize: 15, color: 'text.tertiary' }} />
+                <Typography sx={{ fontSize: 12.5, color: 'text.tertiary', flex: 1, textAlign: 'left' }}>
+                  작업판 · 프로젝트 검색
+                </Typography>
+                <Box component="span" sx={{
+                  fontFamily: MONO, fontSize: 10, color: 'text.tertiary',
+                  border: 1, borderColor: 'divider', borderRadius: 1, px: 1.25, py: 0.25,
+                }}>
+                  ⌘K
+                </Box>
+              </ButtonBase>
             )}
 
-            {/* 알림 popover */}
-            <NotificationsPopover />
+            <Box sx={{ flexGrow: 1 }} />
 
-            {isAdmin && (
-              <Chip
-                label="Admin"
-                color="secondary"
-                variant="outlined"
-                sx={{ color: 'navbar.contrastText', borderColor: 'navbar.contrastText' }}
-              />
-            )}
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2.5 }}>
+              <ServerStatusPill isAdmin={isAdmin} />
 
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-              <Typography variant="body2" sx={{ display: { xs: 'none', sm: 'block' } }}>
-                {user.nickname}
-              </Typography>
-              <IconButton
-                onClick={handleMenuOpen}
-                color="inherit"
-              >
+              {/* 모바일에선 검색 아이콘으로 대체 */}
+              {onOpenPalette && isMobile && (
+                <IconButton color="inherit" onClick={onOpenPalette} title="검색 (⌘K)">
+                  <SearchIcon />
+                </IconButton>
+              )}
+
+              {/* 알림 popover */}
+              <NotificationsPopover />
+
+              {/* 프로필 필 — 아바타 + 닉네임 + Admin 칩 (#558) */}
+              <ButtonBase onClick={handleMenuOpen} sx={{ ...pillSx, gap: 2, pl: 1, pr: 3, py: 0.75 }}>
                 {user.avatar ? (
-                  <Avatar src={user.avatar} sx={{ width: 32, height: 32 }} />
+                  <Avatar src={user.avatar} sx={{ width: 24, height: 24 }} />
                 ) : (
-                  <AccountCircle />
+                  <Avatar sx={{ width: 24, height: 24, background: BRAND_GRADIENTS[0] }}>
+                    <AccountCircle sx={{ fontSize: 18 }} />
+                  </Avatar>
                 )}
-              </IconButton>
+                <Typography sx={{ fontSize: 12.5, fontWeight: 700, color: 'text.primary', display: { xs: 'none', sm: 'block' } }}>
+                  {user.nickname}
+                </Typography>
+                {isAdmin && (
+                  <Box component="span" sx={{
+                    fontSize: 10, fontWeight: 700, borderRadius: 999, px: 1.75, py: 0.25,
+                    bgcolor: 'primary.light',
+                    color: theme.palette.mode === 'dark' ? 'primary.main' : 'primary.dark',
+                  }}>
+                    Admin
+                  </Box>
+                )}
+              </ButtonBase>
             </Box>
 
             <Menu
@@ -167,7 +234,7 @@ function Header({ onMobileToggle, onOpenPalette }) {
                   <ListItemText>대시보드</ListItemText>
                 </MenuItem>
               )}
-              
+
               <MenuItem onClick={handleProfile}>
                 <ListItemIcon>
                   <Settings fontSize="small" />
@@ -212,7 +279,7 @@ function Header({ onMobileToggle, onOpenPalette }) {
                 <ListItemText>로그아웃</ListItemText>
               </MenuItem>
             </Menu>
-          </Box>
+          </>
         )}
       </Toolbar>
     </AppBar>

--- a/frontend/src/components/Sidebar.js
+++ b/frontend/src/components/Sidebar.js
@@ -8,7 +8,6 @@ import {
   ListItemText,
   Box,
   Typography,
-  Divider,
   useTheme,
   useMediaQuery
 } from '@mui/material';
@@ -32,110 +31,44 @@ import {
 } from '@mui/icons-material';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
+import { BRAND_GRADIENTS } from '../utils/brandGradients';
 
-const DRAWER_WIDTH = 250;
+const DRAWER_WIDTH = 236;
 
-const menuItems = [
-  {
-    text: '대시보드',
-    path: '/dashboard',
-    icon: <Dashboard />,
-    roles: ['user', 'admin']
-  },
-  {
-    text: '작업판',
-    path: '/workboards',
-    icon: <ViewModule />,
-    roles: ['user', 'admin']
-  },
-  {
-    text: '프로젝트',
-    path: '/projects',
-    icon: <FolderSpecial />,
-    roles: ['user', 'admin']
-  },
-  {
-    text: '내 컨텐츠',
-    path: '/content',
-    icon: <Image />,
-    roles: ['user', 'admin']
-  },
-  {
-    text: '작업 히스토리',
-    path: '/jobs',
-    icon: <History />,
-    roles: ['user', 'admin']
-  },
-  {
-    text: '프롬프트 데이터',
-    path: '/prompt-data',
-    icon: <TextSnippet />,
-    roles: ['user', 'admin']
-  },
-  {
-    text: '태그',
-    path: '/tags',
-    icon: <LocalOffer />,
-    roles: ['user', 'admin']
-  },
-  {
-    text: '설정',
-    path: '/settings',
-    icon: <Settings />,
-    roles: ['user', 'admin']
-  }
+// v2 셸 (#558) — 섹션 재편: 작업 / 자료 / 관리자, 설정은 하단 고정
+const workItems = [
+  { text: '대시보드', path: '/dashboard', icon: <Dashboard /> },
+  { text: '작업판', path: '/workboards', icon: <ViewModule /> },
+  { text: '프로젝트', path: '/projects', icon: <FolderSpecial /> },
+  { text: '내 컨텐츠', path: '/content', icon: <Image /> },
+  { text: '작업 히스토리', path: '/jobs', icon: <History /> },
+];
+
+const dataItems = [
+  { text: '프롬프트 데이터', path: '/prompt-data', icon: <TextSnippet /> },
+  { text: '태그', path: '/tags', icon: <LocalOffer /> },
 ];
 
 const adminMenuItems = [
-  {
-    text: '관리자 대시보드',
-    path: '/admin/dashboard',
-    icon: <AdminPanelSettings />,
-    roles: ['admin']
-  },
-  {
-    text: '사용자 관리',
-    path: '/admin/users',
-    icon: <People />,
-    roles: ['admin']
-  },
-  {
-    text: '작업판 관리',
-    path: '/admin/workboards',
-    icon: <Apps />,
-    roles: ['admin']
-  },
-  {
-    text: '서버 관리',
-    path: '/admin/servers',
-    icon: <Storage />,
-    roles: ['admin']
-  },
-  {
-    text: '모델 관리',
-    path: '/admin/models',
-    icon: <AutoFixHigh />,
-    roles: ['admin']
-  },
-  {
-    text: '그룹 관리',
-    path: '/admin/groups',
-    icon: <Group />,
-    roles: ['admin']
-  },
-  {
-    text: '시스템 통계',
-    path: '/admin/stats',
-    icon: <BarChart />,
-    roles: ['admin']
-  },
-  {
-    text: '백업 / 복구',
-    path: '/admin/backup',
-    icon: <Backup />,
-    roles: ['admin']
-  }
+  { text: '관리자 대시보드', path: '/admin/dashboard', icon: <AdminPanelSettings /> },
+  { text: '사용자 관리', path: '/admin/users', icon: <People /> },
+  { text: '작업판 관리', path: '/admin/workboards', icon: <Apps /> },
+  { text: '서버 관리', path: '/admin/servers', icon: <Storage /> },
+  { text: '모델 관리', path: '/admin/models', icon: <AutoFixHigh /> },
+  { text: '그룹 관리', path: '/admin/groups', icon: <Group /> },
+  { text: '시스템 통계', path: '/admin/stats', icon: <BarChart /> },
+  { text: '백업 / 복구', path: '/admin/backup', icon: <Backup /> },
 ];
+
+const settingsItem = { text: '설정', path: '/settings', icon: <Settings /> };
+
+function SectionLabel({ children }) {
+  return (
+    <Typography variant="overline" sx={{ display: 'block', px: 3, pt: 3.5, pb: 1, color: 'text.tertiary' }}>
+      {children}
+    </Typography>
+  );
+}
 
 function Sidebar({ mobileOpen, onMobileToggle }) {
   const navigate = useNavigate();
@@ -158,90 +91,87 @@ function Sidebar({ mobileOpen, onMobileToggle }) {
     return location.pathname.startsWith(path);
   };
 
+  const renderItem = (item) => {
+    const active = isPathActive(item.path);
+    return (
+      <ListItem key={item.text} disablePadding>
+        <ListItemButton
+          onClick={() => handleNavigation(item.path)}
+          sx={{
+            borderRadius: '9px',
+            mb: 0.25,
+            py: isMobile ? 1.5 : 1,
+            px: 3,
+            // 활성 = surface 픽 + 그림자 (라이트) / 민트 틴트 표면 (다크) — v2 셸 시안
+            bgcolor: active ? 'navbar.light' : 'transparent',
+            boxShadow: active ? 1 : 'none',
+            color: active
+              ? (theme.palette.mode === 'dark' ? 'primary.main' : 'primary.dark')
+              : 'navbar.contrastText',
+            '&:hover': { bgcolor: 'navbar.light' },
+          }}
+        >
+          <ListItemIcon sx={{ color: 'inherit', minWidth: 36, '& svg': { fontSize: 19 } }}>
+            {item.icon}
+          </ListItemIcon>
+          <ListItemText
+            primary={item.text}
+            sx={{
+              '& .MuiListItemText-primary': {
+                fontSize: isMobile ? '1rem' : '0.85rem',
+                fontWeight: active ? 700 : 500,
+              },
+            }}
+          />
+        </ListItemButton>
+      </ListItem>
+    );
+  };
+
   const drawer = (
-    <Box sx={{ height: '100%', bgcolor: 'navbar.main', color: 'navbar.contrastText' }}>
-      <Box sx={{ p: 2 }}>
-        <Typography variant="h6" sx={{ color: 'navbar.contrastText', fontWeight: 'bold' }}>
-          메뉴
-        </Typography>
+    <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column', bgcolor: 'navbar.main', color: 'navbar.contrastText' }}>
+      {/* 로고 블록 — 탑바에서 사이드바로 이동 (#558) */}
+      <Box
+        onClick={() => handleNavigation('/dashboard')}
+        sx={{ display: 'flex', alignItems: 'center', gap: 2.5, px: 3.5, pt: 4, pb: 2, cursor: 'pointer' }}
+      >
+        <Box sx={{
+          width: 28, height: 28, borderRadius: 2, background: BRAND_GRADIENTS[0],
+          color: 'common.white', display: 'grid', placeItems: 'center',
+          fontSize: 13, fontWeight: 800,
+        }}>
+          V
+        </Box>
+        <Typography sx={{ fontSize: 14.5, fontWeight: 800 }}>VCC Manager</Typography>
       </Box>
 
-      <Divider sx={{ borderColor: 'divider' }} />
+      <SectionLabel>작업</SectionLabel>
+      <List sx={{ px: 2, py: 0 }}>{workItems.map(renderItem)}</List>
 
-      <List sx={{ px: 1 }}>
-        {menuItems.map((item) => (
-          <ListItem key={item.text} disablePadding>
-            <ListItemButton
-              onClick={() => handleNavigation(item.path)}
-              sx={{
-                borderRadius: 1,
-                mb: 0.5,
-                py: isMobile ? 1.5 : 1,
-                bgcolor: isPathActive(item.path) ? 'navbar.light' : 'transparent',
-                '&:hover': { bgcolor: 'navbar.light' },
-              }}
-            >
-              <ListItemIcon sx={{ color: 'navbar.contrastText', minWidth: 40 }}>
-                {item.icon}
-              </ListItemIcon>
-              <ListItemText
-                primary={item.text}
-                sx={{
-                  '& .MuiListItemText-primary': {
-                    fontSize: isMobile ? '1rem' : '0.9rem',
-                    fontWeight: isMobile ? 500 : 400,
-                  },
-                }}
-              />
-            </ListItemButton>
-          </ListItem>
-        ))}
-      </List>
+      <SectionLabel>자료</SectionLabel>
+      <List sx={{ px: 2, py: 0 }}>{dataItems.map(renderItem)}</List>
 
       {isAdmin && (
         <>
-          <Divider sx={{ borderColor: 'divider', my: 1 }} />
-
-          <Box sx={{ px: 2, py: 1 }}>
-            {/* 관리자 구분은 색이 아닌 섹션 라벨로 (#542 — 빨강 일괄 적용 제거, 핸드오프 중립 스타일) */}
-            <Typography variant="overline" sx={{ color: 'grey.500', letterSpacing: '0.06em' }}>
-              관리자 메뉴
-            </Typography>
-          </Box>
-
-          <List sx={{ px: 1 }}>
-            {adminMenuItems.map((item) => (
-              <ListItem key={item.text} disablePadding>
-                <ListItemButton
-                  onClick={() => handleNavigation(item.path)}
-                  sx={{
-                    borderRadius: 1,
-                    mb: 0.5,
-                    py: isMobile ? 1.5 : 1,
-                    bgcolor: isPathActive(item.path) ? 'navbar.light' : 'transparent',
-                    '&:hover': { bgcolor: 'navbar.light' },
-                  }}
-                >
-                  <ListItemIcon sx={{ color: 'navbar.contrastText', minWidth: 40 }}>
-                    {item.icon}
-                  </ListItemIcon>
-                  <ListItemText
-                    primary={item.text}
-                    sx={{
-                      '& .MuiListItemText-primary': {
-                        fontSize: isMobile ? '1rem' : '0.9rem',
-                        fontWeight: isMobile ? 500 : 400,
-                      },
-                    }}
-                  />
-                </ListItemButton>
-              </ListItem>
-            ))}
-          </List>
+          <SectionLabel>관리자</SectionLabel>
+          <List sx={{ px: 2, py: 0 }}>{adminMenuItems.map(renderItem)}</List>
         </>
       )}
+
+      {/* 설정 — 하단 고정 */}
+      <Box sx={{ mt: 'auto' }}>
+        <List sx={{ px: 2, py: 2 }}>{renderItem(settingsItem)}</List>
+      </Box>
     </Box>
   );
+
+  // 라이트: 배경과 한 몸(보더 없음) / 다크: 콘솔 레일 + 보더 — v2 셸 시안
+  const paperSx = {
+    boxSizing: 'border-box',
+    width: DRAWER_WIDTH,
+    bgcolor: 'navbar.main',
+    borderRight: (t) => (t.palette.mode === 'dark' ? `1px solid ${t.palette.divider}` : 'none'),
+  };
 
   return (
     <Box
@@ -263,11 +193,7 @@ function Sidebar({ mobileOpen, onMobileToggle }) {
         }}
         sx={{
           display: { xs: 'block', md: 'none' },
-          '& .MuiDrawer-paper': {
-            boxSizing: 'border-box',
-            width: DRAWER_WIDTH,
-            bgcolor: 'navbar.main',  // 컨텐츠가 Paper 높이를 초과할 때 하단 흰색 노출 방지 (#327)
-          },
+          '& .MuiDrawer-paper': paperSx, // 컨텐츠가 Paper 높이를 초과할 때 하단 흰색 노출 방지 (#327)
         }}
       >
         {drawer}
@@ -278,13 +204,7 @@ function Sidebar({ mobileOpen, onMobileToggle }) {
         variant="permanent"
         sx={{
           display: { xs: 'none', md: 'block' },
-          '& .MuiDrawer-paper': {
-            boxSizing: 'border-box',
-            width: DRAWER_WIDTH,
-            position: 'relative',
-            height: '100%',
-            bgcolor: 'navbar.main',  // 컨텐츠가 Paper 높이를 초과할 때 하단 흰색 노출 방지 (#327)
-          },
+          '& .MuiDrawer-paper': { ...paperSx, position: 'relative', height: '100%' },
         }}
         open
       >


### PR DESCRIPTION
## 변경사항 (UI v2-2, 시안 승인됨)

- **사이드바**: 로고 블록 상단(탑바에서 이동), 섹션 재편(작업/자료/관리자 + 설정 하단 고정), 활성=surface 픽+그림자, 라이트 보더 없음/다크 콘솔 레일
- **레이아웃**: 사이드바 全高 구조 (MainLayout 재배치 — 로고 좌상단 앵커)
- **탑바**: 검색 필('작업판 · 프로젝트 검색 ⌘K' — 팔레트의 실제 검색 범위와 일치하는 정직한 문구), 서버 상태 필(실데이터·60s 폴링·admin 만 클릭 이동), 프로필 필, 알림 벨 유지
- 기능 추가/삭제 없음

## 검증
- `docker compose build --no-cache` 통과, alpha 배포 후 라이트/다크 캡처 — 시안 구조 일치

closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)