### PR TITLE
feat: 복원 안전성 — 복원 중 쓰기 락 + 복원 전 자동 스냅샷 (#589, #590)

### DIFF
--- a/src/middleware/backupLock.js
+++ b/src/middleware/backupLock.js
@@ -1,10 +1,15 @@
 /**
- * 백업 진행 중 데이터 변경 차단 미들웨어
+ * 백업 / 복원 진행 중 데이터 변경 차단 미들웨어 (유지보수 락)
+ *
+ * 백업 중에는 일관된 스냅샷을 위해, 복원 중에는 동시 쓰기로 인한 정합성 손상을
+ * 막기 위해 쓰기 요청을 차단한다 (#589).
  */
 
-// 백업 상태 관리
+// 유지보수 상태 관리
 let backupInProgress = false;
 let currentBackupJobId = null;
+let restoreInProgress = false;
+let currentRestoreJobId = null;
 
 /**
  * 백업 시작
@@ -25,10 +30,35 @@ function endBackupLock() {
 }
 
 /**
+ * 복원 시작 (#589)
+ */
+function startRestoreLock(jobId) {
+  restoreInProgress = true;
+  currentRestoreJobId = jobId;
+  console.log(`🔒 복원 잠금 시작: ${jobId}`);
+}
+
+/**
+ * 복원 종료 (#589)
+ */
+function endRestoreLock() {
+  console.log(`🔓 복원 잠금 해제: ${currentRestoreJobId}`);
+  restoreInProgress = false;
+  currentRestoreJobId = null;
+}
+
+/**
  * 백업 진행 중인지 확인
  */
 function isBackupInProgress() {
   return backupInProgress;
+}
+
+/**
+ * 복원 진행 중인지 확인 (#589)
+ */
+function isRestoreInProgress() {
+  return restoreInProgress;
 }
 
 /**
@@ -39,8 +69,16 @@ function getCurrentBackupJobId() {
 }
 
 /**
- * 백업 중 쓰기 작업 차단 미들웨어
- * POST, PUT, PATCH, DELETE 요청 중 데이터 변경 API를 차단
+ * 현재 복원 작업 ID (#589)
+ */
+function getCurrentRestoreJobId() {
+  return currentRestoreJobId;
+}
+
+/**
+ * 백업/복원 중 쓰기 작업 차단 미들웨어
+ * POST, PUT, PATCH, DELETE 요청 중 데이터 변경 API를 차단.
+ * (이름은 호환 위해 유지하나 복원 중에도 동일하게 차단함 #589)
  */
 function blockDuringBackup(req, res, next) {
   // 읽기 전용 요청은 허용
@@ -48,35 +86,45 @@ function blockDuringBackup(req, res, next) {
     return next();
   }
 
-  if (!backupInProgress) {
+  if (!backupInProgress && !restoreInProgress) {
     return next();
   }
 
   // NOTE: app.use('/api', ...) 로 마운트되므로 req.path 에는 '/api' prefix 가 없음 (#529)
 
-  // 로그인/로그아웃은 백업 중에도 허용 (관리자 진입 경로).
+  // 로그인/로그아웃은 유지보수 중에도 허용 (관리자 진입 경로).
   // signup / 비밀번호 재설정은 User 컬렉션 쓰기라 차단 유지.
   if (req.path === '/auth/signin' || req.path === '/auth/logout') {
     return next();
   }
 
-  // 백업 제어 API 는 허용 (백업 시작은 핸들러 자체 가드로 중복 방지).
+  // 백업 중에는 백업 제어 API 허용 (백업 시작은 핸들러 자체 가드로 중복 방지).
   // 단 복원(restore)은 진행 중 백업과 동시 실행 금지.
-  if (req.path.startsWith('/admin/backup') && !req.path.startsWith('/admin/backup/restore')) {
+  // 복원 중에는 어떤 백업/복원 제어 쓰기도 차단 (재시작/중복 방지) — 상태 조회는 GET 이라 위에서 통과.
+  if (backupInProgress && !restoreInProgress
+      && req.path.startsWith('/admin/backup')
+      && !req.path.startsWith('/admin/backup/restore')) {
     return next();
   }
 
   return res.status(503).json({
     success: false,
-    message: '백업이 진행 중입니다. 잠시 후 다시 시도해주세요.',
-    backupJobId: currentBackupJobId
+    message: restoreInProgress
+      ? '복원이 진행 중입니다. 복원 완료 후 다시 시도해주세요.'
+      : '백업이 진행 중입니다. 잠시 후 다시 시도해주세요.',
+    backupJobId: currentBackupJobId,
+    restoreJobId: currentRestoreJobId
   });
 }
 
 module.exports = {
   startBackupLock,
   endBackupLock,
+  startRestoreLock,
+  endRestoreLock,
   isBackupInProgress,
+  isRestoreInProgress,
   getCurrentBackupJobId,
+  getCurrentRestoreJobId,
   blockDuringBackup
 };

--- a/src/models/BackupJob.js
+++ b/src/models/BackupJob.js
@@ -8,7 +8,8 @@ const backupJobSchema = new mongoose.Schema({
   },
   type: {
     type: String,
-    enum: ['full', 'database', 'files'],
+    // snapshot: 복원 직전 자동 생성되는 롤백용 스냅샷 (#590)
+    enum: ['full', 'database', 'files', 'snapshot'],
     default: 'full'
   },
   fileName: {

--- a/src/models/RestoreJob.js
+++ b/src/models/RestoreJob.js
@@ -54,6 +54,14 @@ const restoreJobSchema = new mongoose.Schema({
     errors: [String],
     warnings: [String]
   },
+  // 복원 직전 자동 생성된 롤백용 스냅샷 (#590). 스냅샷 생성 실패 시 snapshotWarning 에 사유.
+  preRestoreSnapshotId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'BackupJob'
+  },
+  snapshotWarning: {
+    type: String
+  },
   error: {
     message: String,
     stack: String

--- a/src/routes/backup.js
+++ b/src/routes/backup.js
@@ -5,7 +5,10 @@ const fs = require('fs');
 const { requireAdmin } = require('../middleware/auth');
 const backupService = require('../services/backupService');
 const restoreService = require('../services/restoreService');
-const { startBackupLock, endBackupLock, isBackupInProgress, getCurrentBackupJobId } = require('../middleware/backupLock');
+const {
+  startBackupLock, endBackupLock, isBackupInProgress, getCurrentBackupJobId,
+  startRestoreLock, endRestoreLock, isRestoreInProgress, getCurrentRestoreJobId
+} = require('../middleware/backupLock');
 const { generateBackupSignedUrl } = require('../utils/signedUrl');
 
 const router = express.Router();
@@ -62,7 +65,9 @@ router.get('/lock-status', requireAdmin, (req, res) => {
     success: true,
     data: {
       isBackupInProgress: isBackupInProgress(),
-      currentBackupJobId: getCurrentBackupJobId()
+      currentBackupJobId: getCurrentBackupJobId(),
+      isRestoreInProgress: isRestoreInProgress(),
+      currentRestoreJobId: getCurrentRestoreJobId()
     }
   });
 });
@@ -79,6 +84,15 @@ router.post('/', requireAdmin, async (req, res) => {
         success: false,
         message: '이미 백업이 진행 중입니다.',
         backupJobId: getCurrentBackupJobId()
+      });
+    }
+
+    // 복원 진행 중에는 백업 금지 (상호배타)
+    if (isRestoreInProgress()) {
+      return res.status(409).json({
+        success: false,
+        message: '복원이 진행 중입니다. 복원 완료 후 백업을 시작해주세요.',
+        restoreJobId: getCurrentRestoreJobId()
       });
     }
 
@@ -299,6 +313,15 @@ router.post('/restore', requireAdmin, async (req, res) => {
       });
     }
 
+    // 이미 복원 진행 중인지 확인 (중복 실행 방지 #589)
+    if (isRestoreInProgress()) {
+      return res.status(409).json({
+        success: false,
+        message: '이미 복원이 진행 중입니다.',
+        restoreJobId: getCurrentRestoreJobId()
+      });
+    }
+
     const { jobId, options = {} } = req.body;
 
     if (!jobId) {
@@ -336,6 +359,9 @@ router.post('/restore', requireAdmin, async (req, res) => {
       });
     }
 
+    // 복원 잠금 시작 — 복원 중 동시 쓰기 차단 (#589)
+    startRestoreLock(jobId);
+
     // 복구 실행 (비동기로 시작하고 바로 응답)
     restoreService.executeRestore(jobId, filePath, options)
       .then(() => {
@@ -349,6 +375,10 @@ router.post('/restore', requireAdmin, async (req, res) => {
         if (fs.existsSync(filePath)) {
           fs.unlinkSync(filePath);
         }
+      })
+      .finally(() => {
+        // 복원 완료/실패 시 잠금 해제
+        endRestoreLock();
       });
 
     res.json({

--- a/src/services/backupService.js
+++ b/src/services/backupService.js
@@ -134,7 +134,7 @@ async function exportCollection(collectionName, config, job) {
 /**
  * 백업 작업 초기화 (DB에 작업 기록만 생성)
  */
-async function initBackupJob(userId) {
+async function initBackupJob(userId, type = 'full') {
   // 암호화 키 유효성 검사
   validateEncryptionKey();
 
@@ -143,10 +143,10 @@ async function initBackupJob(userId) {
     fs.mkdirSync(BACKUP_DIR, { recursive: true });
   }
 
-  // 백업 작업 생성
+  // 백업 작업 생성 (type: 'full' 수동 / 'snapshot' 복원 직전 자동 #590)
   const job = new BackupJob({
     status: 'pending',
-    type: 'full',
+    type,
     createdBy: userId,
     progress: {
       current: 0,
@@ -174,7 +174,8 @@ async function executeBackup(jobId) {
   await job.save();
 
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-  const fileName = `vcc-backup-${timestamp}.zip`;
+  const prefix = job.type === 'snapshot' ? 'vcc-presnapshot' : 'vcc-backup';
+  const fileName = `${prefix}-${timestamp}.zip`;
   const filePath = path.join(BACKUP_DIR, fileName);
 
   try {
@@ -362,6 +363,8 @@ async function deleteBackup(jobId) {
 async function getLastBackupTime(userId) {
   const lastBackup = await BackupJob.findOne({
     createdBy: userId,
+    // 복원 직전 자동 스냅샷(#590)은 수동 백업 rate limit 계산에서 제외
+    type: { $ne: 'snapshot' },
     status: { $in: ['pending', 'processing', 'completed'] }
   }).sort({ createdAt: -1 });
 

--- a/src/services/restoreService.js
+++ b/src/services/restoreService.js
@@ -3,7 +3,8 @@ const path = require('path');
 const crypto = require('crypto');
 const unzipper = require('unzipper');
 const RestoreJob = require('../models/RestoreJob');
-const { ENCRYPTION_KEY } = require('./backupService');
+const backupService = require('./backupService');
+const { ENCRYPTION_KEY } = backupService;
 
 // 복원 대상 컬렉션 — backup/restore 공유 단일 소스 (#588).
 // 복호화 대상은 백업 시 암호화한 필드(encryptFields)와 동일하게 적용.
@@ -194,6 +195,23 @@ async function executeRestore(jobId, zipPath, options = {}) {
   job.status = 'processing';
   job.options = options;
   await job.save();
+
+  // 복원 직전 자동 스냅샷 (#590) — 잘못된 복원 시 롤백 경로 확보.
+  // best-effort: 실패해도 복원은 진행하되 RestoreJob 에 경고를 남긴다 (options.skipSnapshot 로 명시 생략 가능).
+  if (!options.skipSnapshot) {
+    try {
+      await job.updateProgress(0, 1, '복원 전 스냅샷 생성 중...');
+      const snapshot = await backupService.initBackupJob(job.createdBy, 'snapshot');
+      await backupService.executeBackup(snapshot._id);
+      job.preRestoreSnapshotId = snapshot._id;
+      await job.save();
+      console.log(`📸 복원 전 스냅샷 생성 완료: ${snapshot._id}`);
+    } catch (snapErr) {
+      job.snapshotWarning = `복원 전 스냅샷 생성 실패: ${snapErr.message} (롤백 스냅샷 없이 복원이 진행됩니다)`;
+      await job.save();
+      console.error(`⚠️ 복원 전 스냅샷 생성 실패: ${snapErr.message}`);
+    }
+  }
 
   const statistics = {
     collectionsRestored: {},

--- a/src/tests/restorePathValidation.test.js
+++ b/src/tests/restorePathValidation.test.js
@@ -25,7 +25,11 @@ jest.mock('../middleware/backupLock', () => ({
   startBackupLock: jest.fn(),
   endBackupLock: jest.fn(),
   isBackupInProgress: jest.fn(() => false),
-  getCurrentBackupJobId: jest.fn(() => null)
+  getCurrentBackupJobId: jest.fn(() => null),
+  startRestoreLock: jest.fn(),
+  endRestoreLock: jest.fn(),
+  isRestoreInProgress: jest.fn(() => false),
+  getCurrentRestoreJobId: jest.fn(() => null)
 }));
 
 jest.mock('../services/restoreService', () => ({


### PR DESCRIPTION
백업/복원 정비 Epic #592 의 P1. 복원의 정합성·롤백 안전장치 추가.

## #589 복원 중 쓰기 차단 락
- `backupLock` 을 백업/복원 공통 유지보수 락으로 확장 (`restoreInProgress` / `startRestoreLock` / `endRestoreLock` / `isRestoreInProgress`)
- `blockDuringBackup` 이 **복원 중에도 쓰기(POST/PUT/PATCH/DELETE) 503 차단** — GET·auth signin/logout 만 허용. 복원 중엔 백업/복원 제어 쓰기도 차단(중복/재시작 방지)
- 백업↔복원 **상호배타** 가드 (양쪽 시작 핸들러 교차 확인)
- `GET /lock-status` 에 restore 상태 노출

## #590 복원 전 자동 스냅샷
- `executeRestore` 가 DB 변경 **이전에** 현재 상태를 `type='snapshot'` 백업으로 생성 → 잘못된 복원 시 롤백 경로 확보
- `RestoreJob.preRestoreSnapshotId` 로 스냅샷 링크 저장. 생성 실패 시 `snapshotWarning` 남기고 복원은 진행(best-effort), `options.skipSnapshot` 로 명시 생략 가능
- 스냅샷은 수동 백업 rate limit(`getLastBackupTime`) 에서 제외 — 자동 스냅샷이 사용자 백업을 막지 않음
- `BackupJob.type` 에 `'snapshot'` 추가, 파일명 `vcc-presnapshot-*` 로 구분

## 검증
- 전체 jest 144건 green (backupLock mock 에 신규 락 함수 추가)
- 복원 락은 백업 락과 동일 메커니즘 — 기존 #529 핸들러 가드와 정합

## 후속(선택)
- 프론트 BackupRestorePage 에 '복원 중' 락 표시 / 스냅샷 다운로드(롤백) 안내는 별도 enhancement. 스냅샷은 백업 목록에 `vcc-presnapshot-*` 로 노출돼 현재도 복원(롤백) 가능.

closes #589
closes #590