### PR TITLE
feat: 인증 화면 v2 — 브랜드 패널 분할 레이아웃 (#566)

### DIFF
--- a/frontend/src/components/auth/AuthLayout.js
+++ b/frontend/src/components/auth/AuthLayout.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import { Box, Typography, useTheme } from '@mui/material';
+
+// 인증 화면 공용 레이아웃 (#566) — 좌 브랜드 패널 + 우 폼 카드. 모바일은 상단 띠로 축소.
+// 브랜드 그라데이션은 인증 화면 전용 무드 (라이트 테라코타 / 다크 딥 민트).
+const TAGLINE = '이미지 · 영상 · 텍스트 생성을\n한 곳에서 관리하세요';
+const TAGLINE_SUB = 'ComfyUI · OpenAI · Gemini 백엔드 위에서 작업판으로 생성하고, 프로젝트로 묶고, 파이프라인으로 잇습니다.';
+
+export default function AuthLayout({ children }) {
+  const theme = useTheme();
+  const dark = theme.palette.mode === 'dark';
+  const brandBg = dark
+    ? 'linear-gradient(160deg,#103A32 0%,#0B2620 50%,#071A16 100%)'
+    : 'linear-gradient(160deg,#C96A3B 0%,#B05A30 45%,#8A4520 100%)';
+  const tile = dark ? 'rgba(61,214,184,0.07)' : 'rgba(255,255,255,0.10)';
+  const tileAlt = dark ? 'rgba(61,214,184,0.12)' : 'rgba(255,255,255,0.16)';
+  const tileBorder = dark ? 'rgba(61,214,184,0.12)' : 'rgba(255,255,255,0.14)';
+
+  return (
+    <Box sx={{ display: 'flex', minHeight: '100vh', flexDirection: { xs: 'column', md: 'row' }, bgcolor: 'background.default' }}>
+      {/* 브랜드 패널 */}
+      <Box
+        sx={{
+          flex: { md: 1 },
+          background: brandBg,
+          color: 'common.white',
+          px: { xs: 6, md: 12 },
+          py: { xs: 5, md: 11 },
+          display: 'flex',
+          flexDirection: 'column',
+          position: 'relative',
+          overflow: 'hidden',
+        }}
+      >
+        <Box
+          sx={{
+            width: 40, height: 40, borderRadius: '11px',
+            bgcolor: dark ? 'rgba(61,214,184,0.18)' : 'rgba(255,255,255,0.16)',
+            color: dark ? 'primary.main' : 'common.white',
+            display: 'grid', placeItems: 'center', fontSize: 18, fontWeight: 800,
+          }}
+        >
+          V
+        </Box>
+
+        {/* 추상 타일 패턴 (가짜 스크린샷 금지 원칙 — 장식은 추상으로) */}
+        <Box
+          sx={{
+            position: 'absolute', right: -40, top: 60,
+            display: { xs: 'none', md: 'grid' },
+            gridTemplateColumns: 'repeat(3, 86px)', gap: 2.5,
+            transform: 'rotate(8deg)', opacity: 0.6, pointerEvents: 'none',
+          }}
+        >
+          {Array.from({ length: 9 }).map((_, i) => (
+            <Box key={i} sx={{ aspectRatio: '1', borderRadius: '10px', bgcolor: i % 2 ? tileAlt : tile, border: `1px solid ${tileBorder}` }} />
+          ))}
+        </Box>
+
+        <Box sx={{ mt: 'auto', display: { xs: 'none', md: 'block' } }}>
+          <Typography sx={{ fontSize: 26, fontWeight: 800, letterSpacing: '-0.02em', lineHeight: 1.35, whiteSpace: 'pre-line' }}>
+            {TAGLINE}
+          </Typography>
+          <Typography sx={{ fontSize: 13.5, opacity: 0.75, mt: 2.5, lineHeight: 1.6, maxWidth: 340 }}>
+            {TAGLINE_SUB}
+          </Typography>
+        </Box>
+
+        {/* 모바일 — 로고 옆 타이틀만 */}
+        <Typography sx={{ display: { xs: 'block', md: 'none' }, mt: 3, fontSize: 17, fontWeight: 800 }}>
+          VCC Manager
+        </Typography>
+      </Box>
+
+      {/* 폼 영역 */}
+      <Box sx={{ width: { md: 480 }, display: 'flex', alignItems: 'center', justifyContent: 'center', p: { xs: 6, md: 8 } }}>
+        <Box sx={{ width: '100%', maxWidth: 360 }}>{children}</Box>
+      </Box>
+    </Box>
+  );
+}
+
+// 폼 카드 상단 타이틀 (h2 22/800 + 보조 설명)
+export function AuthTitle({ title, sub }) {
+  return (
+    <Box sx={{ mb: 6 }}>
+      <Typography sx={{ fontSize: 22, fontWeight: 800, letterSpacing: '-0.02em' }}>{title}</Typography>
+      {sub && (
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 1.5, textWrap: 'pretty' }}>
+          {sub}
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/frontend/src/pages/ForgotPassword.js
+++ b/frontend/src/pages/ForgotPassword.js
@@ -20,6 +20,7 @@ import { useNavigate } from 'react-router-dom';
 import { useMutation } from 'react-query';
 import toast from 'react-hot-toast';
 import { authAPI } from '../services/api';
+import AuthLayout, { AuthTitle } from '../components/auth/AuthLayout';
 
 function ForgotPassword() {
   const navigate = useNavigate();
@@ -49,19 +50,8 @@ function ForgotPassword() {
 
   if (emailSent) {
     return (
-      <Container maxWidth="sm">
-        <Box
-          display="flex"
-          justifyContent="center"
-          alignItems="center"
-          minHeight="100vh"
-        >
-          <Paper elevation={3} sx={{ p: 4, width: '100%' }}>
-            <Box textAlign="center" mb={3}>
-              <Typography variant="h4" gutterBottom>
-                이메일 발송 완료
-              </Typography>
-            </Box>
+      <AuthLayout>
+            <AuthTitle title="이메일 발송 완료" />
 
             <Alert severity="success" sx={{ mb: 3 }}>
               <Typography variant="body2">
@@ -87,29 +77,13 @@ function ForgotPassword() {
             >
               로그인 페이지로 돌아가기
             </Button>
-          </Paper>
-        </Box>
-      </Container>
+          </AuthLayout>
     );
   }
 
   return (
-    <Container maxWidth="sm">
-      <Box
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        minHeight="100vh"
-      >
-        <Paper elevation={3} sx={{ p: 4, width: '100%' }}>
-          <Box textAlign="center" mb={4}>
-            <Typography variant="h4" gutterBottom>
-              비밀번호 찾기
-            </Typography>
-            <Typography variant="body1" color="text.secondary">
-              가입하신 이메일 주소를 입력해주세요
-            </Typography>
-          </Box>
+    <AuthLayout>
+          <AuthTitle title="비밀번호 찾기" sub="가입하신 이메일 주소를 입력해주세요" />
 
           <form onSubmit={handleSubmit(onSubmit)}>
             <Box mb={3}>
@@ -179,9 +153,7 @@ function ForgotPassword() {
               로그인 페이지로 돌아가기
             </Link>
           </Box>
-        </Paper>
-      </Box>
-    </Container>
+        </AuthLayout>
   );
 }
 

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -27,6 +27,7 @@ import { useMutation } from 'react-query';
 import toast from 'react-hot-toast';
 import { authAPI } from '../services/api';
 import { useAuth } from '../contexts/AuthContext';
+import AuthLayout, { AuthTitle } from '../components/auth/AuthLayout';
 
 function Login() {
   const theme = useTheme();
@@ -125,22 +126,8 @@ function Login() {
   };
 
   return (
-    <Container maxWidth="sm">
-      <Box
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        minHeight="100vh"
-      >
-        <Paper elevation={3} sx={{ p: 4, width: '100%' }}>
-          <Box textAlign="center" mb={4}>
-            <Typography variant="h4" gutterBottom>
-              Visual Content Creator
-            </Typography>
-            <Typography variant="body1" color="text.secondary">
-              AI 이미지 생성 도구에 액세스하려면 로그인하세요
-            </Typography>
-          </Box>
+    <AuthLayout>
+      <AuthTitle title="로그인" sub="VCC Manager 계정으로 계속하기" />
 
           {/* Email/Password Login Form */}
           <form onSubmit={handleSubmit(onSubmit)}>
@@ -273,12 +260,10 @@ function Login() {
             </Typography>
           </Box>
 
-          <Typography variant="caption" display="block" mt={3} textAlign="center" color="text.secondary">
-            로그인함으로써 서비스 약관 및 개인정보 보호정책에 동의합니다
-          </Typography>
-        </Paper>
-      </Box>
-    </Container>
+      <Typography variant="caption" display="block" mt={4} textAlign="center" color="text.secondary">
+        로그인함으로써 서비스 약관 및 개인정보 보호정책에 동의합니다
+      </Typography>
+    </AuthLayout>
   );
 }
 

--- a/frontend/src/pages/ResetPassword.js
+++ b/frontend/src/pages/ResetPassword.js
@@ -26,6 +26,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useMutation, useQuery } from 'react-query';
 import toast from 'react-hot-toast';
 import { authAPI } from '../services/api';
+import AuthLayout, { AuthTitle } from '../components/auth/AuthLayout';
 
 const validatePassword = (password) => {
   const requirements = {
@@ -142,33 +143,19 @@ function ResetPassword() {
   // Token verification loading state
   if (isVerifying) {
     return (
-      <Container maxWidth="sm">
-        <Box
-          display="flex"
-          justifyContent="center"
-          alignItems="center"
-          minHeight="100vh"
-        >
-          <Paper elevation={3} sx={{ p: 4, width: '100%', textAlign: 'center' }}>
-            <CircularProgress sx={{ mb: 2 }} />
-            <Typography>토큰 검증 중...</Typography>
-          </Paper>
+      <AuthLayout>
+        <Box sx={{ textAlign: 'center' }}>
+          <CircularProgress sx={{ mb: 2 }} />
+          <Typography>토큰 검증 중...</Typography>
         </Box>
-      </Container>
+      </AuthLayout>
     );
   }
 
   // Invalid or expired token
   if (isTokenError || (tokenData && !tokenData.data?.valid)) {
     return (
-      <Container maxWidth="sm">
-        <Box
-          display="flex"
-          justifyContent="center"
-          alignItems="center"
-          minHeight="100vh"
-        >
-          <Paper elevation={3} sx={{ p: 4, width: '100%' }}>
+      <AuthLayout>
             <Box textAlign="center" mb={3}>
               <Typography variant="h4" gutterBottom color="error">
                 링크 만료
@@ -203,23 +190,14 @@ function ResetPassword() {
             >
               로그인 페이지로 돌아가기
             </Button>
-          </Paper>
-        </Box>
-      </Container>
+          </AuthLayout>
     );
   }
 
   // Reset success state
   if (resetSuccess) {
     return (
-      <Container maxWidth="sm">
-        <Box
-          display="flex"
-          justifyContent="center"
-          alignItems="center"
-          minHeight="100vh"
-        >
-          <Paper elevation={3} sx={{ p: 4, width: '100%' }}>
+      <AuthLayout>
             <Box textAlign="center" mb={3}>
               <CheckCircle color="success" sx={{ fontSize: 64, mb: 2 }} />
               <Typography variant="h4" gutterBottom>
@@ -245,31 +223,14 @@ function ResetPassword() {
             >
               로그인 페이지로 이동
             </Button>
-          </Paper>
-        </Box>
-      </Container>
+          </AuthLayout>
     );
   }
 
   // Password reset form
   return (
-    <Container maxWidth="sm">
-      <Box
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        minHeight="100vh"
-        py={4}
-      >
-        <Paper elevation={3} sx={{ p: 4, width: '100%' }}>
-          <Box textAlign="center" mb={4}>
-            <Typography variant="h4" gutterBottom>
-              새 비밀번호 설정
-            </Typography>
-            <Typography variant="body1" color="text.secondary">
-              새로운 비밀번호를 입력해주세요
-            </Typography>
-          </Box>
+    <AuthLayout>
+          <AuthTitle title="새 비밀번호 설정" sub="새로운 비밀번호를 입력해주세요" />
 
           <form onSubmit={handleSubmit(onSubmit)}>
             <Box mb={3}>
@@ -407,9 +368,7 @@ function ResetPassword() {
               로그인 페이지로 돌아가기
             </Link>
           </Box>
-        </Paper>
-      </Box>
-    </Container>
+        </AuthLayout>
   );
 }
 

--- a/frontend/src/pages/Signup.js
+++ b/frontend/src/pages/Signup.js
@@ -31,6 +31,7 @@ import { debounce } from 'lodash';
 import toast from 'react-hot-toast';
 import { authAPI } from '../services/api';
 import { useAuth } from '../contexts/AuthContext';
+import AuthLayout, { AuthTitle } from '../components/auth/AuthLayout';
 
 const validatePassword = (password) => {
   const requirements = {
@@ -180,23 +181,8 @@ function Signup() {
   };
 
   return (
-    <Container maxWidth="sm">
-      <Box
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        minHeight="100vh"
-        py={4}
-      >
-        <Paper elevation={3} sx={{ p: 4, width: '100%' }}>
-          <Box textAlign="center" mb={4}>
-            <Typography variant="h4" gutterBottom>
-              회원가입
-            </Typography>
-            <Typography variant="body1" color="text.secondary">
-              Visual Content Creator에 오신 것을 환영합니다
-            </Typography>
-          </Box>
+    <AuthLayout>
+          <AuthTitle title="회원가입" sub="가입 후 관리자 승인을 거쳐 이용할 수 있습니다" />
 
           {/* Email/Password Signup Form */}
           <form onSubmit={handleSubmit(onSubmit)}>
@@ -424,12 +410,14 @@ function Signup() {
             </Typography>
           </Box>
 
+          <Alert severity="info" sx={{ mt: 4 }}>
+            가입 신청 후 관리자가 승인하면 로그인할 수 있습니다. 승인 상태는 로그인 시 안내됩니다.
+          </Alert>
+
           <Typography variant="caption" display="block" mt={3} textAlign="center" color="text.secondary">
             회원가입함으로써 서비스 약관 및 개인정보 보호정책에 동의합니다
           </Typography>
-        </Paper>
-      </Box>
-    </Container>
+        </AuthLayout>
   );
 }
 


### PR DESCRIPTION
## 변경사항 (UI v2-6, ④-2 — 시안 승인됨)

- **AuthLayout 공용 컴포넌트**: 좌 브랜드 패널(라이트 테라코타/다크 딥 민트 그라데이션, 실제 제품 태그라인, 추상 타일 — 가짜 스크린샷 금지 원칙) + 우 폼 카드(360px), 모바일 상단 띠 축소
- **4개 화면 전환**: Login / Signup / ForgotPassword(발송 완료 상태 포함) / ResetPassword(검증·무효·성공·폼 4상태) — 폼 로직·검증·OAuth 리다이렉트·승인제 토스트 전부 불변
- **Signup 승인제 안내 명시**: 서브타이틀 + 하단 info — 가입 후 승인 대기에서 막히는 경험이 화면에서 설명됨

## 검증
- build --no-cache 통과, 배포 후 라이트 로그인/다크 회원가입 캡처 — 시안 일치

closes #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)