### PR TITLE
feat: 빠진 커스텀 노드 → repo 해석 + 설치 안내 (#614)

### DIFF
--- a/src/routes/workboards.js
+++ b/src/routes/workboards.js
@@ -191,6 +191,40 @@ router.post('/draft-from-workflow', requireAdmin, async (req, res) => {
   }
 });
 
+// 빠진 커스텀 노드 → repo 해석 / 설치 안내 (관리자 전용) (#614)
+router.post('/resolve-nodes', requireAdmin, async (req, res) => {
+  try {
+    const { serverId, nodes } = req.body;
+    if (!Array.isArray(nodes) || nodes.length === 0) {
+      return res.status(400).json({ success: false, message: '해석할 노드 목록(nodes)이 필요합니다.' });
+    }
+    if (!serverId) {
+      return res.status(400).json({ success: false, message: 'serverId 가 필요합니다 (ComfyUI-Manager 매핑 조회용).' });
+    }
+    const server = await Server.findById(serverId);
+    if (!server) {
+      return res.status(404).json({ success: false, message: '서버를 찾을 수 없습니다.' });
+    }
+
+    const raw = await comfyUIService.fetchNodeRepoMap(server.serverUrl);
+    const managerAvailable = !!raw;
+    const nodeRepoMap = workflowConverter.normalizeManagerMap(raw);
+    const { resolutions, unresolved } = workflowConverter.resolveMissingNodes(nodes, nodeRepoMap);
+
+    res.json({
+      success: true,
+      data: {
+        managerAvailable,
+        resolutions,
+        unresolved,
+        ...(managerAvailable ? {} : { note: '대상 서버에서 ComfyUI-Manager 매핑을 조회하지 못했습니다. 노드 이름으로 직접 검색해 설치해야 할 수 있습니다.' }),
+      },
+    });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
 // 작업판 가져오기 (관리자 전용)
 router.post('/import', requireAdmin, async (req, res) => {
   try {

--- a/src/services/comfyUIService.js
+++ b/src/services/comfyUIService.js
@@ -321,6 +321,30 @@ const getObjectInfo = async (serverUrl) => {
   }
 };
 
+/**
+ * ComfyUI-Manager 의 node→repo 매핑 조회 (#614, 방어적).
+ * Manager 미설치/엔드포인트 차이로 실패하면 null 반환(예외 던지지 않음).
+ * 알려진 엔드포인트를 순서대로 시도한다.
+ */
+const fetchNodeRepoMap = async (serverUrl) => {
+  const endpoints = [
+    `${serverUrl}/customnode/getmappings?mode=local`,
+    `${serverUrl}/customnode/getmappings?mode=nickname`,
+    `${serverUrl}/api/customnode/getmappings?mode=local`,
+  ];
+  for (const url of endpoints) {
+    try {
+      const response = await axios.get(url, { timeout: 10000 });
+      if (response.data && typeof response.data === 'object') {
+        return response.data; // 정규화는 workflowConverterService.normalizeManagerMap 가 담당
+      }
+    } catch {
+      // 다음 엔드포인트 시도
+    }
+  }
+  return null; // Manager 없음 / 조회 실패
+};
+
 const validateWorkflow = async (serverUrl, workflowJson) => {
   try {
     const response = await axios.post(`${serverUrl}/prompt`, {
@@ -429,6 +453,7 @@ module.exports = {
   submitWorkflow,
   getServerInfo,
   getObjectInfo,
+  fetchNodeRepoMap,
   validateWorkflow,
   interruptExecution,
   getQueue,

--- a/src/services/workflowConverterService.js
+++ b/src/services/workflowConverterService.js
@@ -275,6 +275,61 @@ function generateDraft(parsed, rawWorkflow) {
   };
 }
 
+// ─────────────────────────────────────────────────────────────
+// P2 (#614): 빠진 커스텀 노드 → repo 해석
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * ComfyUI-Manager 의 node→repo 매핑 응답을 className→repo 로 정규화.
+ * Manager 버전별 shape 차를 흡수한다. 알 수 없는 형태면 {} 반환.
+ *
+ * 지원 형태:
+ *  A) getmappings: { "<git_url>": [ [nodeNames...], { title, ... } ], ... }
+ *  B) flat:        { "<NodeClassName>": { url|reference|files[], title }, ... }
+ */
+function normalizeManagerMap(raw) {
+  const map = {}; // className -> { title, url }
+  if (!raw || typeof raw !== 'object') return map;
+
+  const addEntry = (className, repo) => {
+    if (!className || !repo || !repo.url) return;
+    if (!map[className]) map[className] = repo;
+  };
+
+  for (const [key, val] of Object.entries(raw)) {
+    // 형태 A: key=url, val=[nodeNames, meta]
+    if (Array.isArray(val) && Array.isArray(val[0])) {
+      const meta = (val[1] && typeof val[1] === 'object') ? val[1] : {};
+      const url = meta.url || meta.reference || (/^https?:\/\//.test(key) ? key : null);
+      const title = meta.title || meta.title_aux || null;
+      if (url) for (const node of val[0]) addEntry(node, { title, url });
+      continue;
+    }
+    // 형태 B: key=className, val={url|reference|files, title}
+    if (val && typeof val === 'object' && !Array.isArray(val)) {
+      const url = val.url || val.reference || (Array.isArray(val.files) ? val.files[0] : null);
+      if (url) addEntry(key, { title: val.title || null, url });
+    }
+  }
+  return map;
+}
+
+/**
+ * 빠진 노드(class_type) 들을 repo 로 해석.
+ * 반환: { resolutions: [{node, repos:[{title,url}]}], unresolved: [node...] }
+ */
+function resolveMissingNodes(missingNodes, nodeRepoMap) {
+  const resolutions = [];
+  const unresolved = [];
+  const map = nodeRepoMap || {};
+  for (const node of missingNodes || []) {
+    const repo = map[node];
+    if (repo && repo.url) resolutions.push({ node, repos: [repo] });
+    else unresolved.push(node);
+  }
+  return { resolutions, unresolved };
+}
+
 module.exports = {
   isLinkInput,
   detectFormat,
@@ -283,4 +338,6 @@ module.exports = {
   analyzeWorkflow,
   traceToTextEncoder,
   generateDraft,
+  normalizeManagerMap,
+  resolveMissingNodes,
 };

--- a/src/tests/workflowConverter.test.js
+++ b/src/tests/workflowConverter.test.js
@@ -8,6 +8,8 @@ const {
   analyzeNodes,
   analyzeWorkflow,
   generateDraft,
+  normalizeManagerMap,
+  resolveMissingNodes,
 } = require('../services/workflowConverterService');
 
 // 표준 txt2img API 포맷 워크플로 (축약)
@@ -181,6 +183,56 @@ describe('#608 generateDraft (결정론적 초안)', () => {
     const draft = generateDraft(parsed, wf);
     expect(draft.additionalInputFields).toHaveLength(0);
     expect(draft.notes.join(' ')).toMatch(/커스텀|수동/);
+  });
+});
+
+describe('#614 normalizeManagerMap', () => {
+  test('형태 A: getmappings { url: [[nodes], meta] }', () => {
+    const raw = {
+      'https://github.com/foo/ComfyUI-IPAdapter': [
+        ['IPAdapterApply', 'IPAdapterEncoder'],
+        { title: 'IPAdapter', url: 'https://github.com/foo/ComfyUI-IPAdapter' },
+      ],
+    };
+    const map = normalizeManagerMap(raw);
+    expect(map.IPAdapterApply).toEqual({ title: 'IPAdapter', url: 'https://github.com/foo/ComfyUI-IPAdapter' });
+    expect(map.IPAdapterEncoder.url).toContain('ComfyUI-IPAdapter');
+  });
+
+  test('형태 A: meta.url 없으면 key(url) 사용', () => {
+    const raw = { 'https://github.com/x/Y': [['NodeX'], { title: 'Y' }] };
+    expect(normalizeManagerMap(raw).NodeX).toEqual({ title: 'Y', url: 'https://github.com/x/Y' });
+  });
+
+  test('형태 B: { className: { url, title } }', () => {
+    const raw = { UltimateSDUpscale: { url: 'https://github.com/a/b', title: 'Ultimate' } };
+    expect(normalizeManagerMap(raw).UltimateSDUpscale.url).toBe('https://github.com/a/b');
+  });
+
+  test('이상한 입력은 빈 맵', () => {
+    expect(normalizeManagerMap(null)).toEqual({});
+    expect(normalizeManagerMap('x')).toEqual({});
+    expect(normalizeManagerMap({ k: 123 })).toEqual({});
+  });
+});
+
+describe('#614 resolveMissingNodes', () => {
+  const map = {
+    IPAdapterApply: { title: 'IPAdapter', url: 'https://github.com/foo/ipadapter' },
+    UltimateSDUpscale: { title: 'Ultimate', url: 'https://github.com/a/ultimate' },
+  };
+  test('해석/미해석 분리', () => {
+    const r = resolveMissingNodes(['IPAdapterApply', 'UnknownCustomNode'], map);
+    expect(r.resolutions).toEqual([{ node: 'IPAdapterApply', repos: [{ title: 'IPAdapter', url: 'https://github.com/foo/ipadapter' }] }]);
+    expect(r.unresolved).toEqual(['UnknownCustomNode']);
+  });
+  test('맵 없으면 전부 미해석', () => {
+    const r = resolveMissingNodes(['A', 'B'], null);
+    expect(r.resolutions).toEqual([]);
+    expect(r.unresolved).toEqual(['A', 'B']);
+  });
+  test('빈 노드 목록', () => {
+    expect(resolveMissingNodes([], map)).toEqual({ resolutions: [], unresolved: [] });
   });
 });
 


### PR DESCRIPTION
Epic #609 **P2** — P0 가 감지한 빠진 노드를 출처 repo 로 해석(설치는 P4 informed-confirm).

## 변경
- `workflowConverterService.normalizeManagerMap(raw)`: ComfyUI-Manager getmappings 응답 → `className→{title,url}` 정규화. 버전별 shape 흡수(A: `{url:[[nodes],meta]}`, B: `{className:{url,title}}`).
- `resolveMissingNodes(missing, map)`: 해석/미해석 분리.
- `comfyUIService.fetchNodeRepoMap(serverUrl)`: 대상 서버 Manager 매핑 조회(엔드포인트 순차 시도, 실패 시 null — 방어적, 예외 안 던짐).
- `POST /api/workboards/resolve-nodes` (admin): `{serverId, nodes}` → `{managerAvailable, resolutions, unresolved}`.

## 검증
- 단위 테스트 +7 (normalize A/B/이상입력, resolve). 전체 jest **190 green**.

## 비고
- Manager API shape 는 버전차가 있어 fetch 는 best-effort + 정규화 방어. 순수 로직은 fixture 로 커버. 실 Manager 검증은 알파에서 추후.
- 다음: 프론트에서 변환 다이얼로그에 repo 안내 표시(P2b) / 또는 P4 informed 설치.

closes #614