### PR TITLE
chore: react-query v3 → @tanstack/react-query v5 (#526 ❷)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "@hello-pangea/dnd": "^16.6.0",
     "@mui/icons-material": "^5.15.3",
     "@mui/material": "^5.15.3",
+    "@tanstack/react-query": "^5.101.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.5.2",
@@ -22,14 +23,13 @@
     "react-hook-form": "^7.48.2",
     "react-hot-toast": "^2.4.1",
     "react-markdown": "^10.1.0",
-    "react-query": "^3.39.3",
     "react-router-dom": "^6.8.1"
   },
   "devDependencies": {
     "@types/js-cookie": "^3.0.6",
     "@types/lodash": "^4.14.202",
-    "vite": "^7.3.0",
-    "@vitejs/plugin-react": "^5.1.0"
+    "@vitejs/plugin-react": "^5.1.0",
+    "vite": "^7.3.0"
   },
   "scripts": {
     "start": "vite",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@mui/material':
         specifier: ^5.15.3
         version: 5.18.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/react-query':
+        specifier: ^5.101.0
+        version: 5.101.0(react@18.3.1)
       '@testing-library/jest-dom':
         specifier: ^5.17.0
         version: 5.17.0
@@ -65,9 +68,6 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@18.3.27)(react@18.3.1)
-      react-query:
-        specifier: ^3.39.3
-        version: 3.39.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router-dom:
         specifier: ^6.8.1
         version: 6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -716,6 +716,14 @@ packages:
   '@sinclair/typebox@0.34.47':
     resolution: {integrity: sha512-ZGIBQ+XDvO5JQku9wmwtabcVTHJsgSWAHYtVuM9pBNNR5E88v6Jcj/llpmsjivig5X8A8HHOb4/mbEKPS5EvAw==}
 
+  '@tanstack/query-core@5.101.0':
+    resolution: {integrity: sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==}
+
+  '@tanstack/react-query@5.101.0':
+    resolution: {integrity: sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==}
+    peerDependencies:
+      react: ^18 || ^19
+
   '@testing-library/dom@8.20.1':
     resolution: {integrity: sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==}
     engines: {node: '>=12'}
@@ -901,26 +909,13 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   baseline-browser-mapping@2.9.17:
     resolution: {integrity: sha512-agD0MgJFUP/4nvjqzIB29zRPUuCF7Ge6mEv9s8dHrtYD7QWXRcx75rOADE/d5ah1NI+0vkDl0yorDd5U852IQQ==}
     hasBin: true
 
-  big-integer@1.6.52:
-    resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
-    engines: {node: '>=0.6'}
-
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
-
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
-
-  broadcast-channel@3.7.0:
-    resolution: {integrity: sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==}
 
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
@@ -997,9 +992,6 @@ packages:
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
-
   convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
 
@@ -1053,9 +1045,6 @@ packages:
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
-
-  detect-node@2.1.0:
-    resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -1162,9 +1151,6 @@ packages:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
-  fs.realpath@1.0.0:
-    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1187,10 +1173,6 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
-
-  glob@7.2.3:
-    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   goober@2.1.18:
     resolution: {integrity: sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==}
@@ -1246,13 +1228,6 @@ packages:
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
-
-  inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
-
-  inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
@@ -1382,9 +1357,6 @@ packages:
   js-cookie@3.0.8:
     resolution: {integrity: sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==}
 
-  js-sha3@0.8.0:
-    resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
-
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1420,9 +1392,6 @@ packages:
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
-
-  match-sorter@6.3.4:
-    resolution: {integrity: sha512-jfZW7cWS5y/1xswZo8VBOdudUiSd9nifYRWphc9M5D/ee4w4AoXLgBEdRbgVaxbMuagBPeUC5y2Hi8DO6o9aDg==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -1522,9 +1491,6 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
-  microseconds@0.2.0:
-    resolution: {integrity: sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==}
-
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
@@ -1537,14 +1503,8 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
-
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-
-  nano-time@1.0.0:
-    resolution: {integrity: sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -1574,12 +1534,6 @@ packages:
     resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
     engines: {node: '>= 0.4'}
 
-  oblivious-set@1.0.0:
-    resolution: {integrity: sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==}
-
-  once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
-
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -1590,10 +1544,6 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
-
-  path-is-absolute@1.0.1:
-    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
-    engines: {node: '>=0.10.0'}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -1683,18 +1633,6 @@ packages:
       '@types/react': '>=18'
       react: '>=18'
 
-  react-query@3.39.3:
-    resolution: {integrity: sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: '*'
-      react-native: '*'
-    peerDependenciesMeta:
-      react-dom:
-        optional: true
-      react-native:
-        optional: true
-
   react-redux@8.1.3:
     resolution: {integrity: sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==}
     peerDependencies:
@@ -1760,9 +1698,6 @@ packages:
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
 
-  remove-accents@0.5.0:
-    resolution: {integrity: sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==}
-
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -1770,11 +1705,6 @@ packages:
   resolve@1.22.11:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
-    hasBin: true
-
-  rimraf@3.0.2:
-    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rollup@4.61.1:
@@ -1917,9 +1847,6 @@ packages:
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
-  unload@2.2.0:
-    resolution: {integrity: sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==}
-
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -1993,9 +1920,6 @@ packages:
   which-typed-array@1.1.20:
     resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
     engines: {node: '>= 0.4'}
-
-  wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -2575,6 +2499,13 @@ snapshots:
 
   '@sinclair/typebox@0.34.47': {}
 
+  '@tanstack/query-core@5.101.0': {}
+
+  '@tanstack/react-query@5.101.0(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.101.0
+      react: 18.3.1
+
   '@testing-library/dom@8.20.1':
     dependencies:
       '@babel/code-frame': 7.28.6
@@ -2783,31 +2714,11 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@1.0.2: {}
-
   baseline-browser-mapping@2.9.17: {}
-
-  big-integer@1.6.52: {}
-
-  brace-expansion@1.1.12:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
 
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
-
-  broadcast-channel@3.7.0:
-    dependencies:
-      '@babel/runtime': 7.28.6
-      detect-node: 2.1.0
-      js-sha3: 0.8.0
-      microseconds: 0.2.0
-      nano-time: 1.0.0
-      oblivious-set: 1.0.0
-      rimraf: 3.0.2
-      unload: 2.2.0
 
   browserslist@4.28.1:
     dependencies:
@@ -2880,8 +2791,6 @@ snapshots:
   commander@2.20.3:
     optional: true
 
-  concat-map@0.0.1: {}
-
   convert-source-map@1.9.0: {}
 
   convert-source-map@2.0.0: {}
@@ -2948,8 +2857,6 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   dequal@2.0.3: {}
-
-  detect-node@2.1.0: {}
 
   devlop@1.1.0:
     dependencies:
@@ -3081,8 +2988,6 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
-  fs.realpath@1.0.0: {}
-
   fsevents@2.3.3:
     optional: true
 
@@ -3109,15 +3014,6 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
-
-  glob@7.2.3:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.2
-      once: 1.4.0
-      path-is-absolute: 1.0.1
 
   goober@2.1.18(csstype@3.2.3):
     dependencies:
@@ -3181,13 +3077,6 @@ snapshots:
       resolve-from: 4.0.0
 
   indent-string@4.0.0: {}
-
-  inflight@1.0.6:
-    dependencies:
-      once: 1.4.0
-      wrappy: 1.0.2
-
-  inherits@2.0.4: {}
 
   inline-style-parser@0.2.7: {}
 
@@ -3333,8 +3222,6 @@ snapshots:
 
   js-cookie@3.0.8: {}
 
-  js-sha3@0.8.0: {}
-
   js-tokens@4.0.0: {}
 
   jsesc@3.1.0: {}
@@ -3358,11 +3245,6 @@ snapshots:
       yallist: 3.1.1
 
   lz-string@1.5.0: {}
-
-  match-sorter@6.3.4:
-    dependencies:
-      '@babel/runtime': 7.28.6
-      remove-accents: 0.5.0
 
   math-intrinsics@1.1.0: {}
 
@@ -3595,8 +3477,6 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
-  microseconds@0.2.0: {}
-
   mime-db@1.52.0: {}
 
   mime-types@2.1.35:
@@ -3605,15 +3485,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  minimatch@3.1.2:
-    dependencies:
-      brace-expansion: 1.1.12
-
   ms@2.1.3: {}
-
-  nano-time@1.0.0:
-    dependencies:
-      big-integer: 1.6.52
 
   nanoid@3.3.11: {}
 
@@ -3639,12 +3511,6 @@ snapshots:
       has-symbols: 1.1.0
       object-keys: 1.1.1
 
-  oblivious-set@1.0.0: {}
-
-  once@1.4.0:
-    dependencies:
-      wrappy: 1.0.2
-
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -3665,8 +3531,6 @@ snapshots:
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
-
-  path-is-absolute@1.0.1: {}
 
   path-parse@1.0.7: {}
 
@@ -3760,15 +3624,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-query@3.39.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@babel/runtime': 7.28.6
-      broadcast-channel: 3.7.0
-      match-sorter: 6.3.4
-      react: 18.3.1
-    optionalDependencies:
-      react-dom: 18.3.1(react@18.3.1)
-
   react-redux@8.1.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1):
     dependencies:
       '@babel/runtime': 7.28.6
@@ -3846,8 +3701,6 @@ snapshots:
       unified: 11.0.5
       vfile: 6.0.3
 
-  remove-accents@0.5.0: {}
-
   resolve-from@4.0.0: {}
 
   resolve@1.22.11:
@@ -3855,10 +3708,6 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-
-  rimraf@3.0.2:
-    dependencies:
-      glob: 7.2.3
 
   rollup@4.61.1:
     dependencies:
@@ -4058,11 +3907,6 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  unload@2.2.0:
-    dependencies:
-      '@babel/runtime': 7.28.6
-      detect-node: 2.1.0
-
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
       browserslist: 4.28.1
@@ -4125,8 +3969,6 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-tostringtag: 1.0.2
-
-  wrappy@1.0.2: {}
 
   yallist@3.1.1: {}
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate, useLocation } from 'react-router-dom';
-import { QueryClient, QueryClientProvider, useQueryClient } from 'react-query';
+import { QueryClient, QueryClientProvider, useQueryClient } from '@tanstack/react-query';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { Box } from '@mui/material';
 import { buildVccTheme } from './theme';
@@ -109,10 +109,10 @@ function MainLayout() {
   useEffect(() => {
     const refreshPaths = ['/jobs', '/content'];
     if (refreshPaths.includes(location.pathname)) {
-      queryClient.invalidateQueries('historyJobs');
-      queryClient.invalidateQueries('generatedImages');
-      queryClient.invalidateQueries('uploadedImages');
-      queryClient.invalidateQueries('generatedVideos');
+      queryClient.invalidateQueries({ queryKey: ['historyJobs'] });
+      queryClient.invalidateQueries({ queryKey: ['generatedImages'] });
+      queryClient.invalidateQueries({ queryKey: ['uploadedImages'] });
+      queryClient.invalidateQueries({ queryKey: ['generatedVideos'] });
     }
   }, [location.pathname, queryClient]);
 

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -30,7 +30,7 @@ import {
   Dns as DnsIcon
 } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
-import { useQuery } from 'react-query';
+import { useQuery } from '@tanstack/react-query';
 import { useAuth } from '../contexts/AuthContext';
 import { useColorScheme } from '../contexts/ColorSchemeContext';
 import { serverAPI } from '../services/api';
@@ -53,10 +53,9 @@ const pillSx = {
 // 서버 상태 필 — GET /servers (일반 사용자 접근 가능) 실데이터
 function ServerStatusPill({ isAdmin }) {
   const navigate = useNavigate();
-  const { data } = useQuery('servers', () => serverAPI.getServers(), {
+  const { data } = useQuery({ queryKey: ['servers'], queryFn: () => serverAPI.getServers(),
     staleTime: 30000,
-    refetchInterval: 60000,
-  });
+    refetchInterval: 60000, });
   const servers = data?.data?.data?.servers || [];
   if (!servers.length) return null;
 

--- a/frontend/src/components/PromptGeneratorDialog.js
+++ b/frontend/src/components/PromptGeneratorDialog.js
@@ -15,17 +15,13 @@ import {
   ListItemText
 } from '@mui/material';
 import { Chat, Check } from '@mui/icons-material';
-import { useQuery } from 'react-query';
+import { useQuery } from '@tanstack/react-query';
 import { workboardAPI } from '../services/api';
 import PromptGeneratorPanel from './PromptGeneratorPanel';
 import WorkboardChatPanel from './common/WorkboardChatPanel';
 
 function PromptWorkboardSelectDialog({ open, onClose, onSelect }) {
-  const { data, isLoading } = useQuery(
-    ['promptWorkboards'],
-    () => workboardAPI.getAll({ outputFormat: 'text', limit: 50 }),
-    { enabled: open }
-  );
+  const { data, isLoading } = useQuery({ queryKey: ['promptWorkboards'], queryFn: () => workboardAPI.getAll({ outputFormat: 'text', limit: 50 }), enabled: open });
 
   const workboards = data?.data?.workboards || [];
 

--- a/frontend/src/components/PromptGeneratorPanel.js
+++ b/frontend/src/components/PromptGeneratorPanel.js
@@ -25,7 +25,7 @@ import {
   Chat,
   ContentCopy
 } from '@mui/icons-material';
-import { useQuery } from 'react-query';
+import { useQuery } from '@tanstack/react-query';
 import { useForm, Controller } from 'react-hook-form';
 import { useDropzone } from 'react-dropzone';
 import toast from 'react-hot-toast';
@@ -156,11 +156,7 @@ function PromptGeneratorPanel({
     }
   });
 
-  const { data: workboardData, isLoading: workboardLoading, error: workboardError } = useQuery(
-    ['workboard', workboardId],
-    () => workboardAPI.getById(workboardId),
-    { enabled: !!workboardId && !externalWorkboard }
-  );
+  const { data: workboardData, isLoading: workboardLoading, error: workboardError } = useQuery({ queryKey: ['workboard', workboardId], queryFn: () => workboardAPI.getById(workboardId), enabled: !!workboardId && !externalWorkboard });
 
   const workboard = externalWorkboard || workboardData?.data?.workboard;
 

--- a/frontend/src/components/admin/AdminDashboard.js
+++ b/frontend/src/components/admin/AdminDashboard.js
@@ -17,7 +17,7 @@ import {
   Refresh,
   Error as ErrorIcon
 } from '@mui/icons-material';
-import { useQuery } from 'react-query';
+import { useQuery } from '@tanstack/react-query';
 import { adminAPI, jobAPI } from '../../services/api';
 import config from '../../config';
 import PageHeader from '../common/PageHeader';
@@ -48,16 +48,9 @@ function StatCard({ title, value, subtitle, icon, color = 'primary' }) {
 }
 
 function AdminDashboard() {
-  const { data: stats, isLoading: statsLoading, refetch } = useQuery(
-    'adminStats',
-    adminAPI.getStats
-  );
+  const { data: stats, isLoading: statsLoading, refetch } = useQuery({ queryKey: ['adminStats'], queryFn: adminAPI.getStats });
 
-  const { data: queueStats, isLoading: queueLoading } = useQuery(
-    'queueStatsAdmin',
-    jobAPI.getQueueStats,
-    { refetchInterval: config.monitoring.queueStatusInterval }
-  );
+  const { data: queueStats, isLoading: queueLoading } = useQuery({ queryKey: ['queueStatsAdmin'], queryFn: jobAPI.getQueueStats, refetchInterval: config.monitoring.queueStatusInterval });
 
   if (statsLoading) {
     return (

--- a/frontend/src/components/admin/ServerManagement.js
+++ b/frontend/src/components/admin/ServerManagement.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Box,
   Typography,
@@ -41,7 +41,7 @@ import {
   CloudSync as CloudSyncIcon,
   RestartAlt as RestartAltIcon
 } from '@mui/icons-material';
-import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { serverAPI, jobAPI } from '../../services/api';
 import { getServerTypeColor } from '../../templates/capabilities';
@@ -474,21 +474,13 @@ function ServerManagement() {
   const queryClient = useQueryClient();
 
   // 서버 목록 조회 (admin: 비활성 포함)
-  const { data: serversData, isLoading } = useQuery(
-    ['servers', { includeInactive: true }],
-    () => serverAPI.getServers({ includeInactive: true }),
-    { refetchInterval: 30000 } // 30초마다 갱신
-  );
+  const { data: serversData, isLoading } = useQuery({ queryKey: ['servers', { includeInactive: true }], queryFn: () => serverAPI.getServers({ includeInactive: true }), refetchInterval: 30000 /* 30초마다 갱신 */ });
 
   // ComfyUI 서버들의 LoRA 동기화 상태 조회
   const servers = serversData?.data?.data?.servers || [];
 
   // 요약: 온라인 수 + 전체 큐(서버별 큐 수집 데이터가 없어 전체 큐로 표시)
-  const { data: queueStatsData } = useQuery(
-    'serverQueueStats',
-    () => jobAPI.getQueueStats(),
-    { refetchInterval: 10000 }
-  );
+  const { data: queueStatsData } = useQuery({ queryKey: ['serverQueueStats'], queryFn: () => jobAPI.getQueueStats(), refetchInterval: 10000 });
   const queueStats = queueStatsData?.data?.stats || {};
   const onlineCount = servers.filter((s) => s.healthCheck?.status === 'healthy').length;
   const activeQueue = (queueStats.active || 0) + (queueStats.waiting || 0);
@@ -497,9 +489,7 @@ function ServerManagement() {
     ['ComfyUI', 'OpenAI', 'OpenAI Compatible', 'Gemini'].includes(s.serverType)
   );
 
-  useQuery(
-    ['loraSyncStatuses', comfyUIServers.map(s => s._id).join(',')],
-    async () => {
+  const { data: loraSyncData } = useQuery({ queryKey: ['loraSyncStatuses', comfyUIServers.map(s => s._id).join(',')], queryFn: async () => {
       const statuses = {};
       for (const server of comfyUIServers) {
         try {
@@ -511,23 +501,18 @@ function ServerManagement() {
       }
       return statuses;
     },
-    {
       enabled: comfyUIServers.length > 0,
-      refetchInterval: (data) => {
-        // 동기화 중인 서버가 있으면 3초마다, 아니면 30초마다
+      // v5: refetchInterval 시그니처 (query) => — 동기화 중이면 3초, 아니면 30초 (#526)
+      refetchInterval: (query) => {
+        const data = query.state.data;
         const hasSyncing = data && Object.values(data).some(s => s?.status === 'fetching');
         return hasSyncing ? 3000 : 30000;
-      },
-      onSuccess: (data) => {
-        setLoraSyncStatuses(data || {});
-      }
-    }
-  );
+      } });
+  // v5: query onSuccess 제거 — data 동기화는 effect 로 (#526)
+  useEffect(() => { setLoraSyncStatuses(loraSyncData || {}); }, [loraSyncData]);
 
   // 모델 동기화 상태 조회 (4종 serverType)
-  useQuery(
-    ['modelSyncStatuses', modelSyncSupportedServers.map(s => s._id).join(',')],
-    async () => {
+  const { data: modelSyncData } = useQuery({ queryKey: ['modelSyncStatuses', modelSyncSupportedServers.map(s => s._id).join(',')], queryFn: async () => {
       const statuses = {};
       for (const server of modelSyncSupportedServers) {
         try {
@@ -539,138 +524,102 @@ function ServerManagement() {
       }
       return statuses;
     },
-    {
       enabled: modelSyncSupportedServers.length > 0,
-      refetchInterval: (data) => {
+      refetchInterval: (query) => {
+        const data = query.state.data;
         const hasSyncing = data && Object.values(data).some(s => s?.status === 'fetching');
         return hasSyncing ? 3000 : 30000;
-      },
-      onSuccess: (data) => {
-        setModelSyncStatuses(data || {});
-      }
-    }
-  );
+      } });
+  useEffect(() => { setModelSyncStatuses(modelSyncData || {}); }, [modelSyncData]);
 
   // 서버 생성/수정 mutation
-  const serverMutation = useMutation(
-    async (serverData) => {
+  const serverMutation = useMutation({ mutationFn: async (serverData) => {
       if (selectedServer) {
         return serverAPI.updateServer(selectedServer._id, serverData);
       } else {
         return serverAPI.createServer(serverData);
       }
     },
-    {
       onSuccess: () => {
         toast.success(selectedServer ? '서버가 수정되었습니다.' : '서버가 생성되었습니다.');
         setDialogOpen(false);
         setSelectedServer(null);
-        queryClient.invalidateQueries(['servers']);
+        queryClient.invalidateQueries({ queryKey: ['servers'] });
       },
       onError: (error) => {
         toast.error(error.response?.data?.message || '서버 저장에 실패했습니다.');
-      }
-    }
-  );
+      } });
 
   // 서버 삭제 mutation
-  const deleteMutation = useMutation(
-    (id) => serverAPI.deleteServer(id),
-    {
+  const deleteMutation = useMutation({ mutationFn: (id) => serverAPI.deleteServer(id),
       onSuccess: () => {
         toast.success('서버가 삭제되었습니다.');
         setDeleteConfirmOpen(false);
         setServerToDelete(null);
-        queryClient.invalidateQueries(['servers']);
+        queryClient.invalidateQueries({ queryKey: ['servers'] });
       },
       onError: (error) => {
         toast.error(error.response?.data?.message || '서버 삭제에 실패했습니다.');
-      }
-    }
-  );
+      } });
 
   // 헬스체크 mutation
-  const healthCheckMutation = useMutation(
-    (id) => serverAPI.checkServerHealth(id),
-    {
+  const healthCheckMutation = useMutation({ mutationFn: (id) => serverAPI.checkServerHealth(id),
       onSuccess: () => {
         toast.success('헬스체크가 완료되었습니다.');
-        queryClient.invalidateQueries(['servers']);
+        queryClient.invalidateQueries({ queryKey: ['servers'] });
       },
       onError: (error) => {
         toast.error(error.response?.data?.message || '헬스체크에 실패했습니다.');
-      }
-    }
-  );
+      } });
 
   // 전체 헬스체크 mutation
-  const allHealthCheckMutation = useMutation(
-    () => serverAPI.checkAllServersHealth(),
-    {
+  const allHealthCheckMutation = useMutation({ mutationFn: () => serverAPI.checkAllServersHealth(),
       onSuccess: (response) => {
         const { data } = response.data;
         toast.success(`${data.total}개 서버 헬스체크 완료 (성공: ${data.success}, 실패: ${data.failed})`);
-        queryClient.invalidateQueries(['servers']);
+        queryClient.invalidateQueries({ queryKey: ['servers'] });
       },
       onError: (error) => {
         toast.error(error.response?.data?.message || '헬스체크에 실패했습니다.');
-      }
-    }
-  );
+      } });
 
   // LoRA 동기화 mutation
-  const loraSyncMutation = useMutation(
-    (serverId) => serverAPI.syncLoras(serverId),
-    {
+  const loraSyncMutation = useMutation({ mutationFn: (serverId) => serverAPI.syncLoras(serverId),
       onSuccess: () => {
         toast.success('LoRA 동기화가 시작되었습니다.');
-        queryClient.invalidateQueries(['loraSyncStatuses']);
+        queryClient.invalidateQueries({ queryKey: ['loraSyncStatuses'] });
       },
       onError: (error) => {
         toast.error(error.response?.data?.message || 'LoRA 동기화에 실패했습니다.');
-      }
-    }
-  );
+      } });
 
   // 모델 동기화 mutation (4종 serverType — 각각 dispatch 는 backend 가 처리)
-  const modelSyncMutation = useMutation(
-    (serverId) => serverAPI.syncModels(serverId),
-    {
+  const modelSyncMutation = useMutation({ mutationFn: (serverId) => serverAPI.syncModels(serverId),
       onSuccess: () => {
         toast.success('모델 동기화가 시작되었습니다.');
-        queryClient.invalidateQueries(['modelSyncStatuses']);
+        queryClient.invalidateQueries({ queryKey: ['modelSyncStatuses'] });
       },
       onError: (error) => {
         toast.error(error.response?.data?.message || '모델 동기화에 실패했습니다.');
-      }
-    }
-  );
+      } });
 
   // LoRA / 모델 sync 상태 강제 리셋 mutation (#256)
-  const loraResetMutation = useMutation(
-    (serverId) => serverAPI.resetLorasSync(serverId),
-    {
+  const loraResetMutation = useMutation({ mutationFn: (serverId) => serverAPI.resetLorasSync(serverId),
       onSuccess: () => {
         toast.success('LoRA 동기화 상태가 초기화되었습니다.');
-        queryClient.invalidateQueries(['loraSyncStatuses']);
+        queryClient.invalidateQueries({ queryKey: ['loraSyncStatuses'] });
       },
       onError: (error) => {
         toast.error(error.response?.data?.message || '리셋 실패');
-      }
-    }
-  );
-  const modelResetMutation = useMutation(
-    (serverId) => serverAPI.resetModelsSync(serverId),
-    {
+      } });
+  const modelResetMutation = useMutation({ mutationFn: (serverId) => serverAPI.resetModelsSync(serverId),
       onSuccess: () => {
         toast.success('모델 동기화 상태가 초기화되었습니다.');
-        queryClient.invalidateQueries(['modelSyncStatuses']);
+        queryClient.invalidateQueries({ queryKey: ['modelSyncStatuses'] });
       },
       onError: (error) => {
         toast.error(error.response?.data?.message || '리셋 실패');
-      }
-    }
-  );
+      } });
 
   const handleAddServer = () => {
     setSelectedServer(null);
@@ -727,7 +676,7 @@ function ServerManagement() {
         sx={{ mb: 4 }}
         actions={(
           <>
-            <Button variant="outlined" startIcon={<Refresh />} onClick={handleAllHealthCheck} disabled={allHealthCheckMutation.isLoading}>전체 헬스체크</Button>
+            <Button variant="outlined" startIcon={<Refresh />} onClick={handleAllHealthCheck} disabled={allHealthCheckMutation.isPending}>전체 헬스체크</Button>
             <Button variant="contained" startIcon={<Add />} onClick={handleAddServer}>서버 추가</Button>
           </>
         )}
@@ -799,7 +748,7 @@ function ServerManagement() {
             onClick={() => deleteMutation.mutate(serverToDelete._id)}
             color="error"
             variant="contained"
-            disabled={deleteMutation.isLoading}
+            disabled={deleteMutation.isPending}
           >
             삭제
           </Button>

--- a/frontend/src/components/admin/SystemStats.js
+++ b/frontend/src/components/admin/SystemStats.js
@@ -14,27 +14,17 @@ import {
   LinearProgress,
   Chip
 } from '@mui/material';
-import { useQuery } from 'react-query';
+import { useQuery } from '@tanstack/react-query';
 import { adminAPI, jobAPI } from '../../services/api';
 import config from '../../config';
 import PageHeader from '../common/PageHeader';
 
 function SystemStats() {
-  const { data: stats, isLoading: statsLoading } = useQuery(
-    'adminStatsDetailed',
-    adminAPI.getStats
-  );
+  const { data: stats, isLoading: statsLoading } = useQuery({ queryKey: ['adminStatsDetailed'], queryFn: adminAPI.getStats });
 
-  const { data: recentJobs, isLoading: jobsLoading } = useQuery(
-    'adminAllJobs',
-    () => adminAPI.getJobs({ limit: 20 })
-  );
+  const { data: recentJobs, isLoading: jobsLoading } = useQuery({ queryKey: ['adminAllJobs'], queryFn: () => adminAPI.getJobs({ limit: 20 }) });
 
-  const { data: queueStats, isLoading: queueLoading } = useQuery(
-    'queueStatsDetailed',
-    jobAPI.getQueueStats,
-    { refetchInterval: config.monitoring.queueStatusInterval }
-  );
+  const { data: queueStats, isLoading: queueLoading } = useQuery({ queryKey: ['queueStatsDetailed'], queryFn: jobAPI.getQueueStats, refetchInterval: config.monitoring.queueStatusInterval });
 
   if (statsLoading || jobsLoading || queueLoading) {
     return (

--- a/frontend/src/components/admin/UserManagement.js
+++ b/frontend/src/components/admin/UserManagement.js
@@ -37,7 +37,7 @@ import {
   Close,
   HourglassEmpty
 } from '@mui/icons-material';
-import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { adminAPI } from '../../services/api';
 import PageHeader from '../common/PageHeader';
@@ -54,51 +54,35 @@ function UserManagement() {
 
   const queryClient = useQueryClient();
 
-  const { data, isLoading, refetch } = useQuery(
-    ['adminUsers', { search, approvalStatus, page: page + 1, limit: rowsPerPage }],
-    () => adminAPI.getUsers({ search, approvalStatus, page: page + 1, limit: rowsPerPage }),
-    { keepPreviousData: true }
-  );
+  const { data, isLoading, refetch } = useQuery({ queryKey: ['adminUsers', { search, approvalStatus, page: page + 1, limit: rowsPerPage }], queryFn: () => adminAPI.getUsers({ search, approvalStatus, page: page + 1, limit: rowsPerPage }), placeholderData: keepPreviousData });
 
-  const deleteMutation = useMutation(
-    adminAPI.deleteUser,
-    {
+  const deleteMutation = useMutation({ mutationFn: adminAPI.deleteUser,
       onSuccess: () => {
         toast.success('사용자가 삭제되었습니다');
-        queryClient.invalidateQueries('adminUsers');
+        queryClient.invalidateQueries({ queryKey: ['adminUsers'] });
         setDeleteDialogOpen(false);
       },
       onError: (error) => {
         toast.error('삭제 실패: ' + error.message);
-      }
-    }
-  );
+      } });
 
-  const approveMutation = useMutation(
-    adminAPI.approveUser,
-    {
+  const approveMutation = useMutation({ mutationFn: adminAPI.approveUser,
       onSuccess: () => {
         toast.success('사용자가 승인되었습니다');
-        queryClient.invalidateQueries('adminUsers');
+        queryClient.invalidateQueries({ queryKey: ['adminUsers'] });
       },
       onError: (error) => {
         toast.error('승인 실패: ' + error.message);
-      }
-    }
-  );
+      } });
 
-  const rejectMutation = useMutation(
-    adminAPI.rejectUser,
-    {
+  const rejectMutation = useMutation({ mutationFn: adminAPI.rejectUser,
       onSuccess: () => {
         toast.success('사용자 승인이 거절되었습니다');
-        queryClient.invalidateQueries('adminUsers');
+        queryClient.invalidateQueries({ queryKey: ['adminUsers'] });
       },
       onError: (error) => {
         toast.error('거절 실패: ' + error.message);
-      }
-    }
-  );
+      } });
 
   const users = data?.data?.users || [];
   const pagination = data?.data?.pagination || { total: 0, pages: 0 };
@@ -242,7 +226,7 @@ function UserManagement() {
                                 <IconButton
                                   color="success"
                                   onClick={() => handleApprove(user._id)}
-                                  disabled={approveMutation.isLoading}
+                                  disabled={approveMutation.isPending}
                                   size="small"
                                   title="승인"
                                 >
@@ -251,7 +235,7 @@ function UserManagement() {
                                 <IconButton
                                   color="error"
                                   onClick={() => handleReject(user._id)}
-                                  disabled={rejectMutation.isLoading}
+                                  disabled={rejectMutation.isPending}
                                   size="small"
                                   title="거절"
                                 >
@@ -309,9 +293,9 @@ function UserManagement() {
             onClick={handleDeleteConfirm}
             color="error"
             variant="contained"
-            disabled={deleteMutation.isLoading}
+            disabled={deleteMutation.isPending}
           >
-            {deleteMutation.isLoading ? '삭제 중...' : '삭제'}
+            {deleteMutation.isPending ? '삭제 중...' : '삭제'}
           </Button>
         </DialogActions>
       </Dialog>

--- a/frontend/src/components/admin/WorkboardBasicInfoForm.js
+++ b/frontend/src/components/admin/WorkboardBasicInfoForm.js
@@ -12,7 +12,7 @@ import {
   Alert,
 } from '@mui/material';
 import { Controller, useWatch } from 'react-hook-form';
-import { useQuery } from 'react-query';
+import { useQuery } from '@tanstack/react-query';
 import { serverAPI } from '../../services/api';
 import {
   getCapableOutputFormats,
@@ -24,11 +24,7 @@ function WorkboardBasicInfoForm({ control, setValue, errors, showActiveSwitch = 
   const selectedServerId = useWatch({ control, name: 'serverId' });
   const outputFormat = useWatch({ control, name: 'outputFormat' }) || 'image';
 
-  const { data: serversData } = useQuery(
-    ['servers', { includeInactive: false }],
-    () => serverAPI.getServers({ includeInactive: false }),
-    { enabled: isDialogOpen }
-  );
+  const { data: serversData } = useQuery({ queryKey: ['servers', { includeInactive: false }], queryFn: () => serverAPI.getServers({ includeInactive: false }), enabled: isDialogOpen });
 
   const servers = serversData?.data?.data?.servers || [];
   const selectedServer = servers.find((s) => s._id === selectedServerId);

--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -53,7 +53,7 @@ import {
   PlaylistAdd
 } from '@mui/icons-material';
 import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd';
-import { useQuery } from 'react-query';
+import { useQuery } from '@tanstack/react-query';
 import { useForm, Controller } from 'react-hook-form';
 import toast from 'react-hot-toast';
 import { workboardAPI, serverAPI, groupAPI } from '../../services/api';
@@ -71,11 +71,7 @@ import {
 // admin 의 customField 기본값 입력기 — type=baseModel/lora 일 때 서버 모델 목록 Autocomplete (#391)
 function ServerMetadataDefaultValueInput({ serverId, type, value, onChange, label }) {
   const fetcher = type === 'baseModel' ? serverAPI.getDetailedModels : serverAPI.getLoras;
-  const { data, isLoading } = useQuery(
-    ['adminDefaultValueMetadata', type, serverId],
-    () => fetcher(serverId, { limit: 200, detailed: true }),
-    { enabled: !!serverId, staleTime: 60_000 }
-  );
+  const { data, isLoading } = useQuery({ queryKey: ['adminDefaultValueMetadata', type, serverId], queryFn: () => fetcher(serverId, { limit: 200, detailed: true }), enabled: !!serverId, staleTime: 60_000 });
   const items = data?.data?.data?.items
     || data?.data?.data?.models
     || data?.data?.data?.loraModels

--- a/frontend/src/components/common/CommandPalette.js
+++ b/frontend/src/components/common/CommandPalette.js
@@ -20,7 +20,7 @@ import {
   ArrowForward as ArrowForwardIcon,
 } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
-import { useQuery } from 'react-query';
+import { useQuery } from '@tanstack/react-query';
 import { projectAPI, workboardAPI } from '../../services/api';
 import { useAuth } from '../../contexts/AuthContext';
 
@@ -57,16 +57,8 @@ export default function CommandPalette({ open, onClose }) {
   const inputRef = useRef(null);
   const listRef = useRef(null);
 
-  const { data: projData, isLoading: projLoading } = useQuery(
-    'cmdk-projects',
-    () => projectAPI.getAll({ limit: 100 }),
-    { enabled: open, staleTime: 60_000 }
-  );
-  const { data: wbData, isLoading: wbLoading } = useQuery(
-    'cmdk-workboards',
-    () => workboardAPI.getAll(),
-    { enabled: open, staleTime: 60_000 }
-  );
+  const { data: projData, isLoading: projLoading } = useQuery({ queryKey: ['cmdk-projects'], queryFn: () => projectAPI.getAll({ limit: 100 }), enabled: open, staleTime: 60_000 });
+  const { data: wbData, isLoading: wbLoading } = useQuery({ queryKey: ['cmdk-workboards'], queryFn: () => workboardAPI.getAll(), enabled: open, staleTime: 60_000 });
 
   const projects = projData?.data?.data?.projects || projData?.data?.projects || [];
   const workboards = wbData?.data?.workboards || wbData?.data?.data?.workboards || [];

--- a/frontend/src/components/common/ConversationChatPanel.js
+++ b/frontend/src/components/common/ConversationChatPanel.js
@@ -20,7 +20,7 @@ import {
   Settings as SystemIcon,
   BookmarkAdd as BookmarkAddIcon
 } from '@mui/icons-material';
-import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { conversationAPI, textAPI, imageAPI } from '../../services/api';
 import { useStreamingPrompt } from '../../hooks/useStreamingPrompt';
@@ -35,11 +35,7 @@ function ConversationChatPanel({ workboard, conversationId }) {
   const transcriptRef = useRef(null);
   const queryClient = useQueryClient();
 
-  const { data, isLoading, error } = useQuery(
-    ['conversation', conversationId],
-    () => conversationAPI.getById(conversationId),
-    { enabled: !!conversationId }
-  );
+  const { data, isLoading, error } = useQuery({ queryKey: ['conversation', conversationId], queryFn: () => conversationAPI.getById(conversationId), enabled: !!conversationId });
 
   const conversation = data?.data?.data;
   const messages = conversation?.messages || [];
@@ -50,16 +46,12 @@ function ConversationChatPanel({ workboard, conversationId }) {
     }
   }, [messages.length]);
 
-  const saveMessageMutation = useMutation(
-    ({ conversationJobId: cid, messageIndex }) => textAPI.createGenerated({ conversationJobId: cid, messageIndex }),
-    {
+  const saveMessageMutation = useMutation({ mutationFn: ({ conversationJobId: cid, messageIndex }) => textAPI.createGenerated({ conversationJobId: cid, messageIndex }),
       onSuccess: () => {
         toast.success('생성된 텍스트로 저장되었습니다.');
-        queryClient.invalidateQueries('generatedTexts');
+        queryClient.invalidateQueries({ queryKey: ['generatedTexts'] });
       },
-      onError: (err) => toast.error(err.response?.data?.message || '저장 실패'),
-    }
-  );
+      onError: (err) => toast.error(err.response?.data?.message || '저장 실패'), });
 
   // 스트리밍 전송 (#490)
   const { send: streamSend, streamingText, isStreaming } = useStreamingPrompt();
@@ -112,13 +104,13 @@ function ConversationChatPanel({ workboard, conversationId }) {
       {
         onDone: () => {
           setPendingUserMsg(null);
-          queryClient.invalidateQueries(['conversation', conversationId]);
-          queryClient.invalidateQueries('conversations');
+          queryClient.invalidateQueries({ queryKey: ['conversation', conversationId] });
+          queryClient.invalidateQueries({ queryKey: ['conversations'] });
         },
         onError: (err) => {
           toast.error('전송 실패: ' + (err.message || '알 수 없는 오류'));
           setPendingUserMsg(null);
-          queryClient.invalidateQueries(['conversation', conversationId]);
+          queryClient.invalidateQueries({ queryKey: ['conversation', conversationId] });
         },
       }
     );
@@ -182,7 +174,7 @@ function ConversationChatPanel({ workboard, conversationId }) {
                   <IconButton
                     size="small"
                     onClick={() => saveMessageMutation.mutate({ conversationJobId: conversationId, messageIndex: idx })}
-                    disabled={saveMessageMutation.isLoading}
+                    disabled={saveMessageMutation.isPending}
                   >
                     <BookmarkAddIcon fontSize="small" />
                   </IconButton>

--- a/frontend/src/components/common/ConversationHistoryPanel.js
+++ b/frontend/src/components/common/ConversationHistoryPanel.js
@@ -30,7 +30,7 @@ import {
   ExpandLess,
   ExpandMore
 } from '@mui/icons-material';
-import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import { Chat as ChatIcon, BookmarkAdd as BookmarkAddIcon } from '@mui/icons-material';
@@ -47,34 +47,22 @@ function ConversationHistoryPanel({ fetchFn, queryKey = 'conversations' }) {
   const navigate = useNavigate();
   const effectiveFetch = fetchFn || ((params) => conversationAPI.getMy(params));
 
-  const { data, isLoading, error } = useQuery(
-    [queryKey, page],
-    () => effectiveFetch({ page, limit: 20 }),
-    { keepPreviousData: true }
-  );
+  const { data, isLoading, error } = useQuery({ queryKey: [queryKey, page], queryFn: () => effectiveFetch({ page, limit: 20 }), placeholderData: keepPreviousData });
 
-  const deleteMutation = useMutation(
-    (id) => conversationAPI.delete(id),
-    {
+  const deleteMutation = useMutation({ mutationFn: (id) => conversationAPI.delete(id),
       onSuccess: () => {
         toast.success('대화를 삭제했습니다.');
-        queryClient.invalidateQueries('conversations');
+        queryClient.invalidateQueries({ queryKey: ['conversations'] });
         setDetailItem(null);
       },
-      onError: (err) => toast.error(err.response?.data?.message || '삭제 실패'),
-    }
-  );
+      onError: (err) => toast.error(err.response?.data?.message || '삭제 실패'), });
 
-  const saveMessageMutation = useMutation(
-    ({ conversationJobId, messageIndex }) => textAPI.createGenerated({ conversationJobId, messageIndex }),
-    {
+  const saveMessageMutation = useMutation({ mutationFn: ({ conversationJobId, messageIndex }) => textAPI.createGenerated({ conversationJobId, messageIndex }),
       onSuccess: () => {
         toast.success('생성된 텍스트로 저장되었습니다.');
-        queryClient.invalidateQueries('generatedTexts');
+        queryClient.invalidateQueries({ queryKey: ['generatedTexts'] });
       },
-      onError: (err) => toast.error(err.response?.data?.message || '저장 실패'),
-    }
-  );
+      onError: (err) => toast.error(err.response?.data?.message || '저장 실패'), });
 
   const conversations = data?.data?.data?.conversations || [];
   const pagination = data?.data?.data?.pagination || { current: 1, pages: 0, total: 0 };
@@ -287,7 +275,7 @@ function ConversationHistoryPanel({ fetchFn, queryKey = 'conversations' }) {
                       <IconButton
                         size="small"
                         onClick={() => saveMessageMutation.mutate({ conversationJobId: detailItem._id, messageIndex: idx })}
-                        disabled={saveMessageMutation.isLoading}
+                        disabled={saveMessageMutation.isPending}
                       >
                         <BookmarkAddIcon fontSize="small" />
                       </IconButton>

--- a/frontend/src/components/common/JobHistoryPanel.js
+++ b/frontend/src/components/common/JobHistoryPanel.js
@@ -46,7 +46,7 @@ import {
   ExpandMore,
   ExpandLess
 } from '@mui/icons-material';
-import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { useForm, Controller } from 'react-hook-form';
 import toast from 'react-hot-toast';
@@ -101,11 +101,7 @@ export function SavePromptDialog({ open, onClose, job, onSave }) {
   const tagsArePopulated = jobTags.length > 0 && typeof jobTags[0] === 'object';
 
   // populate되지 않은 경우에만 태그 정보 조회
-  const { data: allTagsData } = useQuery(
-    'allTags',
-    () => tagAPI.getAll({ limit: 200 }),
-    { enabled: open && jobTags.length > 0 && !tagsArePopulated }
-  );
+  const { data: allTagsData } = useQuery({ queryKey: ['allTags'], queryFn: () => tagAPI.getAll({ limit: 200 }), enabled: open && jobTags.length > 0 && !tagsArePopulated });
   const allTags = allTagsData?.data?.tags || [];
 
   const resolvedJobTags = tagsArePopulated
@@ -918,14 +914,9 @@ function JobHistoryPanel({
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
-  const { data, isLoading } = useQuery(
-    [queryKey, { search, status: statusFilter, page, limit: pageSize }],
-    () => fetchFn({ search: search || undefined, status: statusFilter || undefined, page, limit: pageSize }),
-    {
+  const { data, isLoading } = useQuery({ queryKey: [queryKey, { search, status: statusFilter, page, limit: pageSize }], queryFn: () => fetchFn({ search: search || undefined, status: statusFilter || undefined, page, limit: pageSize }),
       refetchInterval: autoRefetch ? config.monitoring.recentJobsInterval : false,
-      keepPreviousData: true
-    }
-  );
+      placeholderData: keepPreviousData });
 
   const defaultExtractor = (data) => {
     // Handle both job route format ({ jobs, pagination }) and project route format ({ data: { jobs, pagination } })
@@ -940,41 +931,34 @@ function JobHistoryPanel({
   const { jobs, pagination } = extractor(data);
 
   // 사용자 설정 가져오기
-  const { data: profileData } = useQuery('userProfile', () => userAPI.getProfile());
+  const { data: profileData } = useQuery({ queryKey: ['userProfile'], queryFn: () => userAPI.getProfile() });
   const userPreferences = profileData?.data?.user?.preferences || {};
 
-  const retryMutation = useMutation(jobAPI.retry, {
-    onSuccess: () => { toast.success('작업을 재시도합니다'); queryClient.invalidateQueries(queryKey); },
-    onError: (error) => { toast.error('재시도 실패: ' + error.message); }
-  });
+  const retryMutation = useMutation({ mutationFn: jobAPI.retry,
+    onSuccess: () => { toast.success('작업을 재시도합니다'); queryClient.invalidateQueries({ queryKey: Array.isArray(queryKey) ? queryKey : [queryKey] }); },
+    onError: (error) => { toast.error('재시도 실패: ' + error.message); } });
 
-  const cancelMutation = useMutation(jobAPI.cancel, {
-    onSuccess: () => { toast.success('작업이 취소되었습니다'); queryClient.invalidateQueries(queryKey); },
-    onError: (error) => { toast.error('취소 실패: ' + error.message); }
-  });
+  const cancelMutation = useMutation({ mutationFn: jobAPI.cancel,
+    onSuccess: () => { toast.success('작업이 취소되었습니다'); queryClient.invalidateQueries({ queryKey: Array.isArray(queryKey) ? queryKey : [queryKey] }); },
+    onError: (error) => { toast.error('취소 실패: ' + error.message); } });
 
-  const deleteMutation = useMutation(
-    ({ id, deleteContent }) => jobAPI.delete(id, deleteContent),
-    {
+  const deleteMutation = useMutation({ mutationFn: ({ id, deleteContent }) => jobAPI.delete(id, deleteContent),
       onSuccess: (response) => {
         const { deletedImagesCount, deletedVideosCount } = response.data;
         if (deletedImagesCount > 0 || deletedVideosCount > 0) {
           toast.success(`작업과 ${deletedImagesCount}개 이미지, ${deletedVideosCount}개 동영상이 삭제되었습니다`);
-          queryClient.invalidateQueries('generatedImages');
-          queryClient.invalidateQueries('generatedVideos');
+          queryClient.invalidateQueries({ queryKey: ['generatedImages'] });
+          queryClient.invalidateQueries({ queryKey: ['generatedVideos'] });
         } else {
           toast.success('작업이 삭제되었습니다');
         }
-        queryClient.invalidateQueries(queryKey);
+        queryClient.invalidateQueries({ queryKey: Array.isArray(queryKey) ? queryKey : [queryKey] });
       },
-      onError: (error) => { toast.error('삭제 실패: ' + error.message); }
-    }
-  );
+      onError: (error) => { toast.error('삭제 실패: ' + error.message); } });
 
-  const savePromptMutation = useMutation(promptDataAPI.create, {
+  const savePromptMutation = useMutation({ mutationFn: promptDataAPI.create,
     onSuccess: () => { toast.success('프롬프트 데이터가 저장되었습니다'); setSavePromptOpen(false); setSavingJob(null); },
-    onError: (error) => { toast.error('프롬프트 저장 실패: ' + (error.response?.data?.message || error.message)); }
-  });
+    onError: (error) => { toast.error('프롬프트 저장 실패: ' + (error.response?.data?.message || error.message)); } });
 
   const handleView = async (job) => {
     setSelectedJob(job);

--- a/frontend/src/components/common/MediaGrid.js
+++ b/frontend/src/components/common/MediaGrid.js
@@ -32,7 +32,7 @@ import {
   Videocam,
   CheckCircle
 } from '@mui/icons-material';
-import { useQuery } from 'react-query';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { imageAPI } from '../../services/api';
 import Pagination from './Pagination';
@@ -373,11 +373,7 @@ function MediaGrid({
   // extraQuery 변화 시 자동으로 새 쿼리 — queryKey 에 직렬화 포함
   const extraQueryKey = extraQuery ? JSON.stringify(extraQuery) : '';
   useEffect(() => { setPage(1); }, [extraQueryKey]);
-  const { data, isLoading } = useQuery(
-    [actualQueryKey, search, page, pageSize, extraQueryKey],
-    () => actualFetchFn({ search: search || undefined, page, limit: pageSize, ...(extraQuery || {}) }),
-    { keepPreviousData: true }
-  );
+  const { data, isLoading } = useQuery({ queryKey: [actualQueryKey, search, page, pageSize, extraQueryKey], queryFn: () => actualFetchFn({ search: search || undefined, page, limit: pageSize, ...(extraQuery || {}) }), placeholderData: keepPreviousData });
 
   const defaultExtractor = (data) => {
     const d = data?.data?.data || data?.data || {};

--- a/frontend/src/components/common/MetadataPickerModal.js
+++ b/frontend/src/components/common/MetadataPickerModal.js
@@ -33,7 +33,7 @@ import {
   ViewList as ListViewIcon,
   ViewStream as ImageListIcon
 } from '@mui/icons-material';
-import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { serverAPI, workboardAPI, userAPI } from '../../services/api';
 import Pagination from './Pagination';
@@ -169,9 +169,8 @@ function MetadataPickerModal({
 
   const queryClient = useQueryClient();
 
-  const { data: profileData } = useQuery('userProfile', () => userAPI.getProfile(), {
-    enabled: open && !isAdmin
-  });
+  const { data: profileData } = useQuery({ queryKey: ['userProfile'], queryFn: () => userAPI.getProfile(),
+    enabled: open && !isAdmin });
   const userPreferences = profileData?.data?.user?.preferences || {};
   const nsfwImageFilter = isAdmin ? false : (userPreferences.nsfwImageFilter ?? true);
   // nsfwModelFilter 우선, 없으면 legacy nsfwLoraFilter fallback (#346)
@@ -179,12 +178,8 @@ function MetadataPickerModal({
     ? (userPreferences[adapter.nsfwItemPreference] ?? userPreferences.nsfwLoraFilter ?? true)
     : false;
 
-  const updatePreferencesMutation = useMutation(
-    (preferences) => userAPI.updateProfile({ preferences }),
-    {
-      onSuccess: () => queryClient.invalidateQueries('userProfile')
-    }
-  );
+  const updatePreferencesMutation = useMutation({ mutationFn: (preferences) => userAPI.updateProfile({ preferences }),
+      onSuccess: () => queryClient.invalidateQueries({ queryKey: ['userProfile'] }) });
 
   const handleNsfwImageToggle = () => {
     updatePreferencesMutation.mutate({ nsfwImageFilter: !nsfwImageFilter });
@@ -387,7 +382,7 @@ function MetadataPickerModal({
                   size="small"
                   checked={nsfwImageFilter}
                   onChange={handleNsfwImageToggle}
-                  disabled={updatePreferencesMutation.isLoading}
+                  disabled={updatePreferencesMutation.isPending}
                 />
               }
               label={<Typography variant="caption">NSFW 미리보기 이미지 숨기기</Typography>}
@@ -399,7 +394,7 @@ function MetadataPickerModal({
                     size="small"
                     checked={nsfwItemFilter}
                     onChange={handleNsfwItemToggle}
-                    disabled={updatePreferencesMutation.isLoading}
+                    disabled={updatePreferencesMutation.isPending}
                   />
                 }
                 label={<Typography variant="caption">{adapter.nsfwItemLabel || `NSFW ${adapter.label} 숨기기`}</Typography>}

--- a/frontend/src/components/common/NotificationsPopover.js
+++ b/frontend/src/components/common/NotificationsPopover.js
@@ -18,7 +18,7 @@ import {
   OpenInNew as OpenInNewIcon,
 } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
-import { useQueryClient } from 'react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import { alpha } from '@mui/material/styles';
 import { MONO } from '../../theme';
 

--- a/frontend/src/components/common/PipelinePanel.js
+++ b/frontend/src/components/common/PipelinePanel.js
@@ -48,7 +48,7 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import MetadataFieldInput from './MetadataFieldInput';
 import ImageViewerDialog from './ImageViewerDialog';
 import PromptDataPickerDialog from './PromptDataPickerDialog';
-import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { pipelineAPI, pipelineRunAPI, projectAPI, jobAPI, tagAPI, textAPI, workboardAPI, promptDataAPI } from '../../services/api';
 import { MONO } from '../../theme';
@@ -109,23 +109,15 @@ function PipelinePanel({ projectId }) {
   const [runningPipelineId, setRunningPipelineId] = useState(null);
   const queryClient = useQueryClient();
 
-  const { data, isLoading } = useQuery(
-    ['pipelines', projectId],
-    () => pipelineAPI.list(projectId),
-    { enabled: !!projectId }
-  );
+  const { data, isLoading } = useQuery({ queryKey: ['pipelines', projectId], queryFn: () => pipelineAPI.list(projectId), enabled: !!projectId });
   const pipelines = data?.data?.data?.pipelines || [];
 
-  const deleteMutation = useMutation(
-    (pid) => pipelineAPI.delete(projectId, pid),
-    {
+  const deleteMutation = useMutation({ mutationFn: (pid) => pipelineAPI.delete(projectId, pid),
       onSuccess: () => {
         toast.success('파이프라인이 삭제되었습니다.');
-        queryClient.invalidateQueries(['pipelines', projectId]);
+        queryClient.invalidateQueries({ queryKey: ['pipelines', projectId] });
       },
-      onError: (err) => toast.error(err.response?.data?.message || '삭제 실패'),
-    }
-  );
+      onError: (err) => toast.error(err.response?.data?.message || '삭제 실패'), });
 
   if (view === 'builder') {
     return (
@@ -706,27 +698,15 @@ function AddStepCard({ isMobile, onAdd }) {
 // 프로젝트의 worldview / system prompt 태그 docs 를 보여주고, 클릭으로
 // 현재 선택된 단계에 add/toggle. drag-drop 라이브러리 없이 click-to-add 패턴.
 function ContextDocPalette({ projectId, selectedStepIdx, selectedStep, onAddDoc }) {
-  const { data: wvTagData } = useQuery('worldviewTag', () => tagAPI.getWorldview(), { staleTime: 60_000 });
-  const { data: spTagData } = useQuery('systemPromptTag', () => tagAPI.getSystemPrompt(), { staleTime: 60_000 });
-  const { data: projectData } = useQuery(
-    ['project', projectId],
-    () => projectAPI.getById(projectId),
-    { enabled: !!projectId, staleTime: 60_000 }
-  );
+  const { data: wvTagData } = useQuery({ queryKey: ['worldviewTag'], queryFn: () => tagAPI.getWorldview(), staleTime: 60_000 });
+  const { data: spTagData } = useQuery({ queryKey: ['systemPromptTag'], queryFn: () => tagAPI.getSystemPrompt(), staleTime: 60_000 });
+  const { data: projectData } = useQuery({ queryKey: ['project', projectId], queryFn: () => projectAPI.getById(projectId), enabled: !!projectId, staleTime: 60_000 });
   const worldviewTag = wvTagData?.data?.tag;
   const systemPromptTag = spTagData?.data?.tag;
   const projectTag = projectData?.data?.data?.project?.tagId;
 
-  const { data: wvDocsData } = useQuery(
-    ['paletteWvDocs', projectId, worldviewTag?._id],
-    () => textAPI.getUploaded({ tags: [projectTag?._id, worldviewTag?._id].filter(Boolean).join(','), limit: 50 }),
-    { enabled: !!projectTag && !!worldviewTag, staleTime: 60_000 }
-  );
-  const { data: spDocsData } = useQuery(
-    ['paletteSpDocs', projectId, systemPromptTag?._id],
-    () => textAPI.getUploaded({ tags: [projectTag?._id, systemPromptTag?._id].filter(Boolean).join(','), limit: 50 }),
-    { enabled: !!projectTag && !!systemPromptTag, staleTime: 60_000 }
-  );
+  const { data: wvDocsData } = useQuery({ queryKey: ['paletteWvDocs', projectId, worldviewTag?._id], queryFn: () => textAPI.getUploaded({ tags: [projectTag?._id, worldviewTag?._id].filter(Boolean).join(','), limit: 50 }), enabled: !!projectTag && !!worldviewTag, staleTime: 60_000 });
+  const { data: spDocsData } = useQuery({ queryKey: ['paletteSpDocs', projectId, systemPromptTag?._id], queryFn: () => textAPI.getUploaded({ tags: [projectTag?._id, systemPromptTag?._id].filter(Boolean).join(','), limit: 50 }), enabled: !!projectTag && !!systemPromptTag, staleTime: 60_000 });
   // 백엔드 texts 라우트는 { success, data: { items, pagination } } shape
   const wvDocs = wvDocsData?.data?.data?.items || [];
   const spDocs = spDocsData?.data?.data?.items || [];
@@ -908,18 +888,11 @@ function PipelineBuilder({ projectId, pipelineId, onClose }) {
   const isNew = !pipelineId;
   const queryClient = useQueryClient();
 
-  const { data: pipelineData, isLoading } = useQuery(
-    ['pipeline', projectId, pipelineId],
-    () => pipelineAPI.get(projectId, pipelineId),
-    { enabled: !!pipelineId }
-  );
+  const { data: pipelineData, isLoading } = useQuery({ queryKey: ['pipeline', projectId, pipelineId], queryFn: () => pipelineAPI.get(projectId, pipelineId), enabled: !!pipelineId });
   const loaded = pipelineData?.data?.data?.pipeline;
 
   // 전체 작업판 목록 — 단계 picker 가 프로젝트 미가입 작업판도 보여줘야 함 (#407).
-  const { data: wbData } = useQuery(
-    ['allWorkboards'],
-    () => workboardAPI.getAll(),
-  );
+  const { data: wbData } = useQuery({ queryKey: ['allWorkboards'], queryFn: () => workboardAPI.getAll() });
   const allWorkboards = wbData?.data?.workboards || wbData?.data?.data?.workboards || [];
 
   const [name, setName] = useState('');
@@ -950,23 +923,19 @@ function PipelineBuilder({ projectId, pipelineId, onClose }) {
     }
   }, [loaded]);
 
-  const saveMutation = useMutation(
-    (payload) => isNew
+  const saveMutation = useMutation({ mutationFn: (payload) => isNew
       ? pipelineAPI.create(projectId, payload)
       : pipelineAPI.update(projectId, pipelineId, payload),
-    {
       onSuccess: () => {
         toast.success('저장되었습니다.');
         // list + single 모두 invalidate — 재진입 시 stale cache 방지
-        queryClient.invalidateQueries(['pipelines', projectId]);
+        queryClient.invalidateQueries({ queryKey: ['pipelines', projectId] });
         if (pipelineId) {
-          queryClient.invalidateQueries(['pipeline', projectId, pipelineId]);
+          queryClient.invalidateQueries({ queryKey: ['pipeline', projectId, pipelineId] });
         }
         onClose();
       },
-      onError: (err) => toast.error(err.response?.data?.message || '저장 실패'),
-    }
-  );
+      onError: (err) => toast.error(err.response?.data?.message || '저장 실패'), });
 
   const handleSave = () => {
     if (!name.trim()) {
@@ -1060,7 +1029,7 @@ function PipelineBuilder({ projectId, pipelineId, onClose }) {
         </Box>
         <Box sx={{ display: 'flex', gap: 1.5, flexShrink: 0 }}>
           <Button onClick={onClose}>취소</Button>
-          <Button variant="contained" onClick={handleSave} disabled={saveMutation.isLoading}>저장</Button>
+          <Button variant="contained" onClick={handleSave} disabled={saveMutation.isPending}>저장</Button>
         </Box>
       </Box>
 
@@ -1482,32 +1451,20 @@ function StepDocsDialog({ open, projectId, step, onClose, onSave }) {
   const [systemPromptDocId, setSystemPromptDocId] = useState(null);
 
   // 빌트인 태그 (세계관 / 시스템 프롬프트)
-  const { data: wvTagData } = useQuery('worldviewTag', () => tagAPI.getWorldview(), { staleTime: 60_000 });
-  const { data: spTagData } = useQuery('systemPromptTag', () => tagAPI.getSystemPrompt(), { staleTime: 60_000 });
+  const { data: wvTagData } = useQuery({ queryKey: ['worldviewTag'], queryFn: () => tagAPI.getWorldview(), staleTime: 60_000 });
+  const { data: spTagData } = useQuery({ queryKey: ['systemPromptTag'], queryFn: () => tagAPI.getSystemPrompt(), staleTime: 60_000 });
   const worldviewTag = wvTagData?.data?.tag;
   const systemPromptTag = spTagData?.data?.tag;
 
   // 프로젝트 정보 (project tagId 필요)
-  const { data: projectData } = useQuery(
-    ['project', projectId],
-    () => projectAPI.getById(projectId),
-    { enabled: !!projectId }
-  );
+  const { data: projectData } = useQuery({ queryKey: ['project', projectId], queryFn: () => projectAPI.getById(projectId), enabled: !!projectId });
   const projectTagId = projectData?.data?.data?.project?.tagId?._id || projectData?.data?.data?.project?.tagId;
 
   // 프로젝트의 세계관 / 시스템 프롬프트 문서 목록 조회
-  const { data: contextDocsData } = useQuery(
-    ['projectContextDocs', projectId, projectTagId, worldviewTag?._id],
-    () => textAPI.getUploaded({ tags: [projectTagId, worldviewTag._id].join(','), limit: 100 }),
-    { enabled: !!(projectTagId && worldviewTag?._id && open) }
-  );
+  const { data: contextDocsData } = useQuery({ queryKey: ['projectContextDocs', projectId, projectTagId, worldviewTag?._id], queryFn: () => textAPI.getUploaded({ tags: [projectTagId, worldviewTag._id].join(','), limit: 100 }), enabled: !!(projectTagId && worldviewTag?._id && open) });
   const contextDocs = contextDocsData?.data?.data?.items || [];
 
-  const { data: spDocsData } = useQuery(
-    ['projectSystemPromptDocs', projectId, projectTagId, systemPromptTag?._id],
-    () => textAPI.getUploaded({ tags: [projectTagId, systemPromptTag._id].join(','), limit: 100 }),
-    { enabled: !!(projectTagId && systemPromptTag?._id && open) }
-  );
+  const { data: spDocsData } = useQuery({ queryKey: ['projectSystemPromptDocs', projectId, projectTagId, systemPromptTag?._id], queryFn: () => textAPI.getUploaded({ tags: [projectTagId, systemPromptTag._id].join(','), limit: 100 }), enabled: !!(projectTagId && systemPromptTag?._id && open) });
   const spDocs = spDocsData?.data?.data?.items || [];
 
   React.useEffect(() => {
@@ -1636,19 +1593,11 @@ function PipelineRunner({ projectId, pipelineId, onClose }) {
   const queryClient = useQueryClient();
   const theme = useTheme();
   const isDesktop = useMediaQuery(theme.breakpoints.up('md'));
-  const { data: pipelineData, isLoading } = useQuery(
-    ['pipeline', projectId, pipelineId],
-    () => pipelineAPI.get(projectId, pipelineId),
-    { enabled: !!pipelineId }
-  );
+  const { data: pipelineData, isLoading } = useQuery({ queryKey: ['pipeline', projectId, pipelineId], queryFn: () => pipelineAPI.get(projectId, pipelineId), enabled: !!pipelineId });
   const pipeline = pipelineData?.data?.data?.pipeline;
 
   // 사이드 레일용 — 같은 프로젝트의 최근 run 들 (Phase 5b 후속). client 에서 same-pipeline filter.
-  const { data: recentRunsData } = useQuery(
-    ['pipelineRuns', projectId],
-    () => pipelineRunAPI.list(projectId, { limit: 20 }),
-    { enabled: !!projectId, staleTime: 30_000 }
-  );
+  const { data: recentRunsData } = useQuery({ queryKey: ['pipelineRuns', projectId], queryFn: () => pipelineRunAPI.list(projectId, { limit: 20 }), enabled: !!projectId, staleTime: 30_000 });
   const recentRuns = (recentRunsData?.data?.data?.runs || [])
     .filter((r) => (r.pipelineId?._id || r.pipelineId) === pipelineId)
     .slice(0, 6);
@@ -1657,46 +1606,34 @@ function PipelineRunner({ projectId, pipelineId, onClose }) {
   const [runId, setRunId] = useState(null);
 
   // 활성 run 의 상태 polling
-  const { data: runData } = useQuery(
-    ['pipelineRun', projectId, runId],
-    () => pipelineRunAPI.get(projectId, runId),
-    {
+  const { data: runData } = useQuery({ queryKey: ['pipelineRun', projectId, runId], queryFn: () => pipelineRunAPI.get(projectId, runId),
       enabled: !!runId,
-      refetchInterval: (data) => {
-        const run = data?.data?.data?.run;
+      // v5: refetchInterval (query) 시그니처 (#526)
+      refetchInterval: (query) => {
+        const run = query.state.data?.data?.data?.run;
         if (!run) return 3000;
         if (run.status === 'pending' || run.status === 'running') return 2000;
         return false; // 종료된 run 은 더 이상 polling 안 함
-      },
-    }
-  );
+      }, });
   const run = runData?.data?.data?.run;
 
-  const startMutation = useMutation(
-    (payload) => pipelineRunAPI.start(projectId, payload),
-    {
+  const startMutation = useMutation({ mutationFn: (payload) => pipelineRunAPI.start(projectId, payload),
       onSuccess: (response) => {
         const newRunId = response.data?.data?.run?._id;
         if (newRunId) {
           setRunId(newRunId);
-          queryClient.invalidateQueries(['pipelineRuns', projectId]);
+          queryClient.invalidateQueries({ queryKey: ['pipelineRuns', projectId] });
         }
       },
-      onError: (err) => toast.error(err.response?.data?.message || '시작 실패'),
-    }
-  );
+      onError: (err) => toast.error(err.response?.data?.message || '시작 실패'), });
 
-  const retryMutation = useMutation(
-    ({ fromStep }) => pipelineRunAPI.retry(projectId, runId, { fromStep }),
-    {
+  const retryMutation = useMutation({ mutationFn: ({ fromStep }) => pipelineRunAPI.retry(projectId, runId, { fromStep }),
       onSuccess: () => {
-        queryClient.invalidateQueries(['pipelineRun', projectId, runId]);
-        queryClient.invalidateQueries(['pipelineRuns', projectId]);
+        queryClient.invalidateQueries({ queryKey: ['pipelineRun', projectId, runId] });
+        queryClient.invalidateQueries({ queryKey: ['pipelineRuns', projectId] });
         toast.success('재시작 요청됨');
       },
-      onError: (err) => toast.error(err.response?.data?.message || '재시작 실패'),
-    }
-  );
+      onError: (err) => toast.error(err.response?.data?.message || '재시작 실패'), });
 
   const handleStart = () => {
     if (!initialPrompt.trim()) {
@@ -1780,9 +1717,9 @@ function PipelineRunner({ projectId, pipelineId, onClose }) {
             <Button
               variant="contained"
               color="success"
-              startIcon={startMutation.isLoading ? <CircularProgress size={18} color="inherit" /> : <PlayArrowIcon />}
+              startIcon={startMutation.isPending ? <CircularProgress size={18} color="inherit" /> : <PlayArrowIcon />}
               onClick={handleStart}
-              disabled={startMutation.isLoading || !initialPrompt.trim()}
+              disabled={startMutation.isPending || !initialPrompt.trim()}
             >
               시작
             </Button>
@@ -1793,7 +1730,7 @@ function PipelineRunner({ projectId, pipelineId, onClose }) {
               color="warning"
               startIcon={<PlayArrowIcon />}
               onClick={() => retryMutation.mutate({ fromStep: firstFailedIdx })}
-              disabled={retryMutation.isLoading}
+              disabled={retryMutation.isPending}
             >
               {firstFailedIdx + 1}단계부터 재시작
             </Button>
@@ -2027,50 +1964,34 @@ export function PipelineHistoryPanel({ projectId }) {
   const queryClient = useQueryClient();
   const [selectedRunId, setSelectedRunId] = useState(null);
 
-  const { data, isLoading } = useQuery(
-    ['pipelineRuns', projectId],
-    () => pipelineRunAPI.list(projectId, { limit: 50 }),
-    { refetchInterval: 5000 }
-  );
+  const { data, isLoading } = useQuery({ queryKey: ['pipelineRuns', projectId], queryFn: () => pipelineRunAPI.list(projectId, { limit: 50 }), refetchInterval: 5000 });
   const runs = data?.data?.data?.runs || [];
 
-  const { data: detailData } = useQuery(
-    ['pipelineRun', projectId, selectedRunId],
-    () => pipelineRunAPI.get(projectId, selectedRunId),
-    {
+  const { data: detailData } = useQuery({ queryKey: ['pipelineRun', projectId, selectedRunId], queryFn: () => pipelineRunAPI.get(projectId, selectedRunId),
       enabled: !!selectedRunId,
-      refetchInterval: (data) => {
-        const run = data?.data?.data?.run;
+      // v5: refetchInterval (query) 시그니처 (#526)
+      refetchInterval: (query) => {
+        const run = query.state.data?.data?.data?.run;
         if (!run) return 3000;
         return (run.status === 'pending' || run.status === 'running') ? 2000 : false;
-      },
-    }
-  );
+      }, });
   const detail = detailData?.data?.data?.run;
 
-  const retryMutation = useMutation(
-    ({ runId, fromStep }) => pipelineRunAPI.retry(projectId, runId, { fromStep }),
-    {
+  const retryMutation = useMutation({ mutationFn: ({ runId, fromStep }) => pipelineRunAPI.retry(projectId, runId, { fromStep }),
       onSuccess: (_, vars) => {
-        queryClient.invalidateQueries(['pipelineRuns', projectId]);
-        queryClient.invalidateQueries(['pipelineRun', projectId, vars.runId]);
+        queryClient.invalidateQueries({ queryKey: ['pipelineRuns', projectId] });
+        queryClient.invalidateQueries({ queryKey: ['pipelineRun', projectId, vars.runId] });
         toast.success('재시작 요청됨');
       },
-      onError: (err) => toast.error(err.response?.data?.message || '재시작 실패'),
-    }
-  );
+      onError: (err) => toast.error(err.response?.data?.message || '재시작 실패'), });
 
-  const deleteMutation = useMutation(
-    (id) => pipelineRunAPI.delete(projectId, id),
-    {
+  const deleteMutation = useMutation({ mutationFn: (id) => pipelineRunAPI.delete(projectId, id),
       onSuccess: () => {
-        queryClient.invalidateQueries(['pipelineRuns', projectId]);
+        queryClient.invalidateQueries({ queryKey: ['pipelineRuns', projectId] });
         if (selectedRunId) setSelectedRunId(null);
         toast.success('삭제되었습니다.');
       },
-      onError: (err) => toast.error(err.response?.data?.message || '삭제 실패'),
-    }
-  );
+      onError: (err) => toast.error(err.response?.data?.message || '삭제 실패'), });
 
   if (selectedRunId && detail) {
     const firstFailedIdx = (detail.steps || []).findIndex((s) => s.status === 'failed');
@@ -2090,7 +2011,7 @@ export function PipelineHistoryPanel({ projectId }) {
               color="warning"
               startIcon={<PlayArrowIcon />}
               onClick={() => retryMutation.mutate({ runId: selectedRunId, fromStep: firstFailedIdx })}
-              disabled={retryMutation.isLoading}
+              disabled={retryMutation.isPending}
             >
               {firstFailedIdx + 1}단계부터 재시작
             </Button>

--- a/frontend/src/components/common/ProjectContextSelector.js
+++ b/frontend/src/components/common/ProjectContextSelector.js
@@ -13,7 +13,7 @@ import {
   Tooltip,
 } from '@mui/material';
 import { Public as PublicIcon } from '@mui/icons-material';
-import { useQuery } from 'react-query';
+import { useQuery } from '@tanstack/react-query';
 import { projectAPI } from '../../services/api';
 
 // 작업판 실행 시 프로젝트 컨텍스트 / 세계관 사용 토글 (#396).
@@ -26,7 +26,7 @@ function ProjectContextSelector({
   onUseWorldviewChange,
   disabled = false,
 }) {
-  const { data: projectsData } = useQuery('projects', () => projectAPI.getAll({ limit: 200 }));
+  const { data: projectsData } = useQuery({ queryKey: ['projects'], queryFn: () => projectAPI.getAll({ limit: 200 }) });
   const projects = projectsData?.data?.data?.projects || projectsData?.data?.projects || [];
 
   return (

--- a/frontend/src/components/common/ProjectEditDialog.js
+++ b/frontend/src/components/common/ProjectEditDialog.js
@@ -13,7 +13,7 @@ import {
   Tab
 } from '@mui/material';
 import { Image as ImageIcon, Close, ArrowBack } from '@mui/icons-material';
-import { useMutation, useQueryClient } from 'react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { projectAPI } from '../../services/api';
 import MediaGrid from './MediaGrid';
@@ -46,22 +46,18 @@ function ProjectEditDialog({ open, onClose, project, onSuccess }) {
     }
   }, [open]);
 
-  const updateMutation = useMutation(
-    (data) => projectAPI.update(project._id, data),
-    {
+  const updateMutation = useMutation({ mutationFn: (data) => projectAPI.update(project._id, data),
       onSuccess: () => {
-        queryClient.invalidateQueries(['project', project._id]);
-        queryClient.invalidateQueries('projects');
-        queryClient.invalidateQueries('favoriteProjects');
+        queryClient.invalidateQueries({ queryKey: ['project', project._id] });
+        queryClient.invalidateQueries({ queryKey: ['projects'] });
+        queryClient.invalidateQueries({ queryKey: ['favoriteProjects'] });
         toast.success('프로젝트가 수정되었습니다');
         onClose();
         if (onSuccess) onSuccess();
       },
       onError: (error) => {
         toast.error(error.response?.data?.message || '수정 실패');
-      }
-    }
-  );
+      } });
 
   const handleSubmit = () => {
     if (!name.trim()) {
@@ -241,7 +237,7 @@ function ProjectEditDialog({ open, onClose, project, onSuccess }) {
         <Button
           variant="contained"
           onClick={handleSubmit}
-          disabled={updateMutation.isLoading}
+          disabled={updateMutation.isPending}
         >
           저장
         </Button>

--- a/frontend/src/components/common/PromptDataPanel.js
+++ b/frontend/src/components/common/PromptDataPanel.js
@@ -28,7 +28,7 @@ import {
   Image as ImageIcon,
   ContentCopy
 } from '@mui/icons-material';
-import { useQuery } from 'react-query';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import Pagination from './Pagination';
 import ImageViewerDialog from './ImageViewerDialog';
 import ProjectTagChip from './ProjectTagChip';
@@ -58,11 +58,7 @@ function PromptDataPanel({
   const [imageViewerOpen, setImageViewerOpen] = useState(false);
   const [viewerImageUrl, setViewerImageUrl] = useState('');
 
-  const { data, isLoading, error } = useQuery(
-    [queryKey, page, pageSize, search],
-    () => fetchFn({ page, limit: pageSize, search: search || undefined }),
-    { keepPreviousData: true }
-  );
+  const { data, isLoading, error } = useQuery({ queryKey: [queryKey, page, pageSize, search], queryFn: () => fetchFn({ page, limit: pageSize, search: search || undefined }), placeholderData: keepPreviousData });
 
   const defaultExtractor = (data) => {
     const d = data?.data?.data || data?.data || {};

--- a/frontend/src/components/common/TagInput.js
+++ b/frontend/src/components/common/TagInput.js
@@ -6,7 +6,7 @@ import {
   Box,
   CircularProgress
 } from '@mui/material';
-import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import { tagAPI } from '../../services/api';
 
 function TagInput({ 
@@ -20,25 +20,16 @@ function TagInput({
   const [inputValue, setInputValue] = useState('');
   const queryClient = useQueryClient();
 
-  const { data: tagsData, isLoading } = useQuery(
-    ['tags', inputValue],
-    () => tagAPI.getAll({ search: inputValue, limit: 20 }),
-    { 
+  const { data: tagsData, isLoading } = useQuery({ queryKey: ['tags', inputValue], queryFn: () => tagAPI.getAll({ search: inputValue, limit: 20 }), 
       enabled: true,
-      keepPreviousData: true
-    }
-  );
+      placeholderData: keepPreviousData });
 
-  const createTagMutation = useMutation(
-    (name) => tagAPI.create({ name }),
-    {
+  const createTagMutation = useMutation({ mutationFn: (name) => tagAPI.create({ name }),
       onSuccess: (response) => {
-        queryClient.invalidateQueries('tags');
+        queryClient.invalidateQueries({ queryKey: ['tags'] });
         const newTag = response.data.tag;
         onChange([...value, newTag]);
-      }
-    }
-  );
+      } });
 
   const availableTags = tagsData?.data?.tags || [];
 
@@ -112,7 +103,7 @@ function TagInput({
             ...params.InputProps,
             endAdornment: (
               <>
-                {isLoading || createTagMutation.isLoading ? (
+                {isLoading || createTagMutation.isPending ? (
                   <CircularProgress color="inherit" size={20} />
                 ) : null}
                 {params.InputProps.endAdornment}

--- a/frontend/src/components/common/TextContentPanel.js
+++ b/frontend/src/components/common/TextContentPanel.js
@@ -28,7 +28,7 @@ import {
   ContentCopy as ContentCopyIcon,
   UploadFile as UploadFileIcon,
 } from '@mui/icons-material';
-import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import { useDropzone } from 'react-dropzone';
 import toast from 'react-hot-toast';
 import { textAPI } from '../../services/api';
@@ -65,57 +65,41 @@ function TextContentPanel({ kind = 'uploaded', defaultTags = [], filterTags = []
   const createFn = textAPI.createUploaded;
 
   const tagIds = (filterTags || []).map((t) => t._id || t).filter(Boolean);
-  const { data, isLoading, error } = useQuery(
-    [queryKey, page, search, tagIds.join(',')],
-    () => {
+  const { data, isLoading, error } = useQuery({ queryKey: [queryKey, page, search, tagIds.join(',')], queryFn: () => {
       const params = { page, limit: 20, search };
       if (tagIds.length > 0) params.tags = tagIds.join(',');
       return listFn(params);
-    },
-    { keepPreviousData: true }
-  );
+    }, placeholderData: keepPreviousData });
 
   const items = data?.data?.data?.items || [];
   const pagination = data?.data?.data?.pagination || { current: 1, pages: 0, total: 0 };
 
-  const upsertMutation = useMutation(
-    (payload) => {
+  const upsertMutation = useMutation({ mutationFn: (payload) => {
       if (payload._id) return updateFn(payload._id, { title: payload.title, content: payload.content, tags: (payload.tags || []).map((t) => t._id || t) });
       return createFn({ title: payload.title, content: payload.content, tags: (payload.tags || []).map((t) => t._id || t) });
     },
-    {
       onSuccess: () => {
         toast.success('저장되었습니다.');
-        queryClient.invalidateQueries(queryKey);
+        queryClient.invalidateQueries({ queryKey: Array.isArray(queryKey) ? queryKey : [queryKey] });
         setEditorOpen(false);
         setEditingItem(null);
       },
-      onError: (err) => toast.error(err.response?.data?.message || '저장 실패'),
-    }
-  );
+      onError: (err) => toast.error(err.response?.data?.message || '저장 실패'), });
 
-  const updateTagsMutation = useMutation(
-    ({ id, tags }) => updateFn(id, { tags: tags.map((t) => t._id || t) }),
-    {
+  const updateTagsMutation = useMutation({ mutationFn: ({ id, tags }) => updateFn(id, { tags: tags.map((t) => t._id || t) }),
       onSuccess: () => {
         toast.success('태그가 갱신되었습니다.');
-        queryClient.invalidateQueries(queryKey);
+        queryClient.invalidateQueries({ queryKey: Array.isArray(queryKey) ? queryKey : [queryKey] });
       },
-      onError: (err) => toast.error(err.response?.data?.message || '태그 갱신 실패'),
-    }
-  );
+      onError: (err) => toast.error(err.response?.data?.message || '태그 갱신 실패'), });
 
-  const deleteMutation = useMutation(
-    (id) => deleteFn(id),
-    {
+  const deleteMutation = useMutation({ mutationFn: (id) => deleteFn(id),
       onSuccess: () => {
         toast.success('삭제되었습니다.');
-        queryClient.invalidateQueries(queryKey);
+        queryClient.invalidateQueries({ queryKey: Array.isArray(queryKey) ? queryKey : [queryKey] });
         setViewerItem(null);
       },
-      onError: (err) => toast.error(err.response?.data?.message || '삭제 실패'),
-    }
-  );
+      onError: (err) => toast.error(err.response?.data?.message || '삭제 실패'), });
 
   const openCreate = () => {
     setEditingItem({ title: '', content: '', tags: defaultTags });
@@ -310,7 +294,7 @@ function TextContentPanel({ kind = 'uploaded', defaultTags = [], filterTags = []
           <Button
             variant="contained"
             onClick={() => upsertMutation.mutate(editingItem)}
-            disabled={!editingItem?.content?.trim() || upsertMutation.isLoading}
+            disabled={!editingItem?.content?.trim() || upsertMutation.isPending}
           >
             저장
           </Button>
@@ -377,7 +361,7 @@ function TextContentPanel({ kind = 'uploaded', defaultTags = [], filterTags = []
         open={uploadOpen}
         onClose={() => setUploadOpen(false)}
         defaultTags={defaultTags}
-        onComplete={() => queryClient.invalidateQueries(queryKey)}
+        onComplete={() => queryClient.invalidateQueries({ queryKey: Array.isArray(queryKey) ? queryKey : [queryKey] })}
       />
     </Box>
   );

--- a/frontend/src/components/common/UpdateLogDialog.js
+++ b/frontend/src/components/common/UpdateLogDialog.js
@@ -11,16 +11,12 @@ import {
   IconButton
 } from '@mui/material';
 import { Close } from '@mui/icons-material';
-import { useQuery } from 'react-query';
+import { useQuery } from '@tanstack/react-query';
 import ReactMarkdown from 'react-markdown';
 import { updatelogAPI } from '../../services/api';
 
 function UpdateLogDialog({ open, onClose, majorVersion }) {
-  const { data, isLoading, isError } = useQuery(
-    ['updatelog', majorVersion],
-    () => updatelogAPI.get(majorVersion),
-    { enabled: open && majorVersion != null }
-  );
+  const { data, isLoading, isError } = useQuery({ queryKey: ['updatelog', majorVersion], queryFn: () => updatelogAPI.get(majorVersion), enabled: open && majorVersion != null });
 
   const content = data?.data?.data?.content;
 

--- a/frontend/src/components/common/WorkboardChatPanel.js
+++ b/frontend/src/components/common/WorkboardChatPanel.js
@@ -27,7 +27,7 @@ import {
   ExpandMore,
   LockOutlined as LockIcon,
 } from '@mui/icons-material';
-import { useMutation, useQuery, useQueryClient } from 'react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Controller, useForm } from 'react-hook-form';
 import toast from 'react-hot-toast';
 import { conversationAPI, textAPI, imageAPI } from '../../services/api';
@@ -71,11 +71,7 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview, onUseMessage }
   useEffect(() => { reset(formDefaults); }, [formDefaults, reset]);
 
   // 대화 시작 후 messages 동기화용 — 시작 전엔 비활성
-  const { data: convData } = useQuery(
-    ['conversation', conversationId],
-    () => conversationAPI.getById(conversationId),
-    { enabled: !!conversationId }
-  );
+  const { data: convData } = useQuery({ queryKey: ['conversation', conversationId], queryFn: () => conversationAPI.getById(conversationId), enabled: !!conversationId });
   const conversation = convData?.data?.data;
   const messages = conversation?.messages || [];
 
@@ -135,14 +131,14 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview, onUseMessage }
             setSettingsOpen(false);
           }
           setPendingUserMsg(null);
-          queryClient.invalidateQueries(['conversation', newCid || cid || conversationId]);
-          queryClient.invalidateQueries('conversations');
+          queryClient.invalidateQueries({ queryKey: ['conversation', newCid || cid || conversationId] });
+          queryClient.invalidateQueries({ queryKey: ['conversations'] });
         },
         onError: (err) => {
           toast.error('전송 실패: ' + (err.message || '알 수 없는 오류'));
           setPendingUserMsg(null);
           if (cid || conversationId) {
-            queryClient.invalidateQueries(['conversation', cid || conversationId]);
+            queryClient.invalidateQueries({ queryKey: ['conversation', cid || conversationId] });
           }
         },
       }
@@ -150,16 +146,12 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview, onUseMessage }
     setAttachImages([]);
   };
 
-  const saveMessageMutation = useMutation(
-    ({ conversationJobId, messageIndex }) => textAPI.createGenerated({ conversationJobId, messageIndex }),
-    {
+  const saveMessageMutation = useMutation({ mutationFn: ({ conversationJobId, messageIndex }) => textAPI.createGenerated({ conversationJobId, messageIndex }),
       onSuccess: () => {
         toast.success('생성된 텍스트로 저장되었습니다.');
-        queryClient.invalidateQueries('generatedTexts');
+        queryClient.invalidateQueries({ queryKey: ['generatedTexts'] });
       },
-      onError: (err) => toast.error(err.response?.data?.message || '저장 실패'),
-    }
-  );
+      onError: (err) => toast.error(err.response?.data?.message || '저장 실패'), });
 
   // 스트리밍 중 자동 스크롤
   useEffect(() => {
@@ -343,7 +335,7 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview, onUseMessage }
                       <IconButton
                         size="small"
                         onClick={() => saveMessageMutation.mutate({ conversationJobId: conversationId, messageIndex: idx })}
-                        disabled={saveMessageMutation.isLoading}
+                        disabled={saveMessageMutation.isPending}
                       >
                         <BookmarkAddIcon fontSize="small" />
                       </IconButton>

--- a/frontend/src/components/common/WorkboardSelectDialog.js
+++ b/frontend/src/components/common/WorkboardSelectDialog.js
@@ -13,17 +13,13 @@ import {
   Alert,
   CircularProgress
 } from '@mui/material';
-import { useQuery } from 'react-query';
+import { useQuery } from '@tanstack/react-query';
 import { workboardAPI } from '../../services/api';
 
 function WorkboardSelectDialog({ open, onClose, onSelect }) {
   // 본 다이얼로그는 image / video 작업판으로 다른 작업판 이어가기 용. text 작업판은 제외.
   // 백엔드 limit max 50 으로 한 번에 가능한 많이 가져오고 클라이언트에서 outputFormat 필터.
-  const { data, isLoading } = useQuery(
-    ['workboards', { limit: 50, isActive: true }],
-    () => workboardAPI.getAll({ isActive: true, limit: 50 }),
-    { enabled: open }
-  );
+  const { data, isLoading } = useQuery({ queryKey: ['workboards', { limit: 50, isActive: true }], queryFn: () => workboardAPI.getAll({ isActive: true, limit: 50 }), enabled: open });
 
   const allWorkboards = data?.data?.workboards || [];
   const workboards = allWorkboards.filter((wb) => (wb.outputFormat || 'image') !== 'text');

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -22,7 +22,7 @@ import {
   TrendingUp,
 } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
-import { useQuery } from 'react-query';
+import { useQuery } from '@tanstack/react-query';
 import {
   dashboardAPI,
   projectAPI,
@@ -145,30 +145,14 @@ function Dashboard() {
   const { user, isAdmin } = useAuth();
   const [updateLogOpen, setUpdateLogOpen] = useState(false);
 
-  const { data: activeRunsRes } = useQuery(
-    'dashboardActiveRuns',
-    dashboardAPI.getActivePipelineRuns,
-    { refetchInterval: config.monitoring.recentJobsInterval }
-  );
-  const { data: projectsRes, isLoading: projectsLoading } = useQuery(
-    'dashboardProjects',
-    () => projectAPI.getAll()
-  );
-  const { data: imagesRes, isLoading: imagesLoading } = useQuery(
-    'dashboardRecentImages',
-    () => imageAPI.getGenerated({ limit: 12 })
-  );
-  const { data: trendRes } = useQuery('dashboardImageTrend', () =>
-    dashboardAPI.getImageTrend(7)
-  );
-  const { data: serversRes } = useQuery(
-    'dashboardServers',
-    () => serverAPI.getServers(),
-    { refetchInterval: config.monitoring.queueStatusInterval }
-  );
-  const { data: workboardsRes } = useQuery('dashboardWorkboardUsage', () =>
-    dashboardAPI.getWorkboardUsage(4)
-  );
+  const { data: activeRunsRes } = useQuery({ queryKey: ['dashboardActiveRuns'], queryFn: dashboardAPI.getActivePipelineRuns, refetchInterval: config.monitoring.recentJobsInterval });
+  const { data: projectsRes, isLoading: projectsLoading } = useQuery({ queryKey: ['dashboardProjects'], queryFn: () => projectAPI.getAll() });
+  const { data: imagesRes, isLoading: imagesLoading } = useQuery({ queryKey: ['dashboardRecentImages'], queryFn: () => imageAPI.getGenerated({ limit: 12 }) });
+  const { data: trendRes } = useQuery({ queryKey: ['dashboardImageTrend'], queryFn: () =>
+    dashboardAPI.getImageTrend(7) });
+  const { data: serversRes } = useQuery({ queryKey: ['dashboardServers'], queryFn: () => serverAPI.getServers(), refetchInterval: config.monitoring.queueStatusInterval });
+  const { data: workboardsRes } = useQuery({ queryKey: ['dashboardWorkboardUsage'], queryFn: () =>
+    dashboardAPI.getWorkboardUsage(4) });
 
   const activeRuns = activeRunsRes?.data?.data?.runs || [];
   const projects = (projectsRes?.data?.data?.projects || []).slice(0, 4);

--- a/frontend/src/pages/ForgotPassword.js
+++ b/frontend/src/pages/ForgotPassword.js
@@ -17,7 +17,7 @@ import {
 } from '@mui/icons-material';
 import { useForm, Controller } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
-import { useMutation } from 'react-query';
+import { useMutation } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { authAPI } from '../services/api';
 import AuthLayout, { AuthTitle } from '../components/auth/AuthLayout';
@@ -29,9 +29,7 @@ function ForgotPassword() {
 
   const { control, handleSubmit, formState: { errors } } = useForm();
 
-  const forgotPasswordMutation = useMutation(
-    (email) => authAPI.requestPasswordReset(email),
-    {
+  const forgotPasswordMutation = useMutation({ mutationFn: (email) => authAPI.requestPasswordReset(email),
       onSuccess: (response, email) => {
         setEmailSent(true);
         setSentEmail(email);
@@ -40,9 +38,7 @@ function ForgotPassword() {
       onError: (error) => {
         const message = error.response?.data?.message || '요청 처리 중 오류가 발생했습니다';
         toast.error(message);
-      }
-    }
-  );
+      } });
 
   const onSubmit = (data) => {
     forgotPasswordMutation.mutate(data.email);
@@ -131,10 +127,10 @@ function ForgotPassword() {
               fullWidth
               variant="contained"
               size="large"
-              disabled={forgotPasswordMutation.isLoading}
+              disabled={forgotPasswordMutation.isPending}
               sx={{ mb: 3, py: 1.5 }}
             >
-              {forgotPasswordMutation.isLoading ? (
+              {forgotPasswordMutation.isPending ? (
                 <CircularProgress size={24} color="inherit" />
               ) : (
                 '비밀번호 재설정 이메일 발송'

--- a/frontend/src/pages/ImageGeneration.js
+++ b/frontend/src/pages/ImageGeneration.js
@@ -41,7 +41,7 @@ import {
   ContentCopy
 } from '@mui/icons-material';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
-import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import { useForm, Controller } from 'react-hook-form';
 import { useDropzone } from 'react-dropzone';
 import toast from 'react-hot-toast';
@@ -62,11 +62,7 @@ function PromptDataSelectDialog({ open, onClose, onSelect }) {
   const [search, setSearch] = useState('');
   const limit = 8;
 
-  const { data, isLoading } = useQuery(
-    ['promptDataList', page, limit, search],
-    () => promptDataAPI.getAll({ page, limit, search: search || undefined }),
-    { enabled: open, keepPreviousData: true }
-  );
+  const { data, isLoading } = useQuery({ queryKey: ['promptDataList', page, limit, search], queryFn: () => promptDataAPI.getAll({ page, limit, search: search || undefined }), enabled: open, placeholderData: keepPreviousData });
 
   const promptDataList = data?.data?.data?.promptDataList || [];
   const pagination = data?.data?.data?.pagination || { total: 0, pages: 1 };
@@ -395,11 +391,7 @@ function ImageGeneration() {
   const promptInputRef = useRef(null);
 
   // 프로젝트 컨텍스트 조회
-  const { data: projectData } = useQuery(
-    ['project', projectId],
-    () => projectAPI.getById(projectId),
-    { enabled: !!projectId }
-  );
+  const { data: projectData } = useQuery({ queryKey: ['project', projectId], queryFn: () => projectAPI.getById(projectId), enabled: !!projectId });
   const projectContext = projectData?.data?.data?.project;
 
   const handleCopyWorkboardId = async () => {
@@ -516,13 +508,10 @@ function ImageGeneration() {
     shouldFocusError: true
   });
 
-  const { data: workboard, isLoading, error } = useQuery(
-    ['workboard', id],
-    () => workboardAPI.getById(id)
-  );
+  const { data: workboard, isLoading, error } = useQuery({ queryKey: ['workboard', id], queryFn: () => workboardAPI.getById(id) });
 
   // 사용자 설정 가져오기
-  const { data: profileData } = useQuery('userProfile', () => userAPI.getProfile());
+  const { data: profileData } = useQuery({ queryKey: ['userProfile'], queryFn: () => userAPI.getProfile() });
   const userPreferences = profileData?.data?.user?.preferences || {};
 
   // 프롬프트의 <lora:이름:가중치> 태그 → 칩 표시용 파싱 (#552, 목업 06)
@@ -545,25 +534,20 @@ function ImageGeneration() {
   };
 
   // 대기 큐 — 우측 레일 표시 (#552)
-  const { data: queueStatsData } = useQuery('queueStats', jobAPI.getQueueStats, {
-    refetchInterval: config.monitoring.queueStatusInterval,
-  });
+  const { data: queueStatsData } = useQuery({ queryKey: ['queueStats'], queryFn: jobAPI.getQueueStats,
+    refetchInterval: config.monitoring.queueStatusInterval, });
   const qs = queueStatsData?.data?.stats;
   const queueStatsText = qs ? `대기 ${qs.waiting ?? 0} · 진행 ${qs.active ?? 0}` : '—';
 
-  const generateMutation = useMutation(
-    jobAPI.create,
-    {
+  const generateMutation = useMutation({ mutationFn: jobAPI.create,
       onSuccess: (data) => {
         toast.success('이미지 생성 작업이 시작되었습니다');
-        queryClient.invalidateQueries('historyJobs');
+        queryClient.invalidateQueries({ queryKey: ['historyJobs'] });
         navigate('/jobs');
       },
       onError: (error) => {
         toast.error('작업 생성 실패: ' + error.message);
-      }
-    }
-  );
+      } });
 
   const workboardData = workboard?.data?.workboard;
   const isComfyUIWorkboard = workboardData?.serverId?.serverType === 'ComfyUI';
@@ -1120,7 +1104,7 @@ function ImageGeneration() {
                 fullWidth
                 variant="contained"
                 size="large"
-                disabled={generating || generateMutation.isLoading}
+                disabled={generating || generateMutation.isPending}
                 startIcon={generating ? <CircularProgress size={20} /> : <Send />}
               >
                 {generating ? '생성 중...' : '이미지 생성 시작'}

--- a/frontend/src/pages/JobHistory.js
+++ b/frontend/src/pages/JobHistory.js
@@ -33,7 +33,7 @@ import {
   CheckCircle,
   Close,
 } from '@mui/icons-material';
-import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import {
@@ -365,23 +365,11 @@ function JobHistory() {
   const [limit, setLimit] = useState(20);
 
   // 데이터
-  const { data: jobsRes, isLoading: jobsLoading } = useQuery(
-    ['historyJobs', limit],
-    () => jobAPI.getMy({ limit }),
-    { refetchInterval: config.monitoring.recentJobsInterval, keepPreviousData: true }
-  );
-  const { data: convsRes, isLoading: convsLoading } = useQuery(
-    ['historyConvs', limit],
-    () => conversationAPI.getMy({ limit }),
-    { keepPreviousData: true }
-  );
-  const { data: runsRes, isLoading: runsLoading } = useQuery(
-    ['historyRuns', limit],
-    () => dashboardAPI.getAllPipelineRuns({ limit }),
-    { refetchInterval: config.monitoring.recentJobsInterval, keepPreviousData: true }
-  );
+  const { data: jobsRes, isLoading: jobsLoading } = useQuery({ queryKey: ['historyJobs', limit], queryFn: () => jobAPI.getMy({ limit }), refetchInterval: config.monitoring.recentJobsInterval, placeholderData: keepPreviousData });
+  const { data: convsRes, isLoading: convsLoading } = useQuery({ queryKey: ['historyConvs', limit], queryFn: () => conversationAPI.getMy({ limit }), placeholderData: keepPreviousData });
+  const { data: runsRes, isLoading: runsLoading } = useQuery({ queryKey: ['historyRuns', limit], queryFn: () => dashboardAPI.getAllPipelineRuns({ limit }), refetchInterval: config.monitoring.recentJobsInterval, placeholderData: keepPreviousData });
 
-  const { data: profileData } = useQuery('userProfile', () => userAPI.getProfile());
+  const { data: profileData } = useQuery({ queryKey: ['userProfile'], queryFn: () => userAPI.getProfile() });
   const userPreferences = profileData?.data?.user?.preferences || {};
 
   const loading = jobsLoading || convsLoading || runsLoading;
@@ -424,27 +412,22 @@ function JobHistory() {
   const [textDetail, setTextDetail] = useState(null);
 
   // ---- mutations ----
-  const deleteMutation = useMutation(
-    ({ id, deleteContent }) => jobAPI.delete(id, deleteContent),
-    {
+  const deleteMutation = useMutation({ mutationFn: ({ id, deleteContent }) => jobAPI.delete(id, deleteContent),
       onSuccess: (response) => {
         const { deletedImagesCount = 0, deletedVideosCount = 0 } = response.data || {};
         if (deletedImagesCount > 0 || deletedVideosCount > 0) {
           toast.success(`작업과 ${deletedImagesCount}개 이미지, ${deletedVideosCount}개 동영상이 삭제되었습니다`);
-          queryClient.invalidateQueries('generatedImages');
-          queryClient.invalidateQueries('generatedVideos');
+          queryClient.invalidateQueries({ queryKey: ['generatedImages'] });
+          queryClient.invalidateQueries({ queryKey: ['generatedVideos'] });
         } else {
           toast.success('작업이 삭제되었습니다');
         }
-        queryClient.invalidateQueries('historyJobs');
+        queryClient.invalidateQueries({ queryKey: ['historyJobs'] });
       },
-      onError: (error) => toast.error('삭제 실패: ' + error.message),
-    }
-  );
-  const savePromptMutation = useMutation(promptDataAPI.create, {
+      onError: (error) => toast.error('삭제 실패: ' + error.message), });
+  const savePromptMutation = useMutation({ mutationFn: promptDataAPI.create,
     onSuccess: () => { toast.success('프롬프트 데이터가 저장되었습니다'); setSaveJob(null); },
-    onError: (error) => toast.error('프롬프트 저장 실패: ' + (error.response?.data?.message || error.message)),
-  });
+    onError: (error) => toast.error('프롬프트 저장 실패: ' + (error.response?.data?.message || error.message)), });
 
   // ---- handlers ----
   const openMedia = (item) => {

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -23,7 +23,7 @@ import {
 } from '@mui/icons-material';
 import { useForm, Controller } from 'react-hook-form';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { useMutation } from 'react-query';
+import { useMutation } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { authAPI } from '../services/api';
 import { useAuth } from '../contexts/AuthContext';
@@ -66,9 +66,7 @@ function Login() {
 
   const { control, handleSubmit, formState: { errors } } = useForm();
 
-  const signinMutation = useMutation(
-    authAPI.signin,
-    {
+  const signinMutation = useMutation({ mutationFn: authAPI.signin,
       onSuccess: async (response) => {
         console.log('🔐 Login success, token received:', !!response.data.token);
         
@@ -109,9 +107,7 @@ function Login() {
         } else {
           toast.error(errorData?.message || '로그인 실패');
         }
-      }
-    }
-  );
+      } });
 
   const handleGoogleLogin = () => {
     window.location.href = '/api/auth/google';
@@ -216,10 +212,10 @@ function Login() {
               fullWidth
               variant="contained"
               size="large"
-              disabled={signinMutation.isLoading}
+              disabled={signinMutation.isPending}
               sx={{ mb: 3, py: 1.5 }}
             >
-              {signinMutation.isLoading ? (
+              {signinMutation.isPending ? (
                 <CircularProgress size={24} color="inherit" />
               ) : (
                 '로그인'

--- a/frontend/src/pages/MyImages.js
+++ b/frontend/src/pages/MyImages.js
@@ -28,7 +28,7 @@ import {
   SelectAll,
   Deselect
 } from '@mui/icons-material';
-import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useDropzone } from 'react-dropzone';
 import toast from 'react-hot-toast';
 import { imageAPI, userAPI, textAPI, projectAPI, tagAPI } from '../services/api';
@@ -188,20 +188,16 @@ function ImageEditDialog({ image, open, onClose, type, onSuccess, isVideo = fals
     return 'generatedImages';
   };
 
-  const updateMutation = useMutation(
-    (data) => getUpdateFn()(image._id, data),
-    {
+  const updateMutation = useMutation({ mutationFn: (data) => getUpdateFn()(image._id, data),
       onSuccess: () => {
-        queryClient.invalidateQueries(getQueryKey());
+        queryClient.invalidateQueries({ queryKey: Array.isArray(getQueryKey()) ? getQueryKey() : [getQueryKey()] });
         toast.success(`${isVideo ? '동영상' : '이미지'} 정보가 수정되었습니다`);
         onSuccess?.();
         onClose();
       },
       onError: (error) => {
         toast.error(error.response?.data?.message || '수정 실패');
-      }
-    }
-  );
+      } });
 
   const handleSave = () => {
     updateMutation.mutate({
@@ -246,7 +242,7 @@ function ImageEditDialog({ image, open, onClose, type, onSuccess, isVideo = fals
         <Button
           variant="contained"
           onClick={handleSave}
-          disabled={updateMutation.isLoading}
+          disabled={updateMutation.isPending}
         >
           저장
         </Button>
@@ -361,72 +357,52 @@ function MyImages() {
   const queryClient = useQueryClient();
 
   // 사용자 설정 가져오기
-  const { data: profileData } = useQuery('userProfile', () => userAPI.getProfile());
+  const { data: profileData } = useQuery({ queryKey: ['userProfile'], queryFn: () => userAPI.getProfile() });
   const userPreferences = profileData?.data?.user?.preferences || {};
 
-  const deleteUploadedMutation = useMutation(
-    imageAPI.deleteUploaded,
-    {
+  const deleteUploadedMutation = useMutation({ mutationFn: imageAPI.deleteUploaded,
       onSuccess: () => {
         toast.success('이미지가 삭제되었습니다');
-        queryClient.invalidateQueries('uploadedImages');
+        queryClient.invalidateQueries({ queryKey: ['uploadedImages'] });
       },
-      onError: () => toast.error('삭제 실패')
-    }
-  );
+      onError: () => toast.error('삭제 실패') });
 
-  const deleteGeneratedMutation = useMutation(
-    ({ id, deleteJob }) => imageAPI.deleteGenerated(id, deleteJob),
-    {
+  const deleteGeneratedMutation = useMutation({ mutationFn: ({ id, deleteJob }) => imageAPI.deleteGenerated(id, deleteJob),
       onSuccess: () => {
         toast.success('이미지가 삭제되었습니다');
-        queryClient.invalidateQueries('generatedImages');
+        queryClient.invalidateQueries({ queryKey: ['generatedImages'] });
       },
-      onError: () => toast.error('삭제 실패')
-    }
-  );
+      onError: () => toast.error('삭제 실패') });
 
-  const deleteVideoMutation = useMutation(
-    ({ id, deleteJob }) => imageAPI.deleteVideo(id, deleteJob),
-    {
+  const deleteVideoMutation = useMutation({ mutationFn: ({ id, deleteJob }) => imageAPI.deleteVideo(id, deleteJob),
       onSuccess: () => {
         toast.success('동영상이 삭제되었습니다');
-        queryClient.invalidateQueries('generatedVideos');
+        queryClient.invalidateQueries({ queryKey: ['generatedVideos'] });
       },
-      onError: () => toast.error('삭제 실패')
-    }
-  );
+      onError: () => toast.error('삭제 실패') });
 
   // Bulk delete mutations
-  const bulkDeleteMutation = useMutation(
-    ({ items, deleteJob }) => imageAPI.bulkDelete(items, deleteJob),
-    {
+  const bulkDeleteMutation = useMutation({ mutationFn: ({ items, deleteJob }) => imageAPI.bulkDelete(items, deleteJob),
       onSuccess: (response) => {
         const result = response.data?.data || response.data;
         toast.success(`${result.deleted}개 항목이 삭제되었습니다${result.failed ? ` (${result.failed}개 실패)` : ''}`);
-        queryClient.invalidateQueries(getQueryKeyForTab());
+        queryClient.invalidateQueries({ queryKey: Array.isArray(getQueryKeyForTab()) ? getQueryKeyForTab() : [getQueryKeyForTab()] });
         setBulkMode(false);
         setSelectedIds(new Set());
         setConfirmOpen(false);
       },
-      onError: () => toast.error('일괄 삭제 실패')
-    }
-  );
+      onError: () => toast.error('일괄 삭제 실패') });
 
-  const bulkDeleteByFilterMutation = useMutation(
-    ({ type, filters }) => imageAPI.bulkDeleteByFilter(type, filters),
-    {
+  const bulkDeleteByFilterMutation = useMutation({ mutationFn: ({ type, filters }) => imageAPI.bulkDeleteByFilter(type, filters),
       onSuccess: (response) => {
         const result = response.data?.data || response.data;
         toast.success(`${result.deleted}개 항목이 삭제되었습니다${result.failed ? ` (${result.failed}개 실패)` : ''}`);
-        queryClient.invalidateQueries(getQueryKeyForTab());
+        queryClient.invalidateQueries({ queryKey: Array.isArray(getQueryKeyForTab()) ? getQueryKeyForTab() : [getQueryKeyForTab()] });
         setBulkMode(false);
         setSelectedIds(new Set());
         setConfirmOpen(false);
       },
-      onError: () => toast.error('일괄 삭제 실패')
-    }
-  );
+      onError: () => toast.error('일괄 삭제 실패') });
 
   const handleEdit = (image) => {
     setEditImage(image);
@@ -464,7 +440,7 @@ function MyImages() {
   };
 
   const handleUploadSuccess = () => {
-    queryClient.invalidateQueries('uploadedImages');
+    queryClient.invalidateQueries({ queryKey: ['uploadedImages'] });
   };
 
   const getTypeForTab = () => {
@@ -525,13 +501,13 @@ function MyImages() {
     setConfirmOpen(true);
   };
 
-  const isBulkDeleting = bulkDeleteMutation.isLoading || bulkDeleteByFilterMutation.isLoading;
+  const isBulkDeleting = bulkDeleteMutation.isPending || bulkDeleteByFilterMutation.isPending;
   const theme = useTheme();
   const isDesktop = useMediaQuery(theme.breakpoints.up('md'));
 
   // 5c 후속 — 필터 레일 source. 프로젝트 목록 + 사용자 태그.
-  const { data: projectsData } = useQuery(['filterRail', 'projects'], () => projectAPI.getAll({ limit: 200 }), { staleTime: 60_000 });
-  const { data: myTagsData }   = useQuery(['filterRail', 'tags'],     () => tagAPI.getMy(),                   { staleTime: 60_000 });
+  const { data: projectsData } = useQuery({ queryKey: ['filterRail', 'projects'], queryFn: () => projectAPI.getAll({ limit: 200 }), staleTime: 60_000 });
+  const { data: myTagsData }   = useQuery({ queryKey: ['filterRail', 'tags'], queryFn: () => tagAPI.getMy(), staleTime: 60_000 });
   const filterProjects = (projectsData?.data?.data?.projects || projectsData?.data?.projects || []).filter((p) => !!p.tagId);
   const filterTags = (myTagsData?.data?.data?.tags || myTagsData?.data?.tags || []).filter((t) => !t.isProjectTag);
 
@@ -554,11 +530,11 @@ function MyImages() {
   // 탭 count badge 용 — 각 탭 limit:1 query (Phase 5c 후속).
   // staleTime 60s 로 페이지 진입 시 1회만 fetch. mediaState 와는 독립 — 사용자가 검색
   // 입력하면 mediaState.pagination.total 로 그쪽이 보여줌.
-  const { data: genImagesCountData } = useQuery(['contentCount', 'generated'], () => imageAPI.getGenerated({ limit: 1, page: 1 }), { staleTime: 60_000 });
-  const { data: upImagesCountData }  = useQuery(['contentCount', 'uploaded'],  () => imageAPI.getUploaded({ limit: 1, page: 1 }),  { staleTime: 60_000 });
-  const { data: videosCountData }    = useQuery(['contentCount', 'video'],     () => imageAPI.getVideos({ limit: 1, page: 1 }),    { staleTime: 60_000 });
-  const { data: upTextsCountData }   = useQuery(['contentCount', 'textUp'],    () => textAPI.getUploaded({ limit: 1, page: 1 }),   { staleTime: 60_000 });
-  const { data: genTextsCountData }  = useQuery(['contentCount', 'textGen'],   () => textAPI.getGenerated({ limit: 1, page: 1 }),  { staleTime: 60_000 });
+  const { data: genImagesCountData } = useQuery({ queryKey: ['contentCount', 'generated'], queryFn: () => imageAPI.getGenerated({ limit: 1, page: 1 }), staleTime: 60_000 });
+  const { data: upImagesCountData }  = useQuery({ queryKey: ['contentCount', 'uploaded'], queryFn: () => imageAPI.getUploaded({ limit: 1, page: 1 }), staleTime: 60_000 });
+  const { data: videosCountData }    = useQuery({ queryKey: ['contentCount', 'video'], queryFn: () => imageAPI.getVideos({ limit: 1, page: 1 }), staleTime: 60_000 });
+  const { data: upTextsCountData }   = useQuery({ queryKey: ['contentCount', 'textUp'], queryFn: () => textAPI.getUploaded({ limit: 1, page: 1 }), staleTime: 60_000 });
+  const { data: genTextsCountData }  = useQuery({ queryKey: ['contentCount', 'textGen'], queryFn: () => textAPI.getGenerated({ limit: 1, page: 1 }), staleTime: 60_000 });
   const counts = [
     genImagesCountData?.data?.data?.pagination?.total,
     upImagesCountData?.data?.data?.pagination?.total,

--- a/frontend/src/pages/Profile.js
+++ b/frontend/src/pages/Profile.js
@@ -41,7 +41,7 @@ import {
   Add
 } from '@mui/icons-material';
 import { useForm, Controller } from 'react-hook-form';
-import { useMutation, useQuery, useQueryClient } from 'react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { userAPI, apiKeyAPI } from '../services/api';
 import { useAuth } from '../contexts/AuthContext';
@@ -92,20 +92,16 @@ function AccountSettings() {
     setIsDirty(hasChanges);
   }, [watchedValues, user]);
 
-  const updateMutation = useMutation(
-    userAPI.updateProfile,
-    {
+  const updateMutation = useMutation({ mutationFn: userAPI.updateProfile,
       onSuccess: (data) => {
         updateProfile(data.data.user);
-        queryClient.invalidateQueries('userProfile');
+        queryClient.invalidateQueries({ queryKey: ['userProfile'] });
         toast.success('프로필이 업데이트되었습니다');
         setIsDirty(false);
       },
       onError: (error) => {
         toast.error('업데이트 실패: ' + error.message);
-      }
-    }
-  );
+      } });
 
   const onSubmit = (data) => {
     updateMutation.mutate(data);
@@ -216,10 +212,10 @@ function AccountSettings() {
           <Button
             type="submit"
             variant="contained"
-            disabled={!isDirty || updateMutation.isLoading}
+            disabled={!isDirty || updateMutation.isPending}
             startIcon={<Save />}
           >
-            {updateMutation.isLoading ? '저장 중...' : '변경사항 저장'}
+            {updateMutation.isPending ? '저장 중...' : '변경사항 저장'}
           </Button>
         </Box>
       </form>
@@ -239,47 +235,35 @@ function SecuritySettings() {
   const queryClient = useQueryClient();
 
   // API Key 목록 조회
-  const { data: apiKeysData } = useQuery('apiKeys', () => apiKeyAPI.getAll());
+  const { data: apiKeysData } = useQuery({ queryKey: ['apiKeys'], queryFn: () => apiKeyAPI.getAll() });
   const apiKeys = apiKeysData?.data?.data || [];
   const activeKeyCount = apiKeys.filter(k => !k.isRevoked).length;
 
-  const deleteMutation = useMutation(
-    userAPI.deleteAccount,
-    {
+  const deleteMutation = useMutation({ mutationFn: userAPI.deleteAccount,
       onSuccess: () => {
         toast.success('계정이 삭제되었습니다');
         logout();
       },
       onError: (error) => {
         toast.error('계정 삭제 실패: ' + error.message);
-      }
-    }
-  );
+      } });
 
-  const createKeyMutation = useMutation(
-    (data) => apiKeyAPI.create(data),
-    {
+  const createKeyMutation = useMutation({ mutationFn: (data) => apiKeyAPI.create(data),
       onSuccess: (response) => {
         setCreatedKey(response.data.data);
         setCreateKeyDialogOpen(false);
         setShowKeyDialogOpen(true);
         setNewKeyName('');
-        queryClient.invalidateQueries('apiKeys');
-      }
-    }
-  );
+        queryClient.invalidateQueries({ queryKey: ['apiKeys'] });
+      } });
 
-  const revokeKeyMutation = useMutation(
-    (id) => apiKeyAPI.revoke(id),
-    {
+  const revokeKeyMutation = useMutation({ mutationFn: (id) => apiKeyAPI.revoke(id),
       onSuccess: () => {
         toast.success('API Key가 파기되었습니다');
         setRevokeDialogOpen(false);
         setRevokeTarget(null);
-        queryClient.invalidateQueries('apiKeys');
-      }
-    }
-  );
+        queryClient.invalidateQueries({ queryKey: ['apiKeys'] });
+      } });
 
   const handleDeleteAccount = () => {
     deleteMutation.mutate();
@@ -453,9 +437,9 @@ function SecuritySettings() {
           <Button
             onClick={handleCreateKey}
             variant="contained"
-            disabled={!newKeyName.trim() || createKeyMutation.isLoading}
+            disabled={!newKeyName.trim() || createKeyMutation.isPending}
           >
-            {createKeyMutation.isLoading ? '생성 중...' : '생성'}
+            {createKeyMutation.isPending ? '생성 중...' : '생성'}
           </Button>
         </DialogActions>
       </Dialog>
@@ -524,9 +508,9 @@ function SecuritySettings() {
             onClick={handleRevokeKey}
             color="error"
             variant="contained"
-            disabled={revokeKeyMutation.isLoading}
+            disabled={revokeKeyMutation.isPending}
           >
-            {revokeKeyMutation.isLoading ? '파기 중...' : '파기'}
+            {revokeKeyMutation.isPending ? '파기 중...' : '파기'}
           </Button>
         </DialogActions>
       </Dialog>
@@ -559,9 +543,9 @@ function SecuritySettings() {
             onClick={handleDeleteAccount}
             color="error"
             variant="contained"
-            disabled={deleteMutation.isLoading}
+            disabled={deleteMutation.isPending}
           >
-            {deleteMutation.isLoading ? '삭제 중...' : '계정 삭제'}
+            {deleteMutation.isPending ? '삭제 중...' : '계정 삭제'}
           </Button>
         </DialogActions>
       </Dialog>
@@ -573,10 +557,7 @@ function Profile() {
   const { user } = useAuth();
   const [selectedTab, setSelectedTab] = useState(0);
 
-  const { data: userStats, isLoading } = useQuery(
-    'userStats',
-    userAPI.getStats
-  );
+  const { data: userStats, isLoading } = useQuery({ queryKey: ['userStats'], queryFn: userAPI.getStats });
 
   const stats = userStats?.data || {};
 

--- a/frontend/src/pages/ProjectDetail.js
+++ b/frontend/src/pages/ProjectDetail.js
@@ -42,7 +42,7 @@ import {
   Deselect
 } from '@mui/icons-material';
 import { useParams, useNavigate } from 'react-router-dom';
-import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { projectAPI, imageAPI, userAPI, promptDataAPI, tagAPI, workboardAPI, pipelineAPI, pipelineRunAPI } from '../services/api';
 import TextContentPanel from '../components/common/TextContentPanel';
@@ -69,22 +69,18 @@ function ImageEditDialog({ image, open, onClose, isVideo = false, projectId }) {
     }
   }, [image]);
 
-  const updateMutation = useMutation(
-    (data) => (isVideo ? imageAPI.updateVideo : imageAPI.updateGenerated)(image._id, data),
-    {
+  const updateMutation = useMutation({ mutationFn: (data) => (isVideo ? imageAPI.updateVideo : imageAPI.updateGenerated)(image._id, data),
       onSuccess: () => {
-        queryClient.invalidateQueries(`projectImages-${projectId}`);
-        queryClient.invalidateQueries(`projectVideos-${projectId}`);
-        queryClient.invalidateQueries(isVideo ? 'generatedVideos' : 'generatedImages');
-        queryClient.invalidateQueries(['project', projectId]);
+        queryClient.invalidateQueries({ queryKey: [`projectImages-${projectId}`] });
+        queryClient.invalidateQueries({ queryKey: [`projectVideos-${projectId}`] });
+        queryClient.invalidateQueries({ queryKey: Array.isArray(isVideo ? 'generatedVideos' : 'generatedImages') ? isVideo ? 'generatedVideos' : 'generatedImages' : [isVideo ? 'generatedVideos' : 'generatedImages'] });
+        queryClient.invalidateQueries({ queryKey: ['project', projectId] });
         toast.success(`${isVideo ? '동영상' : '이미지'} 정보가 수정되었습니다`);
         onClose();
       },
       onError: (error) => {
         toast.error(error.response?.data?.message || '수정 실패');
-      }
-    }
-  );
+      } });
 
   const handleSave = () => {
     updateMutation.mutate({
@@ -129,7 +125,7 @@ function ImageEditDialog({ image, open, onClose, isVideo = false, projectId }) {
         <Button
           variant="contained"
           onClick={handleSave}
-          disabled={updateMutation.isLoading}
+          disabled={updateMutation.isPending}
         >
           저장
         </Button>
@@ -154,54 +150,42 @@ function ImagesTab({ projectId }) {
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [deleteJobChecked, setDeleteJobChecked] = useState(false);
 
-  const { data: profileData } = useQuery('userProfile', () => userAPI.getProfile());
+  const { data: profileData } = useQuery({ queryKey: ['userProfile'], queryFn: () => userAPI.getProfile() });
   const userPreferences = profileData?.data?.user?.preferences || {};
 
-  const deleteGeneratedMutation = useMutation(
-    ({ id, deleteJob }) => imageAPI.deleteGenerated(id, deleteJob),
-    {
+  const deleteGeneratedMutation = useMutation({ mutationFn: ({ id, deleteJob }) => imageAPI.deleteGenerated(id, deleteJob),
       onSuccess: () => {
         toast.success('이미지가 삭제되었습니다');
-        queryClient.invalidateQueries(`projectImages-${projectId}`);
-        queryClient.invalidateQueries('generatedImages');
-        queryClient.invalidateQueries(['project', projectId]);
+        queryClient.invalidateQueries({ queryKey: [`projectImages-${projectId}`] });
+        queryClient.invalidateQueries({ queryKey: ['generatedImages'] });
+        queryClient.invalidateQueries({ queryKey: ['project', projectId] });
       },
-      onError: () => toast.error('삭제 실패')
-    }
-  );
+      onError: () => toast.error('삭제 실패') });
 
-  const deleteVideoMutation = useMutation(
-    ({ id, deleteJob }) => imageAPI.deleteVideo(id, deleteJob),
-    {
+  const deleteVideoMutation = useMutation({ mutationFn: ({ id, deleteJob }) => imageAPI.deleteVideo(id, deleteJob),
       onSuccess: () => {
         toast.success('동영상이 삭제되었습니다');
-        queryClient.invalidateQueries(`projectVideos-${projectId}`);
-        queryClient.invalidateQueries('generatedVideos');
-        queryClient.invalidateQueries(['project', projectId]);
+        queryClient.invalidateQueries({ queryKey: [`projectVideos-${projectId}`] });
+        queryClient.invalidateQueries({ queryKey: ['generatedVideos'] });
+        queryClient.invalidateQueries({ queryKey: ['project', projectId] });
       },
-      onError: () => toast.error('삭제 실패')
-    }
-  );
+      onError: () => toast.error('삭제 실패') });
 
-  const bulkDeleteMutation = useMutation(
-    ({ items, deleteJob }) => imageAPI.bulkDelete(items, deleteJob),
-    {
+  const bulkDeleteMutation = useMutation({ mutationFn: ({ items, deleteJob }) => imageAPI.bulkDelete(items, deleteJob),
       onSuccess: (response) => {
         const result = response.data?.data || response.data;
         toast.success(`${result.deleted}개 항목이 삭제되었습니다${result.failed ? ` (${result.failed}개 실패)` : ''}`);
-        queryClient.invalidateQueries(`projectImages-${projectId}`);
-        queryClient.invalidateQueries(`projectVideos-${projectId}`);
-        queryClient.invalidateQueries('generatedImages');
-        queryClient.invalidateQueries('generatedVideos');
-        queryClient.invalidateQueries(['project', projectId]);
+        queryClient.invalidateQueries({ queryKey: [`projectImages-${projectId}`] });
+        queryClient.invalidateQueries({ queryKey: [`projectVideos-${projectId}`] });
+        queryClient.invalidateQueries({ queryKey: ['generatedImages'] });
+        queryClient.invalidateQueries({ queryKey: ['generatedVideos'] });
+        queryClient.invalidateQueries({ queryKey: ['project', projectId] });
         setBulkMode(false);
         setImageSelectedIds(new Set());
         setVideoSelectedIds(new Set());
         setConfirmOpen(false);
       },
-      onError: () => toast.error('일괄 삭제 실패')
-    }
-  );
+      onError: () => toast.error('일괄 삭제 실패') });
 
   const handleEditImage = (image) => {
     setEditImage(image);
@@ -399,14 +383,14 @@ function ImagesTab({ projectId }) {
           </Alert>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setConfirmOpen(false)} disabled={bulkDeleteMutation.isLoading}>취소</Button>
+          <Button onClick={() => setConfirmOpen(false)} disabled={bulkDeleteMutation.isPending}>취소</Button>
           <Button
             variant="contained"
             color="error"
             onClick={handleBulkDeleteConfirm}
-            disabled={bulkDeleteMutation.isLoading}
+            disabled={bulkDeleteMutation.isPending}
           >
-            {bulkDeleteMutation.isLoading ? '삭제 중...' : '삭제'}
+            {bulkDeleteMutation.isPending ? '삭제 중...' : '삭제'}
           </Button>
         </DialogActions>
       </Dialog>
@@ -425,32 +409,27 @@ function PromptDataTab({ projectId }) {
   const [workboardSelectOpen, setWorkboardSelectOpen] = useState(false);
   const [selectedPromptData, setSelectedPromptData] = useState(null);
 
-  const updateMutation = useMutation(
-    ({ id, data }) => promptDataAPI.update(id, data),
-    {
+  const updateMutation = useMutation({ mutationFn: ({ id, data }) => promptDataAPI.update(id, data),
       onSuccess: () => {
         toast.success('프롬프트 데이터가 수정되었습니다');
-        queryClient.invalidateQueries(`projectPromptData-${projectId}`);
-        queryClient.invalidateQueries('promptDataList');
-        queryClient.invalidateQueries(['project', projectId]);
+        queryClient.invalidateQueries({ queryKey: [`projectPromptData-${projectId}`] });
+        queryClient.invalidateQueries({ queryKey: ['promptDataList'] });
+        queryClient.invalidateQueries({ queryKey: ['project', projectId] });
         setFormOpen(false);
         setEditingPromptData(null);
       },
-      onError: () => toast.error('프롬프트 데이터 수정 실패')
-    }
-  );
+      onError: () => toast.error('프롬프트 데이터 수정 실패') });
 
-  const deleteMutation = useMutation(promptDataAPI.delete, {
+  const deleteMutation = useMutation({ mutationFn: promptDataAPI.delete,
     onSuccess: () => {
       toast.success('프롬프트 데이터가 삭제되었습니다');
-      queryClient.invalidateQueries(`projectPromptData-${projectId}`);
-      queryClient.invalidateQueries('promptDataList');
-      queryClient.invalidateQueries(['project', projectId]);
+      queryClient.invalidateQueries({ queryKey: [`projectPromptData-${projectId}`] });
+      queryClient.invalidateQueries({ queryKey: ['promptDataList'] });
+      queryClient.invalidateQueries({ queryKey: ['project', projectId] });
       setDeleteConfirmOpen(false);
       setDeletingId(null);
     },
-    onError: () => toast.error('프롬프트 데이터 삭제 실패')
-  });
+    onError: () => toast.error('프롬프트 데이터 삭제 실패') });
 
   const handleSave = (data) => {
     updateMutation.mutate({ id: editingPromptData._id, data });
@@ -546,8 +525,8 @@ function PromptDataTab({ projectId }) {
 // 프로젝트 + 타입(세계관/시스템 프롬프트/등) 태그 조합으로 문서를 분류.
 // 상단 chip 필터로 타입 전환. 문서 생성 시 현재 타입 태그가 자동 부여됨.
 function WorldviewTab({ projectTag }) {
-  const { data: wvTagData } = useQuery('worldviewTag', () => tagAPI.getWorldview(), { staleTime: 60_000 });
-  const { data: spTagData } = useQuery('systemPromptTag', () => tagAPI.getSystemPrompt(), { staleTime: 60_000 });
+  const { data: wvTagData } = useQuery({ queryKey: ['worldviewTag'], queryFn: () => tagAPI.getWorldview(), staleTime: 60_000 });
+  const { data: spTagData } = useQuery({ queryKey: ['systemPromptTag'], queryFn: () => tagAPI.getSystemPrompt(), staleTime: 60_000 });
   const worldviewTag = wvTagData?.data?.tag;
   const systemPromptTag = spTagData?.data?.tag;
 
@@ -601,34 +580,23 @@ function WorkboardsTab({ projectId }) {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [pickerOpen, setPickerOpen] = useState(false);
-  const { data, isLoading } = useQuery(
-    ['projectWorkboards', projectId],
-    () => projectAPI.getWorkboards(projectId),
-  );
+  const { data, isLoading } = useQuery({ queryKey: ['projectWorkboards', projectId], queryFn: () => projectAPI.getWorkboards(projectId) });
   const workboards = data?.data?.data?.workboards || [];
 
-  const addMutation = useMutation(
-    (workboardId) => projectAPI.addWorkboard(projectId, workboardId),
-    {
+  const addMutation = useMutation({ mutationFn: (workboardId) => projectAPI.addWorkboard(projectId, workboardId),
       onSuccess: () => {
         toast.success('작업판이 추가되었습니다.');
-        queryClient.invalidateQueries(['projectWorkboards', projectId]);
+        queryClient.invalidateQueries({ queryKey: ['projectWorkboards', projectId] });
         setPickerOpen(false);
       },
-      onError: (err) => toast.error(err.response?.data?.message || '추가 실패'),
-    }
-  );
+      onError: (err) => toast.error(err.response?.data?.message || '추가 실패'), });
 
-  const removeMutation = useMutation(
-    (workboardId) => projectAPI.removeWorkboard(projectId, workboardId),
-    {
+  const removeMutation = useMutation({ mutationFn: (workboardId) => projectAPI.removeWorkboard(projectId, workboardId),
       onSuccess: () => {
         toast.success('작업판이 제거되었습니다.');
-        queryClient.invalidateQueries(['projectWorkboards', projectId]);
+        queryClient.invalidateQueries({ queryKey: ['projectWorkboards', projectId] });
       },
-      onError: (err) => toast.error(err.response?.data?.message || '제거 실패'),
-    }
-  );
+      onError: (err) => toast.error(err.response?.data?.message || '제거 실패'), });
 
   if (isLoading) return <Box display="flex" justifyContent="center" py={4}><CircularProgress /></Box>;
 
@@ -704,11 +672,7 @@ function WorkboardsTab({ projectId }) {
 // 모든 작업판 중 골라 프로젝트에 추가하는 다이얼로그 (#396).
 function WorkboardPickerDialog({ open, onClose, existingIds = [], onPick }) {
   const [search, setSearch] = useState('');
-  const { data, isLoading } = useQuery(
-    ['allWorkboardsForPicker'],
-    () => workboardAPI.getAll(),
-    { enabled: open }
-  );
+  const { data, isLoading } = useQuery({ queryKey: ['allWorkboardsForPicker'], queryFn: () => workboardAPI.getAll(), enabled: open });
   const all = data?.data?.workboards || data?.data?.data?.workboards || [];
   const filtered = all.filter((wb) => {
     if (existingIds.includes(wb._id)) return false;
@@ -926,63 +890,40 @@ function ProjectDetail() {
   const [editOpen, setEditOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
 
-  const { data, isLoading, error } = useQuery(
-    ['project', id],
-    () => projectAPI.getById(id)
-  );
+  const { data, isLoading, error } = useQuery({ queryKey: ['project', id], queryFn: () => projectAPI.getById(id) });
 
   // 탭 라벨용 가벼운 count 조회 (Phase 5a 후속). staleTime 길게 — 새로고침 부담 회피.
-  const { data: pipelinesData } = useQuery(
-    ['pipelines', id],
-    () => pipelineAPI.list(id),
-    { enabled: !!id, staleTime: 60_000 }
-  );
+  const { data: pipelinesData } = useQuery({ queryKey: ['pipelines', id], queryFn: () => pipelineAPI.list(id), enabled: !!id, staleTime: 60_000 });
   const pipelinesCount = (pipelinesData?.data?.data?.pipelines || []).length;
-  const { data: runsData } = useQuery(
-    ['pipelineRuns', id],
-    () => pipelineRunAPI.list(id, { limit: 50 }),
-    { enabled: !!id, staleTime: 30_000 }
-  );
+  const { data: runsData } = useQuery({ queryKey: ['pipelineRuns', id], queryFn: () => pipelineRunAPI.list(id, { limit: 50 }), enabled: !!id, staleTime: 30_000 });
   const runsCount = (runsData?.data?.data?.runs || []).length;
-  const { data: convData } = useQuery(
-    ['projectConversations', id, { limit: 1 }],
-    () => projectAPI.getConversations(id, { limit: 1, page: 1 }),
-    { enabled: !!id, staleTime: 60_000 }
-  );
+  const { data: convData } = useQuery({ queryKey: ['projectConversations', id, { limit: 1 }], queryFn: () => projectAPI.getConversations(id, { limit: 1, page: 1 }), enabled: !!id, staleTime: 60_000 });
   // 백엔드가 pagination.total 을 반환하므로 그쪽이 진실. 없으면 fetch 한 개수 fallback.
   const convCount = convData?.data?.data?.pagination?.total
     ?? (convData?.data?.data?.conversations || []).length;
 
-  const deleteMutation = useMutation(
-    () => projectAPI.delete(id),
-    {
+  const deleteMutation = useMutation({ mutationFn: () => projectAPI.delete(id),
       onSuccess: () => {
-        queryClient.invalidateQueries('projects');
-        queryClient.invalidateQueries('favoriteProjects');
+        queryClient.invalidateQueries({ queryKey: ['projects'] });
+        queryClient.invalidateQueries({ queryKey: ['favoriteProjects'] });
         toast.success('프로젝트가 삭제되었습니다');
         navigate('/projects');
       },
       onError: (error) => {
         toast.error(error.response?.data?.message || '삭제 실패');
-      }
-    }
-  );
+      } });
 
-  const favoriteMutation = useMutation(
-    () => projectAPI.toggleFavorite(id),
-    {
+  const favoriteMutation = useMutation({ mutationFn: () => projectAPI.toggleFavorite(id),
       onSuccess: (response) => {
-        queryClient.invalidateQueries(['project', id]);
-        queryClient.invalidateQueries('projects');
-        queryClient.invalidateQueries('favoriteProjects');
+        queryClient.invalidateQueries({ queryKey: ['project', id] });
+        queryClient.invalidateQueries({ queryKey: ['projects'] });
+        queryClient.invalidateQueries({ queryKey: ['favoriteProjects'] });
         const isFav = response.data?.data?.isFavorite;
         toast.success(isFav ? '즐겨찾기에 추가되었습니다' : '즐겨찾기에서 제거되었습니다');
       },
       onError: (error) => {
         toast.error(error.response?.data?.message || '즐겨찾기 변경 실패');
-      }
-    }
-  );
+      } });
 
   const project = data?.data?.data?.project;
 
@@ -1118,7 +1059,7 @@ function ProjectDetail() {
             color="error"
             variant="contained"
             onClick={() => deleteMutation.mutate()}
-            disabled={deleteMutation.isLoading}
+            disabled={deleteMutation.isPending}
           >
             삭제
           </Button>

--- a/frontend/src/pages/ProjectList.js
+++ b/frontend/src/pages/ProjectList.js
@@ -30,7 +30,7 @@ import {
   GridView,
   ViewList,
 } from '@mui/icons-material';
-import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import { projectAPI } from '../services/api';
@@ -71,15 +71,14 @@ function ProjectCreateDialog({ open, onClose }) {
   const [tagName, setTagName] = useState('');
   const queryClient = useQueryClient();
 
-  const createMutation = useMutation((data) => projectAPI.create(data), {
+  const createMutation = useMutation({ mutationFn: (data) => projectAPI.create(data),
     onSuccess: () => {
-      queryClient.invalidateQueries('projects');
+      queryClient.invalidateQueries({ queryKey: ['projects'] });
       toast.success('프로젝트가 생성되었습니다');
       setName(''); setDescription(''); setTagName('');
       onClose();
     },
-    onError: (error) => toast.error(error.response?.data?.message || '생성 실패'),
-  });
+    onError: (error) => toast.error(error.response?.data?.message || '생성 실패'), });
 
   const handleSubmit = () => {
     if (!name.trim()) return toast.error('프로젝트 이름을 입력해주세요');
@@ -100,7 +99,7 @@ function ProjectCreateDialog({ open, onClose }) {
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose}>취소</Button>
-        <Button variant="contained" onClick={handleSubmit} disabled={createMutation.isLoading}>생성</Button>
+        <Button variant="contained" onClick={handleSubmit} disabled={createMutation.isPending}>생성</Button>
       </DialogActions>
     </Dialog>
   );
@@ -209,22 +208,20 @@ function ProjectList() {
   const [menuAnchor, setMenuAnchor] = useState(null);
   const [menuProject, setMenuProject] = useState(null);
 
-  const { data, isLoading, error } = useQuery('projects', () => projectAPI.getAll());
+  const { data, isLoading, error } = useQuery({ queryKey: ['projects'], queryFn: () => projectAPI.getAll() });
 
-  const deleteMutation = useMutation((id) => projectAPI.delete(id), {
+  const deleteMutation = useMutation({ mutationFn: (id) => projectAPI.delete(id),
     onSuccess: () => {
-      queryClient.invalidateQueries('projects'); queryClient.invalidateQueries('favoriteProjects');
+      queryClient.invalidateQueries({ queryKey: ['projects'] }); queryClient.invalidateQueries({ queryKey: ['favoriteProjects'] });
       toast.success('프로젝트가 삭제되었습니다'); setDeleteProject(null);
     },
-    onError: (e) => toast.error(e.response?.data?.message || '삭제 실패'),
-  });
-  const favoriteMutation = useMutation((id) => projectAPI.toggleFavorite(id), {
+    onError: (e) => toast.error(e.response?.data?.message || '삭제 실패'), });
+  const favoriteMutation = useMutation({ mutationFn: (id) => projectAPI.toggleFavorite(id),
     onSuccess: (res) => {
-      queryClient.invalidateQueries('projects'); queryClient.invalidateQueries('favoriteProjects');
+      queryClient.invalidateQueries({ queryKey: ['projects'] }); queryClient.invalidateQueries({ queryKey: ['favoriteProjects'] });
       toast.success(res.data?.data?.isFavorite ? '즐겨찾기에 추가되었습니다' : '즐겨찾기에서 제거되었습니다');
     },
-    onError: (e) => toast.error(e.response?.data?.message || '즐겨찾기 변경 실패'),
-  });
+    onError: (e) => toast.error(e.response?.data?.message || '즐겨찾기 변경 실패'), });
 
   const projects = data?.data?.data?.projects || [];
   const favoriteIds = data?.data?.data?.favoriteIds || [];
@@ -329,7 +326,7 @@ function ProjectList() {
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setDeleteProject(null)}>취소</Button>
-          <Button color="error" variant="contained" onClick={() => deleteMutation.mutate(deleteProject._id)} disabled={deleteMutation.isLoading}>삭제</Button>
+          <Button color="error" variant="contained" onClick={() => deleteMutation.mutate(deleteProject._id)} disabled={deleteMutation.isPending}>삭제</Button>
         </DialogActions>
       </Dialog>
     </Box>

--- a/frontend/src/pages/PromptDataList.js
+++ b/frontend/src/pages/PromptDataList.js
@@ -11,7 +11,7 @@ import {
   DialogActions
 } from '@mui/material';
 import { Add } from '@mui/icons-material';
-import { useMutation, useQueryClient } from 'react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import { promptDataAPI } from '../services/api';
@@ -29,37 +29,31 @@ function PromptDataList() {
   const [workboardSelectOpen, setWorkboardSelectOpen] = useState(false);
   const [selectedPromptData, setSelectedPromptData] = useState(null);
 
-  const createMutation = useMutation(promptDataAPI.create, {
+  const createMutation = useMutation({ mutationFn: promptDataAPI.create,
     onSuccess: () => {
       toast.success('프롬프트 데이터가 생성되었습니다');
-      queryClient.invalidateQueries('promptDataList');
+      queryClient.invalidateQueries({ queryKey: ['promptDataList'] });
       setFormOpen(false);
     },
-    onError: () => toast.error('프롬프트 데이터 생성 실패')
-  });
+    onError: () => toast.error('프롬프트 데이터 생성 실패') });
 
-  const updateMutation = useMutation(
-    ({ id, data }) => promptDataAPI.update(id, data),
-    {
+  const updateMutation = useMutation({ mutationFn: ({ id, data }) => promptDataAPI.update(id, data),
       onSuccess: () => {
         toast.success('프롬프트 데이터가 수정되었습니다');
-        queryClient.invalidateQueries('promptDataList');
+        queryClient.invalidateQueries({ queryKey: ['promptDataList'] });
         setFormOpen(false);
         setEditingPromptData(null);
       },
-      onError: () => toast.error('프롬프트 데이터 수정 실패')
-    }
-  );
+      onError: () => toast.error('프롬프트 데이터 수정 실패') });
 
-  const deleteMutation = useMutation(promptDataAPI.delete, {
+  const deleteMutation = useMutation({ mutationFn: promptDataAPI.delete,
     onSuccess: () => {
       toast.success('프롬프트 데이터가 삭제되었습니다');
-      queryClient.invalidateQueries('promptDataList');
+      queryClient.invalidateQueries({ queryKey: ['promptDataList'] });
       setDeleteConfirmOpen(false);
       setDeletingId(null);
     },
-    onError: () => toast.error('프롬프트 데이터 삭제 실패')
-  });
+    onError: () => toast.error('프롬프트 데이터 삭제 실패') });
 
   const handleSave = (data) => {
     if (editingPromptData) {

--- a/frontend/src/pages/PromptGeneration.js
+++ b/frontend/src/pages/PromptGeneration.js
@@ -15,7 +15,7 @@ import {
   ContentCopy
 } from '@mui/icons-material';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
-import { useQuery } from 'react-query';
+import { useQuery } from '@tanstack/react-query';
 import { workboardAPI } from '../services/api';
 import { copyToClipboard } from '../utils/clipboard';
 import PromptGeneratorPanel from '../components/PromptGeneratorPanel';
@@ -44,11 +44,7 @@ function PromptGeneration() {
     setUseWorldview(!!initialProjectId);
   }, [initialProjectId, workboardId]);
 
-  const { data: workboardData, isLoading: workboardLoading, error: workboardError } = useQuery(
-    ['workboard', workboardId],
-    () => workboardAPI.getById(workboardId),
-    { enabled: !!workboardId }
-  );
+  const { data: workboardData, isLoading: workboardLoading, error: workboardError } = useQuery({ queryKey: ['workboard', workboardId], queryFn: () => workboardAPI.getById(workboardId), enabled: !!workboardId });
 
   const workboard = workboardData?.data?.workboard;
 

--- a/frontend/src/pages/ResetPassword.js
+++ b/frontend/src/pages/ResetPassword.js
@@ -23,7 +23,7 @@ import {
 } from '@mui/icons-material';
 import { useForm, Controller } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useMutation, useQuery } from 'react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { authAPI } from '../services/api';
 import AuthLayout, { AuthTitle } from '../components/auth/AuthLayout';
@@ -105,18 +105,11 @@ function ResetPassword() {
   const watchedPassword = watch('password');
 
   // Verify token on page load
-  const { data: tokenData, isLoading: isVerifying, isError: isTokenError } = useQuery(
-    ['verifyResetToken', token],
-    () => authAPI.verifyResetToken(token),
-    {
+  const { data: tokenData, isLoading: isVerifying, isError: isTokenError } = useQuery({ queryKey: ['verifyResetToken', token], queryFn: () => authAPI.verifyResetToken(token),
       retry: false,
-      refetchOnWindowFocus: false
-    }
-  );
+      refetchOnWindowFocus: false });
 
-  const resetPasswordMutation = useMutation(
-    (data) => authAPI.resetPassword({ token, ...data }),
-    {
+  const resetPasswordMutation = useMutation({ mutationFn: (data) => authAPI.resetPassword({ token, ...data }),
       onSuccess: () => {
         setResetSuccess(true);
         toast.success('비밀번호가 성공적으로 변경되었습니다');
@@ -124,9 +117,7 @@ function ResetPassword() {
       onError: (error) => {
         const message = error.response?.data?.message || '비밀번호 재설정 중 오류가 발생했습니다';
         toast.error(message);
-      }
-    }
-  );
+      } });
 
   const onSubmit = (data) => {
     resetPasswordMutation.mutate(data);
@@ -346,10 +337,10 @@ function ResetPassword() {
               fullWidth
               variant="contained"
               size="large"
-              disabled={resetPasswordMutation.isLoading}
+              disabled={resetPasswordMutation.isPending}
               sx={{ mb: 3, py: 1.5 }}
             >
-              {resetPasswordMutation.isLoading ? (
+              {resetPasswordMutation.isPending ? (
                 <CircularProgress size={24} color="inherit" />
               ) : (
                 '비밀번호 변경'

--- a/frontend/src/pages/Settings.js
+++ b/frontend/src/pages/Settings.js
@@ -8,7 +8,7 @@ import {
   Alert,
   CircularProgress
 } from '@mui/material';
-import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { userAPI } from '../services/api';
 import PageHeader from '../components/common/PageHeader';
 import toast from 'react-hot-toast';
@@ -51,27 +51,19 @@ function SettingCard({ title, description, children }) {
 function Settings() {
   const queryClient = useQueryClient();
 
-  const { data, isLoading, error } = useQuery(
-    'userProfile',
-    () => userAPI.getProfile(),
-    { staleTime: 0 }
-  );
+  const { data, isLoading, error } = useQuery({ queryKey: ['userProfile'], queryFn: () => userAPI.getProfile(), staleTime: 0 });
 
-  const updateMutation = useMutation(
-    (preferences) => userAPI.updateProfile({ preferences }),
-    {
+  const updateMutation = useMutation({ mutationFn: (preferences) => userAPI.updateProfile({ preferences }),
       onSuccess: () => {
-        queryClient.invalidateQueries('userProfile');
+        queryClient.invalidateQueries({ queryKey: ['userProfile'] });
         toast.success('설정이 저장되었습니다');
       },
       onError: (error) => {
         toast.error('설정 저장 실패: ' + error.message);
-      }
-    }
-  );
+      } });
 
   const preferences = data?.data?.user?.preferences || {};
-  const busy = updateMutation.isLoading;
+  const busy = updateMutation.isPending;
 
   const handleToggle = (key) => (event) => {
     updateMutation.mutate({

--- a/frontend/src/pages/Signup.js
+++ b/frontend/src/pages/Signup.js
@@ -26,7 +26,7 @@ import {
 } from '@mui/icons-material';
 import { useForm, Controller } from 'react-hook-form';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { useMutation, useQuery } from 'react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { debounce } from 'lodash';
 import toast from 'react-hot-toast';
 import { authAPI } from '../services/api';
@@ -130,9 +130,7 @@ function Signup() {
     return null;
   }, 500);
 
-  const signupMutation = useMutation(
-    authAPI.signup,
-    {
+  const signupMutation = useMutation({ mutationFn: authAPI.signup,
       onSuccess: (response) => {
         toast.success('회원가입이 완료되었습니다!', { duration: 6000 });
         const isApproved = response?.data?.user?.approvalStatus === 'approved';
@@ -159,9 +157,7 @@ function Signup() {
         } else {
           toast.error(errorMessage);
         }
-      }
-    }
-  );
+      } });
 
   const handleGoogleSignup = () => {
     window.location.href = '/api/auth/google';
@@ -366,10 +362,10 @@ function Signup() {
               fullWidth
               variant="contained"
               size="large"
-              disabled={signupMutation.isLoading}
+              disabled={signupMutation.isPending}
               sx={{ mb: 3, py: 1.5 }}
             >
-              {signupMutation.isLoading ? (
+              {signupMutation.isPending ? (
                 <CircularProgress size={24} color="inherit" />
               ) : (
                 '회원가입'

--- a/frontend/src/pages/TagSearch.js
+++ b/frontend/src/pages/TagSearch.js
@@ -39,7 +39,7 @@ import {
   Label,
   FolderSpecial
 } from '@mui/icons-material';
-import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { tagAPI } from '../services/api';
 import TagInput from '../components/common/TagInput';
@@ -57,20 +57,16 @@ function TagEditDialog({ open, onClose, tag }) {
   const [color, setColor] = useState(tag?.color || '#C96A3B');
   const queryClient = useQueryClient();
 
-  const updateMutation = useMutation(
-    (data) => tagAPI.update(tag._id, data),
-    {
+  const updateMutation = useMutation({ mutationFn: (data) => tagAPI.update(tag._id, data),
       onSuccess: () => {
-        queryClient.invalidateQueries('myTags');
-        queryClient.invalidateQueries('tags');
+        queryClient.invalidateQueries({ queryKey: ['myTags'] });
+        queryClient.invalidateQueries({ queryKey: ['tags'] });
         toast.success('태그가 수정되었습니다');
         onClose();
       },
       onError: (error) => {
         toast.error(error.response?.data?.message || '수정 실패');
-      }
-    }
-  );
+      } });
 
   const handleSubmit = () => {
     if (!name.trim()) {
@@ -119,7 +115,7 @@ function TagEditDialog({ open, onClose, tag }) {
         <Button
           variant="contained"
           onClick={handleSubmit}
-          disabled={updateMutation.isLoading}
+          disabled={updateMutation.isPending}
         >
           저장
         </Button>
@@ -133,12 +129,10 @@ function TagCreateDialog({ open, onClose }) {
   const [color, setColor] = useState('#C96A3B');
   const queryClient = useQueryClient();
 
-  const createMutation = useMutation(
-    (data) => tagAPI.create(data),
-    {
+  const createMutation = useMutation({ mutationFn: (data) => tagAPI.create(data),
       onSuccess: () => {
-        queryClient.invalidateQueries('myTags');
-        queryClient.invalidateQueries('tags');
+        queryClient.invalidateQueries({ queryKey: ['myTags'] });
+        queryClient.invalidateQueries({ queryKey: ['tags'] });
         toast.success('태그가 생성되었습니다');
         setName('');
         setColor('#C96A3B');
@@ -146,9 +140,7 @@ function TagCreateDialog({ open, onClose }) {
       },
       onError: (error) => {
         toast.error(error.response?.data?.message || '생성 실패');
-      }
-    }
-  );
+      } });
 
   const handleSubmit = () => {
     if (!name.trim()) {
@@ -190,7 +182,7 @@ function TagCreateDialog({ open, onClose }) {
         <Button
           variant="contained"
           onClick={handleSubmit}
-          disabled={createMutation.isLoading}
+          disabled={createMutation.isPending}
         >
           생성
         </Button>
@@ -213,32 +205,21 @@ function TagSearch() {
   const queryClient = useQueryClient();
 
   // 태그 검색 query
-  const { data: searchData, isLoading: searchLoading, error: searchError } = useQuery(
-    ['tagSearch', selectedTags.map(t => t._id).join(',')],
-    () => tagAPI.search({ tags: selectedTags.map(t => t._id).join(',') }),
-    { enabled: selectedTags.length > 0 }
-  );
+  const { data: searchData, isLoading: searchLoading, error: searchError } = useQuery({ queryKey: ['tagSearch', selectedTags.map(t => t._id).join(',')], queryFn: () => tagAPI.search({ tags: selectedTags.map(t => t._id).join(',') }), enabled: selectedTags.length > 0 });
 
   // 태그 관리 query
-  const { data: myTagsData, isLoading: myTagsLoading, error: myTagsError } = useQuery(
-    'myTags',
-    () => tagAPI.getMy()
-  );
+  const { data: myTagsData, isLoading: myTagsLoading, error: myTagsError } = useQuery({ queryKey: ['myTags'], queryFn: () => tagAPI.getMy() });
 
-  const deleteMutation = useMutation(
-    (id) => tagAPI.delete(id),
-    {
+  const deleteMutation = useMutation({ mutationFn: (id) => tagAPI.delete(id),
       onSuccess: () => {
-        queryClient.invalidateQueries('myTags');
-        queryClient.invalidateQueries('tags');
+        queryClient.invalidateQueries({ queryKey: ['myTags'] });
+        queryClient.invalidateQueries({ queryKey: ['tags'] });
         toast.success('태그가 삭제되었습니다');
         setDeleteConfirmTag(null);
       },
       onError: (error) => {
         toast.error(error.response?.data?.message || '삭제 실패');
-      }
-    }
-  );
+      } });
 
   // 검색 결과
   const results = searchData?.data?.results || {};
@@ -580,7 +561,7 @@ function TagSearch() {
                     color="error"
                     variant="contained"
                     onClick={() => deleteMutation.mutate(deleteConfirmTag._id)}
-                    disabled={deleteMutation.isLoading}
+                    disabled={deleteMutation.isPending}
                   >
                     삭제
                   </Button>

--- a/frontend/src/pages/WorkboardCatalogPage.js
+++ b/frontend/src/pages/WorkboardCatalogPage.js
@@ -28,7 +28,7 @@ import {
   Delete,
 } from '@mui/icons-material';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import { workboardAPI, projectAPI } from '../services/api';
 import toast from 'react-hot-toast';
 import {
@@ -127,20 +127,12 @@ function WorkboardCatalogPage({ admin = false }) {
   const [menuWb, setMenuWb] = useState(null);
   const [importOpen, setImportOpen] = useState(false);
 
-  const { data: projectData } = useQuery(
-    ['project', projectId],
-    () => projectAPI.getById(projectId),
-    { enabled: !!projectId }
-  );
+  const { data: projectData } = useQuery({ queryKey: ['project', projectId], queryFn: () => projectAPI.getById(projectId), enabled: !!projectId });
   const projectContext = projectData?.data?.data?.project;
 
-  const { data, isLoading } = useQuery(
-    ['workboardCatalog', admin],
-    () => workboardAPI.getAll(admin
+  const { data, isLoading } = useQuery({ queryKey: ['workboardCatalog', admin], queryFn: () => workboardAPI.getAll(admin
       ? { limit: 500, includeAll: true, includeInactive: true }
-      : { limit: 500 }),
-    { keepPreviousData: true }
-  );
+      : { limit: 500 }), placeholderData: keepPreviousData });
   const workboards = data?.data?.workboards || [];
 
   // admin: 상태(전체/게시됨/보관) 필터를 먼저 적용
@@ -158,24 +150,15 @@ function WorkboardCatalogPage({ admin = false }) {
   // ── admin mutations ──
   // 작업판 관련 캐시 전체 무효화 (#498) — 목록/상세/실행화면/대시보드 일괄 갱신
   const invalidate = () => invalidateWorkboardQueries(queryClient);
-  const deleteMutation = useMutation(workboardAPI.delete, {
+  const deleteMutation = useMutation({ mutationFn: workboardAPI.delete,
     onSuccess: () => { toast.success('작업판이 삭제되었습니다'); invalidate(); },
-    onError: (e) => toast.error('삭제 실패: ' + e.message),
-  });
-  const toggleMutation = useMutation(
-    ({ id, isActive }) => (isActive ? workboardAPI.deactivate(id) : workboardAPI.activate(id)),
-    {
+    onError: (e) => toast.error('삭제 실패: ' + e.message), });
+  const toggleMutation = useMutation({ mutationFn: ({ id, isActive }) => (isActive ? workboardAPI.deactivate(id) : workboardAPI.activate(id)),
       onSuccess: (res) => { toast.success(`작업판이 ${res.data.workboard.isActive ? '활성화' : '비활성화'}되었습니다`); invalidate(); },
-      onError: (e) => toast.error('상태 변경 실패: ' + e.message),
-    }
-  );
-  const duplicateMutation = useMutation(
-    ({ id, name }) => workboardAPI.duplicate(id, { name }),
-    {
+      onError: (e) => toast.error('상태 변경 실패: ' + e.message), });
+  const duplicateMutation = useMutation({ mutationFn: ({ id, name }) => workboardAPI.duplicate(id, { name }),
       onSuccess: () => { toast.success('작업판이 복제되었습니다'); invalidate(); },
-      onError: (e) => toast.error('복제 실패: ' + e.message),
-    }
-  );
+      onError: (e) => toast.error('복제 실패: ' + e.message), });
 
   // ── handlers ──
   const handleSelect = (wb) => { setDetailWb(null); selectWorkboard(wb, projectId, navigate); };

--- a/frontend/src/pages/admin/BackupRestorePage.js
+++ b/frontend/src/pages/admin/BackupRestorePage.js
@@ -36,7 +36,7 @@ import {
   Pending,
   Refresh
 } from '@mui/icons-material';
-import { useQuery, useMutation } from 'react-query';
+import { useQuery, useMutation } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { backupAPI } from '../../services/api';
 import Pagination from '../../components/common/Pagination';
@@ -100,18 +100,10 @@ function BackupRestorePage() {
   const fileInputRef = useRef(null);
 
   // 백업 목록 조회
-  const { data: backupData, isLoading: backupsLoading, refetch: refetchBackups } = useQuery(
-    ['backups', backupPage],
-    () => backupAPI.list({ page: backupPage, limit: 10 }),
-    { refetchInterval: activeJobId ? 2000 : false }
-  );
+  const { data: backupData, isLoading: backupsLoading, refetch: refetchBackups } = useQuery({ queryKey: ['backups', backupPage], queryFn: () => backupAPI.list({ page: backupPage, limit: 10 }), refetchInterval: activeJobId ? 2000 : false });
 
   // 복구 목록 조회
-  const { data: restoreData, isLoading: restoresLoading, refetch: refetchRestores } = useQuery(
-    ['restores', restorePage],
-    () => backupAPI.listRestores({ page: restorePage, limit: 10 }),
-    { refetchInterval: activeJobId ? 2000 : false }
-  );
+  const { data: restoreData, isLoading: restoresLoading, refetch: refetchRestores } = useQuery({ queryKey: ['restores', restorePage], queryFn: () => backupAPI.listRestores({ page: restorePage, limit: 10 }), refetchInterval: activeJobId ? 2000 : false });
 
   // 진행 중인 작업 상태 polling
   useEffect(() => {
@@ -144,9 +136,7 @@ function BackupRestorePage() {
   }, [activeJobId, tabValue, refetchBackups, refetchRestores]);
 
   // 백업 생성
-  const createBackupMutation = useMutation(
-    () => backupAPI.create(),
-    {
+  const createBackupMutation = useMutation({ mutationFn: () => backupAPI.create(),
       onSuccess: (response) => {
         const jobId = response.data.data.jobId;
         setActiveJobId(jobId);
@@ -155,14 +145,10 @@ function BackupRestorePage() {
       },
       onError: (error) => {
         toast.error(error.response?.data?.message || '백업 생성에 실패했습니다.');
-      }
-    }
-  );
+      } });
 
   // 백업 삭제
-  const deleteBackupMutation = useMutation(
-    (id) => backupAPI.delete(id),
-    {
+  const deleteBackupMutation = useMutation({ mutationFn: (id) => backupAPI.delete(id),
       onSuccess: () => {
         toast.success('백업이 삭제되었습니다.');
         setDeleteDialogOpen(false);
@@ -171,14 +157,10 @@ function BackupRestorePage() {
       },
       onError: (error) => {
         toast.error(error.response?.data?.message || '백업 삭제에 실패했습니다.');
-      }
-    }
-  );
+      } });
 
   // 파일 검증
-  const validateMutation = useMutation(
-    (file) => backupAPI.validate(file),
-    {
+  const validateMutation = useMutation({ mutationFn: (file) => backupAPI.validate(file),
       onSuccess: (response) => {
         setValidationResult(response.data.data);
         if (response.data.data.validationResult.isValid) {
@@ -190,14 +172,10 @@ function BackupRestorePage() {
       onError: (error) => {
         toast.error(error.response?.data?.message || '파일 검증에 실패했습니다.');
         setUploadedFile(null);
-      }
-    }
-  );
+      } });
 
   // 복구 실행
-  const restoreMutation = useMutation(
-    ({ jobId, options }) => backupAPI.restore({ jobId, options }),
-    {
+  const restoreMutation = useMutation({ mutationFn: ({ jobId, options }) => backupAPI.restore({ jobId, options }),
       onSuccess: (response) => {
         const jobId = response.data.data.jobId;
         setActiveJobId(jobId);
@@ -209,9 +187,7 @@ function BackupRestorePage() {
       },
       onError: (error) => {
         toast.error(error.response?.data?.message || '복구 실행에 실패했습니다.');
-      }
-    }
-  );
+      } });
 
   const handleFileSelect = async (event) => {
     const file = event.target.files[0];
@@ -284,7 +260,7 @@ function BackupRestorePage() {
             variant="contained"
             startIcon={<Backup />}
             onClick={() => createBackupMutation.mutate()}
-            disabled={createBackupMutation.isLoading || !!activeJobId}
+            disabled={createBackupMutation.isPending || !!activeJobId}
           >
             백업 생성
           </Button>
@@ -506,7 +482,7 @@ function BackupRestorePage() {
             color="error"
             variant="contained"
             onClick={() => deleteBackupMutation.mutate(selectedBackup._id)}
-            disabled={deleteBackupMutation.isLoading}
+            disabled={deleteBackupMutation.isPending}
           >
             삭제
           </Button>
@@ -546,12 +522,12 @@ function BackupRestorePage() {
               fullWidth
               startIcon={<CloudUpload />}
               onClick={() => fileInputRef.current?.click()}
-              disabled={validateMutation.isLoading}
+              disabled={validateMutation.isPending}
             >
               {uploadedFile ? uploadedFile.name : '백업 파일 선택 (.zip)'}
             </Button>
 
-            {validateMutation.isLoading && (
+            {validateMutation.isPending && (
               <Box sx={{ mt: 2 }}>
                 <LinearProgress />
                 <Typography variant="caption" color="text.secondary">
@@ -676,7 +652,7 @@ function BackupRestorePage() {
             onClick={handleRestoreExecute}
             disabled={
               !validationResult?.validationResult?.isValid ||
-              restoreMutation.isLoading ||
+              restoreMutation.isPending ||
               (restoreOptions.skipDatabase && restoreOptions.skipFiles)
             }
             startIcon={<Restore />}

--- a/frontend/src/pages/admin/GroupManagementPage.js
+++ b/frontend/src/pages/admin/GroupManagementPage.js
@@ -33,7 +33,7 @@ import {
   PersonAdd as PersonAddIcon,
   PersonRemove as PersonRemoveIcon
 } from '@mui/icons-material';
-import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { groupAPI, adminAPI } from '../../services/api';
 import PageHeader from '../../components/common/PageHeader';
@@ -112,26 +112,18 @@ function GroupMembersDialog({ open, onClose, group }) {
   const [memberFilter, setMemberFilter] = useState('');
   const queryClient = useQueryClient();
 
-  const { data: usersData, isLoading } = useQuery(
-    ['adminUsers'],
-    () => adminAPI.getUsers({ limit: 1000 }),
-    { enabled: open }
-  );
+  const { data: usersData, isLoading } = useQuery({ queryKey: ['adminUsers'], queryFn: () => adminAPI.getUsers({ limit: 1000 }), enabled: open });
 
   const users = usersData?.data?.users || [];
 
-  const memberMutation = useMutation(
-    ({ userId, action }) => groupAPI.setMember(group._id, userId, action),
-    {
+  const memberMutation = useMutation({ mutationFn: ({ userId, action }) => groupAPI.setMember(group._id, userId, action),
       onSuccess: () => {
-        queryClient.invalidateQueries(['adminUsers']);
-        queryClient.invalidateQueries(['groups']);
+        queryClient.invalidateQueries({ queryKey: ['adminUsers'] });
+        queryClient.invalidateQueries({ queryKey: ['groups'] });
       },
       onError: (err) => {
         toast.error(err.response?.data?.message || '멤버 변경 실패');
-      }
-    }
-  );
+      } });
 
   const isMember = (user) => (user.groupIds || []).some((g) => String(g) === String(group?._id));
 
@@ -178,7 +170,7 @@ function GroupMembersDialog({ open, onClose, group }) {
                         color="warning"
                         startIcon={<PersonRemoveIcon />}
                         onClick={() => memberMutation.mutate({ userId: u._id, action: 'remove' })}
-                        disabled={memberMutation.isLoading}
+                        disabled={memberMutation.isPending}
                       >
                         제거
                       </Button>
@@ -186,7 +178,7 @@ function GroupMembersDialog({ open, onClose, group }) {
                       <Button
                         startIcon={<PersonAddIcon />}
                         onClick={() => memberMutation.mutate({ userId: u._id, action: 'add' })}
-                        disabled={memberMutation.isLoading}
+                        disabled={memberMutation.isPending}
                       >
                         추가
                       </Button>
@@ -217,56 +209,40 @@ function GroupManagementPage() {
   const [selectedGroup, setSelectedGroup] = useState(null);
   const queryClient = useQueryClient();
 
-  const { data: groupsData, isLoading } = useQuery(
-    ['groups'],
-    () => groupAPI.getAll(),
-    { refetchInterval: 30000 }
-  );
+  const { data: groupsData, isLoading } = useQuery({ queryKey: ['groups'], queryFn: () => groupAPI.getAll(), refetchInterval: 30000 });
 
   const groups = groupsData?.data?.data?.groups || [];
 
-  const createMutation = useMutation(
-    (data) => groupAPI.create(data),
-    {
+  const createMutation = useMutation({ mutationFn: (data) => groupAPI.create(data),
       onSuccess: () => {
         toast.success('그룹이 생성되었습니다.');
-        queryClient.invalidateQueries(['groups']);
+        queryClient.invalidateQueries({ queryKey: ['groups'] });
         setFormOpen(false);
         setEditingGroup(null);
       },
       onError: (err) => {
         toast.error(err.response?.data?.message || '그룹 생성 실패');
-      }
-    }
-  );
+      } });
 
-  const updateMutation = useMutation(
-    ({ id, data }) => groupAPI.update(id, data),
-    {
+  const updateMutation = useMutation({ mutationFn: ({ id, data }) => groupAPI.update(id, data),
       onSuccess: () => {
         toast.success('그룹이 수정되었습니다.');
-        queryClient.invalidateQueries(['groups']);
+        queryClient.invalidateQueries({ queryKey: ['groups'] });
         setFormOpen(false);
         setEditingGroup(null);
       },
       onError: (err) => {
         toast.error(err.response?.data?.message || '그룹 수정 실패');
-      }
-    }
-  );
+      } });
 
-  const deleteMutation = useMutation(
-    (id) => groupAPI.delete(id),
-    {
+  const deleteMutation = useMutation({ mutationFn: (id) => groupAPI.delete(id),
       onSuccess: () => {
         toast.success('그룹이 삭제되었습니다.');
-        queryClient.invalidateQueries(['groups']);
+        queryClient.invalidateQueries({ queryKey: ['groups'] });
       },
       onError: (err) => {
         toast.error(err.response?.data?.message || '그룹 삭제 실패');
-      }
-    }
-  );
+      } });
 
   const handleNew = () => {
     setEditingGroup(null);

--- a/frontend/src/pages/admin/MetadataManagementPage.js
+++ b/frontend/src/pages/admin/MetadataManagementPage.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Container, Box, Typography, Tabs, Tab } from '@mui/material';
-import { useQuery } from 'react-query';
+import { useQuery } from '@tanstack/react-query';
 import LoraManagementPage from './LoraManagementPage';
 import ModelManagementPage from './ModelManagementPage';
 import CivitaiAdminHeader from '../../components/admin/CivitaiAdminHeader';
@@ -24,10 +24,7 @@ function MetadataManagementPage() {
   const [hasCivitaiApiKey, setHasCivitaiApiKey] = useState(false);
 
   // 전체 서버 목록
-  const { data: serversData } = useQuery(
-    ['servers', { includeInactive: false }],
-    () => serverAPI.getServers({ includeInactive: false })
-  );
+  const { data: serversData } = useQuery({ queryKey: ['servers', { includeInactive: false }], queryFn: () => serverAPI.getServers({ includeInactive: false }) });
   const allServers = serversData?.data?.data?.servers || [];
 
   // 현재 탭에 호환되는 서버 목록

--- a/frontend/src/pages/admin/WorkboardCreatePage.js
+++ b/frontend/src/pages/admin/WorkboardCreatePage.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useMutation, useQueryClient } from 'react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Container } from '@mui/material';
 import toast from 'react-hot-toast';
 import { workboardAPI } from '../../services/api';
@@ -13,9 +13,7 @@ function WorkboardCreatePage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
-  const createMutation = useMutation(
-    workboardAPI.create,
-    {
+  const createMutation = useMutation({ mutationFn: workboardAPI.create,
       onSuccess: (response) => {
         toast.success('작업판이 생성되었습니다');
         invalidateWorkboardQueries(queryClient);
@@ -28,9 +26,7 @@ function WorkboardCreatePage() {
       },
       onError: (err) => {
         toast.error('생성 실패: ' + (err?.message || ''));
-      }
-    }
-  );
+      } });
 
   const handleSave = (data) => {
     const serverType = data.serverType || 'ComfyUI';

--- a/frontend/src/pages/admin/WorkboardEditorPage.js
+++ b/frontend/src/pages/admin/WorkboardEditorPage.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Container, Box, CircularProgress, Alert } from '@mui/material';
 import toast from 'react-hot-toast';
 import { workboardAPI } from '../../services/api';
@@ -14,20 +14,14 @@ function WorkboardEditorPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
-  const { data, isLoading, error } = useQuery(
-    ['adminWorkboard', id],
-    () => workboardAPI.getByIdAdmin(id),
-    { enabled: !!id, staleTime: 0 }
-  );
+  const { data, isLoading, error } = useQuery({ queryKey: ['adminWorkboard', id], queryFn: () => workboardAPI.getByIdAdmin(id), enabled: !!id, staleTime: 0 });
 
   const workboard = data?.data?.workboard;
 
   // unsaved 경고: WorkboardDetailDialog 내부 react-hook-form 의 dirty 신호를 외부로 끌어올려야
   // 정밀하게 동작 (false-positive 회피). Phase B 에서 dirty lift + useBlocker 로 처리.
 
-  const updateMutation = useMutation(
-    (updateData) => workboardAPI.update(id, updateData),
-    {
+  const updateMutation = useMutation({ mutationFn: (updateData) => workboardAPI.update(id, updateData),
       onSuccess: () => {
         toast.success('작업판이 수정되었습니다');
         invalidateWorkboardQueries(queryClient);
@@ -35,9 +29,7 @@ function WorkboardEditorPage() {
       },
       onError: (err) => {
         toast.error('수정 실패: ' + (err?.message || ''));
-      }
-    }
-  );
+      } });
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## 변경사항 (47개 파일, 기능 변화 0 목표)

- **일괄 변환** (균형괄호 파서 codemod): 위치 인자 → 객체형(`{queryKey, queryFn}`/`{mutationFn}`), 문자열 단일 키 35곳 배열화, `invalidateQueries` 등 queryKey 객체화 — 가변 인자(JobHistoryPanel 의 prop 키)는 `Array.isArray` 가드
- `keepPreviousData: true` → `placeholderData: keepPreviousData` (12곳, named import 추가)
- mutation `.isLoading` → `.isPending` (57곳 — v5 에서 제거)
- **v5 제거 API 수동 전환**: 쿼리측 `onSuccess` 2건(ServerManagement 동기화 상태) → `useEffect` / `refetchInterval` 함수 시그니처 3건 → `(query) => query.state.data`

## 검증
- Vite 빌드 통과, **11페이지 콘솔 에러 0**
- 뮤테이션 왕복 실동작 (설정 토글 on→토스트→off 원복), ⌘K 팔레트 쿼리 동작 확인
- `react-query` 의존성/임포트 잔존 0

closes #526

🤖 Generated with [Claude Code](https://claude.com/claude-code)