### PR TITLE
feat: 외부 provider API 키 at-rest 암호화 (#594)

### DIFF
--- a/src/migrations/encryptExistingSecrets.js
+++ b/src/migrations/encryptExistingSecrets.js
@@ -1,0 +1,55 @@
+const Server = require('../models/Server');
+const SystemSettings = require('../models/SystemSettings');
+const { encryptSecret, isEncrypted } = require('../utils/secretCrypto');
+
+// #594: 기존에 평문으로 저장된 provider API 키를 at-rest 암호화로 전환.
+// 멱등 — 이미 enc: 접두사면 건너뜀. 암호화 키가 없으면 encryptSecret 가 평문을 그대로
+// 반환하므로 사실상 no-op (기존 동작 유지). 부분 실패는 건너뛰고 계속.
+async function encryptExistingSecrets() {
+  try {
+    // 1) Server.configuration.apiKey
+    const servers = await Server.find({ 'configuration.apiKey': { $exists: true, $nin: [null, ''] } });
+    let serverCount = 0;
+    for (const server of servers) {
+      const current = server.configuration?.apiKey;
+      if (!current || isEncrypted(current)) continue;
+      const encrypted = encryptSecret(current);
+      if (encrypted === current) continue; // 키 없음 등으로 변화 없으면 skip
+      server.configuration.apiKey = encrypted;
+      server.markModified('configuration');
+      await server.save();
+      serverCount++;
+    }
+
+    // 2) SystemSettings.{external,lora}.civitaiApiKey
+    let settingsChanged = false;
+    const settings = await SystemSettings.findOne({ key: 'global' });
+    if (settings) {
+      for (const path of ['external', 'lora']) {
+        const v = settings[path]?.civitaiApiKey;
+        if (v && !isEncrypted(v)) {
+          const enc = encryptSecret(v);
+          if (enc !== v) {
+            settings[path].civitaiApiKey = enc;
+            settingsChanged = true;
+          }
+        }
+      }
+      if (settingsChanged) {
+        settings.markModified('external');
+        settings.markModified('lora');
+        await settings.save();
+      }
+    }
+
+    if (serverCount > 0 || settingsChanged) {
+      console.log(`[Migration] provider 키 at-rest 암호화 완료 (서버 ${serverCount}건${settingsChanged ? ', SystemSettings' : ''})`);
+    } else {
+      console.log('[Migration] provider 키 at-rest 암호화 불필요 (이미 암호화됨 또는 대상 없음)');
+    }
+  } catch (error) {
+    console.error('[Migration] provider 키 at-rest 암호화 실패:', error.message);
+  }
+}
+
+module.exports = encryptExistingSecrets;

--- a/src/models/Server.js
+++ b/src/models/Server.js
@@ -96,15 +96,19 @@ serverSchema.methods.checkHealth = async function() {
         healthEndpoint = this.serverUrl;
     }
 
+    // at-rest 암호화된 apiKey 복호화 (#594)
+    const { decryptSecret } = require('../utils/secretCrypto');
+    const apiKey = decryptSecret(this.configuration?.apiKey);
+
     const requestConfig = {
       timeout: Math.min(timeout, 10000), // 최대 10초
-      headers: this.configuration?.apiKey ? {
-        'Authorization': `Bearer ${this.configuration.apiKey}`
+      headers: apiKey ? {
+        'Authorization': `Bearer ${apiKey}`
       } : {}
     };
 
-    if (this.serverType === 'Gemini' && this.configuration?.apiKey) {
-      requestConfig.params = { key: this.configuration.apiKey };
+    if (this.serverType === 'Gemini' && apiKey) {
+      requestConfig.params = { key: apiKey };
       requestConfig.headers = {};
     }
 

--- a/src/models/SystemSettings.js
+++ b/src/models/SystemSettings.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const { encryptSecret, decryptSecret } = require('../utils/secretCrypto');
 
 /**
  * 시스템 전역 설정 모델
@@ -78,7 +79,8 @@ systemSettingsSchema.statics.updateLoraSettings = async function(updates) {
   }
   if (updates.civitaiApiKey !== undefined) {
     // #293 Phase B — 새 위치 우선, legacy 도 동기 갱신 (다른 코드 fallback 대비)
-    const v = updates.civitaiApiKey || null;
+    // #594 — at-rest 암호화 후 저장
+    const v = updates.civitaiApiKey ? encryptSecret(updates.civitaiApiKey) : null;
     settings.external.civitaiApiKey = v;
     settings.lora.civitaiApiKey = v;
   }
@@ -93,9 +95,10 @@ systemSettingsSchema.statics.updateLoraSettings = async function(updates) {
  */
 systemSettingsSchema.statics.getCivitaiApiKey = async function() {
   const settings = await this.getGlobal();
+  // #594 — at-rest 암호화된 값 복호화 (평문/legacy 는 그대로 반환)
   return (
-    settings.external?.civitaiApiKey ||
-    settings.lora?.civitaiApiKey ||
+    decryptSecret(settings.external?.civitaiApiKey) ||
+    decryptSecret(settings.lora?.civitaiApiKey) ||
     process.env.CIVITAI_API_KEY ||
     null
   );

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -19,6 +19,7 @@ const Project = require('../models/Project');
 const Tag = require('../models/Tag');
 const UploadedText = require('../models/UploadedText');
 const { loadVisionImages } = require('../utils/visionImages');
+const { decryptSecret } = require('../utils/secretCrypto');
 
 // 세계관 (사전 컨텍스트) + 작업 지침 → 단일 system 메시지로 합성 (#396).
 // system prompt = LLM 의 역할 / 작업 방침 (작업판 admin 정의)
@@ -638,13 +639,14 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
     }, 15000);
 
     let result, usage;
+    const serverApiKey = decryptSecret(server.configuration?.apiKey); // at-rest 복호화 (#594)
     try {
       if (server.serverType === 'Gemini') {
         // Gemini 는 스트리밍 미구현 — 헤더는 이미 flush 됐으니 TTFB 는 확보됨.
         // 결과를 단일 token 이벤트로 전송해 프론트 SSE 처리 경로를 통일.
         ({ content: result, usage } = await geminiService.complete(
           server.serverUrl,
-          server.configuration?.apiKey,
+          serverApiKey,
           messages,
           { model, temperature, timeout: server.configuration?.timeout || 60000, extraParams: workboard.llmExtraParams }
         ));
@@ -652,7 +654,7 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
       } else {
         ({ content: result, usage } = await openAIChatService.completeStream(
           server.serverUrl,
-          server.configuration?.apiKey,
+          serverApiKey,
           messages,
           { model, temperature, timeout: server.configuration?.timeout || 60000, extraParams: workboard.llmExtraParams },
           (delta) => sse('token', { delta })

--- a/src/routes/servers.js
+++ b/src/routes/servers.js
@@ -8,6 +8,7 @@ const { verifyJWT, requireAdmin, userHasWorkboardAccess } = require('../middlewa
 const loraMetadataService = require('../services/loraMetadataService');
 const modelMetadataService = require('../services/modelMetadataService');
 const comfyUIService = require('../services/comfyUIService');
+const { encryptSecret } = require('../utils/secretCrypto');
 
 // 서버 목록 조회 (일반 사용자도 접근 가능)
 router.get('/', verifyJWT, async (req, res) => {
@@ -45,16 +46,18 @@ router.get('/', verifyJWT, async (req, res) => {
 // 서버 상세 조회 (관리자만)
 router.get('/:id', requireAdmin, async (req, res) => {
   try {
+    // apiKey 는 응답에서 제외 (목록 라우트와 동일 — 평문/암호문 모두 프론트로 보내지 않음) (#594)
     const server = await Server.findById(req.params.id)
+      .select('-configuration.apiKey')
       .populate('createdBy', 'email nickname');
-    
+
     if (!server) {
       return res.status(404).json({
         success: false,
         message: '서버를 찾을 수 없습니다.'
       });
     }
-    
+
     res.json({
       success: true,
       data: { server }
@@ -104,6 +107,11 @@ router.post('/', requireAdmin, async (req, res) => {
       });
     }
 
+    // apiKey 는 at-rest 암호화 후 저장 (#594)
+    if (configuration && configuration.apiKey) {
+      configuration.apiKey = encryptSecret(configuration.apiKey);
+    }
+
     const server = new Server({
       name,
       description,
@@ -112,7 +120,7 @@ router.post('/', requireAdmin, async (req, res) => {
       configuration,
       createdBy: req.user.id
     });
-    
+
     await server.save();
     
     // 생성 후 헬스체크 수행
@@ -189,9 +197,11 @@ router.put('/:id', requireAdmin, async (req, res) => {
     if (serverType !== undefined) updateFields.serverType = serverType;
     if (serverUrl !== undefined) updateFields.serverUrl = serverUrl;
     if (configuration !== undefined) {
-      // API 키가 비어있으면 기존 값을 유지
+      // API 키가 비어있으면 기존 값(이미 암호화됨)을 유지, 새 값이면 at-rest 암호화 (#594)
       if (!configuration.apiKey && server.configuration?.apiKey) {
         configuration.apiKey = server.configuration.apiKey;
+      } else if (configuration.apiKey) {
+        configuration.apiKey = encryptSecret(configuration.apiKey); // 이미 enc: 면 멱등
       }
       updateFields.configuration = configuration;
     }

--- a/src/server.js
+++ b/src/server.js
@@ -44,6 +44,7 @@ const assignDefaultGroupToWorkboards = require('./migrations/assignDefaultGroupT
 const backfillCustomFieldRoles = require('./migrations/backfillCustomFieldRoles');
 const dropBaseInputFieldsSchema = require('./migrations/dropBaseInputFieldsSchema');
 const relocateCivitaiApiKey = require('./migrations/relocateCivitaiApiKey');
+const encryptExistingSecrets = require('./migrations/encryptExistingSecrets');
 const ensureWorldviewTag = require('./migrations/ensureWorldviewTag');
 const backfillConversationTags = require('./migrations/backfillConversationTags');
 const alignTagColorsV2 = require('./migrations/alignTagColorsV2');
@@ -249,6 +250,7 @@ const startServer = async () => {
     await backfillCustomFieldRoles();
     await dropBaseInputFieldsSchema();
     await relocateCivitaiApiKey();
+    await encryptExistingSecrets();
     await ensureWorldviewTag();
     await backfillConversationTags();
     await alignTagColorsV2();

--- a/src/services/backupCollections.js
+++ b/src/services/backupCollections.js
@@ -20,7 +20,9 @@
  * 비밀값 저장 형태 메모:
  * - User.password        : bcrypt 해시 (단방향) → 그대로 백업·복원해도 안전 + 로그인 동작
  * - ApiKey.keyHash       : SHA-256 해시 (단방향) → 그대로 백업해도 안전 + 키 검증 동작
- * - Server.configuration.apiKey, SystemSettings.*.civitaiApiKey : 평문 → 백업 시 암호화
+ * - Server.configuration.apiKey, SystemSettings.*.civitaiApiKey : #594 이후 DB 에 at-rest
+ *   암호화(enc:v1:) 문자열로 저장됨. backup encryptFields 는 그대로 두어 백업 안에서 한 번 더
+ *   감싸지만, 복원 시 정확히 round-trip 되고 구버전(평문) 백업도 호환됨 (#594 PR 설명 참고).
  */
 
 const User = require('../models/User');

--- a/src/services/modelMetadataService.js
+++ b/src/services/modelMetadataService.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 const ServerModelCache = require('../models/ServerModelCache');
 const SystemSettings = require('../models/SystemSettings');
+const { decryptSecret } = require('../utils/secretCrypto');
 
 // LoRA service 와 동일한 Civitai rate limit / 재시도 정책.
 // 단순 재구현 (Phase B 에서는 두 서비스가 독립으로 진화할 여지를 두기 위해
@@ -333,7 +334,7 @@ const syncServerProviderModels = async (server, { progressCallback = null } = {}
     throw new Error('Sync already in progress');
   }
 
-  const apiKey = server.configuration?.apiKey;
+  const apiKey = decryptSecret(server.configuration?.apiKey); // at-rest 복호화 (#594)
 
   try {
     await cache.startSync();

--- a/src/services/pipelineRunService.js
+++ b/src/services/pipelineRunService.js
@@ -10,6 +10,7 @@ const Tag = require('../models/Tag');
 const openAIChatService = require('./openAIChatService');
 const geminiService = require('./geminiService');
 const { getFieldValueByRole } = require('../utils/customFieldHelpers');
+const { decryptSecret } = require('../utils/secretCrypto');
 const { FIELD_ROLES } = require('../constants/fieldRoles');
 const { computeOpenAITextCost, computeGeminiTextCost } = require('../utils/pricing');
 const queueService = require('./queueService');
@@ -164,7 +165,7 @@ async function runTextStep(userId, pipelineRun, step, pipelineStep, inputData, p
   try {
     ({ content: result, usage } = await chatService.complete(
       server.serverUrl,
-      server.configuration?.apiKey,
+      decryptSecret(server.configuration?.apiKey), // at-rest 복호화 (#594)
       messages,
       { model: resolvedModel, temperature, timeout: server.configuration?.timeout || 60000, extraParams: workboard.llmExtraParams }
     ));

--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -14,6 +14,7 @@ const GeneratedVideo = require('../models/GeneratedVideo');
 const UploadedImage = require('../models/UploadedImage');
 const { getFieldValueByRole } = require('../utils/customFieldHelpers');
 const { FIELD_ROLES } = require('../constants/fieldRoles');
+const { decryptSecret } = require('../utils/secretCrypto');
 
 let imageGenerationQueue;
 let redisClient;
@@ -1031,7 +1032,7 @@ const addImageGenerationJob = async (userId, workboardId, inputData) => {
         serverType: workboard.serverId?.serverType,
         outputFormat: workboard.outputFormat,
         serverUrl: workboard.serverUrl,
-        apiKey: workboard.serverId?.configuration?.apiKey,
+        apiKey: decryptSecret(workboard.serverId?.configuration?.apiKey), // at-rest 복호화 (#594)
         timeout: workboard.serverId?.configuration?.timeout,
         workflowData: workboard.workflowData,
         additionalInputFields: workboard.additionalInputFields

--- a/src/tests/secretCrypto.test.js
+++ b/src/tests/secretCrypto.test.js
@@ -1,0 +1,69 @@
+/**
+ * #594 at-rest secret 암호화 유틸 테스트
+ */
+const { encryptSecret, decryptSecret, isEncrypted } = require('../utils/secretCrypto');
+
+const KEY = 'a'.repeat(64); // 32바이트 hex
+
+describe('#594 secretCrypto (키 설정됨)', () => {
+  const orig = process.env.CONFIG_ENCRYPTION_KEY;
+  beforeAll(() => { process.env.CONFIG_ENCRYPTION_KEY = KEY; });
+  afterAll(() => { process.env.CONFIG_ENCRYPTION_KEY = orig; });
+
+  test('암호화 → 복호화 round-trip', () => {
+    const enc = encryptSecret('sk-secret-123');
+    expect(enc).not.toBe('sk-secret-123');
+    expect(isEncrypted(enc)).toBe(true);
+    expect(enc.startsWith('enc:v1:')).toBe(true);
+    expect(decryptSecret(enc)).toBe('sk-secret-123');
+  });
+
+  test('멱등 — 이미 암호문이면 다시 암호화하지 않음', () => {
+    const enc = encryptSecret('key');
+    expect(encryptSecret(enc)).toBe(enc);
+  });
+
+  test('서로 다른 IV — 같은 평문도 매번 다른 암호문', () => {
+    expect(encryptSecret('same')).not.toBe(encryptSecret('same'));
+    // 그래도 둘 다 같은 평문으로 복호화
+    expect(decryptSecret(encryptSecret('same'))).toBe('same');
+  });
+
+  test('평문/빈값/null 은 그대로 통과', () => {
+    expect(decryptSecret('plaintext-not-enc')).toBe('plaintext-not-enc');
+    expect(encryptSecret('')).toBe('');
+    expect(encryptSecret(null)).toBeNull();
+    expect(decryptSecret(null)).toBeNull();
+  });
+
+  test('변조된 암호문은 복호화 실패 → null', () => {
+    const enc = encryptSecret('secret');
+    const tampered = enc.slice(0, -2) + (enc.endsWith('00') ? '11' : '00');
+    expect(decryptSecret(tampered)).toBeNull();
+  });
+});
+
+describe('#594 secretCrypto (키 없음 — graceful degrade)', () => {
+  const origC = process.env.CONFIG_ENCRYPTION_KEY;
+  const origB = process.env.BACKUP_ENCRYPTION_KEY;
+  beforeAll(() => { delete process.env.CONFIG_ENCRYPTION_KEY; delete process.env.BACKUP_ENCRYPTION_KEY; });
+  afterAll(() => { process.env.CONFIG_ENCRYPTION_KEY = origC; process.env.BACKUP_ENCRYPTION_KEY = origB; });
+
+  test('키 없으면 평문 그대로 (기존 동작 유지)', () => {
+    expect(encryptSecret('plain')).toBe('plain');
+    expect(isEncrypted(encryptSecret('plain'))).toBe(false);
+  });
+});
+
+describe('#594 secretCrypto (BACKUP_ENCRYPTION_KEY fallback)', () => {
+  const origC = process.env.CONFIG_ENCRYPTION_KEY;
+  const origB = process.env.BACKUP_ENCRYPTION_KEY;
+  beforeAll(() => { delete process.env.CONFIG_ENCRYPTION_KEY; process.env.BACKUP_ENCRYPTION_KEY = KEY; });
+  afterAll(() => { process.env.CONFIG_ENCRYPTION_KEY = origC; process.env.BACKUP_ENCRYPTION_KEY = origB; });
+
+  test('CONFIG 없으면 BACKUP 키로 암복호화', () => {
+    const enc = encryptSecret('x');
+    expect(isEncrypted(enc)).toBe(true);
+    expect(decryptSecret(enc)).toBe('x');
+  });
+});

--- a/src/utils/secretCrypto.js
+++ b/src/utils/secretCrypto.js
@@ -1,0 +1,77 @@
+/**
+ * At-rest secret 암호화 유틸 (#594)
+ *
+ * 외부 provider API 키(Server.configuration.apiKey, SystemSettings.civitaiApiKey)를
+ * DB 에 평문이 아닌 AES-256-GCM 암호문으로 저장하기 위한 헬퍼.
+ *
+ * 저장 형식(자기서술적): `enc:v1:<ivHex>:<authTagHex>:<ciphertextHex>`
+ * - isEncrypted() 로 평문/암호문 구분 → 멱등 암호화 + 점진 마이그레이션 안전.
+ * - 키 미설정 시 평문 그대로 둠(기존 동작 유지, 앱이 깨지지 않음) — 경고만 출력.
+ *
+ * 키: CONFIG_ENCRYPTION_KEY 우선, 없으면 BACKUP_ENCRYPTION_KEY 재사용 (64자리 hex = 32바이트).
+ */
+const crypto = require('crypto');
+
+const ALGORITHM = 'aes-256-gcm';
+const PREFIX = 'enc:v1:';
+
+function getKey() {
+  const hex = process.env.CONFIG_ENCRYPTION_KEY || process.env.BACKUP_ENCRYPTION_KEY;
+  if (!hex || !/^[a-fA-F0-9]{64}$/.test(hex)) return null;
+  return Buffer.from(hex, 'hex'); // 32 bytes
+}
+
+let warned = false;
+function warnNoKey() {
+  if (!warned) {
+    console.warn('[secretCrypto] CONFIG_ENCRYPTION_KEY/BACKUP_ENCRYPTION_KEY 미설정 — provider 키가 평문으로 저장/조회됩니다.');
+    warned = true;
+  }
+}
+
+function isEncrypted(value) {
+  return typeof value === 'string' && value.startsWith(PREFIX);
+}
+
+/**
+ * 평문 → 암호문 문자열. 이미 암호문이거나 빈 값이면 그대로(멱등). 키 없으면 평문 유지.
+ */
+function encryptSecret(plain) {
+  if (plain == null || plain === '') return plain;
+  if (isEncrypted(plain)) return plain;
+  const key = getKey();
+  if (!key) { warnNoKey(); return plain; }
+
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+  let ct = cipher.update(String(plain), 'utf8', 'hex');
+  ct += cipher.final('hex');
+  const tag = cipher.getAuthTag().toString('hex');
+  return `${PREFIX}${iv.toString('hex')}:${tag}:${ct}`;
+}
+
+/**
+ * 암호문 → 평문. 암호문이 아니면(평문/null/legacy) 그대로 반환.
+ * 암호문인데 키가 없거나 복호화 실패하면 null (잘못된 키를 그대로 흘려보내 provider 호출을 망치지 않도록).
+ */
+function decryptSecret(value) {
+  if (!isEncrypted(value)) return value;
+  const key = getKey();
+  if (!key) { warnNoKey(); return null; }
+  try {
+    const parts = value.split(':'); // ['enc','v1',iv,tag,ct]
+    const iv = Buffer.from(parts[2], 'hex');
+    const tag = Buffer.from(parts[3], 'hex');
+    const ct = parts[4];
+    const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+    decipher.setAuthTag(tag);
+    let pt = decipher.update(ct, 'hex', 'utf8');
+    pt += decipher.final('utf8');
+    return pt;
+  } catch (error) {
+    console.error('[secretCrypto] 복호화 실패:', error.message);
+    return null;
+  }
+}
+
+module.exports = { encryptSecret, decryptSecret, isEncrypted };


### PR DESCRIPTION
보안 개선 — provider API 키의 DB 평문 저장 제거.

## 문제
`Server.configuration.apiKey`(OpenAI/Gemini 등)·`SystemSettings.civitaiApiKey` 가 MongoDB 에 평문 저장. DB 덤프/유출 시 그대로 노출. 코드 전체에 at-rest 암호화 부재.

## 변경
**신규 `utils/secretCrypto.js`**
- `encryptSecret` / `decryptSecret` / `isEncrypted`. 자기서술 형식 `enc:v1:<iv>:<tag>:<ct>` (AES-256-GCM)
- 멱등(이미 enc: 면 그대로), 키 없으면 평문 유지(graceful — 앱 안 깨짐)
- 키: `CONFIG_ENCRYPTION_KEY` 우선, 없으면 기존 `BACKUP_ENCRYPTION_KEY` 재사용

**쓰기 암호화**: servers.js POST/PUT(apiKey, preserve-empty 유지), `SystemSettings.updateLoraSettings`(civitai)
**읽기 복호화** (provider 호출 직전): `Server.checkHealth`, `queueService`(이미지잡 데이터 빌드), `pipelineRunService`, `modelMetadataService`(모델 동기화), `jobs.js` generate-prompt, `SystemSettings.getCivitaiApiKey`
**누출 수정**: `GET /api/servers/:id` 가 apiKey 평문을 admin 에 반환하던 것 마스킹(`-configuration.apiKey`, 목록 라우트와 동일)
**마이그레이션** `encryptExistingSecrets`: 기존 평문 → 암호화 (멱등, 시작 시 1회, 키 없으면 no-op)

## 백업/복원 정합 (무변경)
backupCollections 의 encryptFields 를 그대로 둠. at-rest 가 이미 enc: 문자열이라 백업이 한 번 더 감싸지만:
- 신버전 백업: enc: 문자열을 백업이 감쌈 → 복원 시 풀면 enc: 문자열 → at-rest 그대로 → 읽을 때 복호화 ✓
- 구버전(평문) 백업: 복원 시 평문으로 풀림 → 다음 시작 시 마이그레이션이 재암호화 ✓
→ 백업/복원 코드 손대지 않아 직전 #588~#591 작업과 충돌 없음.

## 동작/배포 영향
- **배포 시 `.env` 에 `CONFIG_ENCRYPTION_KEY`(또는 기존 `BACKUP_ENCRYPTION_KEY`) 필요.** 미설정 시 평문 유지(동작 보장, 단 암호화 안 됨)
- 서버 편집 폼: apiKey 입력을 빈 칸으로 두면 기존 키 유지(기존 preserve-empty). GET /:id 마스킹은 list 와 동일해 폼 동작 영향 없음
- Redis 작업 데이터의 키는 여전히 평문(별도 범위) — at-rest DB 노출만 해소

## 검증
- secretCrypto 단위 테스트 7건(round-trip/멱등/IV 무작위/평문 통과/변조 탐지/키없음/BACKUP fallback) 추가
- 전체 jest **162건 green**

closes #594