### PR TITLE
fix: 부팅 시 백업 디렉토리 고아 파일 자동 정리 (#624)

### DIFF
--- a/src/migrations/cleanupOrphanBackupFiles.js
+++ b/src/migrations/cleanupOrphanBackupFiles.js
@@ -1,0 +1,77 @@
+const fs = require('fs');
+const path = require('path');
+const BackupJob = require('../models/BackupJob');
+
+// #624: 백업 디렉토리의 고아 파일 정리.
+// 크래시(디스크 부족 등)로 백업이 죽으면 ① 스트리밍 임시 디렉토리(.db-tmp-*)의 정리가
+// 실행되지 못해 남고, ② 완료 안 된 백업의 부분 zip 은 job.filePath 에 안 박혀 UI 삭제로도
+// 안 지워진다 → 디스크를 영구 점유. 부팅 시점엔 진행 중 백업이 없으므로(=in-memory 락 +
+// #620 stuck 정리 이후) BackupJob 에 참조되지 않는 zip 은 안전하게 고아로 간주해 삭제한다.
+
+const BACKUP_DIR = process.env.BACKUP_PATH || './backups';
+const UPLOAD_DIR = process.env.UPLOAD_PATH || './uploads';
+const RESTORE_TEMP_DIR = process.env.TEMP_PATH || path.join(UPLOAD_DIR, 'restore-temp');
+
+/**
+ * 순수 로직: 디렉토리 엔트리 + 참조된 파일명 집합 → 삭제 대상 분류.
+ * @param {{name:string,isDir:boolean}[]} entries
+ * @param {Set<string>} referenced  BackupJob 가 참조하는 basename 집합
+ */
+function selectOrphans(entries, referenced) {
+  const tmpDirs = [];
+  const zips = [];
+  for (const e of entries) {
+    if (e.isDir) {
+      if (e.name.startsWith('.db-tmp-')) tmpDirs.push(e.name);
+    } else if (e.name.endsWith('.zip') && !referenced.has(e.name)) {
+      zips.push(e.name);
+    }
+  }
+  return { tmpDirs, zips };
+}
+
+async function cleanupOrphanBackupFiles() {
+  try {
+    if (!fs.existsSync(BACKUP_DIR)) {
+      console.log('[Migration] 백업 디렉토리 없음 — 고아 정리 불필요');
+      return;
+    }
+
+    const dirents = fs.readdirSync(BACKUP_DIR, { withFileTypes: true });
+    const entries = dirents.map((d) => ({ name: d.name, isDir: d.isDirectory() }));
+
+    const jobs = await BackupJob.find({}).select('fileName filePath').lean();
+    const referenced = new Set();
+    for (const j of jobs) {
+      if (j.fileName) referenced.add(j.fileName);
+      if (j.filePath) referenced.add(path.basename(j.filePath));
+    }
+
+    const { tmpDirs, zips } = selectOrphans(entries, referenced);
+    for (const d of tmpDirs) fs.rmSync(path.join(BACKUP_DIR, d), { recursive: true, force: true });
+    for (const z of zips) fs.rmSync(path.join(BACKUP_DIR, z), { force: true });
+
+    // restore 추출 임시 디렉토리(항상 transient)도 정리
+    let restoreTemps = 0;
+    if (fs.existsSync(RESTORE_TEMP_DIR)) {
+      for (const d of fs.readdirSync(RESTORE_TEMP_DIR)) {
+        if (d.startsWith('restore-')) {
+          fs.rmSync(path.join(RESTORE_TEMP_DIR, d), { recursive: true, force: true });
+          restoreTemps += 1;
+        }
+      }
+    }
+
+    const total = tmpDirs.length + zips.length + restoreTemps;
+    if (total > 0) {
+      console.log(`[Migration] 고아 백업 파일 정리: 임시디렉토리 ${tmpDirs.length} + 미참조 zip ${zips.length} + 복원임시 ${restoreTemps}`);
+    } else {
+      console.log('[Migration] 고아 백업 파일 정리 불필요 (대상 없음)');
+    }
+  } catch (error) {
+    console.error('[Migration] 고아 백업 파일 정리 오류:', error.message);
+  }
+}
+
+cleanupOrphanBackupFiles.selectOrphans = selectOrphans; // 테스트용
+module.exports = cleanupOrphanBackupFiles;

--- a/src/server.js
+++ b/src/server.js
@@ -40,6 +40,7 @@ const dropWorkboardApiFormat = require('./migrations/dropWorkboardApiFormat');
 const dropLegacyModelCacheCollection = require('./migrations/dropLegacyModelCacheCollection');
 const cleanupStuckSyncs = require('./migrations/cleanupStuckSyncs');
 const cleanupStuckBackupRestoreJobs = require('./migrations/cleanupStuckBackupRestoreJobs');
+const cleanupOrphanBackupFiles = require('./migrations/cleanupOrphanBackupFiles');
 const initializeDefaultGroup = require('./migrations/initializeDefaultGroup');
 const assignDefaultGroupToWorkboards = require('./migrations/assignDefaultGroupToWorkboards');
 const backfillCustomFieldRoles = require('./migrations/backfillCustomFieldRoles');
@@ -247,6 +248,7 @@ const startServer = async () => {
     await dropLegacyModelCacheCollection();
     await cleanupStuckSyncs();
     await cleanupStuckBackupRestoreJobs();
+    await cleanupOrphanBackupFiles();
     await initializeDefaultGroup();
     await assignDefaultGroupToWorkboards();
     await backfillCustomFieldRoles();

--- a/src/tests/cleanupOrphanBackupFiles.test.js
+++ b/src/tests/cleanupOrphanBackupFiles.test.js
@@ -1,0 +1,40 @@
+/**
+ * #624 백업 디렉토리 고아 파일 선택 로직 테스트 (순수 함수)
+ */
+const cleanupOrphanBackupFiles = require('../migrations/cleanupOrphanBackupFiles');
+const { selectOrphans } = cleanupOrphanBackupFiles;
+
+test('.db-tmp-* 디렉토리는 항상 삭제 대상', () => {
+  const entries = [
+    { name: '.db-tmp-abc', isDir: true },
+    { name: '.db-tmp-def', isDir: true },
+  ];
+  const { tmpDirs } = selectOrphans(entries, new Set());
+  expect(tmpDirs.sort()).toEqual(['.db-tmp-abc', '.db-tmp-def']);
+});
+
+test('참조된 zip 은 보존, 미참조 zip 만 삭제', () => {
+  const entries = [
+    { name: 'vcc-backup-keep.zip', isDir: false },
+    { name: 'vcc-backup-orphan.zip', isDir: false },
+    { name: 'vcc-presnapshot-orphan.zip', isDir: false },
+  ];
+  const referenced = new Set(['vcc-backup-keep.zip']);
+  const { zips } = selectOrphans(entries, referenced);
+  expect(zips.sort()).toEqual(['vcc-backup-orphan.zip', 'vcc-presnapshot-orphan.zip']);
+});
+
+test('zip 이 아닌 일반 파일/디렉토리는 건드리지 않음', () => {
+  const entries = [
+    { name: 'metadata.json', isDir: false },
+    { name: 'somedir', isDir: true },
+    { name: 'note.txt', isDir: false },
+  ];
+  const { tmpDirs, zips } = selectOrphans(entries, new Set());
+  expect(tmpDirs).toEqual([]);
+  expect(zips).toEqual([]);
+});
+
+test('빈 입력', () => {
+  expect(selectOrphans([], new Set())).toEqual({ tmpDirs: [], zips: [] });
+});


### PR DESCRIPTION
## 문제
UI 에서 백업을 삭제해도 디스크 용량이 안 줄어듦 → 크래시 잔재(추적 안 되는 고아 파일):
- `.db-tmp-<jobId>/` 스트리밍 임시 디렉토리(정리 rmSync 미실행)
- 완료 안 된 백업의 부분 zip(job.filePath 미기록 → deleteBackup 대상 아님)
(저장 위치는 named volume backups_data → /app/backups. 이미지 아님.)

## 수정
부팅 시 `cleanupOrphanBackupFiles` (#620 stuck 정리 다음):
- BACKUP_DIR `.db-tmp-*` 무조건 삭제(항상 transient)
- BackupJob(fileName/filePath) **미참조 `*.zip` 삭제** (시작 시점엔 진행 중 백업 없음 → 미참조 = 고아)
- restore-temp 추출 임시 디렉토리 정리

## 검증
- `selectOrphans` 순수 로직 테스트 4건(.db-tmp/참조보존·미참조삭제/비zip 무시/빈입력). 전체 jest **203 green**.

## 비고
- 미참조 zip 삭제는 시작 시점 기준이라 안전(진행 중 백업 없음). DB 가 통째로 유실돼 job 레코드가 사라진 경우엔 해당 zip 도 고아로 간주됨(엣지).
- 배포 후 재시작 시 본서버의 크래시 잔재가 자동 회수됩니다.

closes #624