### PR TITLE
feat: AI 프롬프트 생성 — 다이얼로그 내 멀티턴 + 응답별 반환 (#574)

### DIFF
--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,3 +1,0 @@
-allowBuilds:
-  core-js: set this to true or false
-  core-js-pure: set this to true or false

--- a/frontend/src/components/PromptGeneratorDialog.js
+++ b/frontend/src/components/PromptGeneratorDialog.js
@@ -18,6 +18,7 @@ import { Chat, Check } from '@mui/icons-material';
 import { useQuery } from 'react-query';
 import { workboardAPI } from '../services/api';
 import PromptGeneratorPanel from './PromptGeneratorPanel';
+import WorkboardChatPanel from './common/WorkboardChatPanel';
 
 function PromptWorkboardSelectDialog({ open, onClose, onSelect }) {
   const { data, isLoading } = useQuery(
@@ -69,6 +70,9 @@ function PromptWorkboardSelectDialog({ open, onClose, onSelect }) {
 
 function PromptGeneratorDialog({ open, onClose, onApply }) {
   const [selectedWorkboard, setSelectedWorkboard] = useState(null);
+  // #574: 대상 작업판이 채팅 모드면 다이얼로그 안에서 멀티턴 — 응답별 '이 응답을 프롬프트로 사용' 으로 반환
+  const conversationMode = !!(selectedWorkboard?.additionalInputFields || [])
+    .find((f) => f.name === 'conversation_mode')?.defaultValue;
   const [selectDialogOpen, setSelectDialogOpen] = useState(false);
   const [generatedPrompt, setGeneratedPrompt] = useState(null);
 
@@ -169,6 +173,14 @@ function PromptGeneratorDialog({ open, onClose, onApply }) {
                 작업판 선택
               </Button>
             </Box>
+          ) : conversationMode ? (
+            <WorkboardChatPanel
+              workboard={selectedWorkboard}
+              onUseMessage={(content) => {
+                if (onApply) onApply(content);
+                handleClose();
+              }}
+            />
           ) : (
             <PromptGeneratorPanel
               workboard={selectedWorkboard}
@@ -181,15 +193,17 @@ function PromptGeneratorDialog({ open, onClose, onApply }) {
         </DialogContent>
         <DialogActions>
           <Button onClick={handleClose}>취소</Button>
-          <Button
-            variant="contained"
-            color="primary"
-            onClick={handleApply}
-            disabled={!generatedPrompt}
-            startIcon={<Check />}
-          >
-            적용
-          </Button>
+          {!conversationMode && (
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={handleApply}
+              disabled={!generatedPrompt}
+              startIcon={<Check />}
+            >
+              적용
+            </Button>
+          )}
         </DialogActions>
       </Dialog>
 

--- a/frontend/src/components/common/WorkboardChatPanel.js
+++ b/frontend/src/components/common/WorkboardChatPanel.js
@@ -40,7 +40,7 @@ import ChatBubble from './chat/ChatBubble';
 // PromptGeneration 페이지에서 workboard.conversation_mode = true 일 때 PromptGeneratorPanel 대신 렌더.
 // 매번 새 대화로 시작. 첫 메시지 전송 전엔 설정 (model / temperature / system_prompt 등) 편집 가능,
 // 전송 후엔 lock + collapse.
-function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
+function WorkboardChatPanel({ workboard, projectId, useWorldview, onUseMessage }) {
   const [conversationId, setConversationId] = useState(null);
   const [settingsOpen, setSettingsOpen] = useState(true);
   const [newMessage, setNewMessage] = useState('');
@@ -332,15 +332,23 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview }) {
                 content={msg.content}
                 attachments={msg.attachments}
                 actions={msg.role === 'assistant' && (
-                  <Tooltip title="이 응답을 텍스트 컨텐츠로 저장">
-                    <IconButton
-                      size="small"
-                      onClick={() => saveMessageMutation.mutate({ conversationJobId: conversationId, messageIndex: idx })}
-                      disabled={saveMessageMutation.isLoading}
-                    >
-                      <BookmarkAddIcon fontSize="small" />
-                    </IconButton>
-                  </Tooltip>
+                  <>
+                    {/* 호출 모드 (#574): 이 응답을 호출측 프롬프트로 반환 */}
+                    {onUseMessage && (
+                      <Button variant="outlined" color="primary" onClick={() => onUseMessage(msg.content)}>
+                        이 응답을 프롬프트로 사용
+                      </Button>
+                    )}
+                    <Tooltip title="이 응답을 텍스트 컨텐츠로 저장">
+                      <IconButton
+                        size="small"
+                        onClick={() => saveMessageMutation.mutate({ conversationJobId: conversationId, messageIndex: idx })}
+                        disabled={saveMessageMutation.isLoading}
+                      >
+                        <BookmarkAddIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  </>
                 )}
               />
             ))}


### PR DESCRIPTION
## 변경사항 (설계: "작업판 = 함수, 반환 = 대화 중 선택한 메시지")

- 이미지 작업판의 'AI 프롬프트 생성' 호출에서 **멀티턴 텍스트 작업판 지원**: conversation_mode 작업판 선택 시 다이얼로그 안에서 멀티턴 대화, 각 AI 응답에 **'이 응답을 프롬프트로 사용'** → 해당 메시지가 호출측 프롬프트 필드로 반환 + 다이얼로그 닫힘
- 단일턴 작업판은 기존 '적용' 흐름 그대로 (하위호환)
- 대화는 ConversationJob 으로 저장 → 히스토리에서 이어가기 가능 (부산물)

## 검증 (라이브 E2E)
Playwright 로 실제 시나리오 구동: 이미지 작업판 → AI 프롬프트 생성 → GPT Chat(멀티턴) 선택 → 메시지 전송 → 스트리밍 응답 → 버튼 클릭 → **프롬프트 필드에 응답 반영 확인** ("Majestic alpine mountains at sunrise…")

closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)