### PR TITLE
feat: Settings / Profile 페이지 v2화 (#564)

### DIFF
--- a/frontend/src/pages/Profile.js
+++ b/frontend/src/pages/Profile.js
@@ -47,24 +47,25 @@ import { useMutation, useQuery, useQueryClient } from 'react-query';
 import toast from 'react-hot-toast';
 import { userAPI, apiKeyAPI } from '../services/api';
 import { useAuth } from '../contexts/AuthContext';
+import { MONO } from '../theme';
+import { BRAND_GRADIENTS } from '../utils/brandGradients';
 
+// v2 스탯 카드 — outlined + mono 숫자 (#564)
 function StatCard({ title, value, subtitle }) {
   return (
-    <Card>
-      <CardContent sx={{ textAlign: 'center' }}>
-        <Typography variant="h4" component="div" gutterBottom>
-          {value}
+    <Paper variant="outlined" sx={{ p: 4, height: '100%' }}>
+      <Typography variant="caption" sx={{ color: 'text.tertiary', fontWeight: 600 }}>
+        {title}
+      </Typography>
+      <Typography sx={{ fontSize: 22, fontWeight: 800, fontFamily: MONO, mt: 0.5 }}>
+        {value}
+      </Typography>
+      {subtitle && (
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+          {subtitle}
         </Typography>
-        <Typography color="text.secondary" gutterBottom>
-          {title}
-        </Typography>
-        {subtitle && (
-          <Typography variant="caption" color="text.secondary">
-            {subtitle}
-          </Typography>
-        )}
-      </CardContent>
-    </Card>
+      )}
+    </Paper>
   );
 }
 
@@ -113,7 +114,7 @@ function AccountSettings() {
   };
 
   return (
-    <Paper sx={{ p: 3 }}>
+    <Paper variant="outlined" sx={{ p: 4 }}>
       <Typography variant="h6" gutterBottom>
         계정 설정
       </Typography>
@@ -315,7 +316,7 @@ function SecuritySettings() {
 
   return (
     <>
-      <Paper sx={{ p: 3 }}>
+      <Paper variant="outlined" sx={{ p: 4 }}>
         <Typography variant="h6" gutterBottom>
           보안 설정
         </Typography>
@@ -588,23 +589,18 @@ function Profile() {
   };
 
   return (
-    <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
-      <Box display="flex" alignItems="center" mb={4}>
+    <Container maxWidth="lg" sx={{ mb: 8 }}>
+      <Box display="flex" alignItems="center" gap={4} mb={5}>
         <Avatar
           src={user?.avatar}
-          sx={{ width: 80, height: 80, mr: 3 }}
+          sx={{ width: 72, height: 72, fontSize: 26, fontWeight: 800, background: BRAND_GRADIENTS[0] }}
         >
           {user?.nickname?.charAt(0).toUpperCase()}
         </Avatar>
         <Box>
-          <Typography variant="h4" gutterBottom>
-            {user?.nickname || '사용자'}
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            {user?.email}
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            가입일: {user?.createdAt ? new Date(user.createdAt).toLocaleDateString() : '-'}
+          <Typography variant="h1">{user?.nickname || '사용자'}</Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+            {user?.email} · 가입일 {user?.createdAt ? new Date(user.createdAt).toLocaleDateString() : '-'}
           </Typography>
         </Box>
       </Box>

--- a/frontend/src/pages/Settings.js
+++ b/frontend/src/pages/Settings.js
@@ -4,16 +4,49 @@ import {
   Paper,
   Typography,
   Box,
-  FormControlLabel,
   Switch,
-  Divider,
   Alert,
   CircularProgress
 } from '@mui/material';
-import { Settings as SettingsIcon } from '@mui/icons-material';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import { userAPI } from '../services/api';
+import PageHeader from '../components/common/PageHeader';
 import toast from 'react-hot-toast';
+
+// 설정 행 — 좌측 라벨+설명, 우측 스위치 (v2, #564)
+function SettingRow({ label, caption, checked, onChange, disabled }) {
+  return (
+    <Box sx={{
+      display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 4,
+      px: 4, py: 3, '& + &': { borderTop: 1, borderColor: 'divider' },
+    }}>
+      <Box sx={{ minWidth: 0 }}>
+        <Typography variant="body1" sx={{ fontWeight: 600 }}>{label}</Typography>
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5, textWrap: 'pretty' }}>
+          {caption}
+        </Typography>
+      </Box>
+      <Switch checked={checked} onChange={onChange} disabled={disabled} sx={{ flexShrink: 0, mt: -0.5 }} />
+    </Box>
+  );
+}
+
+// 설정 섹션 카드 — outlined + 헤더 라인 (v2)
+function SettingCard({ title, description, children }) {
+  return (
+    <Paper variant="outlined" sx={{ mb: 4, overflow: 'hidden' }}>
+      <Box sx={{ px: 4, py: 3, borderBottom: 1, borderColor: 'divider' }}>
+        <Typography variant="h6">{title}</Typography>
+        {description && (
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.25 }}>
+            {description}
+          </Typography>
+        )}
+      </Box>
+      {children}
+    </Paper>
+  );
+}
 
 function Settings() {
   const queryClient = useQueryClient();
@@ -38,6 +71,7 @@ function Settings() {
   );
 
   const preferences = data?.data?.user?.preferences || {};
+  const busy = updateMutation.isLoading;
 
   const handleToggle = (key) => (event) => {
     updateMutation.mutate({
@@ -47,7 +81,7 @@ function Settings() {
 
   if (isLoading) {
     return (
-      <Container maxWidth="md" sx={{ mt: 4 }}>
+      <Container maxWidth="md">
         <Box display="flex" justifyContent="center" py={8}>
           <CircularProgress />
         </Box>
@@ -57,7 +91,7 @@ function Settings() {
 
   if (error) {
     return (
-      <Container maxWidth="md" sx={{ mt: 4 }}>
+      <Container maxWidth="md">
         <Alert severity="error">
           설정을 불러오는 중 오류가 발생했습니다: {error.message}
         </Alert>
@@ -66,204 +100,69 @@ function Settings() {
   }
 
   return (
-    <Container maxWidth="md" sx={{ mt: 4, mb: 4 }}>
-      <Box display="flex" alignItems="center" gap={2} mb={4}>
-        <SettingsIcon fontSize="large" color="primary" />
-        <Typography variant="h4">
-          설정
-        </Typography>
-      </Box>
+    <Container maxWidth="md" sx={{ mb: 8 }}>
+      <PageHeader title="설정" description="삭제 동작, 계속하기, NSFW 필터, 작업판 검색 조건의 기본 동작을 설정합니다." />
 
-      <Paper sx={{ p: 3 }}>
-        <Typography variant="h6" gutterBottom>
-          삭제 동작 설정
-        </Typography>
-        <Typography variant="body2" color="text.secondary" paragraph>
-          작업 히스토리와 컨텐츠(이미지/동영상) 삭제 시의 동작을 설정합니다.
-        </Typography>
+      <SettingCard title="삭제 동작" description="작업 히스토리와 컨텐츠(이미지/동영상) 삭제 시의 연동 동작">
+        <SettingRow
+          label="작업 히스토리 삭제 시 연관 컨텐츠도 같이 삭제"
+          caption="이 옵션이 켜져 있으면 히스토리 삭제 시 생성된 이미지나 동영상도 같이 삭제됩니다. 삭제 전에 확인 창이 표시됩니다."
+          checked={preferences.deleteContentWithHistory || false}
+          onChange={handleToggle('deleteContentWithHistory')}
+          disabled={busy}
+        />
+        <SettingRow
+          label="컨텐츠 삭제 시 작업 히스토리도 같이 삭제"
+          caption="이 옵션이 켜져 있으면 이미지/동영상 삭제 시 해당 작업 히스토리도 같이 삭제됩니다. 삭제 전에 확인 창이 표시됩니다."
+          checked={preferences.deleteHistoryWithContent || false}
+          onChange={handleToggle('deleteHistoryWithContent')}
+          disabled={busy}
+        />
+      </SettingCard>
 
-        <Box sx={{ ml: 2 }}>
-          <FormControlLabel
-            control={
-              <Switch
-                checked={preferences.deleteContentWithHistory || false}
-                onChange={handleToggle('deleteContentWithHistory')}
-                disabled={updateMutation.isLoading}
-              />
-            }
-            label={
-              <Box>
-                <Typography variant="body1">
-                  작업 히스토리 삭제 시 연관 컨텐츠도 같이 삭제
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  이 옵션이 켜져 있으면 히스토리 삭제 시 생성된 이미지나 동영상도 같이 삭제됩니다. 삭제 전에 확인 창이 표시됩니다.
-                </Typography>
-              </Box>
-            }
-            sx={{ display: 'flex', alignItems: 'flex-start', my: 2 }}
-          />
+      <SettingCard title="작업 계속하기" description='작업 히스토리에서 "계속하기" 사용 시의 동작'>
+        <SettingRow
+          label="계속하기 시 무조건 랜덤 시드 사용"
+          caption='이 옵션이 켜져 있으면 히스토리에서 "계속하기"로 작업판을 호출했을 때 랜덤 시드 스위치가 자동으로 켜집니다.'
+          checked={preferences.useRandomSeedOnContinue || false}
+          onChange={handleToggle('useRandomSeedOnContinue')}
+          disabled={busy}
+        />
+      </SettingCard>
 
-          <FormControlLabel
-            control={
-              <Switch
-                checked={preferences.deleteHistoryWithContent || false}
-                onChange={handleToggle('deleteHistoryWithContent')}
-                disabled={updateMutation.isLoading}
-              />
-            }
-            label={
-              <Box>
-                <Typography variant="body1">
-                  컨텐츠 삭제 시 작업 히스토리도 같이 삭제
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  이 옵션이 켜져 있으면 이미지/동영상 삭제 시 해당 작업 히스토리도 같이 삭제됩니다. 삭제 전에 확인 창이 표시됩니다.
-                </Typography>
-              </Box>
-            }
-            sx={{ display: 'flex', alignItems: 'flex-start', my: 2 }}
-          />
-        </Box>
+      <SettingCard title="LoRA NSFW 필터" description="LoRA 목록에서 NSFW(성인용) 콘텐츠의 표시 여부">
+        <SettingRow
+          label="NSFW LoRA 숨기기"
+          caption="이 옵션이 켜져 있으면 NSFW로 분류된 LoRA 모델이 목록에서 숨겨집니다."
+          checked={preferences.nsfwLoraFilter ?? true}
+          onChange={handleToggle('nsfwLoraFilter')}
+          disabled={busy}
+        />
+        <SettingRow
+          label="NSFW 미리보기 이미지 숨기기"
+          caption="이 옵션이 켜져 있으면 LoRA 카드에서 NSFW로 분류된 미리보기 이미지가 숨겨집니다."
+          checked={preferences.nsfwImageFilter ?? true}
+          onChange={handleToggle('nsfwImageFilter')}
+          disabled={busy}
+        />
+      </SettingCard>
 
-        <Divider sx={{ my: 3 }} />
-
-        <Typography variant="h6" gutterBottom>
-          작업 계속하기 설정
-        </Typography>
-        <Typography variant="body2" color="text.secondary" paragraph>
-          작업 히스토리에서 "계속하기" 기능 사용 시의 동작을 설정합니다.
-        </Typography>
-
-        <Box sx={{ ml: 2 }}>
-          <FormControlLabel
-            control={
-              <Switch
-                checked={preferences.useRandomSeedOnContinue || false}
-                onChange={handleToggle('useRandomSeedOnContinue')}
-                disabled={updateMutation.isLoading}
-              />
-            }
-            label={
-              <Box>
-                <Typography variant="body1">
-                  계속하기 시 무조건 랜덤 시드 사용
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  이 옵션이 켜져 있으면 히스토리에서 "계속하기"로 작업판을 호출했을 때 랜덤 시드 스위치가 자동으로 켜집니다.
-                </Typography>
-              </Box>
-            }
-            sx={{ display: 'flex', alignItems: 'flex-start', my: 2 }}
-          />
-        </Box>
-
-        <Divider sx={{ my: 3 }} />
-
-        <Typography variant="h6" gutterBottom>
-          LoRA NSFW 필터 설정
-        </Typography>
-        <Typography variant="body2" color="text.secondary" paragraph>
-          LoRA 목록에서 NSFW(성인용) 콘텐츠의 표시 여부를 설정합니다.
-        </Typography>
-
-        <Box sx={{ ml: 2 }}>
-          <FormControlLabel
-            control={
-              <Switch
-                checked={preferences.nsfwLoraFilter ?? true}
-                onChange={handleToggle('nsfwLoraFilter')}
-                disabled={updateMutation.isLoading}
-              />
-            }
-            label={
-              <Box>
-                <Typography variant="body1">
-                  NSFW LoRA 숨기기
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  이 옵션이 켜져 있으면 NSFW로 분류된 LoRA 모델이 목록에서 숨겨집니다.
-                </Typography>
-              </Box>
-            }
-            sx={{ display: 'flex', alignItems: 'flex-start', my: 2 }}
-          />
-
-          <FormControlLabel
-            control={
-              <Switch
-                checked={preferences.nsfwImageFilter ?? true}
-                onChange={handleToggle('nsfwImageFilter')}
-                disabled={updateMutation.isLoading}
-              />
-            }
-            label={
-              <Box>
-                <Typography variant="body1">
-                  NSFW 미리보기 이미지 숨기기
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  이 옵션이 켜져 있으면 LoRA 카드에서 NSFW로 분류된 미리보기 이미지가 숨겨집니다.
-                </Typography>
-              </Box>
-            }
-            sx={{ display: 'flex', alignItems: 'flex-start', my: 2 }}
-          />
-        </Box>
-
-        <Divider sx={{ my: 3 }} />
-
-        <Typography variant="h6" gutterBottom>
-          작업판 검색 설정
-        </Typography>
-        <Typography variant="body2" color="text.secondary" paragraph>
-          작업판 목록의 검색 필터 조건의 보존 여부를 설정합니다.
-        </Typography>
-
-        <Box sx={{ ml: 2 }}>
-          <FormControlLabel
-            control={
-              <Switch
-                checked={preferences.resetWorkboardOutputFormat || false}
-                onChange={handleToggle('resetWorkboardOutputFormat')}
-                disabled={updateMutation.isLoading}
-              />
-            }
-            label={
-              <Box>
-                <Typography variant="body1">
-                  작업판 출력 형식 검색 조건 보존하지 않음
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  이 옵션이 켜져 있으면 작업판 목록에 진입할 때 출력 형식 필터가 '전체'로 초기화됩니다.
-                </Typography>
-              </Box>
-            }
-            sx={{ display: 'flex', alignItems: 'flex-start', my: 2 }}
-          />
-
-          <FormControlLabel
-            control={
-              <Switch
-                checked={preferences.resetWorkboardApiFormat || false}
-                onChange={handleToggle('resetWorkboardApiFormat')}
-                disabled={updateMutation.isLoading}
-              />
-            }
-            label={
-              <Box>
-                <Typography variant="body1">
-                  작업판 서버 타입 검색 조건 보존하지 않음
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  이 옵션이 켜져 있으면 작업판 목록에 진입할 때 서버 타입 필터가 '전체'로 초기화됩니다.
-                </Typography>
-              </Box>
-            }
-            sx={{ display: 'flex', alignItems: 'flex-start', my: 2 }}
-          />
-        </Box>
-      </Paper>
+      <SettingCard title="작업판 검색" description="작업판 목록의 검색 필터 조건 보존 여부">
+        <SettingRow
+          label="작업판 출력 형식 검색 조건 보존하지 않음"
+          caption="이 옵션이 켜져 있으면 작업판 목록에 진입할 때 출력 형식 필터가 '전체'로 초기화됩니다."
+          checked={preferences.resetWorkboardOutputFormat || false}
+          onChange={handleToggle('resetWorkboardOutputFormat')}
+          disabled={busy}
+        />
+        <SettingRow
+          label="작업판 서버 타입 검색 조건 보존하지 않음"
+          caption="이 옵션이 켜져 있으면 작업판 목록에 진입할 때 서버 타입 필터가 '전체'로 초기화됩니다."
+          checked={preferences.resetWorkboardApiFormat || false}
+          onChange={handleToggle('resetWorkboardApiFormat')}
+          disabled={busy}
+        />
+      </SettingCard>
     </Container>
   );
 }


### PR DESCRIPTION
## 변경사항 (UI v2-5, ④-1)

- **Settings**: PageHeader(h1) + 섹션 4개를 outlined 카드로 분리(헤더 라인 + 설명), 설정 항목은 SettingRow(좌측 라벨·설명 / 우측 스위치, 행 간 보더)
- **Profile**: 브랜드 그라데이션 아바타 + h1 닉네임 헤더, 스탯 카드 4종 v2(outlined·mono 숫자·좌측 정렬), 계정/보안 카드 outlined + 4px 간격
- 기능 변경 없음

## 검증
- build --no-cache 통과, alpha 배포 후 두 페이지 캡처 확인

closes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)