### PR TITLE
feat: 백업 전 디스크 여유 사전 점검 (#622)

### DIFF
--- a/src/routes/backup.js
+++ b/src/routes/backup.js
@@ -109,6 +109,17 @@ router.post('/', requireAdmin, async (req, res) => {
       }
     }
 
+    // 디스크 여유 사전 점검 (#622) — 부족하면 백업 시작 거부(디스크를 채워 DB 까지 죽는 사고 방지)
+    const disk = await backupService.checkDiskSpace();
+    if (!disk.ok) {
+      const gb = (n) => (n / 1024 / 1024 / 1024).toFixed(2);
+      return res.status(507).json({
+        success: false,
+        message: `디스크 여유 공간이 부족해 백업을 시작할 수 없습니다. 필요 약 ${gb(disk.requiredBytes)}GB, 가용 ${gb(disk.availableBytes)}GB. 공간을 확보한 뒤 다시 시도해주세요.`,
+        diskCheck: disk
+      });
+    }
+
     // 백업 작업 생성 (DB에만 기록)
     const job = await backupService.initBackupJob(req.user._id);
     const jobId = job._id.toString();

--- a/src/services/backupService.js
+++ b/src/services/backupService.js
@@ -147,6 +147,80 @@ async function writeCollectionNdjson(config, outPath) {
 /**
  * 백업 작업 초기화 (DB에 작업 기록만 생성)
  */
+/**
+ * 디렉토리의 총 바이트 크기 (재귀, 심볼릭링크 무시). 접근 불가 항목은 건너뜀.
+ */
+function dirSizeBytes(dir) {
+  let total = 0;
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  for (const e of entries) {
+    const p = path.join(dir, e.name);
+    try {
+      if (e.isDirectory()) total += dirSizeBytes(p);
+      else if (e.isFile()) total += fs.statSync(p).size;
+    } catch {
+      // 접근 불가 항목 무시
+    }
+  }
+  return total;
+}
+
+/**
+ * 디스크 점검 판정 (순수 함수, 테스트 용이).
+ * @param {{estimatedBytes:number, availableBytes:number|null, safetyFactor:number}} p
+ */
+function decideDiskSpace({ estimatedBytes, availableBytes, safetyFactor = 1.5 }) {
+  const requiredBytes = Math.ceil(estimatedBytes * safetyFactor);
+  if (availableBytes === null || availableBytes === undefined) {
+    return { ok: true, availableBytes: null, estimatedBytes, requiredBytes, reason: 'disk-unmeasurable' };
+  }
+  if (availableBytes < requiredBytes) {
+    return { ok: false, availableBytes, estimatedBytes, requiredBytes, reason: 'insufficient-space' };
+  }
+  return { ok: true, availableBytes, estimatedBytes, requiredBytes };
+}
+
+/**
+ * 백업 디스크 여유 사전 점검 (#622).
+ * 추정 필요 공간 = (uploads 디렉토리 크기 + DB dataSize) 에 안전 배수 적용.
+ * 반환: { ok, availableBytes|null, estimatedBytes, requiredBytes, reason? }
+ * 가용 공간을 측정할 수 없으면(statfs 미지원 등) ok:true + warning 으로 통과(현행 동작 유지).
+ */
+async function checkDiskSpace({ safetyFactor = 1.5 } = {}) {
+  // 1) 추정 크기: uploads + DB dataSize
+  const uploadsBytes = dirSizeBytes(UPLOAD_DIR);
+  let dbBytes = 0;
+  try {
+    const mongoose = require('mongoose');
+    if (mongoose.connection?.db) {
+      const stats = await mongoose.connection.db.stats();
+      dbBytes = (stats.dataSize || 0);
+    }
+  } catch {
+    // DB stats 실패 시 uploads 만으로 추정
+  }
+  const estimatedBytes = uploadsBytes + dbBytes;
+
+  // 2) 가용 공간 (BACKUP_DIR 가 위치한 파일시스템)
+  let availableBytes = null;
+  try {
+    if (!fs.existsSync(BACKUP_DIR)) fs.mkdirSync(BACKUP_DIR, { recursive: true });
+    if (typeof fs.statfsSync === 'function') {
+      const fsStats = fs.statfsSync(BACKUP_DIR);
+      availableBytes = fsStats.bavail * fsStats.bsize;
+    }
+  } catch {
+    availableBytes = null;
+  }
+
+  return decideDiskSpace({ estimatedBytes, availableBytes, safetyFactor });
+}
+
 async function initBackupJob(userId, type = 'full') {
   // 암호화 키 유효성 검사
   validateEncryptionKey();
@@ -400,6 +474,8 @@ module.exports = {
   getBackupFilePath,
   deleteBackup,
   getLastBackupTime,
+  checkDiskSpace,
+  decideDiskSpace,
   ENCRYPTION_KEY,
   // 테스트용 내부 헬퍼 (#591)
   processDoc,

--- a/src/tests/backupDiskCheck.test.js
+++ b/src/tests/backupDiskCheck.test.js
@@ -1,0 +1,36 @@
+/**
+ * #622 백업 디스크 사전 점검 판정 로직 테스트
+ */
+const { decideDiskSpace } = require('../services/backupService');
+
+const GB = 1024 * 1024 * 1024;
+
+test('가용 공간이 필요량보다 크면 ok', () => {
+  const r = decideDiskSpace({ estimatedBytes: 2 * GB, availableBytes: 10 * GB, safetyFactor: 1.5 });
+  expect(r.ok).toBe(true);
+  expect(r.requiredBytes).toBe(3 * GB); // 2GB * 1.5
+});
+
+test('가용 공간이 필요량보다 작으면 거부', () => {
+  const r = decideDiskSpace({ estimatedBytes: 10 * GB, availableBytes: 12 * GB, safetyFactor: 1.5 });
+  expect(r.ok).toBe(false);
+  expect(r.reason).toBe('insufficient-space');
+  expect(r.requiredBytes).toBe(15 * GB);
+});
+
+test('경계값: 정확히 같으면 통과', () => {
+  const r = decideDiskSpace({ estimatedBytes: 8 * GB, availableBytes: 12 * GB, safetyFactor: 1.5 });
+  expect(r.ok).toBe(true); // required 12GB == available 12GB
+});
+
+test('가용 공간 측정 불가(null)면 통과 + reason', () => {
+  const r = decideDiskSpace({ estimatedBytes: 100 * GB, availableBytes: null });
+  expect(r.ok).toBe(true);
+  expect(r.reason).toBe('disk-unmeasurable');
+});
+
+test('safetyFactor 기본값 1.5 적용', () => {
+  const r = decideDiskSpace({ estimatedBytes: 4 * GB, availableBytes: 5 * GB });
+  expect(r.requiredBytes).toBe(6 * GB);
+  expect(r.ok).toBe(false); // 6GB 필요 > 5GB 가용
+});


### PR DESCRIPTION
디스크 부족으로 백업이 중단되고 Mongo 까지 죽던 사고(#620/#624) 의 **근본 예방**.

## 변경
- `backupService.checkDiskSpace()`: (uploads 디렉토리 크기 + DB dataSize) × 안전배수(기본 1.5) = 필요 공간 vs `fs.statfsSync(BACKUP_DIR)` 가용 공간 비교. 측정 불가(statfs 미지원)면 통과 + `reason: disk-unmeasurable`(현행 동작 유지).
- `decideDiskSpace()`: 순수 판정 함수(테스트 분리).
- 백업 시작 라우트(`POST /api/admin/backup`): rate-limit 다음에 점검, 부족하면 **507 + 안내 메시지로 시작 거부**(디스크를 채워 DB 까지 죽는 사고 방지).

## 검증
- 테스트 5건(충분/부족/경계값/측정불가/safetyFactor). 전체 jest **208 green**.

## 비고
- 추정은 dataSize 기반 근사(압축 전) + 1.5x 여유라 보수적. 실행 중 임계 도달 시 중단은 별도(현재는 시작 차단으로 대부분 예방).

closes #622