### PR TITLE
fix: 재시작 시 멈춘 백업/복원 작업 자동 정리 (#620)

### DIFF
--- a/src/migrations/cleanupStuckBackupRestoreJobs.js
+++ b/src/migrations/cleanupStuckBackupRestoreJobs.js
@@ -1,0 +1,37 @@
+const BackupJob = require('../models/BackupJob');
+const RestoreJob = require('../models/RestoreJob');
+
+// #620: 백업/복원은 in-memory 락 + 단일 프로세스 실행이라 서버 재시작을 넘어 이어질 수 없다.
+// 디스크 부족 등으로 프로세스(또는 Mongo)가 죽으면 BackupJob.status 가 'processing' 에
+// 멈춘 채 DB 에 남아 UI 가 무한 '진행중' 으로 표시된다. 부팅 시점에 남아있는
+// pending/processing 잡은 정의상 orphan 이므로 failed 로 정리한다.
+// (RestoreJob 'pending' 은 검증 완료 후 사용자 실행 대기 상태라 건드리지 않는다.)
+async function cleanupStuckBackupRestoreJobs() {
+  try {
+    const now = new Date();
+
+    const backupResult = await BackupJob.updateMany(
+      { status: { $in: ['pending', 'processing'] } },
+      { $set: { status: 'failed', completedAt: now, error: { message: '서버 재시작으로 중단된 백업입니다 (디스크 부족 등으로 중단됐을 수 있습니다).' } } }
+    );
+    if (backupResult.modifiedCount > 0) {
+      console.log(`[Migration] 중단된 백업 작업 정리: ${backupResult.modifiedCount}건 (processing/pending → failed)`);
+    }
+
+    const restoreResult = await RestoreJob.updateMany(
+      { status: { $in: ['processing', 'validating'] } },
+      { $set: { status: 'failed', completedAt: now, error: { message: '서버 재시작으로 중단된 복원입니다.' } } }
+    );
+    if (restoreResult.modifiedCount > 0) {
+      console.log(`[Migration] 중단된 복원 작업 정리: ${restoreResult.modifiedCount}건 (processing/validating → failed)`);
+    }
+
+    if (backupResult.modifiedCount === 0 && restoreResult.modifiedCount === 0) {
+      console.log('[Migration] 중단된 백업/복원 작업 정리 불필요 (대상 없음)');
+    }
+  } catch (error) {
+    console.error('[Migration] 중단된 백업/복원 작업 정리 오류:', error.message);
+  }
+}
+
+module.exports = cleanupStuckBackupRestoreJobs;

--- a/src/server.js
+++ b/src/server.js
@@ -39,6 +39,7 @@ const dropBackupJobTTL = require('./migrations/dropBackupJobTTL');
 const dropWorkboardApiFormat = require('./migrations/dropWorkboardApiFormat');
 const dropLegacyModelCacheCollection = require('./migrations/dropLegacyModelCacheCollection');
 const cleanupStuckSyncs = require('./migrations/cleanupStuckSyncs');
+const cleanupStuckBackupRestoreJobs = require('./migrations/cleanupStuckBackupRestoreJobs');
 const initializeDefaultGroup = require('./migrations/initializeDefaultGroup');
 const assignDefaultGroupToWorkboards = require('./migrations/assignDefaultGroupToWorkboards');
 const backfillCustomFieldRoles = require('./migrations/backfillCustomFieldRoles');
@@ -245,6 +246,7 @@ const startServer = async () => {
     await dropWorkboardApiFormat();
     await dropLegacyModelCacheCollection();
     await cleanupStuckSyncs();
+    await cleanupStuckBackupRestoreJobs();
     await initializeDefaultGroup();
     await assignDefaultGroupToWorkboards();
     await backfillCustomFieldRoles();

--- a/src/tests/cleanupStuckBackupRestoreJobs.test.js
+++ b/src/tests/cleanupStuckBackupRestoreJobs.test.js
@@ -1,0 +1,45 @@
+/**
+ * #620 부팅 시 멈춘 백업/복원 작업 정리 테스트
+ */
+jest.mock('../models/BackupJob', () => ({ updateMany: jest.fn() }));
+jest.mock('../models/RestoreJob', () => ({ updateMany: jest.fn() }));
+
+const BackupJob = require('../models/BackupJob');
+const RestoreJob = require('../models/RestoreJob');
+const cleanupStuckBackupRestoreJobs = require('../migrations/cleanupStuckBackupRestoreJobs');
+
+beforeEach(() => {
+  BackupJob.updateMany.mockReset();
+  RestoreJob.updateMany.mockReset();
+});
+
+test('pending/processing 백업과 processing/validating 복원을 failed 로 정리', async () => {
+  BackupJob.updateMany.mockResolvedValue({ modifiedCount: 1 });
+  RestoreJob.updateMany.mockResolvedValue({ modifiedCount: 0 });
+
+  await cleanupStuckBackupRestoreJobs();
+
+  const [bFilter, bUpdate] = BackupJob.updateMany.mock.calls[0];
+  expect(bFilter).toEqual({ status: { $in: ['pending', 'processing'] } });
+  expect(bUpdate.$set.status).toBe('failed');
+  expect(bUpdate.$set.completedAt).toBeInstanceOf(Date);
+  expect(bUpdate.$set.error.message).toMatch(/재시작/);
+
+  const [rFilter, rUpdate] = RestoreJob.updateMany.mock.calls[0];
+  // RestoreJob 'pending'(검증완료·사용자대기)은 제외
+  expect(rFilter).toEqual({ status: { $in: ['processing', 'validating'] } });
+  expect(rUpdate.$set.status).toBe('failed');
+});
+
+test('대상이 없으면 그래도 두 컬렉션 모두 시도(멱등)', async () => {
+  BackupJob.updateMany.mockResolvedValue({ modifiedCount: 0 });
+  RestoreJob.updateMany.mockResolvedValue({ modifiedCount: 0 });
+  await cleanupStuckBackupRestoreJobs();
+  expect(BackupJob.updateMany).toHaveBeenCalledTimes(1);
+  expect(RestoreJob.updateMany).toHaveBeenCalledTimes(1);
+});
+
+test('DB 오류가 나도 throw 하지 않음(부팅 차단 방지)', async () => {
+  BackupJob.updateMany.mockRejectedValue(new Error('db down'));
+  await expect(cleanupStuckBackupRestoreJobs()).resolves.toBeUndefined();
+});


### PR DESCRIPTION
## 증상
백업 중 디스크 초과 → 백업 멈춤 + MongoDB 사망 → 재시작 후에도 백업이 '진행중' 으로 영구 표시.

## 원인
백업 잠금은 in-memory(재시작 시 해제)지만, **`BackupJob.status` 가 'processing' 에 멈춘 채 DB 에 잔류** → 프론트가 status 칩을 그대로 표시해 무한 '진행중'. 프로세스/Mongo 사망으로 `fail()`/`complete()` 미실행.

## 수정
- 신규 `migrations/cleanupStuckBackupRestoreJobs`: 부팅 시 `BackupJob`(pending/processing) + `RestoreJob`(processing/validating) → `failed` 로 정리. **백업/복원은 in-memory 락 + 단일 프로세스라 재시작을 넘어 이어질 수 없으므로 부팅 시 잔류 = orphan.** RestoreJob 'pending'(검증완료·사용자 실행 대기)은 제외.
- `server.js` 부팅 시퀀스 등록(cleanupStuckSyncs 옆).

## 검증
- 테스트 3건(필터 정확성/멱등/DB 오류 비차단 — 부팅 차단 방지). 전체 jest **199 green**.

## 적용
재시작 시 자동 정리. (알파엔 stuck 없음 — 본서버에서 발생한 것으로 추정. 배포 후 재시작 시 잔류 '진행중' 자동 해소.)

## 후속(별도)
디스크 부족으로 인한 백업 중단 자체 사전 점검은 #591 후속으로.

closes #620