### PR TITLE
feat: LLM 보조 변수 제안 (애매/커스텀 노드) (#618)

### DIFF
--- a/src/routes/workboards.js
+++ b/src/routes/workboards.js
@@ -8,6 +8,9 @@ const ServerLoraCache = require('../models/ServerLoraCache');
 const loraMetadataService = require('../services/loraMetadataService');
 const comfyUIService = require('../services/comfyUIService');
 const workflowConverter = require('../services/workflowConverterService');
+const openAIChatService = require('../services/openAIChatService');
+const geminiService = require('../services/geminiService');
+const { decryptSecret } = require('../utils/secretCrypto');
 const { escapeRegex } = require('../utils/escapeRegex');
 const router = express.Router();
 
@@ -141,7 +144,7 @@ router.post('/analyze-workflow', requireAdmin, async (req, res) => {
 // ComfyUI 워크플로 → 작업판 초안 생성 (관리자 전용) — 결정론적 역할 매핑 (#608)
 router.post('/draft-from-workflow', requireAdmin, async (req, res) => {
   try {
-    const { workflow, serverId } = req.body;
+    const { workflow, serverId, llmServerId, llmModel } = req.body;
     if (!workflow) {
       return res.status(400).json({ success: false, message: '워크플로 JSON 이 필요합니다.' });
     }
@@ -168,7 +171,34 @@ router.post('/draft-from-workflow', requireAdmin, async (req, res) => {
     }
 
     const nodeAnalysis = workflowConverter.analyzeNodes(parsed, objectInfo);
-    const draft = workflowConverter.generateDraft(parsed, workflow);
+
+    // 변수 picks: 결정론적 + (선택) LLM 보조 (#P1)
+    const detPicks = workflowConverter.collectDeterministicPicks(parsed);
+    let allPicks = detPicks;
+    let llmNote = null;
+    if (llmServerId && llmModel) {
+      const llmServer = await Server.findById(llmServerId);
+      if (llmServer) {
+        const svc = llmServer.serverType === 'Gemini' ? geminiService : openAIChatService;
+        const apiKey = decryptSecret(llmServer.configuration?.apiKey);
+        const llmComplete = async (messages) => {
+          const { content } = await svc.complete(llmServer.serverUrl, apiKey, messages, { model: llmModel, temperature: 0.2 });
+          return content;
+        };
+        try {
+          const llmPicks = await workflowConverter.proposeLlmPicks({ parsed, existingPicks: detPicks, llmComplete });
+          allPicks = [...detPicks, ...llmPicks];
+          if (llmPicks.length) llmNote = `AI 보조로 변수 ${llmPicks.length}개를 추가 제안했습니다 (편집기에서 확인하세요).`;
+        } catch (e) {
+          llmNote = `AI 보조에 실패해 기본(결정론적) 추출만 적용했습니다: ${e.message}`;
+        }
+      }
+    } else if (llmServerId && !llmModel) {
+      llmNote = 'AI 보조를 쓰려면 LLM 모델도 지정해야 합니다 — 기본 추출만 적용했습니다.';
+    }
+
+    const draft = workflowConverter.buildDraftFromPicks(parsed, workflow, allPicks);
+    if (llmNote) draft.notes = [llmNote, ...draft.notes];
 
     res.json({
       success: true,

--- a/src/services/workflowConverterService.js
+++ b/src/services/workflowConverterService.js
@@ -181,11 +181,13 @@ function traceToTextEncoder(nodeMap, startId, depth = 0, seen = new Set()) {
  * 반환: { workflowData(string), additionalInputFields[], notes[] }
  * 표준 노드만 보수적으로 변수화(LLM 없음). 모르는/애매한 건 노출하지 않고 note 로 남긴다.
  */
-function generateDraft(parsed, rawWorkflow) {
-  const nodeMap = buildNodeMap(parsed);
-  const notes = [];
+const ALLOWED_FIELD_TYPES = new Set(['string', 'number', 'boolean', 'select', 'image', 'baseModel', 'lora']);
 
-  // 1) positive/negative 프롬프트 인코더 식별 (샘플러 추적)
+/**
+ * 결정론적 역할 후보 수집: [{nodeId, key, role}]. (표준 노드, class_type 기반)
+ */
+function collectDeterministicPicks(parsed) {
+  const nodeMap = buildNodeMap(parsed);
   const positiveEncoders = new Set();
   const negativeEncoders = new Set();
   for (const node of parsed.nodes) {
@@ -196,13 +198,10 @@ function generateDraft(parsed, rawWorkflow) {
     if (neg) negativeEncoders.add(neg);
   }
 
-  // 2) 역할 후보 수집: [{nodeId, key, role}]
   const picks = [];
-  const promptCounter = { n: 0 };
   for (const node of parsed.nodes) {
     const has = (k) => node.inputs.some((i) => i.key === k && i.kind === 'literal');
     const ct = node.classType;
-
     if (ct === 'CheckpointLoaderSimple' && has('ckpt_name')) picks.push({ nodeId: node.id, key: 'ckpt_name', role: 'base_model' });
     else if (/^LoraLoader/.test(ct) && has('lora_name')) picks.push({ nodeId: node.id, key: 'lora_name', role: 'lora' });
     else if (ct === 'LoadImage' && has('image')) picks.push({ nodeId: node.id, key: 'image', role: 'image' });
@@ -214,11 +213,23 @@ function generateDraft(parsed, rawWorkflow) {
     } else if (isTextEncoder(ct) && has('text')) {
       if (positiveEncoders.has(node.id)) picks.push({ nodeId: node.id, key: 'text', role: 'prompt' });
       else if (negativeEncoders.has(node.id)) picks.push({ nodeId: node.id, key: 'text', role: 'negative_prompt' });
-      else { promptCounter.n += 1; picks.push({ nodeId: node.id, key: 'text', role: 'prompt', extra: true }); }
+      else picks.push({ nodeId: node.id, key: 'text', role: 'prompt' });
     }
   }
+  return picks;
+}
 
-  // 3) 이름 유일화 + 필드/치환 생성
+/**
+ * picks(결정론적 + LLM 보조 혼합) → 작업판 초안.
+ * pick = { nodeId, key, role?, name?, type?, label?, source? }
+ * role 이 ROLE_META 에 있으면 그 메타를 기본값으로, name/type/label 오버라이드 우선.
+ */
+function buildDraftFromPicks(parsed, rawWorkflow, picks) {
+  const nodeMap = buildNodeMap(parsed);
+  const notes = [];
+  const workflowObj = typeof rawWorkflow === 'string' ? JSON.parse(rawWorkflow) : JSON.parse(JSON.stringify(rawWorkflow));
+  const additionalInputFields = [];
+
   const usedNames = new Set();
   const uniqueName = (base) => {
     let name = base; let i = 2;
@@ -227,36 +238,36 @@ function generateDraft(parsed, rawWorkflow) {
     return name;
   };
 
-  // 원본 raw 워크플로 복제 후 placeholder 주입
-  const workflowObj = typeof rawWorkflow === 'string' ? JSON.parse(rawWorkflow) : JSON.parse(JSON.stringify(rawWorkflow));
-  const additionalInputFields = [];
-
+  const usedKeys = new Set();
   for (const pick of picks) {
+    const dedupeKey = `${pick.nodeId}.${pick.key}`;
+    if (usedKeys.has(dedupeKey)) continue; // 같은 입력 중복 방지(LLM 이 결정론과 겹칠 때)
     const meta = ROLE_META[pick.role];
-    if (!meta) continue;
-    // prompt 가 여러 개면 prompt, prompt_2 … / 라벨도 맞춤
-    const name = uniqueName(pick.role);
-    const currentValue = workflowObj?.[pick.nodeId]?.inputs?.[pick.key];
+    const type = pick.type || meta?.type;
+    if (!type || !ALLOWED_FIELD_TYPES.has(type)) continue; // 타입 미상이면 건너뜀
+    if (!workflowObj?.[pick.nodeId]?.inputs || !(pick.key in workflowObj[pick.nodeId].inputs)) continue; // 실재 입력만
+
+    const baseName = pick.name || pick.role || pick.key;
+    const name = uniqueName(baseName);
+    const labelBase = pick.label || meta?.label || baseName;
+    const label = name === baseName ? labelBase : `${labelBase} ${name.split('_').pop()}`;
+    const currentValue = workflowObj[pick.nodeId].inputs[pick.key];
     const classType = nodeMap.get(pick.nodeId)?.classType || '';
 
     additionalInputFields.push({
       name,
-      label: name === pick.role ? meta.label : `${meta.label} ${name.split('_').pop()}`,
-      type: meta.type,
+      label,
+      type,
       required: pick.role === 'prompt' && name === 'prompt',
-      defaultValue: meta.type === 'image' ? undefined : currentValue,
+      defaultValue: type === 'image' ? undefined : currentValue,
       formatString: `{{##${name}##}}`,
-      description: `${classType} 노드(${pick.nodeId})의 ${pick.key} 에서 추출`,
+      description: `${classType} 노드(${pick.nodeId})의 ${pick.key} 에서 추출${pick.source === 'llm' ? ' (AI 제안)' : ''}`,
     });
-
-    // 워크플로 값 자리에 placeholder 주입
-    if (workflowObj[pick.nodeId] && workflowObj[pick.nodeId].inputs) {
-      workflowObj[pick.nodeId].inputs[pick.key] = `{{##${name}##}}`;
-    }
+    workflowObj[pick.nodeId].inputs[pick.key] = `{{##${name}##}}`;
+    usedKeys.add(dedupeKey);
   }
 
-  // 4) note: 노출 안 한 흔한 튜닝 리터럴 안내(steps/cfg/sampler 등) — 편집기에서 추가 가능
-  const exposedKeys = new Set(picks.map((p) => `${p.nodeId}.${p.key}`));
+  const exposedKeys = new Set([...usedKeys]);
   const tunables = parsed.literalInputs.filter(
     (l) => !exposedKeys.has(`${l.nodeId}.${l.key}`) &&
       ['steps', 'cfg', 'denoise', 'sampler_name', 'scheduler', 'batch_size'].includes(l.key)
@@ -268,11 +279,11 @@ function generateDraft(parsed, rawWorkflow) {
     notes.push('표준 노드에서 변수를 찾지 못했습니다. 커스텀 노드 위주 워크플로일 수 있어 편집기에서 수동 지정이 필요합니다.');
   }
 
-  return {
-    workflowData: JSON.stringify(workflowObj, null, 2),
-    additionalInputFields,
-    notes,
-  };
+  return { workflowData: JSON.stringify(workflowObj, null, 2), additionalInputFields, notes };
+}
+
+function generateDraft(parsed, rawWorkflow) {
+  return buildDraftFromPicks(parsed, rawWorkflow, collectDeterministicPicks(parsed));
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -330,6 +341,84 @@ function resolveMissingNodes(missingNodes, nodeRepoMap) {
   return { resolutions, unresolved };
 }
 
+// ─────────────────────────────────────────────────────────────
+// P1: LLM 보조 변수 제안 (애매/커스텀 노드)
+// ─────────────────────────────────────────────────────────────
+
+/** content 에서 JSON 배열만 안전하게 추출 (LLM 이 prose/```json 로 감쌀 수 있음) */
+function extractJsonArray(content) {
+  if (typeof content !== 'string') return null;
+  const start = content.indexOf('[');
+  const end = content.lastIndexOf(']');
+  if (start < 0 || end <= start) return null;
+  try {
+    const arr = JSON.parse(content.slice(start, end + 1));
+    return Array.isArray(arr) ? arr : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 결정론으로 못 잡은 리터럴 후보를 LLM 에 태워 추가 변수 제안.
+ * llmComplete(messages) → string(content) 를 주입(테스트/서비스 분리).
+ * 반환: 검증된 추가 picks [{nodeId, key, name, type, label, role?, source:'llm'}]
+ */
+async function proposeLlmPicks({ parsed, existingPicks = [], llmComplete, maxCandidates = 60 }) {
+  if (typeof llmComplete !== 'function') return [];
+  const existing = new Set(existingPicks.map((p) => `${p.nodeId}.${p.key}`));
+  const candidates = parsed.literalInputs
+    .filter((l) => !existing.has(`${l.nodeId}.${l.key}`))
+    .slice(0, maxCandidates);
+  if (candidates.length === 0) return [];
+
+  const candidateView = candidates.map((c) => ({
+    nodeId: c.nodeId, classType: c.classType, key: c.key, valueType: c.valueType,
+    sample: typeof c.value === 'string' ? c.value.slice(0, 80) : c.value,
+  }));
+
+  const messages = [
+    {
+      role: 'system',
+      content: [
+        'You convert ComfyUI workflow inputs into user-facing workboard variables.',
+        'From the given LITERAL input candidates, pick ONLY the ones a user would meaningfully want to control.',
+        'Skip fixed/internal constants unless clearly meaningful.',
+        'Allowed types: string, number, boolean, select, image, baseModel, lora.',
+        'Reply with ONLY a JSON array, each item: {"nodeId","key","name","type","label"}.',
+        'name: snake_case ascii. Reference ONLY the given nodeId+key pairs.',
+      ].join(' '),
+    },
+    { role: 'user', content: `Candidates:\n${JSON.stringify(candidateView, null, 2)}` },
+  ];
+
+  let content;
+  try {
+    content = await llmComplete(messages);
+  } catch {
+    return [];
+  }
+  const proposals = extractJsonArray(content);
+  if (!proposals) return [];
+
+  const candKey = new Set(candidates.map((c) => `${c.nodeId}.${c.key}`));
+  const seen = new Set();
+  const picks = [];
+  for (const p of proposals) {
+    if (!p || typeof p !== 'object') continue;
+    const nodeId = String(p.nodeId);
+    const key = String(p.key);
+    const dk = `${nodeId}.${key}`;
+    if (!candKey.has(dk) || seen.has(dk)) continue; // 실재 후보 + 중복 제거
+    const name = typeof p.name === 'string' ? p.name.trim().replace(/[^a-zA-Z0-9_]/g, '_').replace(/^_+|_+$/g, '') : '';
+    if (!name) continue;
+    const type = ALLOWED_FIELD_TYPES.has(p.type) ? p.type : 'string';
+    seen.add(dk);
+    picks.push({ nodeId, key, name, type, label: typeof p.label === 'string' ? p.label : name, source: 'llm' });
+  }
+  return picks;
+}
+
 module.exports = {
   isLinkInput,
   detectFormat,
@@ -337,7 +426,10 @@ module.exports = {
   analyzeNodes,
   analyzeWorkflow,
   traceToTextEncoder,
+  collectDeterministicPicks,
+  buildDraftFromPicks,
   generateDraft,
+  proposeLlmPicks,
   normalizeManagerMap,
   resolveMissingNodes,
 };

--- a/src/tests/workflowConverter.test.js
+++ b/src/tests/workflowConverter.test.js
@@ -8,6 +8,9 @@ const {
   analyzeNodes,
   analyzeWorkflow,
   generateDraft,
+  collectDeterministicPicks,
+  buildDraftFromPicks,
+  proposeLlmPicks,
   normalizeManagerMap,
   resolveMissingNodes,
 } = require('../services/workflowConverterService');
@@ -183,6 +186,68 @@ describe('#608 generateDraft (결정론적 초안)', () => {
     const draft = generateDraft(parsed, wf);
     expect(draft.additionalInputFields).toHaveLength(0);
     expect(draft.notes.join(' ')).toMatch(/커스텀|수동/);
+  });
+});
+
+describe('#P1 proposeLlmPicks (LLM 보조)', () => {
+  // 커스텀 노드가 있는 워크플로 — 결정론은 못 잡고 LLM 이 제안
+  const CUSTOM_WF = {
+    '1': { class_type: 'FooSampler', inputs: { my_prompt: 'hello', steps: 8, ref: ['2', 0] } },
+    '2': { class_type: 'BarLoader', inputs: { ckpt: 'x.safetensors' } },
+  };
+
+  test('LLM 제안을 검증해 picks 로 변환 (실재 후보만)', async () => {
+    const parsed = parseWorkflow(CUSTOM_WF);
+    const llmComplete = async () => JSON.stringify([
+      { nodeId: '1', key: 'my_prompt', name: 'prompt', type: 'string', label: '프롬프트' },
+      { nodeId: '9', key: 'ghost', name: 'x', type: 'string' }, // 실재 안 함 → 제거
+    ]);
+    const picks = await proposeLlmPicks({ parsed, existingPicks: [], llmComplete });
+    expect(picks).toHaveLength(1);
+    expect(picks[0]).toMatchObject({ nodeId: '1', key: 'my_prompt', name: 'prompt', type: 'string', source: 'llm' });
+  });
+
+  test('이미 결정론이 잡은 입력은 후보에서 제외', async () => {
+    const parsed = parseWorkflow(CUSTOM_WF);
+    const llmComplete = async () => JSON.stringify([{ nodeId: '1', key: 'my_prompt', name: 'p', type: 'string' }]);
+    const picks = await proposeLlmPicks({ parsed, existingPicks: [{ nodeId: '1', key: 'my_prompt' }], llmComplete });
+    expect(picks).toHaveLength(0);
+  });
+
+  test('잘못된 type 은 string 으로, prose 로 감싼 JSON 도 파싱', async () => {
+    const parsed = parseWorkflow(CUSTOM_WF);
+    const llmComplete = async () => 'Here you go:\n[{"nodeId":"1","key":"steps","name":"steps","type":"bogus"}]\nDone.';
+    const picks = await proposeLlmPicks({ parsed, existingPicks: [], llmComplete });
+    expect(picks).toHaveLength(1);
+    expect(picks[0].type).toBe('string');
+  });
+
+  test('LLM 호출 실패/비JSON 이면 빈 배열', async () => {
+    const parsed = parseWorkflow(CUSTOM_WF);
+    expect(await proposeLlmPicks({ parsed, existingPicks: [], llmComplete: async () => 'no json here' })).toEqual([]);
+    expect(await proposeLlmPicks({ parsed, existingPicks: [], llmComplete: async () => { throw new Error('boom'); } })).toEqual([]);
+    expect(await proposeLlmPicks({ parsed, existingPicks: [], llmComplete: undefined })).toEqual([]);
+  });
+
+  test('buildDraftFromPicks 가 결정론+LLM picks 를 합쳐 placeholder 주입', async () => {
+    const parsed = parseWorkflow(CUSTOM_WF);
+    const det = collectDeterministicPicks(parsed); // 표준 노드 없음 → []
+    const llmPicks = [{ nodeId: '1', key: 'my_prompt', name: 'prompt', type: 'string', source: 'llm' }];
+    const draft = buildDraftFromPicks(parsed, CUSTOM_WF, [...det, ...llmPicks]);
+    const wf = JSON.parse(draft.workflowData);
+    expect(wf['1'].inputs.my_prompt).toBe('{{##prompt##}}');
+    const f = draft.additionalInputFields.find((x) => x.name === 'prompt');
+    expect(f.description).toMatch(/AI 제안/);
+  });
+
+  test('LLM pick 이 결정론과 같은 입력을 가리키면 중복 주입 안 함', () => {
+    const parsed = parseWorkflow(API_WF);
+    const det = collectDeterministicPicks(parsed); // CLIPTextEncode '6' text=prompt 포함
+    const dupe = [{ nodeId: '6', key: 'text', name: 'prompt_dup', type: 'string', source: 'llm' }];
+    const draft = buildDraftFromPicks(parsed, API_WF, [...det, ...dupe]);
+    const wf = JSON.parse(draft.workflowData);
+    expect(wf['6'].inputs.text).toBe('{{##prompt##}}'); // 결정론 우선, dupe 무시
+    expect(draft.additionalInputFields.filter((f) => f.name.startsWith('prompt_dup'))).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
Epic #609 **P1** — 결정론이 못 잡는 리터럴 후보를 LLM 으로 추가 제안. 설계 결론대로 **raw 그래프 아니라 '리터럴 후보 + 스키마'에만** 태우고 validator 검증.

## 변경
- `generateDraft` → `collectDeterministicPicks` + `buildDraftFromPicks` 리팩터(동작 보존, #608 테스트 그대로 통과)
- `proposeLlmPicks({parsed, existingPicks, llmComplete})`: 미할당 리터럴 후보만 LLM 에 제시 → JSON 응답 파싱(prose 감싸도 추출) + 검증(**실재 후보만 / 중복 제거 / 타입 화이트리스트 / 이름 sanitize**)
- `buildDraftFromPicks`: 결정론+LLM picks 병합, 같은 입력 중복 주입 방지(결정론 우선)
- `draft-from-workflow` 라우트: optional `llmServerId`+`llmModel` → OpenAI/Gemini 서비스(키 복호화)로 보조, 실패 시 결정론 폴백 + note

## 검증
- 테스트 +7 (LLM 은 `llmComplete` mock — 제안검증/기존중복제외/타입폴백+prose/실패폴백/병합주입/결정론우선). 전체 jest **196 green**.

## 다음
프론트(P1b): 변환 다이얼로그에 'AI 보조' 토글 + LLM 서버/모델 선택.

closes #618