### PR TITLE
feat: ComfyUI 워크플로 파서 + 필요 커스텀 노드 감지 (#607)

### DIFF
--- a/src/routes/workboards.js
+++ b/src/routes/workboards.js
@@ -6,6 +6,8 @@ const Server = require('../models/Server');
 const Group = require('../models/Group');
 const ServerLoraCache = require('../models/ServerLoraCache');
 const loraMetadataService = require('../services/loraMetadataService');
+const comfyUIService = require('../services/comfyUIService');
+const workflowConverter = require('../services/workflowConverterService');
 const { escapeRegex } = require('../utils/escapeRegex');
 const router = express.Router();
 
@@ -85,6 +87,54 @@ router.get('/', requireAuth, async (req, res) => {
     });
   } catch (error) {
     res.status(500).json({ message: error.message });
+  }
+});
+
+// ComfyUI 워크플로 분석 (관리자 전용) — 파싱 + 필요/빠진 커스텀 노드 감지 (#607)
+router.post('/analyze-workflow', requireAdmin, async (req, res) => {
+  try {
+    const { workflow, serverId } = req.body;
+    if (!workflow) {
+      return res.status(400).json({ success: false, message: '워크플로 JSON 이 필요합니다.' });
+    }
+
+    // 1) 파싱 (서버 없이도 가능). 포맷/파싱 오류는 400.
+    let parsed;
+    try {
+      parsed = workflowConverter.parseWorkflow(workflow);
+    } catch (e) {
+      return res.status(400).json({ success: false, message: e.message });
+    }
+
+    // 2) serverId 가 있으면 /object_info 로 빠진 노드 비교 (선택, 실패해도 분석은 반환)
+    let objectInfo = null;
+    let serverWarning = null;
+    if (serverId) {
+      const server = await Server.findById(serverId);
+      if (!server) {
+        return res.status(404).json({ success: false, message: '서버를 찾을 수 없습니다.' });
+      }
+      try {
+        objectInfo = await comfyUIService.getObjectInfo(server.serverUrl);
+      } catch (e) {
+        serverWarning = `서버 노드 목록을 불러오지 못해 빠진 노드 검사를 건너뜁니다: ${e.message}`;
+      }
+    }
+
+    const nodeAnalysis = workflowConverter.analyzeNodes(parsed, objectInfo);
+    res.json({
+      success: true,
+      data: {
+        format: parsed.format,
+        nodeCount: parsed.nodes.length,
+        literalInputCount: parsed.literalInputs.length,
+        ...nodeAnalysis,
+        literalInputs: parsed.literalInputs,
+        serverWarning,
+      },
+    });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
   }
 });
 

--- a/src/services/workflowConverterService.js
+++ b/src/services/workflowConverterService.js
@@ -1,0 +1,130 @@
+/**
+ * ComfyUI 워크플로 → vcc 작업판 변환 (#609)
+ *
+ * P0 (#607): API 포맷 워크플로 파싱 + 링크/리터럴 분류 + 필요/빠진 커스텀 노드 감지.
+ * 결정론적 — LLM / 플러그인 설치 불필요.
+ *
+ * 용어
+ * - API 포맷: ComfyUI "Save (API Format)" 결과. `{ "<nodeId>": { class_type, inputs }, ... }`
+ * - UI 포맷: ComfyUI "Save" 결과. `{ nodes: [...], links: [...] }` — 본 단계 미지원.
+ * - 링크 입력:  `["6", 0]` 처럼 다른 노드 출력이 들어옴(내부 배선) → 변수 후보 아님.
+ * - 리터럴 입력: 사용자가 박은 상수값 → 변수 후보.
+ */
+
+/**
+ * 입력이 ComfyUI 링크(`[sourceNodeId, outputIndex]`)인지 판정.
+ * sourceNodeId 가 실제 그래프에 존재해야 링크로 인정(리터럴 2-요소 배열 오인 방지).
+ */
+function isLinkInput(value, nodeIds) {
+  return (
+    Array.isArray(value) &&
+    value.length === 2 &&
+    (typeof value[0] === 'string' || typeof value[0] === 'number') &&
+    typeof value[1] === 'number' &&
+    nodeIds.has(String(value[0]))
+  );
+}
+
+/**
+ * 워크플로 포맷 감지: 'api' | 'ui' | 'unknown'
+ */
+function detectFormat(obj) {
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return 'unknown';
+  // UI 포맷: nodes 배열 + links
+  if (Array.isArray(obj.nodes) && 'links' in obj) return 'ui';
+  // API 포맷: 값들이 { class_type, inputs } 모양
+  const values = Object.values(obj);
+  if (values.length === 0) return 'unknown';
+  const apiLike = values.filter(
+    (v) => v && typeof v === 'object' && typeof v.class_type === 'string'
+  ).length;
+  if (apiLike >= Math.ceil(values.length * 0.5)) return 'api';
+  return 'unknown';
+}
+
+/**
+ * API 포맷 워크플로 파싱.
+ * 반환: { format, nodes: [{id, classType, inputs:[{key, kind, value, source}]}], classTypes:[], literalInputs:[] }
+ * 미지원/오류 시 throw.
+ */
+function parseWorkflow(input) {
+  let obj = input;
+  if (typeof input === 'string') {
+    try {
+      obj = JSON.parse(input);
+    } catch (e) {
+      throw new Error(`워크플로 JSON 파싱 실패: ${e.message}`);
+    }
+  }
+
+  const format = detectFormat(obj);
+  if (format === 'ui') {
+    throw new Error('UI 포맷 워크플로입니다. ComfyUI 의 "Save (API Format)" 로 저장한 JSON 을 넣어주세요.');
+  }
+  if (format !== 'api') {
+    throw new Error('인식할 수 없는 워크플로 형식입니다. ComfyUI API 포맷 JSON 이 필요합니다.');
+  }
+
+  const nodeIds = new Set(Object.keys(obj));
+  const nodes = [];
+  const classTypes = new Set();
+  const literalInputs = [];
+
+  for (const [id, node] of Object.entries(obj)) {
+    if (!node || typeof node !== 'object' || typeof node.class_type !== 'string') continue;
+    const classType = node.class_type;
+    classTypes.add(classType);
+
+    const inputs = [];
+    const rawInputs = node.inputs && typeof node.inputs === 'object' ? node.inputs : {};
+    for (const [key, value] of Object.entries(rawInputs)) {
+      if (isLinkInput(value, nodeIds)) {
+        inputs.push({ key, kind: 'link', source: { nodeId: String(value[0]), outputIndex: value[1] } });
+      } else {
+        inputs.push({ key, kind: 'literal', value });
+        literalInputs.push({ nodeId: id, classType, key, value, valueType: typeof value });
+      }
+    }
+    nodes.push({ id, classType, inputs });
+  }
+
+  return { format, nodes, classTypes: [...classTypes], literalInputs };
+}
+
+/**
+ * 파싱된 워크플로 + ComfyUI /object_info 를 비교해 필요/빠진 노드 산출.
+ * objectInfo 가 없으면(서버 미연결) missingNodes 는 null 로 둔다(판단 불가).
+ */
+function analyzeNodes(parsed, objectInfo) {
+  const requiredNodes = [...parsed.classTypes].sort();
+  if (!objectInfo || typeof objectInfo !== 'object') {
+    return { requiredNodes, missingNodes: null, installedNodes: null };
+  }
+  const installed = new Set(Object.keys(objectInfo));
+  const missingNodes = requiredNodes.filter((ct) => !installed.has(ct));
+  const installedNodes = requiredNodes.filter((ct) => installed.has(ct));
+  return { requiredNodes, missingNodes, installedNodes };
+}
+
+/**
+ * 편의: 파싱 + 노드 분석을 한 번에.
+ */
+function analyzeWorkflow(input, objectInfo) {
+  const parsed = parseWorkflow(input);
+  const nodeAnalysis = analyzeNodes(parsed, objectInfo);
+  return {
+    format: parsed.format,
+    nodeCount: parsed.nodes.length,
+    literalInputCount: parsed.literalInputs.length,
+    ...nodeAnalysis,
+    literalInputs: parsed.literalInputs,
+  };
+}
+
+module.exports = {
+  isLinkInput,
+  detectFormat,
+  parseWorkflow,
+  analyzeNodes,
+  analyzeWorkflow,
+};

--- a/src/tests/workflowConverter.test.js
+++ b/src/tests/workflowConverter.test.js
@@ -1,0 +1,137 @@
+/**
+ * #607 ComfyUI 워크플로 파서 + 필요 노드 감지 테스트
+ */
+const {
+  isLinkInput,
+  detectFormat,
+  parseWorkflow,
+  analyzeNodes,
+  analyzeWorkflow,
+} = require('../services/workflowConverterService');
+
+// 표준 txt2img API 포맷 워크플로 (축약)
+const API_WF = {
+  '4': { class_type: 'CheckpointLoaderSimple', inputs: { ckpt_name: 'sdxl.safetensors' } },
+  '5': { class_type: 'EmptyLatentImage', inputs: { width: 1024, height: 1024, batch_size: 1 } },
+  '6': { class_type: 'CLIPTextEncode', inputs: { text: 'a cat', clip: ['4', 1] } },
+  '7': { class_type: 'CLIPTextEncode', inputs: { text: 'blurry', clip: ['4', 1] } },
+  '3': {
+    class_type: 'KSampler',
+    inputs: {
+      seed: 12345, steps: 20, cfg: 7,
+      model: ['4', 0], positive: ['6', 0], negative: ['7', 0], latent_image: ['5', 0],
+    },
+  },
+};
+
+describe('#607 detectFormat', () => {
+  test('API 포맷 인식', () => {
+    expect(detectFormat(API_WF)).toBe('api');
+  });
+  test('UI 포맷 인식', () => {
+    expect(detectFormat({ nodes: [{ id: 1 }], links: [] })).toBe('ui');
+  });
+  test('알 수 없는 형식', () => {
+    expect(detectFormat({ foo: 'bar' })).toBe('unknown');
+    expect(detectFormat(null)).toBe('unknown');
+    expect(detectFormat([])).toBe('unknown');
+  });
+});
+
+describe('#607 isLinkInput', () => {
+  const ids = new Set(['3', '4', '5', '6', '7']);
+  test('존재하는 노드로의 [id, idx] 는 링크', () => {
+    expect(isLinkInput(['4', 0], ids)).toBe(true);
+  });
+  test('존재하지 않는 노드 id 는 링크 아님(리터럴 2-배열 오인 방지)', () => {
+    expect(isLinkInput(['999', 0], ids)).toBe(false);
+  });
+  test('스칼라 리터럴은 링크 아님', () => {
+    expect(isLinkInput('a cat', ids)).toBe(false);
+    expect(isLinkInput(12345, ids)).toBe(false);
+    expect(isLinkInput(true, ids)).toBe(false);
+  });
+});
+
+describe('#607 parseWorkflow', () => {
+  test('문자열 JSON 도 파싱', () => {
+    const parsed = parseWorkflow(JSON.stringify(API_WF));
+    expect(parsed.format).toBe('api');
+    expect(parsed.nodes).toHaveLength(5);
+  });
+
+  test('class_type 수집', () => {
+    const parsed = parseWorkflow(API_WF);
+    expect(parsed.classTypes.sort()).toEqual(
+      ['CLIPTextEncode', 'CheckpointLoaderSimple', 'EmptyLatentImage', 'KSampler'].sort()
+    );
+  });
+
+  test('링크 vs 리터럴 분류 — KSampler', () => {
+    const parsed = parseWorkflow(API_WF);
+    const ksampler = parsed.nodes.find((n) => n.classType === 'KSampler');
+    const links = ksampler.inputs.filter((i) => i.kind === 'link').map((i) => i.key).sort();
+    const lits = ksampler.inputs.filter((i) => i.kind === 'literal').map((i) => i.key).sort();
+    expect(links).toEqual(['latent_image', 'model', 'negative', 'positive']);
+    expect(lits).toEqual(['cfg', 'seed', 'steps']);
+  });
+
+  test('리터럴 입력 후보 수집 (prompt/seed/size/ckpt 등)', () => {
+    const parsed = parseWorkflow(API_WF);
+    const keys = parsed.literalInputs.map((l) => `${l.classType}.${l.key}`);
+    expect(keys).toContain('CheckpointLoaderSimple.ckpt_name');
+    expect(keys).toContain('CLIPTextEncode.text');
+    expect(keys).toContain('KSampler.seed');
+    expect(keys).toContain('EmptyLatentImage.width');
+    // 링크 입력은 후보에서 제외
+    expect(keys).not.toContain('KSampler.model');
+  });
+
+  test('UI 포맷은 명확한 메시지로 거부', () => {
+    expect(() => parseWorkflow({ nodes: [], links: [] })).toThrow(/Save \(API Format\)/);
+  });
+
+  test('깨진 JSON 거부', () => {
+    expect(() => parseWorkflow('{ not json')).toThrow(/파싱 실패/);
+  });
+});
+
+describe('#607 analyzeNodes (필요/빠진 노드)', () => {
+  test('object_info 와 비교해 빠진 커스텀 노드 산출', () => {
+    const parsed = parseWorkflow(API_WF);
+    // EmptyLatentImage 가 설치 안 된 서버라고 가정
+    const objectInfo = {
+      CheckpointLoaderSimple: {}, CLIPTextEncode: {}, KSampler: {},
+    };
+    const r = analyzeNodes(parsed, objectInfo);
+    expect(r.missingNodes).toEqual(['EmptyLatentImage']);
+    expect(r.installedNodes.sort()).toEqual(['CLIPTextEncode', 'CheckpointLoaderSimple', 'KSampler'].sort());
+  });
+
+  test('object_info 없으면 missingNodes=null (판단 불가)', () => {
+    const parsed = parseWorkflow(API_WF);
+    const r = analyzeNodes(parsed, null);
+    expect(r.missingNodes).toBeNull();
+    expect(r.requiredNodes.length).toBe(4);
+  });
+
+  test('모두 설치돼 있으면 빈 배열', () => {
+    const parsed = parseWorkflow(API_WF);
+    const objectInfo = { CheckpointLoaderSimple: {}, CLIPTextEncode: {}, KSampler: {}, EmptyLatentImage: {} };
+    expect(analyzeNodes(parsed, objectInfo).missingNodes).toEqual([]);
+  });
+});
+
+describe('#607 analyzeWorkflow (통합)', () => {
+  test('커스텀 노드 포함 워크플로의 빠진 노드 감지', () => {
+    const wf = {
+      ...API_WF,
+      '10': { class_type: 'IPAdapterApply', inputs: { weight: 0.8, image: ['4', 0] } },
+    };
+    const objectInfo = { CheckpointLoaderSimple: {}, CLIPTextEncode: {}, KSampler: {}, EmptyLatentImage: {} };
+    const a = analyzeWorkflow(wf, objectInfo);
+    expect(a.format).toBe('api');
+    expect(a.missingNodes).toEqual(['IPAdapterApply']);
+    expect(a.literalInputs.some((l) => l.classType === 'IPAdapterApply' && l.key === 'weight')).toBe(true);
+  });
+});


### PR DESCRIPTION
ComfyUI 워크플로 → 작업판 변환(Epic #609) **P0** 첫 단계.

## 변경
- **`services/workflowConverterService.js`** (결정론적, LLM/설치 없음)
  - `detectFormat`: api / ui / unknown
  - `parseWorkflow`: API 포맷 파싱, **링크(`[id,idx]`) vs 리터럴 입력 분류**(소스 노드 존재 검증으로 오인 방지), class_type 수집, 리터럴 입력 후보 수집. UI 포맷은 "Save (API Format)" 안내로 거부.
  - `analyzeNodes`: `/object_info` 비교 → 필요/빠진 커스텀 노드 산출 (서버 미연결 시 null)
- **`POST /api/workboards/analyze-workflow`** (admin): 파싱 + serverId 있으면 `comfyUIService.getObjectInfo` 로 빠진 노드 검사. 서버 조회 실패해도 분석은 반환(serverWarning).

## 검증
- 단위 테스트 16건(포맷 감지 / 링크·리터럴 분류 / 필요·빠진 노드 / 커스텀 노드 감지). 전체 jest **178 green**.

## 다음
#608 결정론적 역할 매핑 → 작업판 초안 생성 (이번 파서의 리터럴 후보 + class_type 활용).

closes #607