### PR TITLE
test: 깨진 jest suite 4개 수리 — 전체 142건 green (#535)

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,5 @@
+// Jest 공통 테스트 환경 (#535)
+// secretFailFast(#379 계열) 가 요구하는 필수 env — 미설정 시 모듈 로드 단계에서 throw 되어
+// filesRoute/restorePathValidation 등 17+21건이 환경 문제로 실패했었다.
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'jest-test-secret-not-for-production';
+process.env.NODE_ENV = process.env.NODE_ENV || 'test';

--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
   "jest": {
     "roots": [
       "<rootDir>/src"
+    ],
+    "setupFiles": [
+      "<rootDir>/jest.setup.js"
     ]
   }
 }

--- a/src/tests/customFieldHelpers.test.js
+++ b/src/tests/customFieldHelpers.test.js
@@ -46,10 +46,16 @@ describe('customFieldHelpers (#199 Phase F4)', () => {
       expect(getFieldValueByRole(workboard, inputData, FIELD_ROLES.MODEL)).toBe('SDXL/illustrious.safetensors');
     });
 
-    test('legacy well-known 키 fallback (aiModel)', () => {
-      const inputData = { aiModel: 'legacy-model-id' };
+    test('well-known 키 fallback (base_model)', () => {
+      const inputData = { additionalParams: { base_model: 'legacy-model-id' } };
       const wbEmpty = { additionalInputFields: [] };
       expect(getFieldValueByRole(wbEmpty, inputData, FIELD_ROLES.MODEL)).toBe('legacy-model-id');
+    });
+
+    test('aiModel camelCase 별칭은 미지원 — snake_case 단일화 (0d72b24), legacy 복원은 프론트 매핑 담당', () => {
+      const inputData = { aiModel: 'legacy-model-id' };
+      const wbEmpty = { additionalInputFields: [] };
+      expect(getFieldValueByRole(wbEmpty, inputData, FIELD_ROLES.MODEL)).toBeUndefined();
     });
 
     test('type 매치 필드가 well-known fallback 보다 우선', () => {
@@ -96,7 +102,7 @@ describe('customFieldHelpers (#199 Phase F4)', () => {
     test('legacy systemPrompt / referenceImageMethod / temperature / maxTokens 매핑', () => {
       const inputData = {
         systemPrompt: 'You are helpful',
-        referenceImageMethods: 'inpaint',
+        referenceImageMethod: 'inpaint',
         temperature: 0.5,
         maxTokens: 1024
       };

--- a/src/tests/database.test.js
+++ b/src/tests/database.test.js
@@ -42,9 +42,9 @@ describe('Database Connection Configuration', () => {
         'mongodb://127.0.0.1:27017/test-db'
       ];
 
+      // NOTE: 'mongodb://localhost' 는 포트/DB 가 없어도 유효한 mongodb URI 라 invalid 목록에서 제외 (#535)
       const invalidURIs = [
         'redis://localhost:6379', // Wrong protocol
-        'mongodb://localhost', // Missing port and database
         'http://localhost:27017' // Wrong protocol
       ];
 


### PR DESCRIPTION
## 진단 결과 (실동작·이력 기준 — CLAUDE.md 디버깅 정책)

| suite | 실패 | 원인 | 수리 |
|---|---|---|---|
| filesRoute (17) + restorePathValidation (21) | 모듈 로드 throw | **환경 문제** — secretFailFast 가 JWT_SECRET 요구, 테스트 env 미제공 | `jest.setup.js` 신설 + setupFiles |
| database (1) | 논리 버그 | 'mongodb://localhost' 는 유효 URI 인데 invalid 목록에 포함 | 목록 수정 |
| customFieldHelpers (2) | **테스트 드리프트** | aiModel camel 별칭은 `0d72b24 snake_case 단일화`에서 의도 제거(#475 가 폼 고정 키만 선별 복원, legacy 복원은 프론트 매핑 담당) / `referenceImageMethods` 오타 | 현 계약으로 재작성(미지원 명시 테스트 추가) + 오타 |

**코드 결함은 0건** — 전부 테스트/환경 측. 

## 결과
- 87 pass / 24 fail → **142 pass / 0 fail** (12 suites)
- zip-slip 방어 검증(restorePathValidation 535줄) 부활 → **unzipper 0.12 업그레이드 unblock** (#525 잔여)
- 전체 테스트 설계(예정된 굵직한 작업)의 green baseline 확보

closes #535

🤖 Generated with [Claude Code](https://claude.com/claude-code)