### PR TITLE
feat: admin v2 2차 — 시스템 통계 / 백업·복구 / 모델 / 그룹 (#570)

### DIFF
--- a/frontend/src/components/admin/AdminDashboard.js
+++ b/frontend/src/components/admin/AdminDashboard.js
@@ -2,8 +2,6 @@ import React from 'react';
 import {
   Grid,
   Paper,
-  Card,
-  CardContent,
   Typography,
   Box,
   Alert,

--- a/frontend/src/components/admin/SystemStats.js
+++ b/frontend/src/components/admin/SystemStats.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import {
   Box,
-  Card,
-  CardContent,
+  Paper,
   Typography,
   Grid,
   CircularProgress,
@@ -18,6 +17,7 @@ import {
 import { useQuery } from 'react-query';
 import { adminAPI, jobAPI } from '../../services/api';
 import config from '../../config';
+import PageHeader from '../common/PageHeader';
 
 function SystemStats() {
   const { data: stats, isLoading: statsLoading } = useQuery(
@@ -68,15 +68,12 @@ function SystemStats() {
 
   return (
     <Box>
-      <Typography variant="h5" gutterBottom>
-        시스템 통계
-      </Typography>
+      <PageHeader title="시스템 통계" description="사용자 · 작업판 단위 사용량 집계" />
 
       <Grid container spacing={3}>
         {/* 사용자 통계 */}
         <Grid item xs={12} md={6}>
-          <Card>
-            <CardContent>
+          <Paper variant="outlined" sx={{ p: 4 }}>
               <Typography variant="h6" gutterBottom>
                 사용자 통계
               </Typography>
@@ -118,14 +115,12 @@ function SystemStats() {
                   color="secondary"
                 />
               </Box>
-            </CardContent>
-          </Card>
+            </Paper>
         </Grid>
 
         {/* 작업 통계 */}
         <Grid item xs={12} md={6}>
-          <Card>
-            <CardContent>
+          <Paper variant="outlined" sx={{ p: 4 }}>
               <Typography variant="h6" gutterBottom>
                 작업 통계
               </Typography>
@@ -175,14 +170,12 @@ function SystemStats() {
                   color="info"
                 />
               </Box>
-            </CardContent>
-          </Card>
+            </Paper>
         </Grid>
 
         {/* 저장소 통계 */}
         <Grid item xs={12} md={6}>
-          <Card>
-            <CardContent>
+          <Paper variant="outlined" sx={{ p: 4 }}>
               <Typography variant="h6" gutterBottom>
                 저장소 통계
               </Typography>
@@ -204,14 +197,12 @@ function SystemStats() {
                   {formatBytes(systemStats.images?.totalSize || 0)}
                 </Typography>
               </Box>
-            </CardContent>
-          </Card>
+            </Paper>
         </Grid>
 
         {/* 큐 상태 */}
         <Grid item xs={12} md={6}>
-          <Card>
-            <CardContent>
+          <Paper variant="outlined" sx={{ p: 4 }}>
               <Typography variant="h6" gutterBottom>
                 현재 큐 상태
               </Typography>
@@ -258,14 +249,12 @@ function SystemStats() {
                   </Box>
                 </Grid>
               </Grid>
-            </CardContent>
-          </Card>
+            </Paper>
         </Grid>
 
         {/* 최근 작업 목록 */}
         <Grid item xs={12}>
-          <Card>
-            <CardContent>
+          <Paper variant="outlined" sx={{ p: 4 }}>
               <Typography variant="h6" gutterBottom>
                 최근 작업 목록
               </Typography>
@@ -311,8 +300,7 @@ function SystemStats() {
                   </TableBody>
                 </Table>
               </TableContainer>
-            </CardContent>
-          </Card>
+            </Paper>
         </Grid>
       </Grid>
     </Box>

--- a/frontend/src/components/admin/UserManagement.js
+++ b/frontend/src/components/admin/UserManagement.js
@@ -2,8 +2,6 @@ import React, { useState } from 'react';
 import {
   Box,
   Paper,
-  Card,
-  CardContent,
   Typography,
   Table,
   TableBody,

--- a/frontend/src/pages/Profile.js
+++ b/frontend/src/pages/Profile.js
@@ -14,8 +14,6 @@ import {
   Select,
   MenuItem,
   Divider,
-  Card,
-  CardContent,
   Alert,
   Dialog,
   DialogTitle,

--- a/frontend/src/pages/admin/BackupRestorePage.js
+++ b/frontend/src/pages/admin/BackupRestorePage.js
@@ -40,6 +40,7 @@ import { useQuery, useMutation } from 'react-query';
 import toast from 'react-hot-toast';
 import { backupAPI } from '../../services/api';
 import Pagination from '../../components/common/Pagination';
+import PageHeader from '../../components/common/PageHeader';
 
 function TabPanel({ children, value, index }) {
   return (
@@ -261,10 +262,13 @@ function BackupRestorePage() {
 
   return (
     <Box>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
-        <Typography variant="h5" fontWeight="bold">
-          백업 / 복구 관리
-        </Typography>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', flexWrap: 'wrap', gap: 3, mb: 4.5 }}>
+        <Box>
+          <Typography variant="h1">백업 / 복구 관리</Typography>
+          <Typography variant="body1" color="text.secondary" sx={{ mt: 0.5 }}>
+            온디맨드 백업 생성 · 다운로드 · ZIP 복원
+          </Typography>
+        </Box>
         <Box sx={{ display: 'flex', gap: 1 }}>
           <Button
             variant="outlined"
@@ -295,7 +299,7 @@ function BackupRestorePage() {
         </Box>
       </Box>
 
-      <Paper sx={{ p: 2 }}>
+      <Paper variant="outlined" sx={{ p: 4 }}>
         <Tabs value={tabValue} onChange={(e, v) => setTabValue(v)}>
           <Tab label="백업 목록" />
           <Tab label="복구 히스토리" />

--- a/frontend/src/pages/admin/GroupManagementPage.js
+++ b/frontend/src/pages/admin/GroupManagementPage.js
@@ -36,6 +36,7 @@ import {
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import toast from 'react-hot-toast';
 import { groupAPI, adminAPI } from '../../services/api';
+import PageHeader from '../../components/common/PageHeader';
 
 // 그룹 생성/편집 다이얼로그
 function GroupFormDialog({ open, onClose, group, onSave }) {
@@ -301,18 +302,18 @@ function GroupManagementPage() {
   };
 
   return (
-    <Container maxWidth="lg" sx={{ py: 3 }}>
-      <Stack direction="row" justifyContent="space-between" alignItems="center" mb={3}>
-        <Box>
-          <Typography variant="h5">그룹 관리</Typography>
-          <Typography variant="body2" color="text.secondary">
-            사용자 그룹을 정의하고, 작업판 단위 접근 권한을 관리합니다. admin 은 implicit all-access 이므로 그룹과 무관합니다.
-          </Typography>
-        </Box>
+    <Container maxWidth="lg" sx={{ mb: 8 }}>
+      <PageHeader
+        title="그룹 관리"
+        description="사용자 그룹을 정의하고, 작업판 단위 접근 권한을 관리합니다. admin 은 implicit all-access 이므로 그룹과 무관합니다."
+        actions={(
+          <>
         <Button variant="contained" startIcon={<AddIcon />} onClick={handleNew}>
           새 그룹
         </Button>
-      </Stack>
+          </>
+        )}
+      />
 
       {isLoading ? (
         <Box display="flex" justifyContent="center" py={6}>

--- a/frontend/src/pages/admin/MetadataManagementPage.js
+++ b/frontend/src/pages/admin/MetadataManagementPage.js
@@ -5,6 +5,7 @@ import LoraManagementPage from './LoraManagementPage';
 import ModelManagementPage from './ModelManagementPage';
 import CivitaiAdminHeader from '../../components/admin/CivitaiAdminHeader';
 import { serverAPI, adminAPI } from '../../services/api';
+import PageHeader from '../../components/common/PageHeader';
 
 const MODEL_SERVER_TYPES = ['ComfyUI', 'OpenAI', 'OpenAI Compatible', 'Gemini'];
 const LORA_SERVER_TYPES = ['ComfyUI'];
@@ -64,10 +65,8 @@ function MetadataManagementPage() {
   }, []);
 
   return (
-    <Container maxWidth="xl" sx={{ py: 3, overflow: 'hidden' }}>
-      <Typography variant="h5" gutterBottom>
-        모델 관리
-      </Typography>
+    <Container maxWidth="xl" sx={{ mb: 8, overflow: 'hidden' }}>
+      <PageHeader title="모델 관리" description="모델 · LoRA 메타데이터와 Civitai 연동을 관리합니다." />
 
       <CivitaiAdminHeader
         selectedServerId={selectedServerId}

--- a/frontend/src/pages/admin/SystemStatsPage.js
+++ b/frontend/src/pages/admin/SystemStatsPage.js
@@ -1,15 +1,10 @@
 import React from 'react';
-import { Container, Typography, Box } from '@mui/material';
+import { Container } from '@mui/material';
 import SystemStats from '../../components/admin/SystemStats';
 
 function SystemStatsPage() {
   return (
-    <Container maxWidth="xl" sx={{ mt: 2, mb: 4 }}>
-      <Box mb={3}>
-        <Typography variant="h4" gutterBottom>
-          시스템 통계
-        </Typography>
-      </Box>
+    <Container maxWidth="xl" sx={{ mb: 8 }}>
       <SystemStats />
     </Container>
   );


### PR DESCRIPTION
## 변경사항 (UI v2-8, ④-3 2차 — 1차 #568 과 동일 패턴)

- **시스템 통계**: 래퍼 이중 타이틀 해소, PageHeader, Card 5종 → outlined Paper
- **백업/복구**: h1 헤더+설명, 카드 outlined·4px 간격
- **모델 관리 / 그룹 관리**: PageHeader (그룹은 '새 그룹' 버튼 actions 통합)
- 기능 변경 없음, 미사용 import 정리 포함

## 검증
- build --no-cache 통과, 4개 화면 캡처 확인

closes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)