### PR TITLE
feat: 프롬프트 생성(대화형) v2 — 말풍선 대화 + v2 헤더 (#572)

### DIFF
--- a/frontend/src/components/PromptGeneratorPanel.js
+++ b/frontend/src/components/PromptGeneratorPanel.js
@@ -289,7 +289,7 @@ function PromptGeneratorPanel({
       <form onSubmit={handleSubmit(onSubmit)}>
         <Grid container spacing={compact ? 2 : 3}>
           <Grid item xs={12} md={compact ? 12 : 6}>
-            <Paper sx={{ p: compact ? 2 : 3 }} elevation={compact ? 0 : 1}>
+            <Paper sx={{ p: compact ? 2 : 4 }} variant={compact ? 'elevation' : 'outlined'} elevation={0}>
               {!compact && (
                 <Typography variant="h6" gutterBottom>
                   입력 설정
@@ -404,7 +404,7 @@ function PromptGeneratorPanel({
           </Grid>
 
           <Grid item xs={12} md={compact ? 12 : 6}>
-            <Paper sx={{ p: compact ? 2 : 3, minHeight: compact ? 200 : 400 }} elevation={compact ? 0 : 1}>
+            <Paper sx={{ p: compact ? 2 : 4, minHeight: compact ? 200 : 400 }} variant={compact ? 'elevation' : 'outlined'} elevation={0}>
               <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
                 <Typography variant={compact ? 'subtitle1' : 'h6'}>
                   생성된 프롬프트

--- a/frontend/src/components/common/ConversationChatPanel.js
+++ b/frontend/src/components/common/ConversationChatPanel.js
@@ -25,6 +25,7 @@ import toast from 'react-hot-toast';
 import { conversationAPI, textAPI, imageAPI } from '../../services/api';
 import { useStreamingPrompt } from '../../hooks/useStreamingPrompt';
 import ImageUploadField from './ImageUploadField';
+import ChatBubble from './chat/ChatBubble';
 
 // 멀티턴 대화 모드 패널 (#375).
 // `conversationId` 가 주어졌을 때 PromptGeneration 페이지에서 PromptGeneratorPanel 대신 렌더.
@@ -141,7 +142,7 @@ function ConversationChatPanel({ workboard, conversationId }) {
   const isSending = isStreaming;
 
   return (
-    <Paper elevation={1} sx={{ p: { xs: 2, md: 3 } }}>
+    <Paper variant="outlined" sx={{ p: { xs: 3, md: 4 } }}>
       <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 2, flexWrap: 'wrap' }}>
         <Chip label="대화 이어가기" color="secondary" />
         {conversation.model && <Chip label={conversation.model} variant="outlined" />}
@@ -166,36 +167,17 @@ function ConversationChatPanel({ workboard, conversationId }) {
           overflow: 'auto',
           mb: 2,
           p: 2,
-          bgcolor: 'grey.50',
           borderRadius: 1,
         }}
       >
-        <Stack spacing={1.5} divider={<Divider flexItem />}>
+        <Stack spacing={3.5}>
           {messages.map((msg, idx) => (
-            <Box key={idx} sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
-              <Box sx={{ pt: 0.5 }}>
-                {msg.role === 'user' && <PersonIcon fontSize="small" color="primary" />}
-                {msg.role === 'assistant' && <AssistantIcon fontSize="small" color="action" />}
-                {msg.role === 'system' && <SystemIcon fontSize="small" color="action" />}
-              </Box>
-              <Box sx={{ flex: '1 1 0', minWidth: 0 }}>
-                <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'uppercase', letterSpacing: 0.5 }}>
-                  {msg.role}
-                </Typography>
-                <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', mt: 0.25 }}>
-                  {msg.content}
-                </Typography>
-                {/* 첨부 이미지 썸네일 (#517) */}
-                {msg.attachments?.length > 0 && (
-                  <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap', mt: 0.75 }}>
-                    {msg.attachments.map((a, ai) => (
-                      <Box key={ai} component="img" src={a.url} alt="첨부 이미지"
-                        sx={{ width: 72, height: 72, objectFit: 'cover', borderRadius: 1, border: '1px solid', borderColor: 'divider' }} />
-                    ))}
-                  </Box>
-                )}
-              </Box>
-              {msg.role === 'assistant' && (
+            <ChatBubble
+              key={idx}
+              role={msg.role}
+              content={msg.content}
+              attachments={msg.attachments}
+              actions={msg.role === 'assistant' && (
                 <Tooltip title="이 응답을 텍스트 컨텐츠로 저장">
                   <IconButton
                     size="small"
@@ -206,37 +188,11 @@ function ConversationChatPanel({ workboard, conversationId }) {
                   </IconButton>
                 </Tooltip>
               )}
-            </Box>
+            />
           ))}
           {/* 낙관적 사용자 말풍선 + 실시간 어시스턴트 말풍선 (#490) */}
-          {pendingUserMsg && (
-            <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
-              <Box sx={{ pt: 0.5 }}><PersonIcon fontSize="small" color="primary" /></Box>
-              <Box sx={{ flex: '1 1 0', minWidth: 0 }}>
-                <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'uppercase', letterSpacing: 0.5 }}>
-                  user
-                </Typography>
-                <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', mt: 0.25 }}>
-                  {pendingUserMsg}
-                </Typography>
-              </Box>
-            </Box>
-          )}
-          {isStreaming && (
-            <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
-              <Box sx={{ pt: 0.5 }}><AssistantIcon fontSize="small" color="action" /></Box>
-              <Box sx={{ flex: '1 1 0', minWidth: 0 }}>
-                <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'uppercase', letterSpacing: 0.5 }}>
-                  assistant
-                </Typography>
-                <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', mt: 0.25 }}>
-                  {streamingText}
-                  {!streamingText && <CircularProgress size={14} color="secondary" sx={{ ml: 0.5 }} />}
-                  {streamingText && <Box component="span" sx={{ opacity: 0.5 }}>▍</Box>}
-                </Typography>
-              </Box>
-            </Box>
-          )}
+          {pendingUserMsg && <ChatBubble role="user" content={pendingUserMsg} />}
+          {isStreaming && <ChatBubble role="assistant" streaming streamingText={streamingText} />}
         </Stack>
         {conversation.status === 'processing' && !isStreaming && (
           <Alert severity="info" sx={{ mt: 2 }}>

--- a/frontend/src/components/common/WorkboardChatPanel.js
+++ b/frontend/src/components/common/WorkboardChatPanel.js
@@ -34,6 +34,7 @@ import { conversationAPI, textAPI, imageAPI } from '../../services/api';
 import { useStreamingPrompt } from '../../hooks/useStreamingPrompt';
 import MetadataFieldInput from './MetadataFieldInput';
 import ImageUploadField from './ImageUploadField';
+import ChatBubble from './chat/ChatBubble';
 
 // 텍스트 작업판의 멀티턴 대화 모드 패널 (#391).
 // PromptGeneration 페이지에서 workboard.conversation_mode = true 일 때 PromptGeneratorPanel 대신 렌더.
@@ -254,7 +255,7 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
   };
 
   return (
-    <Paper elevation={1} sx={{ p: { xs: 2, md: 3 } }}>
+    <Paper variant="outlined" sx={{ p: { xs: 3, md: 4 } }}>
       {/* 헤더 */}
       <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 2, flexWrap: 'wrap' }}>
         <Chip label="대화 모드" color="secondary" />
@@ -315,7 +316,6 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
           overflow: 'auto',
           mb: 2,
           p: 2,
-          bgcolor: 'grey.50',
           borderRadius: 1,
         }}
       >
@@ -324,32 +324,14 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
             아래 입력창에 메시지를 입력해 대화를 시작하세요.
           </Typography>
         ) : (
-          <Stack spacing={1.5} divider={<Divider flexItem />}>
+          <Stack spacing={3.5}>
             {messages.map((msg, idx) => (
-              <Box key={idx} sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
-                <Box sx={{ pt: 0.5 }}>
-                  {msg.role === 'user' && <PersonIcon fontSize="small" color="primary" />}
-                  {msg.role === 'assistant' && <AssistantIcon fontSize="small" color="action" />}
-                  {msg.role === 'system' && <SystemIcon fontSize="small" color="action" />}
-                </Box>
-                <Box sx={{ flex: '1 1 0', minWidth: 0 }}>
-                  <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'uppercase', letterSpacing: 0.5 }}>
-                    {msg.role}
-                  </Typography>
-                  <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', mt: 0.25 }}>
-                    {msg.content}
-                  </Typography>
-                  {/* 첨부 이미지 썸네일 (#517) */}
-                  {msg.attachments?.length > 0 && (
-                    <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap', mt: 0.75 }}>
-                      {msg.attachments.map((a, ai) => (
-                        <Box key={ai} component="img" src={a.url} alt="첨부 이미지"
-                          sx={{ width: 72, height: 72, objectFit: 'cover', borderRadius: 1, border: '1px solid', borderColor: 'divider' }} />
-                      ))}
-                    </Box>
-                  )}
-                </Box>
-                {msg.role === 'assistant' && (
+              <ChatBubble
+                key={idx}
+                role={msg.role}
+                content={msg.content}
+                attachments={msg.attachments}
+                actions={msg.role === 'assistant' && (
                   <Tooltip title="이 응답을 텍스트 컨텐츠로 저장">
                     <IconButton
                       size="small"
@@ -360,38 +342,12 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
                     </IconButton>
                   </Tooltip>
                 )}
-              </Box>
+              />
             ))}
             {/* 낙관적 사용자 말풍선 — 보낸 직후 ~ 저장본 refetch 전까지 (#490) */}
-            {pendingUserMsg && (
-              <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
-                <Box sx={{ pt: 0.5 }}><PersonIcon fontSize="small" color="primary" /></Box>
-                <Box sx={{ flex: '1 1 0', minWidth: 0 }}>
-                  <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'uppercase', letterSpacing: 0.5 }}>
-                    user
-                  </Typography>
-                  <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', mt: 0.25 }}>
-                    {pendingUserMsg}
-                  </Typography>
-                </Box>
-              </Box>
-            )}
+            {pendingUserMsg && <ChatBubble role="user" content={pendingUserMsg} />}
             {/* 실시간 어시스턴트 말풍선 — 토큰 스트리밍 (#490) */}
-            {isStreaming && (
-              <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
-                <Box sx={{ pt: 0.5 }}><AssistantIcon fontSize="small" color="action" /></Box>
-                <Box sx={{ flex: '1 1 0', minWidth: 0 }}>
-                  <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'uppercase', letterSpacing: 0.5 }}>
-                    assistant
-                  </Typography>
-                  <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', mt: 0.25 }}>
-                    {streamingText}
-                    {!streamingText && <CircularProgress size={14} color="secondary" sx={{ ml: 0.5 }} />}
-                    {streamingText && <Box component="span" sx={{ opacity: 0.5 }}>▍</Box>}
-                  </Typography>
-                </Box>
-              </Box>
-            )}
+            {isStreaming && <ChatBubble role="assistant" streaming streamingText={streamingText} />}
           </Stack>
         )}
         {conversation?.status === 'failed' && conversation?.error?.message && (

--- a/frontend/src/components/common/chat/ChatBubble.js
+++ b/frontend/src/components/common/chat/ChatBubble.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import { Box, Typography, CircularProgress } from '@mui/material';
+import { BRAND_GRADIENTS } from '../../../utils/brandGradients';
+
+/**
+ * v2 채팅 말풍선 (#572) — 대화형 화면 공용.
+ * - user: 테라코타 틴트 버블, 우측 정렬
+ * - assistant: 카드형 버블, 좌측 정렬
+ * - system: 중앙 캡션
+ * streaming 이면 content 대신 streamingText + 커서를 표시한다 (로직은 호출측 소유).
+ */
+export default function ChatBubble({ role, content, attachments, actions, streaming, streamingText }) {
+  if (role === 'system') {
+    return (
+      <Box sx={{ alignSelf: 'center', maxWidth: '92%', textAlign: 'center', py: 1 }}>
+        <Typography variant="caption" sx={{ color: 'text.tertiary', whiteSpace: 'pre-wrap' }}>
+          {content}
+        </Typography>
+      </Box>
+    );
+  }
+
+  const isUser = role === 'user';
+  return (
+    <Box
+      sx={{
+        display: 'flex', gap: 2.5, maxWidth: '88%',
+        alignSelf: isUser ? 'flex-end' : 'flex-start',
+        flexDirection: isUser ? 'row-reverse' : 'row',
+      }}
+    >
+      <Box
+        sx={{
+          width: 28, height: 28, borderRadius: '50%', flex: '0 0 auto',
+          display: 'grid', placeItems: 'center', fontSize: 10.5, fontWeight: 800, mt: 0.5,
+          ...(isUser
+            ? { background: BRAND_GRADIENTS[0], color: 'common.white' }
+            : { bgcolor: 'info.light', color: 'info.main' }),
+        }}
+      >
+        {isUser ? '나' : 'AI'}
+      </Box>
+      <Box sx={{ minWidth: 0 }}>
+        <Box
+          sx={{
+            borderRadius: '14px', px: 3.5, py: 2.75,
+            ...(isUser
+              ? { bgcolor: 'primary.light', borderBottomRightRadius: '4px' }
+              : {
+                  bgcolor: 'background.paper', border: 1, borderColor: 'divider',
+                  boxShadow: 1, borderBottomLeftRadius: '4px',
+                }),
+          }}
+        >
+          {attachments?.length > 0 && (
+            <Box sx={{ display: 'flex', gap: 1.5, flexWrap: 'wrap', mb: 2 }}>
+              {attachments.map((a, ai) => (
+                <Box
+                  key={ai}
+                  component="img"
+                  src={a.url}
+                  alt="첨부 이미지"
+                  sx={{ width: 64, height: 64, objectFit: 'cover', borderRadius: 2, border: '1px solid', borderColor: 'divider' }}
+                />
+              ))}
+            </Box>
+          )}
+          <Typography component="div" variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', fontSize: 13.5, lineHeight: 1.65 }}>
+            {streaming ? (
+              <>
+                {streamingText}
+                {!streamingText && <CircularProgress size={14} sx={{ ml: 0.5 }} />}
+                {streamingText && <Box component="span" sx={{ opacity: 0.5 }}>▍</Box>}
+              </>
+            ) : content}
+          </Typography>
+        </Box>
+        {actions && <Box sx={{ display: 'flex', gap: 1.5, mt: 1.5, justifyContent: isUser ? 'flex-end' : 'flex-start' }}>{actions}</Box>}
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/pages/PromptGeneration.js
+++ b/frontend/src/pages/PromptGeneration.js
@@ -24,6 +24,8 @@ import WorkboardChatPanel from '../components/common/WorkboardChatPanel';
 import ProjectContextSelector from '../components/common/ProjectContextSelector';
 import toast from 'react-hot-toast';
 import { MONO } from '../theme';
+import { BRAND_GRADIENTS } from '../utils/brandGradients';
+import { ToneChip } from '../components/common/ToneChip';
 
 function PromptGeneration() {
   const { workboardId } = useParams();
@@ -89,35 +91,46 @@ function PromptGeneration() {
   }
 
   return (
-    <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
-      <Box display="flex" alignItems="center" gap={2} mb={3}>
-        <Button
-          startIcon={<ArrowBack />}
-          onClick={() => navigate(conversationId ? '/jobs' : '/prompt-workboards')}
-        >
-          {conversationId ? '히스토리로' : '작업판 선택'}
-        </Button>
-        <Box display="flex" alignItems="center" gap={1}>
-          <Chat color="secondary" />
-          <Typography variant="h5">{workboard.name}</Typography>
+    <Container maxWidth="lg" sx={{ mb: 8 }}>
+      <Button
+        startIcon={<ArrowBack />}
+        onClick={() => navigate(conversationId ? '/jobs' : '/prompt-workboards')}
+        sx={{ mb: 3 }}
+      >
+        {conversationId ? '히스토리로' : '작업판 선택'}
+      </Button>
+
+      {/* 페이지 헤더 — 작업판 실행과 동일 패턴 (#572) */}
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 4, flexWrap: 'wrap', mb: 5 }}>
+        <Box sx={{
+          width: 48, height: 48, borderRadius: 2, background: BRAND_GRADIENTS[2],
+          color: 'common.white', display: 'grid', placeItems: 'center', boxShadow: 2, flex: '0 0 auto',
+        }}>
+          <Chat fontSize="small" />
         </Box>
-        <Chip label={conversationId ? '대화 이어가기' : '프롬프트 생성'} color="secondary" />
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
+            <Typography variant="h1">{workboard.name}</Typography>
+            <ToneChip tone="info" label={conversationId ? '대화 이어가기' : '텍스트 생성'} />
+          </Box>
+          {workboard.description && !conversationId && (
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5, textWrap: 'pretty' }}>
+              {workboard.description}
+            </Typography>
+          )}
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1, flexWrap: 'wrap' }}>
+            <Typography variant="caption" sx={{ fontFamily: MONO, color: 'text.tertiary' }}>
+              ID: {workboard._id}
+            </Typography>
+            <IconButton size="small" onClick={handleCopyWorkboardId} aria-label="작업판 ID 복사">
+              <ContentCopy fontSize="inherit" />
+            </IconButton>
+            <Typography variant="caption" sx={{ color: 'text.tertiary' }}>
+              {workboard.serverId?.name || '서버 미설정'} · v{workboard.version || 1} · 사용횟수 {workboard.usageCount || 0}회
+            </Typography>
+          </Box>
+        </Box>
       </Box>
-
-      <Box display="flex" alignItems="center" gap={0.5} mb={2}>
-        <Typography variant="caption" color="text.secondary" sx={{ fontFamily: MONO }}>
-          작업판 ID: {workboard._id}
-        </Typography>
-        <IconButton size="small" onClick={handleCopyWorkboardId} aria-label="작업판 ID 복사">
-          <ContentCopy fontSize="inherit" />
-        </IconButton>
-      </Box>
-
-      {workboard.description && !conversationId && (
-        <Alert severity="info" sx={{ mb: 3 }}>
-          {workboard.description}
-        </Alert>
-      )}
 
       {/* 프로젝트 컨텍스트 / 세계관 토글 (#396). 멀티턴 이어가기 (conversationId 진입) 시엔 숨김 — 이미 첫 턴에 주입됨. */}
       {!conversationId && (


### PR DESCRIPTION
## 변경사항 (UI v2-9, ④-4 — 시안 승인, '다른 작업판에서 사용' 제외 결정 반영)

- **ChatBubble 공용 컴포넌트** (`components/common/chat/`): user 테라코타 틴트(우측)/assistant 카드(좌측)/system 캡션, 첨부 썸네일, 스트리밍 커서, 액션 슬롯
- **WorkboardChatPanel / ConversationChatPanel**: 아이콘+role 라벨 행 → ChatBubble (낙관적 사용자 말풍선 #490, 스트리밍, '텍스트 컨텐츠로 저장' 북마크 전부 불변), grey 박스 transcript → 투명+간격 3.5
- **페이지 헤더**: 작업판 실행(#552)과 동일 패턴 — 두 실행 화면 일관성
- 패널/설정/결과 카드 outlined 전환. 단발 모드(PromptGeneratorPanel)는 다이얼로그(compact)에선 기존 외형 유지

## 검증
- build --no-cache 통과, 빈 상태(라이트) + 실대화(다크, 기존 대화 이어가기) 캡처 확인

closes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)