### PR TITLE
fix: 이미지/비디오 뷰어 이월 인덱스로 인한 흰 화면 보정 (#583)

### DIFF
--- a/frontend/src/components/common/ImageViewerDialog.js
+++ b/frontend/src/components/common/ImageViewerDialog.js
@@ -44,7 +44,10 @@ function ImageViewerDialog({
     return img;
   });
 
-  const currentImage = normalizedImages[currentIndex];
+  // 이전 항목에서 선택했던 인덱스가 더 짧은 이미지 목록으로 이월돼
+  // 범위를 벗어나면 흰 화면이 뜨므로 유효 범위로 보정한다.
+  const safeIndex = Math.min(Math.max(currentIndex, 0), normalizedImages.length - 1);
+  const currentImage = normalizedImages[safeIndex];
   
   const handleDownload = async () => {
     try {
@@ -54,7 +57,7 @@ function ImageViewerDialog({
       
       const link = document.createElement('a');
       link.href = blobUrl;
-      link.download = currentImage.originalName || `image_${currentIndex + 1}.png`;
+      link.download = currentImage.originalName || `image_${safeIndex + 1}.png`;
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
@@ -70,8 +73,8 @@ function ImageViewerDialog({
     }
   };
 
-  const displayTitle = normalizedImages.length > 1 
-    ? `${title} (${currentIndex + 1} / ${normalizedImages.length})`
+  const displayTitle = normalizedImages.length > 1
+    ? `${title} (${safeIndex + 1} / ${normalizedImages.length})`
     : title;
 
   return (
@@ -102,7 +105,7 @@ function ImageViewerDialog({
       <DialogContent sx={{ textAlign: 'center', p: 2, bgcolor: 'black' }}>
         <img
           src={currentImage.url}
-          alt={`Image ${currentIndex + 1}`}
+          alt={`Image ${safeIndex + 1}`}
           style={{
             maxWidth: '100%',
             maxHeight: '70vh',
@@ -137,8 +140,8 @@ function ImageViewerDialog({
                   width: 60,
                   height: 60,
                   cursor: 'pointer',
-                  border: index === currentIndex ? '2px solid white' : 'none',
-                  opacity: index === currentIndex ? 1 : 0.7,
+                  border: index === safeIndex ? '2px solid white' : 'none',
+                  opacity: index === safeIndex ? 1 : 0.7,
                   '&:hover': { opacity: 1 }
                 }}
                 variant="rounded"

--- a/frontend/src/components/common/VideoViewerDialog.js
+++ b/frontend/src/components/common/VideoViewerDialog.js
@@ -27,7 +27,10 @@ function VideoViewerDialog({
 
   if (!videos || videos.length === 0) return null;
 
-  const currentVideo = videos[currentIndex];
+  // 이전 항목의 인덱스가 더 짧은 목록으로 이월돼 범위를 벗어나면
+  // 빈 플레이어가 뜨므로 유효 범위로 보정한다.
+  const safeIndex = Math.min(Math.max(currentIndex, 0), videos.length - 1);
+  const currentVideo = videos[safeIndex];
 
   const handleDownload = async () => {
     if (!currentVideo) return;
@@ -65,11 +68,11 @@ function VideoViewerDialog({
   };
 
   const handlePrev = () => {
-    setCurrentIndex(prev => Math.max(0, prev - 1));
+    setCurrentIndex(Math.max(0, safeIndex - 1));
   };
 
   const handleNext = () => {
-    setCurrentIndex(prev => Math.min(videos.length - 1, prev + 1));
+    setCurrentIndex(Math.min(videos.length - 1, safeIndex + 1));
   };
 
   return (
@@ -85,7 +88,7 @@ function VideoViewerDialog({
       <DialogTitle sx={{ color: 'white', pb: 1 }}>
         <Box display="flex" justifyContent="space-between" alignItems="center">
           <Typography variant="h6">
-            {title} {videos.length > 1 && `(${currentIndex + 1}/${videos.length})`}
+            {title} {videos.length > 1 && `(${safeIndex + 1}/${videos.length})`}
           </Typography>
           <Box>
             <IconButton onClick={handleDownload} sx={{ color: 'white', mr: 1 }}>
@@ -99,7 +102,7 @@ function VideoViewerDialog({
       </DialogTitle>
       <DialogContent sx={{ textAlign: 'center', p: 2, bgcolor: 'black' }}>
         <video
-          key={currentVideo?._id || currentIndex}
+          key={currentVideo?._id || safeIndex}
           src={currentVideo?.url}
           controls
           autoPlay
@@ -115,7 +118,7 @@ function VideoViewerDialog({
             <Button
               variant="outlined"
               onClick={handlePrev}
-              disabled={currentIndex === 0}
+              disabled={safeIndex === 0}
               startIcon={<NavigateBefore />}
               sx={{ color: 'white', borderColor: 'white' }}
             >
@@ -124,7 +127,7 @@ function VideoViewerDialog({
             <Button
               variant="outlined"
               onClick={handleNext}
-              disabled={currentIndex === videos.length - 1}
+              disabled={safeIndex === videos.length - 1}
               endIcon={<NavigateNext />}
               sx={{ color: 'white', borderColor: 'white' }}
             >


### PR DESCRIPTION
## 변경 사항
다중 이미지 히스토리 항목에서 2번째 이상 이미지를 본 뒤, 다른 1장짜리 히스토리를 열면 흰 화면이 뜨던 문제를 수정합니다.

### 원인
`ImageViewerDialog` / `VideoViewerDialog` 의 내부 `currentIndex` 상태가 `[open, selectedIndex]` 변화에만 리셋돼, `selectedIndex` 가 동일(0)하고 `images`/`videos` 배열만 더 짧게 교체되면 이전 인덱스(예: 1)가 범위를 벗어나 `undefined` 를 렌더 → 흰 화면(비디오는 빈 플레이어).

### 수정
- 렌더 시점에 인덱스를 배열 길이로 clamp 한 `safeIndex` 도입
- 제목 카운터 / alt / 다운로드 파일명 / 썸네일 강조 / 비디오 이전·다음 버튼 모두 `safeIndex` 기준으로 정렬

closes #583