### PR TITLE
feat: admin v2 1차 — 사용자 관리 + 관리자 대시보드 (#568)

### DIFF
--- a/frontend/src/components/admin/AdminDashboard.js
+++ b/frontend/src/components/admin/AdminDashboard.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   Grid,
+  Paper,
   Card,
   CardContent,
   Typography,
@@ -21,40 +22,30 @@ import {
 import { useQuery } from 'react-query';
 import { adminAPI, jobAPI } from '../../services/api';
 import config from '../../config';
+import PageHeader from '../common/PageHeader';
+import { MONO } from '../../theme';
 
+// v2 스탯 카드 — outlined + mono 숫자 (#568)
 function StatCard({ title, value, subtitle, icon, color = 'primary' }) {
   return (
-    <Card>
-      <CardContent>
-        <Box display="flex" alignItems="center" justifyContent="space-between">
-          <Box>
-            <Typography color="text.secondary" gutterBottom variant="body2">
-              {title}
+    <Paper variant="outlined" sx={{ p: 4, height: '100%' }}>
+      <Box display="flex" alignItems="flex-start" justifyContent="space-between" gap={2}>
+        <Box sx={{ minWidth: 0 }}>
+          <Typography variant="caption" sx={{ color: 'text.tertiary', fontWeight: 600 }}>
+            {title}
+          </Typography>
+          <Typography sx={{ fontSize: 22, fontWeight: 800, fontFamily: MONO, mt: 0.5 }}>
+            {value}
+          </Typography>
+          {subtitle && (
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+              {subtitle}
             </Typography>
-            <Typography variant="h4" component="div">
-              {value}
-            </Typography>
-            {subtitle && (
-              <Typography variant="body2" color="text.secondary">
-                {subtitle}
-              </Typography>
-            )}
-          </Box>
-          <Box
-            sx={{
-              backgroundColor: `${color}.light`,
-              borderRadius: '50%',
-              p: 1,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center'
-            }}
-          >
-            {icon}
-          </Box>
+          )}
         </Box>
-      </CardContent>
-    </Card>
+        <Box sx={{ color: `${color}.main`, opacity: 0.7, '& svg': { fontSize: 20 } }}>{icon}</Box>
+      </Box>
+    </Paper>
   );
 }
 
@@ -83,12 +74,11 @@ function AdminDashboard() {
 
   return (
     <Box>
-      <Box display="flex" justifyContent="space-between" alignItems="center" mb={3}>
-        <Typography variant="h5">시스템 개요</Typography>
-        <IconButton onClick={() => refetch()}>
-          <Refresh />
-        </IconButton>
-      </Box>
+      <PageHeader
+        title="관리자 대시보드"
+        description="시스템 개요 · 작업 큐 상태"
+        actions={<IconButton onClick={() => refetch()}><Refresh /></IconButton>}
+      />
 
       <Grid container spacing={3} mb={4}>
         <Grid item xs={12} sm={6} md={3}>
@@ -135,11 +125,11 @@ function AdminDashboard() {
       <Grid container spacing={3}>
         {/* 작업 큐 상태 */}
         <Grid item xs={12} md={8} lg={6}>
-          <Card>
-            <CardContent>
-              <Typography variant="h6" gutterBottom>
-                작업 큐 상태
-              </Typography>
+          <Paper variant="outlined">
+            <Box sx={{ px: 4, py: 2.5, borderBottom: 1, borderColor: 'divider' }}>
+              <Typography variant="h6">작업 큐 상태</Typography>
+            </Box>
+            <Box sx={{ p: 4 }}>
               
               {queueLoading ? (
                 <CircularProgress size={24} />
@@ -180,8 +170,8 @@ function AdminDashboard() {
                   </Grid>
                 </Box>
               )}
-            </CardContent>
-          </Card>
+            </Box>
+          </Paper>
         </Grid>
 
         {/* 시스템 알림 */}

--- a/frontend/src/components/admin/UserManagement.js
+++ b/frontend/src/components/admin/UserManagement.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import {
   Box,
+  Paper,
   Card,
   CardContent,
   Typography,
@@ -41,6 +42,9 @@ import {
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import toast from 'react-hot-toast';
 import { adminAPI } from '../../services/api';
+import PageHeader from '../common/PageHeader';
+import EmptyState from '../common/EmptyState';
+import { ToneChip } from '../common/ToneChip';
 
 function UserManagement() {
   const [search, setSearch] = useState('');
@@ -120,33 +124,16 @@ function UserManagement() {
     rejectMutation.mutate(userId);
   };
 
+  // 상태 표기는 ToneChip 단일화 (#568)
   const getApprovalStatusChip = (user) => {
     switch (user.approvalStatus) {
       case 'approved':
-        return (
-          <Chip
-            label="승인됨"
-            color="success"
-            icon={<Check fontSize="small" />}
-          />
-        );
+        return <ToneChip tone="success" label="승인됨" />;
       case 'rejected':
-        return (
-          <Chip
-            label="거절됨"
-            color="error"
-            icon={<Close fontSize="small" />}
-          />
-        );
+        return <ToneChip tone="error" label="거절됨" />;
       case 'pending':
       default:
-        return (
-          <Chip
-            label="대기중"
-            color="warning"
-            icon={<HourglassEmpty fontSize="small" />}
-          />
-        );
+        return <ToneChip tone="warning" label="대기중" />;
     }
   };
 
@@ -161,19 +148,13 @@ function UserManagement() {
 
   return (
     <Box>
-      <Box display="flex" justifyContent="space-between" alignItems="center" mb={3}>
-        <Typography variant="h5">사용자 관리</Typography>
-        <Button
-          variant="outlined"
-          onClick={() => refetch()}
-          startIcon={<Refresh />}
-        >
-          새로고침
-        </Button>
-      </Box>
+      <PageHeader
+        title="사용자 관리"
+        description="가입 승인 · 권한 · 계정 상태를 관리합니다."
+        actions={<Button variant="outlined" onClick={() => refetch()} startIcon={<Refresh />}>새로고침</Button>}
+      />
 
-      <Card>
-        <CardContent>
+      <Paper variant="outlined" sx={{ p: 4 }}>
           <Box mb={3} display="flex" gap={2} flexWrap="wrap">
             <TextField
               placeholder="이메일 또는 닉네임으로 검색..."
@@ -208,9 +189,7 @@ function UserManagement() {
               <CircularProgress />
             </Box>
           ) : users.length === 0 ? (
-            <Alert severity="info">
-              {search ? '검색 결과가 없습니다.' : '등록된 사용자가 없습니다.'}
-            </Alert>
+            <EmptyState description={search ? '검색 결과가 없습니다.' : '등록된 사용자가 없습니다.'} />
           ) : (
             <>
               <TableContainer>
@@ -242,26 +221,12 @@ function UserManagement() {
                         </TableCell>
                         <TableCell>{user.email}</TableCell>
                         <TableCell>
-                          {user.isAdmin ? (
-                            <Chip
-                              label="관리자"
-                              color="secondary"
-                              icon={<AdminPanelSettings fontSize="small" />}
-                            />
-                          ) : (
-                            <Chip
-                              label="일반 사용자"
-                              color="default"
-                              icon={<Person fontSize="small" />}
-                            />
-                          )}
+                          {user.isAdmin
+                            ? <ToneChip tone="accent" label="관리자" />
+                            : <ToneChip tone="neutral" label="일반 사용자" />}
                         </TableCell>
                         <TableCell>
-                          <Chip
-                            label={user.isActive ? '활성' : '비활성'}
-                            color={user.isActive ? 'success' : 'default'}
-                            variant="outlined"
-                          />
+                          <ToneChip tone={user.isActive ? 'success' : 'neutral'} label={user.isActive ? '활성' : '비활성'} />
                         </TableCell>
                         <TableCell>
                           {getApprovalStatusChip(user)}
@@ -324,8 +289,7 @@ function UserManagement() {
               />
             </>
           )}
-        </CardContent>
-      </Card>
+      </Paper>
 
       {/* 삭제 확인 다이얼로그 */}
       <Dialog open={deleteDialogOpen} onClose={() => setDeleteDialogOpen(false)}>

--- a/frontend/src/pages/admin/AdminDashboardPage.js
+++ b/frontend/src/pages/admin/AdminDashboardPage.js
@@ -1,15 +1,10 @@
 import React from 'react';
-import { Container, Typography, Box } from '@mui/material';
+import { Container } from '@mui/material';
 import AdminDashboard from '../../components/admin/AdminDashboard';
 
 function AdminDashboardPage() {
   return (
-    <Container maxWidth="xl" sx={{ mt: 2, mb: 4 }}>
-      <Box mb={3}>
-        <Typography variant="h4" gutterBottom>
-          관리자 대시보드
-        </Typography>
-      </Box>
+    <Container maxWidth="xl" sx={{ mb: 8 }}>
       <AdminDashboard />
     </Container>
   );

--- a/frontend/src/pages/admin/UserManagementPage.js
+++ b/frontend/src/pages/admin/UserManagementPage.js
@@ -1,15 +1,10 @@
 import React from 'react';
-import { Container, Typography, Box } from '@mui/material';
+import { Container } from '@mui/material';
 import UserManagement from '../../components/admin/UserManagement';
 
 function UserManagementPage() {
   return (
-    <Container maxWidth="xl" sx={{ mt: 2, mb: 4 }}>
-      <Box mb={3}>
-        <Typography variant="h4" gutterBottom>
-          사용자 관리
-        </Typography>
-      </Box>
+    <Container maxWidth="xl" sx={{ mb: 8 }}>
       <UserManagement />
     </Container>
   );


### PR DESCRIPTION
## 변경사항 (UI v2-7, ④-3 1차)

- **이중 타이틀 해소**: 래퍼 페이지(h4)와 컴포넌트(h5)가 같은 제목을 두 번 렌더하던 것 → 컴포넌트의 PageHeader 로 단일화
- **사용자 관리**: outlined 카드 + ToneChip 단일화 (승인 success/error/warning · 권한 accent/neutral · 계정 success/neutral) + EmptyState
- **관리자 대시보드**: StatCard v2(mono 숫자), 작업 큐 카드 헤더 라인 분리
- 기능 변경 없음

## 검증
- build --no-cache 통과, 배포 후 두 화면 캡처 확인

closes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)