### PR TITLE
fix: v1 팔레트 rgba 잔재 정리 — 시맨틱 토큰화 (#562)

### DIFF
--- a/frontend/src/components/common/ToneChip.js
+++ b/frontend/src/components/common/ToneChip.js
@@ -9,7 +9,7 @@ const TONE_SX = {
   info: { bgcolor: 'info.light', color: 'info.main' },
   warning: { bgcolor: 'warning.light', color: 'warning.main' },
   error: { bgcolor: 'error.light', color: 'error.main' },
-  accent: { bgcolor: (t) => (t.palette.mode === 'dark' ? 'rgba(118,118,224,0.22)' : 'rgba(91,91,214,0.12)'), color: 'primary.main' },
+  accent: { bgcolor: 'primary.light', color: 'primary.main' }, // v2 — .light 토큰이 모드별 틴트 (#562)
   neutral: { bgcolor: 'grey.100', color: 'text.secondary' },
 };
 

--- a/frontend/src/components/common/WorkboardCatalog.js
+++ b/frontend/src/components/common/WorkboardCatalog.js
@@ -19,12 +19,13 @@ import {
 
 
 // 작업판 종류(생성 엔진) — outputFormat + serverType 로 유도. 카드 좌측 아이콘.
+// 틴트는 시맨틱 .light 토큰 — 라이트(솔리드 틴트)/다크(rgba) 자동 전환 (#562, v1 rgba 잔재 제거)
 export const KIND_META = {
-  'gpt-chat':  { icon: SmartToy,    label: '텍스트 생성', color: 'info.main',     tint: 'rgba(47,119,228,0.12)' },
-  'gpt-image': { icon: ImageIcon,   label: '이미지 (API)', color: '#5B2DBF',      tint: 'rgba(91,45,191,0.10)' },
-  'sdxl':      { icon: Hexagon,     label: 'SDXL',        color: 'primary.main',  tint: 'rgba(91,91,214,0.10)' },
-  'i2v':       { icon: Movie,       label: '영상 (I2V)',  color: 'warning.main',  tint: 'rgba(190,116,21,0.14)' },
-  'lora':      { icon: AutoFixHigh, label: 'LoRA 학습',    color: 'success.main',  tint: 'rgba(31,157,85,0.12)' },
+  'gpt-chat':  { icon: SmartToy,    label: '텍스트 생성', color: 'info.main',      tint: 'info.light' },
+  'gpt-image': { icon: ImageIcon,   label: '이미지 (API)', color: 'secondary.main', tint: 'secondary.light' },
+  'sdxl':      { icon: Hexagon,     label: 'SDXL',        color: 'primary.main',   tint: 'primary.light' },
+  'i2v':       { icon: Movie,       label: '영상 (I2V)',  color: 'warning.main',   tint: 'warning.light' },
+  'lora':      { icon: AutoFixHigh, label: 'LoRA 학습',    color: 'success.main',   tint: 'success.light' },
 };
 
 export function deriveOut(wb) {

--- a/frontend/src/pages/JobHistory.js
+++ b/frontend/src/pages/JobHistory.js
@@ -202,7 +202,7 @@ function RowVisual({ item }) {
   return (
     <Box sx={{
       width: size, height: size, borderRadius: 2, flex: '0 0 auto',
-      bgcolor: (t) => t.palette.mode === 'dark' ? 'rgba(118,118,224,0.18)' : 'rgba(91,91,214,0.10)',
+      bgcolor: 'primary.light', // v2 토큰 틴트 (#562)
       color: 'primary.main', display: 'grid', placeItems: 'center',
     }}>
       {icon}


### PR DESCRIPTION
v1 iris 팔레트 기준 rgba 리터럴 잔재를 시맨틱 `.light` 토큰으로 — v2 팔레트와 일치 + 라이트(솔리드 틴트)/다크(rgba) 자동 전환.
- KIND_META 틴트 5종 + `#5B2DBF` (WorkboardCatalog)
- ToneChip accent 톤, JobHistory 타입 아이콘 타일

closes #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)