### PR TITLE
feat: 복원 오류 관측성 — dbErrors/fileErrors 분리 + 상세 기록 (#631)

### DIFF
--- a/src/models/RestoreJob.js
+++ b/src/models/RestoreJob.js
@@ -47,7 +47,18 @@ const restoreJobSchema = new mongoose.Schema({
       videos: { type: Number, default: 0 }
     },
     skipped: { type: Number, default: 0 },
-    errors: { type: Number, default: 0 }
+    errors: { type: Number, default: 0 }, // 총합 (dbErrors + fileErrors) — 호환 유지
+    dbErrors: { type: Number, default: 0 }, // #631
+    fileErrors: { type: Number, default: 0 },
+    // 실패 항목 상세 (사후 규명용). type: 'db'|'file', + collection/docId 또는 dir/file + message
+    errorDetails: [{
+      type: { type: String },
+      collection: String,
+      docId: String,
+      dir: String,
+      file: String,
+      message: String
+    }]
   },
   validationResult: {
     isValid: Boolean,

--- a/src/services/restoreService.js
+++ b/src/services/restoreService.js
@@ -84,7 +84,18 @@ function decryptFields(doc, fieldsToDecrypt) {
  * 단일 문서 복구 (복호화 → _id 보존 create / overwrite upsert). (#591 스트리밍 분리)
  * 성공 시 true. 통계는 statistics 에 누적.
  */
+// 실패 항목 상세 기록 (#631). errorDetails 과다 방지 상한 — 초과분은 카운트만.
+const MAX_ERROR_DETAILS = 100;
+function recordError(statistics, detail) {
+  statistics.errors++;
+  if (detail.type === 'file') statistics.fileErrors = (statistics.fileErrors || 0) + 1;
+  else statistics.dbErrors = (statistics.dbErrors || 0) + 1;
+  if (!statistics.errorDetails) statistics.errorDetails = [];
+  if (statistics.errorDetails.length < MAX_ERROR_DETAILS) statistics.errorDetails.push(detail);
+}
+
 async function restoreOneDoc(doc, config, options, statistics) {
+  let docId;
   try {
     // 암호화 필드 복호화 (백업 시 암호화한 encryptFields 와 동일)
     let processedDoc = doc;
@@ -92,7 +103,7 @@ async function restoreOneDoc(doc, config, options, statistics) {
       processedDoc = decryptFields(doc, config.encryptFields);
     }
 
-    const docId = processedDoc._id;
+    docId = processedDoc._id;
     delete processedDoc._id;
 
     if (options.overwriteExisting) {
@@ -109,7 +120,7 @@ async function restoreOneDoc(doc, config, options, statistics) {
     return true;
   } catch (docError) {
     console.error(`${config.name} 문서 복구 오류:`, docError.message);
-    statistics.errors++;
+    recordError(statistics, { type: 'db', collection: config.name, docId: docId ? String(docId) : undefined, message: docError.message });
     return false;
   }
 }
@@ -137,7 +148,7 @@ async function restoreCollection(config, tempExtractDir, options, statistics) {
         doc = JSON.parse(trimmed);
       } catch (parseErr) {
         console.error(`${config.name} NDJSON 파싱 오류:`, parseErr.message);
-        statistics.errors++;
+        recordError(statistics, { type: 'db', collection: config.name, message: `NDJSON 파싱 오류: ${parseErr.message}` });
         continue;
       }
       await restoreOneDoc(doc, config, options, statistics);
@@ -299,7 +310,10 @@ async function executeRestore(jobId, zipPath, options = {}) {
       videos: 0
     },
     skipped: 0,
-    errors: 0
+    errors: 0,
+    dbErrors: 0,
+    fileErrors: 0,
+    errorDetails: []
   };
 
   const totalSteps = BACKUP_COLLECTIONS.length + 3; // 컬렉션 + 파일 디렉토리 3개
@@ -336,7 +350,7 @@ async function executeRestore(jobId, zipPath, options = {}) {
           }
         } catch (colError) {
           console.error(`${name} 컬렉션 복구 오류:`, colError.message);
-          statistics.errors++;
+          recordError(statistics, { type: 'db', collection: name, message: `컬렉션 복구 오류: ${colError.message}` });
         }
       }
     }
@@ -373,7 +387,7 @@ async function executeRestore(jobId, zipPath, options = {}) {
               }
             } catch (fileError) {
               console.error(`파일 복구 오류 (${file}):`, fileError.message);
-              statistics.errors++;
+              recordError(statistics, { type: 'file', dir, file, message: fileError.message });
             }
           }
         }
@@ -434,7 +448,8 @@ module.exports = {
   executeRestore,
   getRestoreStatus,
   listRestores,
-  // 테스트용 내부 헬퍼 (#591)
+  // 테스트용 내부 헬퍼 (#591, #631)
   restoreOneDoc,
-  restoreCollection
+  restoreCollection,
+  recordError
 };

--- a/src/tests/restoreErrorObservability.test.js
+++ b/src/tests/restoreErrorObservability.test.js
@@ -1,0 +1,45 @@
+/**
+ * #631 복원 오류 관측성 — recordError 로직 테스트
+ */
+const { recordError } = require('../services/restoreService');
+
+function freshStats() {
+  return { errors: 0, dbErrors: 0, fileErrors: 0, errorDetails: [] };
+}
+
+test('db 오류는 dbErrors + errors 증가, 상세 기록', () => {
+  const s = freshStats();
+  recordError(s, { type: 'db', collection: 'Workboard', docId: 'abc', message: 'dup key' });
+  expect(s.errors).toBe(1);
+  expect(s.dbErrors).toBe(1);
+  expect(s.fileErrors).toBe(0);
+  expect(s.errorDetails[0]).toMatchObject({ type: 'db', collection: 'Workboard', docId: 'abc', message: 'dup key' });
+});
+
+test('file 오류는 fileErrors + errors 증가, 상세 기록', () => {
+  const s = freshStats();
+  recordError(s, { type: 'file', dir: 'generated', file: 'x.png', message: 'EISDIR' });
+  expect(s.errors).toBe(1);
+  expect(s.fileErrors).toBe(1);
+  expect(s.dbErrors).toBe(0);
+  expect(s.errorDetails[0]).toMatchObject({ type: 'file', dir: 'generated', file: 'x.png' });
+});
+
+test('db/file 혼합 카운트', () => {
+  const s = freshStats();
+  recordError(s, { type: 'db', collection: 'A', message: 'e' });
+  recordError(s, { type: 'file', dir: 'reference', file: 'y', message: 'e' });
+  recordError(s, { type: 'db', collection: 'B', message: 'e' });
+  expect(s.errors).toBe(3);
+  expect(s.dbErrors).toBe(2);
+  expect(s.fileErrors).toBe(1);
+  expect(s.errorDetails).toHaveLength(3);
+});
+
+test('errorDetails 는 100개 상한, 초과분은 카운트만', () => {
+  const s = freshStats();
+  for (let i = 0; i < 130; i++) recordError(s, { type: 'db', collection: 'C', docId: String(i), message: 'e' });
+  expect(s.errors).toBe(130);      // 카운트는 전부
+  expect(s.dbErrors).toBe(130);
+  expect(s.errorDetails).toHaveLength(100); // 상세는 상한까지만
+});


### PR DESCRIPTION
## 배경
OrbStack 이전 복원에서 `errors=1` 이 떴으나, 복원이 DB·파일 오류를 `statistics.errors` 한 숫자로 뭉뚱그리고 실패 항목을 RestoreJob 에 안 남겨 **사후 규명 불가**였음(데이터 유실은 없었음).

## 변경
- `RestoreJob.statistics`: `dbErrors` / `fileErrors` / `errorDetails[]` 추가 (`errors` 는 총합 호환 유지)
- `restoreService.recordError()`: db/file 분류 카운트 + 실패 항목 기록
  - db: `{type, collection, docId, message}` / file: `{type, dir, file, message}`
  - `errorDetails` 상한 100 (초과분은 카운트만)
- 오류 지점 4곳 모두 적용: 문서 복구 / NDJSON 파싱 / 컬렉션 복구 / 파일 복사
- → 재발 시 RestoreJob 조회로 **'무엇이 왜 실패했는지' 즉시 규명**

## 검증
- `recordError` 테스트 4건(db/file/혼합/상한). 전체 jest **212 green**.

closes #631