### PR TITLE
feat: ComfyUI 워크플로 → 작업판 초안 생성 (결정론적 역할 매핑) (#608)

### DIFF
--- a/src/routes/workboards.js
+++ b/src/routes/workboards.js
@@ -138,6 +138,59 @@ router.post('/analyze-workflow', requireAdmin, async (req, res) => {
   }
 });
 
+// ComfyUI 워크플로 → 작업판 초안 생성 (관리자 전용) — 결정론적 역할 매핑 (#608)
+router.post('/draft-from-workflow', requireAdmin, async (req, res) => {
+  try {
+    const { workflow, serverId } = req.body;
+    if (!workflow) {
+      return res.status(400).json({ success: false, message: '워크플로 JSON 이 필요합니다.' });
+    }
+
+    let parsed;
+    try {
+      parsed = workflowConverter.parseWorkflow(workflow);
+    } catch (e) {
+      return res.status(400).json({ success: false, message: e.message });
+    }
+
+    // 빠진 노드 검사 (서버 연결 시, 선택)
+    let objectInfo = null;
+    let serverWarning = null;
+    if (serverId) {
+      const server = await Server.findById(serverId);
+      if (server) {
+        try {
+          objectInfo = await comfyUIService.getObjectInfo(server.serverUrl);
+        } catch (e) {
+          serverWarning = `서버 노드 목록을 불러오지 못해 빠진 노드 검사를 건너뜁니다: ${e.message}`;
+        }
+      }
+    }
+
+    const nodeAnalysis = workflowConverter.analyzeNodes(parsed, objectInfo);
+    const draft = workflowConverter.generateDraft(parsed, workflow);
+
+    res.json({
+      success: true,
+      data: {
+        // 작업판 편집기로 바로 넘길 수 있는 초안
+        draft: {
+          workflowData: draft.workflowData,
+          additionalInputFields: draft.additionalInputFields,
+        },
+        notes: draft.notes,
+        analysis: {
+          requiredNodes: nodeAnalysis.requiredNodes,
+          missingNodes: nodeAnalysis.missingNodes,
+        },
+        serverWarning,
+      },
+    });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
 // 작업판 가져오기 (관리자 전용)
 router.post('/import', requireAdmin, async (req, res) => {
   try {

--- a/src/services/workflowConverterService.js
+++ b/src/services/workflowConverterService.js
@@ -121,10 +121,166 @@ function analyzeWorkflow(input, objectInfo) {
   };
 }
 
+// ─────────────────────────────────────────────────────────────
+// P0 (#608): 결정론적 역할 매핑 → 작업판 초안 생성
+// ─────────────────────────────────────────────────────────────
+
+const SAMPLER_TYPES = new Set([
+  'KSampler', 'KSamplerAdvanced', 'SamplerCustom', 'SamplerCustomAdvanced',
+]);
+// 텍스트 인코더(프롬프트) 노드 판정 — CLIPTextEncode / CLIPTextEncodeSDXL 등
+const isTextEncoder = (ct) => /CLIPTextEncode/i.test(ct);
+
+// 역할 메타: 변수 기본 이름 + vcc 필드 타입 + 한국어 라벨
+const ROLE_META = {
+  base_model: { type: 'baseModel', label: '베이스 모델' },
+  prompt: { type: 'string', label: '프롬프트' },
+  negative_prompt: { type: 'string', label: '네거티브 프롬프트' },
+  seed: { type: 'number', label: '시드' },
+  width: { type: 'number', label: '가로' },
+  height: { type: 'number', label: '세로' },
+  lora: { type: 'lora', label: 'LoRA' },
+  image: { type: 'image', label: '이미지' },
+};
+
+/** nodeId → 원본 노드 객체 맵 (파싱 전 raw 기준으로 다시 만들기 위해 parsed.nodes 사용) */
+function buildNodeMap(parsed) {
+  const map = new Map();
+  for (const n of parsed.nodes) map.set(n.id, n);
+  return map;
+}
+
+/** 노드의 특정 입력(link)의 소스 nodeId 반환 (없으면 null) */
+function linkSource(node, inputKey) {
+  const inp = node?.inputs.find((i) => i.key === inputKey && i.kind === 'link');
+  return inp ? inp.source.nodeId : null;
+}
+
+/**
+ * 샘플러의 positive/negative 입력에서 거꾸로 추적해 CLIPTextEncode 노드 id 를 찾는다.
+ * conditioning 체인(ControlNet 등)을 몇 홉 통과 — 못 찾으면 null (LLM/관리자 영역).
+ */
+function traceToTextEncoder(nodeMap, startId, depth = 0, seen = new Set()) {
+  if (!startId || depth > 4 || seen.has(startId)) return null;
+  seen.add(startId);
+  const node = nodeMap.get(startId);
+  if (!node) return null;
+  if (isTextEncoder(node.classType)) return startId;
+  // 링크 입력들을 따라 한 홉씩 (conditioning 계열 우선이 이상적이나 단순화: 모든 link 추적)
+  for (const inp of node.inputs) {
+    if (inp.kind === 'link') {
+      const found = traceToTextEncoder(nodeMap, inp.source.nodeId, depth + 1, seen);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+/**
+ * 파싱된 워크플로 → 작업판 초안.
+ * 반환: { workflowData(string), additionalInputFields[], notes[] }
+ * 표준 노드만 보수적으로 변수화(LLM 없음). 모르는/애매한 건 노출하지 않고 note 로 남긴다.
+ */
+function generateDraft(parsed, rawWorkflow) {
+  const nodeMap = buildNodeMap(parsed);
+  const notes = [];
+
+  // 1) positive/negative 프롬프트 인코더 식별 (샘플러 추적)
+  const positiveEncoders = new Set();
+  const negativeEncoders = new Set();
+  for (const node of parsed.nodes) {
+    if (!SAMPLER_TYPES.has(node.classType)) continue;
+    const pos = traceToTextEncoder(nodeMap, linkSource(node, 'positive'));
+    const neg = traceToTextEncoder(nodeMap, linkSource(node, 'negative'));
+    if (pos) positiveEncoders.add(pos);
+    if (neg) negativeEncoders.add(neg);
+  }
+
+  // 2) 역할 후보 수집: [{nodeId, key, role}]
+  const picks = [];
+  const promptCounter = { n: 0 };
+  for (const node of parsed.nodes) {
+    const has = (k) => node.inputs.some((i) => i.key === k && i.kind === 'literal');
+    const ct = node.classType;
+
+    if (ct === 'CheckpointLoaderSimple' && has('ckpt_name')) picks.push({ nodeId: node.id, key: 'ckpt_name', role: 'base_model' });
+    else if (/^LoraLoader/.test(ct) && has('lora_name')) picks.push({ nodeId: node.id, key: 'lora_name', role: 'lora' });
+    else if (ct === 'LoadImage' && has('image')) picks.push({ nodeId: node.id, key: 'image', role: 'image' });
+    else if (ct === 'EmptyLatentImage') {
+      if (has('width')) picks.push({ nodeId: node.id, key: 'width', role: 'width' });
+      if (has('height')) picks.push({ nodeId: node.id, key: 'height', role: 'height' });
+    } else if (SAMPLER_TYPES.has(ct) && has('seed')) {
+      picks.push({ nodeId: node.id, key: 'seed', role: 'seed' });
+    } else if (isTextEncoder(ct) && has('text')) {
+      if (positiveEncoders.has(node.id)) picks.push({ nodeId: node.id, key: 'text', role: 'prompt' });
+      else if (negativeEncoders.has(node.id)) picks.push({ nodeId: node.id, key: 'text', role: 'negative_prompt' });
+      else { promptCounter.n += 1; picks.push({ nodeId: node.id, key: 'text', role: 'prompt', extra: true }); }
+    }
+  }
+
+  // 3) 이름 유일화 + 필드/치환 생성
+  const usedNames = new Set();
+  const uniqueName = (base) => {
+    let name = base; let i = 2;
+    while (usedNames.has(name)) { name = `${base}_${i}`; i += 1; }
+    usedNames.add(name);
+    return name;
+  };
+
+  // 원본 raw 워크플로 복제 후 placeholder 주입
+  const workflowObj = typeof rawWorkflow === 'string' ? JSON.parse(rawWorkflow) : JSON.parse(JSON.stringify(rawWorkflow));
+  const additionalInputFields = [];
+
+  for (const pick of picks) {
+    const meta = ROLE_META[pick.role];
+    if (!meta) continue;
+    // prompt 가 여러 개면 prompt, prompt_2 … / 라벨도 맞춤
+    const name = uniqueName(pick.role);
+    const currentValue = workflowObj?.[pick.nodeId]?.inputs?.[pick.key];
+    const classType = nodeMap.get(pick.nodeId)?.classType || '';
+
+    additionalInputFields.push({
+      name,
+      label: name === pick.role ? meta.label : `${meta.label} ${name.split('_').pop()}`,
+      type: meta.type,
+      required: pick.role === 'prompt' && name === 'prompt',
+      defaultValue: meta.type === 'image' ? undefined : currentValue,
+      formatString: `{{##${name}##}}`,
+      description: `${classType} 노드(${pick.nodeId})의 ${pick.key} 에서 추출`,
+    });
+
+    // 워크플로 값 자리에 placeholder 주입
+    if (workflowObj[pick.nodeId] && workflowObj[pick.nodeId].inputs) {
+      workflowObj[pick.nodeId].inputs[pick.key] = `{{##${name}##}}`;
+    }
+  }
+
+  // 4) note: 노출 안 한 흔한 튜닝 리터럴 안내(steps/cfg/sampler 등) — 편집기에서 추가 가능
+  const exposedKeys = new Set(picks.map((p) => `${p.nodeId}.${p.key}`));
+  const tunables = parsed.literalInputs.filter(
+    (l) => !exposedKeys.has(`${l.nodeId}.${l.key}`) &&
+      ['steps', 'cfg', 'denoise', 'sampler_name', 'scheduler', 'batch_size'].includes(l.key)
+  );
+  if (tunables.length) {
+    notes.push(`노출하지 않은 튜닝 값 ${tunables.length}개(steps/cfg/sampler 등) — 필요하면 편집기에서 변수로 추가하세요.`);
+  }
+  if (!additionalInputFields.length) {
+    notes.push('표준 노드에서 변수를 찾지 못했습니다. 커스텀 노드 위주 워크플로일 수 있어 편집기에서 수동 지정이 필요합니다.');
+  }
+
+  return {
+    workflowData: JSON.stringify(workflowObj, null, 2),
+    additionalInputFields,
+    notes,
+  };
+}
+
 module.exports = {
   isLinkInput,
   detectFormat,
   parseWorkflow,
   analyzeNodes,
   analyzeWorkflow,
+  traceToTextEncoder,
+  generateDraft,
 };

--- a/src/tests/workflowConverter.test.js
+++ b/src/tests/workflowConverter.test.js
@@ -7,6 +7,7 @@ const {
   parseWorkflow,
   analyzeNodes,
   analyzeWorkflow,
+  generateDraft,
 } = require('../services/workflowConverterService');
 
 // 표준 txt2img API 포맷 워크플로 (축약)
@@ -119,6 +120,67 @@ describe('#607 analyzeNodes (필요/빠진 노드)', () => {
     const parsed = parseWorkflow(API_WF);
     const objectInfo = { CheckpointLoaderSimple: {}, CLIPTextEncode: {}, KSampler: {}, EmptyLatentImage: {} };
     expect(analyzeNodes(parsed, objectInfo).missingNodes).toEqual([]);
+  });
+});
+
+describe('#608 generateDraft (결정론적 초안)', () => {
+  test('표준 txt2img → 역할 변수 추출 + placeholder 주입', () => {
+    const parsed = parseWorkflow(API_WF);
+    const draft = generateDraft(parsed, API_WF);
+    const byName = Object.fromEntries(draft.additionalInputFields.map((f) => [f.name, f]));
+
+    // 핵심 역할 추출
+    expect(byName.base_model?.type).toBe('baseModel');
+    expect(byName.base_model?.defaultValue).toBe('sdxl.safetensors');
+    expect(byName.prompt).toBeTruthy();
+    expect(byName.negative_prompt).toBeTruthy();
+    expect(byName.seed?.type).toBe('number');
+    expect(byName.width?.type).toBe('number');
+    expect(byName.height?.type).toBe('number');
+
+    // positive/negative 판별 (샘플러 추적): 'a cat'=prompt, 'blurry'=negative_prompt
+    expect(byName.prompt.defaultValue).toBe('a cat');
+    expect(byName.negative_prompt.defaultValue).toBe('blurry');
+  });
+
+  test('workflowData 에 placeholder 가 박히고 링크는 보존', () => {
+    const parsed = parseWorkflow(API_WF);
+    const draft = generateDraft(parsed, API_WF);
+    const wf = JSON.parse(draft.workflowData);
+    expect(wf['4'].inputs.ckpt_name).toBe('{{##base_model##}}');
+    expect(wf['6'].inputs.text).toBe('{{##prompt##}}');
+    expect(wf['7'].inputs.text).toBe('{{##negative_prompt##}}');
+    expect(wf['3'].inputs.seed).toBe('{{##seed##}}');
+    // 링크 입력은 그대로
+    expect(wf['3'].inputs.positive).toEqual(['6', 0]);
+    // 노출 안 한 튜닝값은 원본 유지
+    expect(wf['3'].inputs.steps).toBe(20);
+  });
+
+  test('steps/cfg 등 미노출 튜닝값은 note 로 안내', () => {
+    const parsed = parseWorkflow(API_WF);
+    const draft = generateDraft(parsed, API_WF);
+    expect(draft.notes.join(' ')).toMatch(/튜닝/);
+  });
+
+  test('이름 충돌 시 _2 로 유일화 (LoRA 2개)', () => {
+    const wf = {
+      ...API_WF,
+      '8': { class_type: 'LoraLoader', inputs: { lora_name: 'a.safetensors', model: ['4', 0], clip: ['4', 1] } },
+      '9': { class_type: 'LoraLoader', inputs: { lora_name: 'b.safetensors', model: ['8', 0], clip: ['8', 1] } },
+    };
+    const parsed = parseWorkflow(wf);
+    const draft = generateDraft(parsed, wf);
+    const loraNames = draft.additionalInputFields.filter((f) => f.type === 'lora').map((f) => f.name).sort();
+    expect(loraNames).toEqual(['lora', 'lora_2']);
+  });
+
+  test('커스텀 노드만 있으면 변수 못 찾고 note 안내', () => {
+    const wf = { '1': { class_type: 'SomeCustomNode', inputs: { foo: ['1', 0] } } };
+    const parsed = parseWorkflow(wf);
+    const draft = generateDraft(parsed, wf);
+    expect(draft.additionalInputFields).toHaveLength(0);
+    expect(draft.notes.join(' ')).toMatch(/커스텀|수동/);
   });
 });
 


### PR DESCRIPTION
Epic #609 **P0** 두 번째 — #607 파서 위에 결정론적 변수 추출 + 작업판 초안.

## 변경
- **`generateDraft(parsed, raw)`** — 표준 노드를 class_type 기반 역할 매핑:
  - ckpt_name→base_model, lora_name→lora, LoadImage.image→image, EmptyLatentImage.width/height, KSampler.seed→seed, CLIPTextEncode.text→prompt/negative_prompt
  - **positive/negative 판별**: 샘플러 positive/negative 입력에서 CLIPTextEncode 까지 역추적(conditioning 몇 홉)
  - 리터럴만 변수화(**링크 보존**), 이름 충돌 `_2` 유일화, defaultValue=원본 리터럴
  - steps/cfg/sampler 등은 **보수적으로 미노출** → note 안내(편집기에서 추가)
  - `{{##name##}}` 주입한 `workflowData` + `additionalInputFields` 초안 반환 (기존 런타임 호환)
- **`POST /api/workboards/draft-from-workflow`** (admin): 파싱 + 빠진 노드 검사 + 초안 생성 → 작업판 편집기로 바로 넘길 형태

## 검증
- 테스트 +5 (역할 추출 / placeholder 주입·링크 보존 / 튜닝 note / 이름 유일화 / 커스텀 노드). 전체 jest **183 green**.

## 다음
P0 완료. 후속: 프론트(워크플로 붙여넣기→초안 미리보기→편집기) 연결, P1(LLM 보조).

closes #608