### PR TITLE
feat: 태그 색상 팔레트 v2 정렬 — full-stack (#546)

### DIFF
--- a/frontend/src/components/common/ConversationHistoryPanel.js
+++ b/frontend/src/components/common/ConversationHistoryPanel.js
@@ -251,7 +251,7 @@ function ConversationHistoryPanel({ fetchFn, queryKey = 'conversations' }) {
                   {detailItem.worldviewContext && (
                     <Paper variant="outlined" sx={{ p: 1.5, bgcolor: 'rgba(156, 39, 176, 0.04)' }}>
                       <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 0.5 }}>
-                        <PublicIcon fontSize="small" sx={{ color: '#9c27b0' }} />
+                        <PublicIcon fontSize="small" sx={{ color: 'secondary.main' }} />
                         <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>사전 컨텍스트 (세계관)</Typography>
                       </Stack>
                       <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>

--- a/frontend/src/components/common/JobHistoryPanel.js
+++ b/frontend/src/components/common/JobHistoryPanel.js
@@ -112,7 +112,7 @@ export function SavePromptDialog({ open, onClose, job, onSave }) {
     ? jobTags
     : jobTags.map(tagId => {
         const found = allTags.find(t => t._id === tagId);
-        return found || { _id: tagId, name: tagId, color: '#1976d2' };
+        return found || { _id: tagId, name: tagId, color: '#C96A3B' };
       });
 
   // 태그 ID 배열 (프롬프트 저장 시 전달용)

--- a/frontend/src/components/common/TagInput.js
+++ b/frontend/src/components/common/TagInput.js
@@ -93,7 +93,7 @@ function TagInput({
             key={option._id || index}
             label={option.name}
             sx={{ 
-              bgcolor: option.color || '#1976d2',
+              bgcolor: option.color || '#C96A3B',
               color: 'white',
               '& .MuiChip-deleteIcon': {
                 color: 'rgba(255,255,255,0.7)',
@@ -126,7 +126,7 @@ function TagInput({
           <Chip
             label={option.name}
             sx={{ 
-              bgcolor: option.color || '#1976d2',
+              bgcolor: option.color || '#C96A3B',
               color: 'white',
               mr: 1
             }}

--- a/frontend/src/constants/builtinTags.js
+++ b/frontend/src/constants/builtinTags.js
@@ -7,8 +7,8 @@ export const BUILTIN_TAG_NAMES = Object.freeze({
 });
 
 export const BUILTIN_TAG_META = Object.freeze({
-  [BUILTIN_TAG_NAMES.WORLDVIEW]: { label: '세계관', color: '#9c27b0' },
-  [BUILTIN_TAG_NAMES.SYSTEM_PROMPT]: { label: '시스템 프롬프트', color: '#2196f3' },
+  [BUILTIN_TAG_NAMES.WORLDVIEW]: { label: '세계관', color: '#7A5CC4' },
+  [BUILTIN_TAG_NAMES.SYSTEM_PROMPT]: { label: '시스템 프롬프트', color: '#4A7DBF' },
 });
 
 // 세계관 탭에 표시할 타입 chip 목록 (순서 고정)

--- a/frontend/src/pages/ProjectList.js
+++ b/frontend/src/pages/ProjectList.js
@@ -47,7 +47,7 @@ function TagPill({ tag }) {
   return (
     <Box component="span" sx={{
       display: 'inline-flex', alignItems: 'center', height: 21, px: '10px', borderRadius: 999,
-      fontSize: 10.5, fontWeight: 600, color: '#fff', bgcolor: tag.color || '#7c4dff', whiteSpace: 'nowrap',
+      fontSize: 10.5, fontWeight: 600, color: '#fff', bgcolor: tag.color || '#C96A3B', whiteSpace: 'nowrap',
     }}>
       {tag.name}
     </Box>

--- a/frontend/src/pages/TagSearch.js
+++ b/frontend/src/pages/TagSearch.js
@@ -54,7 +54,7 @@ function SearchTabPanel({ children, value, index }) {
 
 function TagEditDialog({ open, onClose, tag }) {
   const [name, setName] = useState(tag?.name || '');
-  const [color, setColor] = useState(tag?.color || '#1976d2');
+  const [color, setColor] = useState(tag?.color || '#C96A3B');
   const queryClient = useQueryClient();
 
   const updateMutation = useMutation(
@@ -83,7 +83,7 @@ function TagEditDialog({ open, onClose, tag }) {
   React.useEffect(() => {
     if (tag) {
       setName(tag.name || '');
-      setColor(tag.color || '#1976d2');
+      setColor(tag.color || '#C96A3B');
     }
   }, [tag]);
 
@@ -130,7 +130,7 @@ function TagEditDialog({ open, onClose, tag }) {
 
 function TagCreateDialog({ open, onClose }) {
   const [name, setName] = useState('');
-  const [color, setColor] = useState('#1976d2');
+  const [color, setColor] = useState('#C96A3B');
   const queryClient = useQueryClient();
 
   const createMutation = useMutation(
@@ -141,7 +141,7 @@ function TagCreateDialog({ open, onClose }) {
         queryClient.invalidateQueries('tags');
         toast.success('태그가 생성되었습니다');
         setName('');
-        setColor('#1976d2');
+        setColor('#C96A3B');
         onClose();
       },
       onError: (error) => {

--- a/src/constants/builtinTags.js
+++ b/src/constants/builtinTags.js
@@ -9,8 +9,8 @@ const BUILTIN_TAG_NAMES = Object.freeze({
 
 // UI 표시용 메타 (한국어 라벨 + 기본 색)
 const BUILTIN_TAG_META = Object.freeze({
-  [BUILTIN_TAG_NAMES.WORLDVIEW]: { label: '세계관', color: '#9c27b0' },
-  [BUILTIN_TAG_NAMES.SYSTEM_PROMPT]: { label: '시스템 프롬프트', color: '#2196f3' },
+  [BUILTIN_TAG_NAMES.WORLDVIEW]: { label: '세계관', color: '#7A5CC4' },
+  [BUILTIN_TAG_NAMES.SYSTEM_PROMPT]: { label: '시스템 프롬프트', color: '#4A7DBF' },
 });
 
 module.exports = { BUILTIN_TAG_NAMES, BUILTIN_TAG_META };

--- a/src/migrations/alignTagColorsV2.js
+++ b/src/migrations/alignTagColorsV2.js
@@ -1,0 +1,25 @@
+const Tag = require('../models/Tag');
+const { BUILTIN_TAG_NAMES, BUILTIN_TAG_META } = require('../constants/builtinTags');
+
+// #546 — 태그 색을 v2 팔레트로 정렬.
+// 구 기본값과 "정확히 일치" 하는 색만 변경한다 — 사용자가 직접 고른 커스텀 색은 보존.
+// (구 기본값: 일반 태그 #1976d2 / 세계관 #9c27b0 / 시스템 프롬프트 #2196f3)
+const COLOR_MAP = Object.freeze({
+  '#1976d2': '#C96A3B', // 구 MUI 블루 기본값 → v2 primary
+  '#9c27b0': BUILTIN_TAG_META[BUILTIN_TAG_NAMES.WORLDVIEW].color,
+  '#2196f3': BUILTIN_TAG_META[BUILTIN_TAG_NAMES.SYSTEM_PROMPT].color,
+});
+
+async function alignTagColorsV2() {
+  let total = 0;
+  for (const [from, to] of Object.entries(COLOR_MAP)) {
+    const res = await Tag.updateMany({ color: from }, { $set: { color: to } });
+    total += res.modifiedCount || 0;
+  }
+  if (total > 0) {
+    console.log(`🎨 alignTagColorsV2: ${total}개 태그 색을 v2 팔레트로 이전`);
+  }
+  return total;
+}
+
+module.exports = alignTagColorsV2;

--- a/src/migrations/ensureWorldviewTag.js
+++ b/src/migrations/ensureWorldviewTag.js
@@ -1,4 +1,5 @@
 const Tag = require('../models/Tag');
+const { BUILTIN_TAG_NAMES, BUILTIN_TAG_META } = require('../constants/builtinTags');
 const User = require('../models/User');
 
 // 세계관 (사전 컨텍스트) 역할 태그 자동 시드 (#396).
@@ -22,7 +23,7 @@ async function ensureWorldviewTag() {
       userId: user._id,
       createdBy: user._id,
       name: '세계관',
-      color: '#9c27b0',
+      color: BUILTIN_TAG_META[BUILTIN_TAG_NAMES.WORLDVIEW].color,
       isWorldviewTag: true,
     });
     created += 1;

--- a/src/models/Tag.js
+++ b/src/models/Tag.js
@@ -14,7 +14,7 @@ const tagSchema = new mongoose.Schema({
   },
   color: {
     type: String,
-    default: '#1976d2'
+    default: '#C96A3B' // v2 primary (#546 — 구 MUI 블루에서 정렬)
   },
   usageCount: {
     type: Number,

--- a/src/server.js
+++ b/src/server.js
@@ -46,6 +46,7 @@ const dropBaseInputFieldsSchema = require('./migrations/dropBaseInputFieldsSchem
 const relocateCivitaiApiKey = require('./migrations/relocateCivitaiApiKey');
 const ensureWorldviewTag = require('./migrations/ensureWorldviewTag');
 const backfillConversationTags = require('./migrations/backfillConversationTags');
+const alignTagColorsV2 = require('./migrations/alignTagColorsV2');
 
 dotenv.config();
 
@@ -250,6 +251,7 @@ const startServer = async () => {
     await relocateCivitaiApiKey();
     await ensureWorldviewTag();
     await backfillConversationTags();
+    await alignTagColorsV2();
 
     // Initialize job queues after database connection
     console.log('Initializing job queues...');

--- a/src/tests/builtinTagsMirror.test.js
+++ b/src/tests/builtinTagsMirror.test.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+const { BUILTIN_TAG_NAMES, BUILTIN_TAG_META } = require('../constants/builtinTags');
+
+/**
+ * #546 — builtinTags 백엔드 ↔ 프론트 미러 동기화 회귀 테스트.
+ * 두 파일은 모듈 시스템이 달라(CJS vs ESM) 공유가 불가능한 의도적 미러 —
+ * 한쪽만 바뀌는 회귀를 여기서 잡는다 (single-source-of-truth 정책).
+ */
+describe('builtinTags 미러 동기화', () => {
+  const frontendSrc = fs.readFileSync(
+    path.join(__dirname, '../../frontend/src/constants/builtinTags.js'),
+    'utf8'
+  );
+
+  test('태그 이름이 프론트 미러와 일치', () => {
+    for (const name of Object.values(BUILTIN_TAG_NAMES)) {
+      expect(frontendSrc).toContain(`'${name}'`);
+    }
+  });
+
+  test('태그 색이 프론트 미러와 일치', () => {
+    for (const meta of Object.values(BUILTIN_TAG_META)) {
+      expect(frontendSrc).toContain(meta.color);
+    }
+  });
+});


### PR DESCRIPTION
## 변경사항

태그 색이 구 MUI 팔레트로 full-stack(스키마 default + 양쪽 builtinTags 미러 + 프론트 fallback 8곳 혼재)에 분산돼 있던 것을 v2 팔레트로 일괄 정렬.

| 대상 | 변경 |
|---|---|
| 기본 태그색 | `#1976d2` → `#C96A3B` (v2 primary) — Tag 스키마 default + 프론트 fallback 8곳(`#7c4dff` 혼재 포함) |
| 세계관 | `#9c27b0` → `#7A5CC4` (v2 secondary) — 양쪽 builtinTags |
| 시스템 프롬프트 | `#2196f3` → `#4A7DBF` (v2 info) |

- **마이그레이션** `alignTagColorsV2`: 구 기본값과 **정확히 일치하는 색만** 이전 — 사용자 커스텀 색 보존. 부팅 시 멱등 실행
- ensureWorldviewTag 하드코딩 → builtinTags 상수 참조
- **미러 동기화 회귀 테스트** 신설 — 백엔드 테스트가 프론트 미러 파일을 읽어 이름/색 일치 검증 (SSOT 정책, 한쪽만 바뀌는 회귀 차단)

## 검증
- jest 144/144 green (+2), backend/frontend build --no-cache 통과
- 머지 후 재기동 시 마이그레이션 실행 로그 + 태그 화면 확인 예정

closes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)