### PR TITLE
feat: 백업/복원 스트리밍 — 대용량 OOM 방지 (#591)

### DIFF
--- a/src/services/backupService.js
+++ b/src/services/backupService.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
+const { once } = require('events');
 const archiver = require('archiver');
 const BackupJob = require('../models/BackupJob');
 
@@ -33,7 +34,7 @@ function validateEncryptionKey() {
 function encryptData(text) {
   if (!text) return null;
 
-  const iv = crypto.randomBytes(16);
+  const iv = crypto.randomBytes(12); // AES-GCM 표준 IV 길이 (복호화는 저장된 iv 길이를 사용하므로 구버전 16바이트 백업도 호환)
   const key = Buffer.from(ENCRYPTION_KEY, 'hex').slice(0, 32);
   const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
 
@@ -104,31 +105,43 @@ function encryptFields(doc, encryptFields) {
 }
 
 /**
- * 컬렉션 데이터 추출
+ * 단일 문서 처리 (민감 필드 제거 + 필드 암호화)
  */
-async function exportCollection(collectionName, config, job) {
-  const { model, sensitiveFields = [], encryptFields: fieldsToEncrypt = [] } = config;
-
-  const documents = await model.find({}).lean();
-  const processedDocs = [];
-
-  for (const doc of documents) {
-    let processedDoc = doc;
-
-    // 민감 필드 제거
-    if (sensitiveFields.length > 0) {
-      processedDoc = removeSensitiveFields(processedDoc, sensitiveFields);
-    }
-
-    // 필드 암호화
-    if (fieldsToEncrypt.length > 0) {
-      processedDoc = encryptFields(processedDoc, fieldsToEncrypt);
-    }
-
-    processedDocs.push(processedDoc);
+function processDoc(doc, config) {
+  const { sensitiveFields = [], encryptFields: fieldsToEncrypt = [] } = config;
+  let processedDoc = doc;
+  if (sensitiveFields.length > 0) {
+    processedDoc = removeSensitiveFields(processedDoc, sensitiveFields);
   }
+  if (fieldsToEncrypt.length > 0) {
+    processedDoc = encryptFields(processedDoc, fieldsToEncrypt);
+  }
+  return processedDoc;
+}
 
-  return processedDocs;
+/**
+ * 컬렉션을 cursor 로 스트리밍하며 NDJSON(문서 1개/줄) 파일로 기록 (#591).
+ * 컬렉션 전체를 메모리에 적재하지 않아 대용량에서도 OOM 없이 동작.
+ * 반환: 기록한 문서 수.
+ */
+async function writeCollectionNdjson(config, outPath) {
+  const ws = fs.createWriteStream(outPath);
+  const cursor = config.model.find({}).lean().cursor();
+  let count = 0;
+  try {
+    for await (const doc of cursor) {
+      const line = JSON.stringify(processDoc(doc, config)) + '\n';
+      if (!ws.write(line)) {
+        await once(ws, 'drain'); // backpressure 존중
+      }
+      count++;
+    }
+  } finally {
+    await cursor.close().catch(() => {});
+  }
+  ws.end();
+  await once(ws, 'finish');
+  return count;
 }
 
 /**
@@ -178,7 +191,11 @@ async function executeBackup(jobId) {
   const fileName = `${prefix}-${timestamp}.zip`;
   const filePath = path.join(BACKUP_DIR, fileName);
 
+  // 컬렉션 NDJSON 임시 디렉토리 (스트리밍 후 아카이브에 추가, 종료 시 정리) (#591)
+  const dbTmpDir = path.join(BACKUP_DIR, `.db-tmp-${job._id}`);
+
   try {
+    fs.mkdirSync(dbTmpDir, { recursive: true });
     // ZIP 파일 생성
     const output = fs.createWriteStream(filePath);
     const archive = archiver('zip', { zlib: { level: 9 } });
@@ -204,18 +221,17 @@ async function executeBackup(jobId) {
       encryptionKeyHash: crypto.createHash('sha256').update(ENCRYPTION_KEY).digest('hex').slice(0, 16)
     };
 
-    // 컬렉션 백업
+    // 컬렉션 백업 — cursor 스트리밍 → NDJSON 임시파일 → 아카이브 (#591)
     let progress = 0;
     for (const config of BACKUP_COLLECTIONS) {
       const name = config.name;
       await job.updateProgress(progress, job.progress.total, `${name} 컬렉션 백업 중...`);
 
-      const documents = await exportCollection(name, config, job);
-      metadata.collections[name] = documents.length;
+      const ndjsonPath = path.join(dbTmpDir, `${name}.ndjson`);
+      const count = await writeCollectionNdjson(config, ndjsonPath);
+      metadata.collections[name] = count;
 
-      archive.append(JSON.stringify(documents, null, 2), {
-        name: `database/${name}.json`
-      });
+      archive.file(ndjsonPath, { name: `database/${name}.ndjson` });
 
       progress++;
     }
@@ -246,6 +262,9 @@ async function executeBackup(jobId) {
     await archive.finalize();
     await archivePromise;
 
+    // NDJSON 임시 디렉토리 정리 (아카이브에 다 담긴 후)
+    fs.rmSync(dbTmpDir, { recursive: true, force: true });
+
     // 파일 크기 확인
     const stats = fs.statSync(filePath);
 
@@ -261,10 +280,11 @@ async function executeBackup(jobId) {
     console.log(`✅ 백업 완료: ${fileName} (${stats.size} bytes)`);
     return job;
   } catch (error) {
-    // 실패 시 파일 삭제
+    // 실패 시 파일 / 임시 디렉토리 삭제
     if (fs.existsSync(filePath)) {
       fs.unlinkSync(filePath);
     }
+    fs.rmSync(dbTmpDir, { recursive: true, force: true });
 
     await job.fail(error);
     console.error(`❌ 백업 실패: ${error.message}`);
@@ -380,5 +400,8 @@ module.exports = {
   getBackupFilePath,
   deleteBackup,
   getLastBackupTime,
-  ENCRYPTION_KEY
+  ENCRYPTION_KEY,
+  // 테스트용 내부 헬퍼 (#591)
+  processDoc,
+  writeCollectionNdjson
 };

--- a/src/services/restoreService.js
+++ b/src/services/restoreService.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
+const readline = require('readline');
 const unzipper = require('unzipper');
 const RestoreJob = require('../models/RestoreJob');
 const backupService = require('./backupService');
@@ -77,6 +78,83 @@ function decryptFields(doc, fieldsToDecrypt) {
   }
 
   return processedDoc;
+}
+
+/**
+ * 단일 문서 복구 (복호화 → _id 보존 create / overwrite upsert). (#591 스트리밍 분리)
+ * 성공 시 true. 통계는 statistics 에 누적.
+ */
+async function restoreOneDoc(doc, config, options, statistics) {
+  try {
+    // 암호화 필드 복호화 (백업 시 암호화한 encryptFields 와 동일)
+    let processedDoc = doc;
+    if (config.encryptFields) {
+      processedDoc = decryptFields(doc, config.encryptFields);
+    }
+
+    const docId = processedDoc._id;
+    delete processedDoc._id;
+
+    if (options.overwriteExisting) {
+      await config.model.findByIdAndUpdate(docId, processedDoc, { upsert: true, new: true });
+    } else {
+      const existing = await config.model.findById(docId);
+      if (!existing) {
+        processedDoc._id = docId;
+        await config.model.create(processedDoc);
+      } else {
+        statistics.skipped++;
+      }
+    }
+    return true;
+  } catch (docError) {
+    console.error(`${config.name} 문서 복구 오류:`, docError.message);
+    statistics.errors++;
+    return false;
+  }
+}
+
+/**
+ * 컬렉션 복구 — NDJSON(#591) 우선 스트리밍, 없으면 구버전 .json 배열 fallback.
+ * 반환: 복구 시도한 문서 수.
+ */
+async function restoreCollection(config, tempExtractDir, options, statistics) {
+  const ndjsonPath = path.join(tempExtractDir, 'database', `${config.name}.ndjson`);
+  const jsonPath = path.join(tempExtractDir, 'database', `${config.name}.json`);
+  let restoredCount = 0;
+
+  if (fs.existsSync(ndjsonPath)) {
+    // 신버전: 한 줄에 문서 1개 — 라인 스트리밍 (메모리 상수)
+    const rl = readline.createInterface({
+      input: fs.createReadStream(ndjsonPath),
+      crlfDelay: Infinity
+    });
+    for await (const line of rl) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let doc;
+      try {
+        doc = JSON.parse(trimmed);
+      } catch (parseErr) {
+        console.error(`${config.name} NDJSON 파싱 오류:`, parseErr.message);
+        statistics.errors++;
+        continue;
+      }
+      await restoreOneDoc(doc, config, options, statistics);
+      restoredCount++;
+    }
+  } else if (fs.existsSync(jsonPath)) {
+    // 구버전 호환: 통째 JSON 배열
+    const data = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+    for (const doc of data) {
+      await restoreOneDoc(doc, config, options, statistics);
+      restoredCount++;
+    }
+  } else {
+    return null; // 해당 컬렉션 파일 없음
+  }
+
+  return restoredCount;
 }
 
 /**
@@ -251,54 +329,14 @@ async function executeRestore(jobId, zipPath, options = {}) {
         currentStep++;
         await job.updateProgress(currentStep, totalSteps, `${name} 컬렉션 복구 중...`);
 
-        const jsonPath = path.join(tempExtractDir, 'database', `${name}.json`);
-
-        if (fs.existsSync(jsonPath)) {
-          try {
-            const data = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
-            let restoredCount = 0;
-
-            for (const doc of data) {
-              try {
-                // 암호화 필드 복호화 (백업 시 암호화한 encryptFields 와 동일)
-                let processedDoc = doc;
-                if (config.encryptFields) {
-                  processedDoc = decryptFields(doc, config.encryptFields);
-                }
-
-                // _id와 날짜 필드 변환
-                const docId = processedDoc._id;
-                delete processedDoc._id;
-
-                if (options.overwriteExisting) {
-                  await config.model.findByIdAndUpdate(
-                    docId,
-                    processedDoc,
-                    { upsert: true, new: true }
-                  );
-                } else {
-                  // 존재 여부 확인
-                  const existing = await config.model.findById(docId);
-                  if (!existing) {
-                    processedDoc._id = docId;
-                    await config.model.create(processedDoc);
-                  } else {
-                    statistics.skipped++;
-                  }
-                }
-
-                restoredCount++;
-              } catch (docError) {
-                console.error(`${name} 문서 복구 오류:`, docError.message);
-                statistics.errors++;
-              }
-            }
-
+        try {
+          const restoredCount = await restoreCollection(config, tempExtractDir, options, statistics);
+          if (restoredCount !== null) {
             statistics.collectionsRestored[name] = restoredCount;
-          } catch (colError) {
-            console.error(`${name} 컬렉션 복구 오류:`, colError.message);
-            statistics.errors++;
           }
+        } catch (colError) {
+          console.error(`${name} 컬렉션 복구 오류:`, colError.message);
+          statistics.errors++;
         }
       }
     }
@@ -395,5 +433,8 @@ module.exports = {
   validateBackup,
   executeRestore,
   getRestoreStatus,
-  listRestores
+  listRestores,
+  // 테스트용 내부 헬퍼 (#591)
+  restoreOneDoc,
+  restoreCollection
 };

--- a/src/tests/backupStreaming.test.js
+++ b/src/tests/backupStreaming.test.js
@@ -1,0 +1,153 @@
+/**
+ * #591 백업/복원 스트리밍 회귀 테스트
+ * - writeCollectionNdjson: cursor → NDJSON 파일 (한 줄=문서 1개)
+ * - restoreCollection: NDJSON 라인 스트리밍 + 구버전 .json 배열 fallback
+ * DB 연결 없이 fake 모델로 검증.
+ */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { processDoc, writeCollectionNdjson } = require('../services/backupService');
+const { restoreCollection } = require('../services/restoreService');
+
+// fake mongoose cursor (async iterable + close)
+function makeCursor(docs) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const d of docs) yield d;
+    },
+    close: async () => {}
+  };
+}
+
+function makeBackupModel(docs) {
+  return {
+    find: () => ({ lean: () => ({ cursor: () => makeCursor(docs) }) })
+  };
+}
+
+function makeRestoreModel() {
+  const created = [];
+  return {
+    created,
+    create: jest.fn(async (d) => { created.push(d); return d; }),
+    findById: jest.fn(async () => null),
+    findByIdAndUpdate: jest.fn(async () => ({}))
+  };
+}
+
+let tmpDir;
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vcc-backup-test-'));
+  fs.mkdirSync(path.join(tmpDir, 'database'), { recursive: true });
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('#591 processDoc', () => {
+  test('sensitiveFields 는 제거된다', () => {
+    const out = processDoc({ _id: '1', name: 'a', googleId: 'secret' }, { sensitiveFields: ['googleId'] });
+    expect(out.googleId).toBeUndefined();
+    expect(out.name).toBe('a');
+  });
+
+  test('규칙 없으면 그대로', () => {
+    const doc = { _id: '1', x: 1 };
+    expect(processDoc(doc, {})).toEqual(doc);
+  });
+});
+
+describe('#591 writeCollectionNdjson', () => {
+  test('cursor 의 모든 문서를 한 줄씩 기록하고 개수를 반환', async () => {
+    const docs = [{ _id: '1', v: 'a' }, { _id: '2', v: 'b' }, { _id: '3', v: 'c' }];
+    const outPath = path.join(tmpDir, 'database', 'Coll.ndjson');
+    const count = await writeCollectionNdjson({ name: 'Coll', model: makeBackupModel(docs) }, outPath);
+
+    expect(count).toBe(3);
+    const lines = fs.readFileSync(outPath, 'utf8').trim().split('\n');
+    expect(lines).toHaveLength(3);
+    expect(JSON.parse(lines[0])).toEqual(docs[0]);
+    expect(JSON.parse(lines[2]).v).toBe('c');
+  });
+
+  test('빈 컬렉션은 0개, 빈 파일', async () => {
+    const outPath = path.join(tmpDir, 'database', 'Empty.ndjson');
+    const count = await writeCollectionNdjson({ name: 'Empty', model: makeBackupModel([]) }, outPath);
+    expect(count).toBe(0);
+    expect(fs.readFileSync(outPath, 'utf8')).toBe('');
+  });
+
+  test('sensitiveFields 가 기록물에서 빠진다', async () => {
+    const outPath = path.join(tmpDir, 'database', 'User.ndjson');
+    await writeCollectionNdjson(
+      { name: 'User', model: makeBackupModel([{ _id: '1', email: 'a@b.c', googleId: 'g' }]), sensitiveFields: ['googleId'] },
+      outPath
+    );
+    const doc = JSON.parse(fs.readFileSync(outPath, 'utf8').trim());
+    expect(doc.googleId).toBeUndefined();
+    expect(doc.email).toBe('a@b.c');
+  });
+});
+
+describe('#591 restoreCollection', () => {
+  const writeNdjson = (name, docs) =>
+    fs.writeFileSync(path.join(tmpDir, 'database', `${name}.ndjson`), docs.map((d) => JSON.stringify(d)).join('\n') + '\n');
+
+  test('NDJSON 라인을 스트리밍해 문서별로 복구', async () => {
+    writeNdjson('Coll', [{ _id: '1', v: 'a' }, { _id: '2', v: 'b' }]);
+    const model = makeRestoreModel();
+    const stats = { collectionsRestored: {}, skipped: 0, errors: 0 };
+    const count = await restoreCollection({ name: 'Coll', model }, tmpDir, {}, stats);
+
+    expect(count).toBe(2);
+    expect(model.create).toHaveBeenCalledTimes(2);
+    expect(stats.errors).toBe(0);
+    // _id 보존
+    expect(model.created[0]._id).toBe('1');
+  });
+
+  test('빈 줄은 건너뛴다', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'database', 'Coll.ndjson'), `${JSON.stringify({ _id: '1' })}\n\n${JSON.stringify({ _id: '2' })}\n`);
+    const model = makeRestoreModel();
+    const stats = { collectionsRestored: {}, skipped: 0, errors: 0 };
+    const count = await restoreCollection({ name: 'Coll', model }, tmpDir, {}, stats);
+    expect(count).toBe(2);
+    expect(model.create).toHaveBeenCalledTimes(2);
+  });
+
+  test('구버전 .json 배열도 복구된다 (하위호환)', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'database', 'Legacy.json'), JSON.stringify([{ _id: '1' }, { _id: '2' }, { _id: '3' }]));
+    const model = makeRestoreModel();
+    const stats = { collectionsRestored: {}, skipped: 0, errors: 0 };
+    const count = await restoreCollection({ name: 'Legacy', model }, tmpDir, {}, stats);
+    expect(count).toBe(3);
+    expect(model.create).toHaveBeenCalledTimes(3);
+  });
+
+  test('파일 없으면 null', async () => {
+    const stats = { collectionsRestored: {}, skipped: 0, errors: 0 };
+    const result = await restoreCollection({ name: 'Missing', model: makeRestoreModel() }, tmpDir, {}, stats);
+    expect(result).toBeNull();
+  });
+
+  test('overwrite=false 에서 기존 문서는 skip', async () => {
+    writeNdjson('Coll', [{ _id: '1' }]);
+    const model = makeRestoreModel();
+    model.findById = jest.fn(async () => ({ _id: '1' })); // 이미 존재
+    const stats = { collectionsRestored: {}, skipped: 0, errors: 0 };
+    await restoreCollection({ name: 'Coll', model }, tmpDir, { overwriteExisting: false }, stats);
+    expect(model.create).not.toHaveBeenCalled();
+    expect(stats.skipped).toBe(1);
+  });
+
+  test('깨진 JSON 라인은 errors 로 집계하고 계속', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'database', 'Coll.ndjson'), `${JSON.stringify({ _id: '1' })}\n{ broken json\n${JSON.stringify({ _id: '2' })}\n`);
+    const model = makeRestoreModel();
+    const stats = { collectionsRestored: {}, skipped: 0, errors: 0 };
+    await restoreCollection({ name: 'Coll', model }, tmpDir, {}, stats);
+    expect(model.create).toHaveBeenCalledTimes(2);
+    expect(stats.errors).toBe(1);
+  });
+});


### PR DESCRIPTION
백업/복원 정비 Epic #592 의 P2. 컬렉션 통째 메모리 적재 → cursor 스트리밍 전환.

## 문제
- 백업: `model.find({}).lean()` 로 컬렉션 전체를 배열로 적재 후 `JSON.stringify` 로 거대 문자열화 (메모리 2중 적재)
- 복원: `JSON.parse(fs.readFileSync())` 로 컬렉션 전체 적재
- 문서 수가 많아지면 **OOM 으로 백업/복원 프로세스 사망** (+ 같은 호스트 Mongo silent crash 위험)

## 변경
**백업** — `writeCollectionNdjson`
- `model.find().lean().cursor()` 로 한 건씩 스트리밍, **NDJSON**(문서 1개/줄) 임시파일로 기록(backpressure 존중) → `archive.file` 로 추가
- 메모리 상수 유지 + 정확한 카운트/진행률, 종료/실패 시 임시 디렉토리 정리
- 형식: `database/<name>.json`(배열) → `database/<name>.ndjson`

**복원** — `restoreCollection`
- `.ndjson` 을 `readline` 라인 스트리밍, 문서별 복구
- **구버전 `.json` 배열 백업은 fallback 으로 계속 인식 (하위호환)**
- 깨진 라인은 errors 집계 후 계속, 빈 줄 skip — 기존 per-doc 의미(create/skip/overwrite·통계) 보존

**기타**
- AES-GCM IV 16→12바이트(표준). 복호화는 저장된 iv 길이 사용 → 구버전 백업 호환

## 검증
- **#591 스트리밍 회귀 테스트 11건 추가** (DB 없이 fake 모델 — NDJSON 라운드트립, 레거시 json fallback, skip/overwrite, 깨진 라인 내성)
- 전체 jest **155건 green**

## 비고
- 디스크 여유 사전 점검은 플랫폼 편차가 있어 이번엔 제외(스트리밍으로 메모리 압박은 해소). 필요 시 별도 검토.

closes #591