### PR TITLE
fix: 백업/복원 대상 컬렉션 보강 + 단일 소스화 (#588)

### DIFF
--- a/src/services/backupCollections.js
+++ b/src/services/backupCollections.js
@@ -1,0 +1,70 @@
+/**
+ * 백업 / 복원 대상 컬렉션 — 단일 소스 (#588)
+ *
+ * backupService 와 restoreService 가 각자 목록을 하드코딩하다 drift 가 생겨
+ * (초기 이미지 중심 목록에 머물러 Project/세계관/파이프라인/대화 등 누락) 데이터 유실
+ * 위험이 있었음. 이 모듈을 단일 소스로 사용한다.
+ *
+ * 순서: 복원 시 의존성(참조 대상) 우선으로 배치. 복원은 _id 보존 create 라 순서가
+ *       참조 무결성에 결정적이진 않지만 가독성/안전 차원에서 정렬.
+ *
+ * 제외 대상:
+ * - 운영성: BackupJob / RestoreJob (백업 작업 기록 자체)
+ * - 캐시성(재생성 가능): LoraCache / ServerLoraCache / ServerModelCache
+ *   → 서버 동기화로 다시 채워지므로 백업 불필요 (이전엔 LoraCache 만 백업돼 우선순위 역전)
+ *
+ * 필드 처리:
+ * - sensitiveFields: 백업 시 제외 (복원 불가). 평문 민감정보 중 복원이 무의미/위험한 것.
+ * - encryptFields:  백업 시 AES-256-GCM 암호화, 복원 시 동일 키로 복호화. 평문 secret 보존용.
+ *
+ * 비밀값 저장 형태 메모:
+ * - User.password        : bcrypt 해시 (단방향) → 그대로 백업·복원해도 안전 + 로그인 동작
+ * - ApiKey.keyHash       : SHA-256 해시 (단방향) → 그대로 백업해도 안전 + 키 검증 동작
+ * - Server.configuration.apiKey, SystemSettings.*.civitaiApiKey : 평문 → 백업 시 암호화
+ */
+
+const User = require('../models/User');
+const Group = require('../models/Group');
+const Tag = require('../models/Tag');
+const Server = require('../models/Server');
+const Project = require('../models/Project');
+const Workboard = require('../models/Workboard');
+const UploadedText = require('../models/UploadedText');
+const UploadedImage = require('../models/UploadedImage');
+const PromptData = require('../models/PromptData');
+const Pipeline = require('../models/Pipeline');
+const ImageGenerationJob = require('../models/ImageGenerationJob');
+const ConversationJob = require('../models/ConversationJob');
+const GeneratedImage = require('../models/GeneratedImage');
+const GeneratedVideo = require('../models/GeneratedVideo');
+const GeneratedText = require('../models/GeneratedText');
+const PipelineRun = require('../models/PipelineRun');
+const ApiKey = require('../models/ApiKey');
+const SystemSettings = require('../models/SystemSettings');
+
+const BACKUP_COLLECTIONS = [
+  // 참조 대상 (사용자 / 그룹 / 태그 / 서버)
+  { name: 'User', model: User, sensitiveFields: ['googleId'] },
+  { name: 'Group', model: Group },
+  { name: 'Tag', model: Tag },
+  { name: 'Server', model: Server, encryptFields: ['configuration.apiKey'] },
+  // 워크스페이스 / 작업판 / 문서
+  { name: 'Project', model: Project },
+  { name: 'Workboard', model: Workboard },
+  { name: 'UploadedText', model: UploadedText },
+  { name: 'UploadedImage', model: UploadedImage },
+  { name: 'PromptData', model: PromptData },
+  { name: 'Pipeline', model: Pipeline },
+  // 작업 / 생성 결과
+  { name: 'ImageGenerationJob', model: ImageGenerationJob },
+  { name: 'ConversationJob', model: ConversationJob },
+  { name: 'GeneratedImage', model: GeneratedImage },
+  { name: 'GeneratedVideo', model: GeneratedVideo },
+  { name: 'GeneratedText', model: GeneratedText },
+  { name: 'PipelineRun', model: PipelineRun },
+  // 인증 / 시스템 설정
+  { name: 'ApiKey', model: ApiKey },
+  { name: 'SystemSettings', model: SystemSettings, encryptFields: ['external.civitaiApiKey', 'lora.civitaiApiKey'] },
+];
+
+module.exports = { BACKUP_COLLECTIONS };

--- a/src/services/backupService.js
+++ b/src/services/backupService.js
@@ -4,31 +4,8 @@ const crypto = require('crypto');
 const archiver = require('archiver');
 const BackupJob = require('../models/BackupJob');
 
-// MongoDB 모델들
-const User = require('../models/User');
-const Server = require('../models/Server');
-const Workboard = require('../models/Workboard');
-const ImageGenerationJob = require('../models/ImageGenerationJob');
-const GeneratedImage = require('../models/GeneratedImage');
-const GeneratedVideo = require('../models/GeneratedVideo');
-const UploadedImage = require('../models/UploadedImage');
-const PromptData = require('../models/PromptData');
-const Tag = require('../models/Tag');
-const LoraCache = require('../models/LoraCache');
-
-// 백업할 컬렉션 목록
-const COLLECTIONS = {
-  User: { model: User, sensitiveFields: ['googleId'] },
-  Server: { model: Server, encryptFields: ['configuration.apiKey'] },
-  Workboard: { model: Workboard },
-  ImageGenerationJob: { model: ImageGenerationJob },
-  GeneratedImage: { model: GeneratedImage },
-  GeneratedVideo: { model: GeneratedVideo },
-  UploadedImage: { model: UploadedImage },
-  PromptData: { model: PromptData },
-  Tag: { model: Tag },
-  LoraCache: { model: LoraCache }
-};
+// 백업 대상 컬렉션 — backup/restore 공유 단일 소스 (#588)
+const { BACKUP_COLLECTIONS } = require('./backupCollections');
 
 // 백업 디렉토리
 const BACKUP_DIR = process.env.BACKUP_PATH || './backups';
@@ -173,7 +150,7 @@ async function initBackupJob(userId) {
     createdBy: userId,
     progress: {
       current: 0,
-      total: Object.keys(COLLECTIONS).length + 3, // 컬렉션 + 파일 디렉토리 3개
+      total: BACKUP_COLLECTIONS.length + 3, // 컬렉션 + 파일 디렉토리 3개
       stage: '대기 중...'
     }
   });
@@ -228,7 +205,8 @@ async function executeBackup(jobId) {
 
     // 컬렉션 백업
     let progress = 0;
-    for (const [name, config] of Object.entries(COLLECTIONS)) {
+    for (const config of BACKUP_COLLECTIONS) {
+      const name = config.name;
       await job.updateProgress(progress, job.progress.total, `${name} 컬렉션 백업 중...`);
 
       const documents = await exportCollection(name, config, job);

--- a/src/services/restoreService.js
+++ b/src/services/restoreService.js
@@ -5,31 +5,9 @@ const unzipper = require('unzipper');
 const RestoreJob = require('../models/RestoreJob');
 const { ENCRYPTION_KEY } = require('./backupService');
 
-// MongoDB 모델들
-const User = require('../models/User');
-const Server = require('../models/Server');
-const Workboard = require('../models/Workboard');
-const ImageGenerationJob = require('../models/ImageGenerationJob');
-const GeneratedImage = require('../models/GeneratedImage');
-const GeneratedVideo = require('../models/GeneratedVideo');
-const UploadedImage = require('../models/UploadedImage');
-const PromptData = require('../models/PromptData');
-const Tag = require('../models/Tag');
-const LoraCache = require('../models/LoraCache');
-
-// 복구할 컬렉션 목록 (순서 중요 - 의존성 고려)
-const COLLECTIONS = {
-  User: { model: User },
-  Server: { model: Server, decryptFields: ['configuration.apiKey'] },
-  Tag: { model: Tag },
-  Workboard: { model: Workboard },
-  UploadedImage: { model: UploadedImage },
-  PromptData: { model: PromptData },
-  ImageGenerationJob: { model: ImageGenerationJob },
-  GeneratedImage: { model: GeneratedImage },
-  GeneratedVideo: { model: GeneratedVideo },
-  LoraCache: { model: LoraCache }
-};
+// 복원 대상 컬렉션 — backup/restore 공유 단일 소스 (#588).
+// 복호화 대상은 백업 시 암호화한 필드(encryptFields)와 동일하게 적용.
+const { BACKUP_COLLECTIONS } = require('./backupCollections');
 
 const UPLOAD_DIR = process.env.UPLOAD_PATH || './uploads';
 const TEMP_DIR = process.env.TEMP_PATH || path.join(UPLOAD_DIR, 'restore-temp');
@@ -176,11 +154,11 @@ async function validateBackup(zipPath, userId) {
       }
     }
 
-    // 컬렉션 확인
-    const requiredCollections = Object.keys(COLLECTIONS);
+    // 컬렉션 확인 — 보강된 단일 소스 목록 기준으로 누락 경고 (#588)
+    const requiredCollections = BACKUP_COLLECTIONS.map((c) => c.name);
     for (const col of requiredCollections) {
       if (metadata.collections && metadata.collections[col] === undefined) {
-        warnings.push(`${col} 컬렉션이 백업에 없습니다.`);
+        warnings.push(`${col} 컬렉션이 백업에 없습니다. (구버전 백업일 수 있음 — 해당 데이터는 복원되지 않습니다)`);
       }
     }
 
@@ -228,7 +206,7 @@ async function executeRestore(jobId, zipPath, options = {}) {
     errors: 0
   };
 
-  const totalSteps = Object.keys(COLLECTIONS).length + 3; // 컬렉션 + 파일 디렉토리 3개
+  const totalSteps = BACKUP_COLLECTIONS.length + 3; // 컬렉션 + 파일 디렉토리 3개
   let currentStep = 0;
 
   // 임시 디렉토리 생성
@@ -250,7 +228,8 @@ async function executeRestore(jobId, zipPath, options = {}) {
 
     // 데이터베이스 복구
     if (!options.skipDatabase) {
-      for (const [name, config] of Object.entries(COLLECTIONS)) {
+      for (const config of BACKUP_COLLECTIONS) {
+        const name = config.name;
         currentStep++;
         await job.updateProgress(currentStep, totalSteps, `${name} 컬렉션 복구 중...`);
 
@@ -263,10 +242,10 @@ async function executeRestore(jobId, zipPath, options = {}) {
 
             for (const doc of data) {
               try {
-                // 암호화 필드 복호화
+                // 암호화 필드 복호화 (백업 시 암호화한 encryptFields 와 동일)
                 let processedDoc = doc;
-                if (config.decryptFields) {
-                  processedDoc = decryptFields(doc, config.decryptFields);
+                if (config.encryptFields) {
+                  processedDoc = decryptFields(doc, config.encryptFields);
                 }
 
                 // _id와 날짜 필드 변환


### PR DESCRIPTION
## 문제
백업 `COLLECTIONS` 목록이 초기(이미지 중심) 시점에 고정돼, 이후 추가된 핵심 데이터가 누락 → "전체 백업" 복원 시 **Project / 세계관 문서 / 파이프라인 / 대화 기록 등이 조용히 유실**. validate 도 같은 불완전 목록 기준이라 경고조차 못 함.

## 변경
- **신규 `services/backupCollections.js`** — backup/restore 가 공유하는 단일 소스. 각자 하드코딩하던 목록 drift 차단.
- **누락 컬렉션 추가**: Project, UploadedText, Pipeline, ConversationJob, GeneratedText, Group, PipelineRun, ApiKey, SystemSettings (총 10 → 18)
- **캐시 제외**: 재생성 가능한 LoraCache 등은 백업 대상에서 뺌 (우선순위 역전 정리)
- **validate 동기화**: 보강 목록 기준으로 누락 컬렉션 경고 (구버전 백업 복원 시 안내)
- **secret 처리**:
  - `SystemSettings.external/lora.civitaiApiKey`(평문) → 백업 시 암호화 필드
  - `ApiKey.keyHash`(SHA-256 단방향) → 그대로 백업, 복원 후 키 검증 동작 (평문 노출 없음)
  - `User.password`(bcrypt)·`Server.configuration.apiKey`(암호화) 기존대로

## 검증
- backup/restore/공유모듈 require 정상, 18개 컬렉션·암호화/민감 필드 매핑 확인
- 기존 backup 테스트(backupLock, restorePathValidation) 38건 green
- 프론트 BackupRestorePage 는 collections 를 동적 렌더 → 수정 불필요

## 참고 / 후속
- 복원 중 쓰기 락(#589), 복원 전 스냅샷(#590), 스트리밍(#591) 은 별도 이슈
- **알려진 caveat**: SystemSettings 는 unique key('global') 싱글톤이라, 복원 대상 DB 에 이미 다른 _id 의 설정이 있으면 non-overwrite 복원 시 해당 문서만 skip(per-doc try/catch 로 안전). googleId 는 기존대로 백업 제외(복원 후 Google 로그인 재연결 필요) — 정책 변경은 별도 논의.

closes #588