### PR TITLE
feat: 서버 백업 파일로 복원(업로드 우회) + 대용량 가드 + 업로드 스크립트 (#634)

### DIFF
--- a/docs/BACKUP_RESTORE.md
+++ b/docs/BACKUP_RESTORE.md
@@ -94,8 +94,18 @@ vcc-backup-2026-06-20T10-30-00-000Z.zip
 
 ## 복구
 
-### 웹 UI
-관리자 > **백업 / 복구** > **복구하기** → 백업 파일(.zip) 업로드 → 검증 결과 확인 → 옵션 선택 → 복구 실행.
+### 웹 UI — 두 가지 방식
+복구하기 다이얼로그에서 방식을 고릅니다:
+
+- **서버 백업 (권장, 대용량 안전)**: 서버 `/app/backups`에 있는 백업 파일을 목록에서 골라 복원. 업로드가 없어 크기 제한이 없습니다. 백업 파일을 서버에 올릴 때:
+  ```bash
+  ./scripts/upload-backup-file.sh <백업파일.zip>        # 프로덕션
+  ./scripts/upload-backup-file.sh --dev <백업파일.zip>  # 개발
+  ```
+  (한 줄로 backend 컨테이너의 `/app/backups`에 복사 → UI "서버 백업" 탭에 표시)
+- **파일 업로드**: 2GB 이하 백업을 브라우저로 업로드. 그보다 크면 위 "서버 백업" 방식을 쓰세요(대용량 HTTP 업로드는 느리고 실패하기 쉬움).
+
+검증 결과 확인 → 옵션 선택 → 복구 실행.
 
 옵션: 기존 데이터 덮어쓰기 / 데이터베이스 건너뛰기 / 파일 건너뛰기.
 
@@ -149,7 +159,9 @@ vcc-backup-2026-06-20T10-30-00-000Z.zip
 | GET | `/api/admin/backup/list` | 백업 목록 |
 | DELETE | `/api/admin/backup/:id` | 백업 삭제 |
 | GET | `/api/admin/backup/lock-status` | 백업/복원 진행 상태 |
-| POST | `/api/admin/backup/restore/validate` | 복구 파일 검증 |
+| GET | `/api/admin/backup/restore/server-files` | 서버 백업 파일 목록 (서버사이드 복원) |
+| POST | `/api/admin/backup/restore/server-validate` | 서버 백업 파일 검증 (업로드 우회) |
+| POST | `/api/admin/backup/restore/validate` | 복구 파일 검증 (업로드) |
 | POST | `/api/admin/backup/restore` | 복구 실행 |
 | GET | `/api/admin/backup/restore/status/:id` | 복구 상태 조회 |
 | GET | `/api/admin/backup/restore/list` | 복구 히스토리 |

--- a/frontend/src/pages/admin/BackupRestorePage.js
+++ b/frontend/src/pages/admin/BackupRestorePage.js
@@ -23,6 +23,7 @@ import {
   Tabs,
   Tab,
   Tooltip,
+  TextField,
   CircularProgress
 } from '@mui/material';
 import {
@@ -97,7 +98,12 @@ function BackupRestorePage() {
   const [uploadedFile, setUploadedFile] = useState(null);
   const [validationResult, setValidationResult] = useState(null);
   const [activeJobId, setActiveJobId] = useState(null);
+  const [restoreMode, setRestoreMode] = useState('server'); // 'server' | 'upload' (#634)
+  const [selectedServerFile, setSelectedServerFile] = useState('');
   const fileInputRef = useRef(null);
+
+  // 업로드 무한 상태 방어: 큰 파일은 브라우저 업로드 대신 서버 백업 방식으로 유도 (#634)
+  const UPLOAD_SOFT_LIMIT = 2 * 1024 * 1024 * 1024; // 2GB
 
   // 백업 목록 조회
   const { data: backupData, isLoading: backupsLoading, refetch: refetchBackups } = useQuery({ queryKey: ['backups', backupPage], queryFn: () => backupAPI.list({ page: backupPage, limit: 10 }), refetchInterval: activeJobId ? 2000 : false });
@@ -192,11 +198,37 @@ function BackupRestorePage() {
   const handleFileSelect = async (event) => {
     const file = event.target.files[0];
     if (file) {
+      // 대용량은 브라우저 업로드가 실패/무한 상태를 유발 → 서버 백업 방식으로 안내 (#634)
+      if (file.size > UPLOAD_SOFT_LIMIT) {
+        toast.error('파일이 너무 큽니다. 대용량 백업은 서버에 올린 뒤 "서버 백업" 탭에서 복원하세요. (scripts/upload-backup-file.sh)');
+        if (fileInputRef.current) fileInputRef.current.value = '';
+        return;
+      }
       setUploadedFile(file);
       setValidationResult(null);
       validateMutation.mutate(file);
     }
   };
+
+  // 서버 백업 파일 목록 (서버 탭에서만 조회) (#634)
+  const { data: serverFilesData, refetch: refetchServerFiles } = useQuery({
+    queryKey: ['serverBackupFiles'],
+    queryFn: () => backupAPI.listServerBackupFiles(),
+    enabled: restoreDialogOpen && restoreMode === 'server',
+  });
+  const serverBackupFiles = serverFilesData?.data?.data?.files || [];
+
+  const validateServerMutation = useMutation({
+    mutationFn: (fileName) => backupAPI.validateServerBackup(fileName),
+    onSuccess: (response) => {
+      setValidationResult(response.data.data);
+      if (response.data.data.validationResult?.isValid) toast.success('백업 파일이 유효합니다.');
+      else toast.error('백업 파일 검증에 실패했습니다.');
+    },
+    onError: (error) => {
+      toast.error(error.response?.data?.message || '서버 백업 검증에 실패했습니다.');
+    },
+  });
 
   const handleDownload = async (backupId) => {
     try {
@@ -507,32 +539,82 @@ function BackupRestorePage() {
           </Box>
         </DialogTitle>
         <DialogContent>
-          <Box sx={{ mt: 2 }}>
-            {/* 파일 업로드 */}
-            <input
-              type="file"
-              accept=".zip"
-              ref={fileInputRef}
-              onChange={handleFileSelect}
-              style={{ display: 'none' }}
-            />
-
-            <Button
-              variant="outlined"
-              fullWidth
-              startIcon={<CloudUpload />}
-              onClick={() => fileInputRef.current?.click()}
-              disabled={validateMutation.isPending}
+          <Box sx={{ mt: 1 }}>
+            {/* 복원 방식 선택: 서버 백업(권장) / 파일 업로드 (#634) */}
+            <Tabs
+              value={restoreMode}
+              onChange={(e, v) => { setRestoreMode(v); setValidationResult(null); setUploadedFile(null); setSelectedServerFile(''); }}
+              sx={{ mb: 2 }}
             >
-              {uploadedFile ? uploadedFile.name : '백업 파일 선택 (.zip)'}
-            </Button>
+              <Tab value="server" label="서버 백업 (권장)" />
+              <Tab value="upload" label="파일 업로드" />
+            </Tabs>
 
-            {validateMutation.isPending && (
-              <Box sx={{ mt: 2 }}>
-                <LinearProgress />
-                <Typography variant="caption" color="text.secondary">
-                  파일 검증 중...
+            {restoreMode === 'server' && (
+              <Box>
+                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+                  서버에 올려둔 백업 파일을 선택해 복원합니다. 대용량 백업은 <code>scripts/upload-backup-file.sh</code> 로 올리세요.
                 </Typography>
+                {serverBackupFiles.length === 0 ? (
+                  <Alert severity="info">서버에 백업 파일이 없습니다. <code>./scripts/upload-backup-file.sh &lt;파일.zip&gt;</code> 로 올린 뒤 새로고침하세요.</Alert>
+                ) : (
+                  <TextField
+                    select fullWidth size="small" label="서버 백업 파일"
+                    value={selectedServerFile}
+                    onChange={(e) => { setSelectedServerFile(e.target.value); setValidationResult(null); }}
+                    SelectProps={{ native: true }} InputLabelProps={{ shrink: true }}
+                  >
+                    <option value="">— 선택 —</option>
+                    {serverBackupFiles.map((f) => (
+                      <option key={f.fileName} value={f.fileName}>
+                        {f.fileName} ({(f.size / 1024 / 1024).toFixed(0)}MB)
+                      </option>
+                    ))}
+                  </TextField>
+                )}
+                <Box sx={{ mt: 1, display: 'flex', gap: 1 }}>
+                  <Button size="small" onClick={() => refetchServerFiles()}>목록 새로고침</Button>
+                  <Button
+                    size="small" variant="outlined"
+                    disabled={!selectedServerFile || validateServerMutation.isPending}
+                    onClick={() => { setValidationResult(null); validateServerMutation.mutate(selectedServerFile); }}
+                  >
+                    검증
+                  </Button>
+                </Box>
+                {validateServerMutation.isPending && (
+                  <Box sx={{ mt: 2 }}><LinearProgress /><Typography variant="caption" color="text.secondary">검증 중...</Typography></Box>
+                )}
+              </Box>
+            )}
+
+            {restoreMode === 'upload' && (
+              <Box>
+                <input
+                  type="file"
+                  accept=".zip"
+                  ref={fileInputRef}
+                  onChange={handleFileSelect}
+                  style={{ display: 'none' }}
+                />
+                <Button
+                  variant="outlined"
+                  fullWidth
+                  startIcon={<CloudUpload />}
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={validateMutation.isPending}
+                >
+                  {uploadedFile ? uploadedFile.name : '백업 파일 선택 (.zip)'}
+                </Button>
+                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
+                  2GB 이하 백업만 업로드 가능합니다. 더 큰 백업은 "서버 백업" 탭을 사용하세요.
+                </Typography>
+                {validateMutation.isPending && (
+                  <Box sx={{ mt: 2 }}>
+                    <LinearProgress />
+                    <Typography variant="caption" color="text.secondary">파일 검증 중...</Typography>
+                  </Box>
+                )}
               </Box>
             )}
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -204,6 +204,9 @@ export const backupAPI = {
   restore: (data) => api.post('/admin/backup/restore', data),
   getRestoreStatus: (id) => api.get(`/admin/backup/restore/status/${id}`),
   listRestores: (params) => api.get('/admin/backup/restore/list', { params }),
+  // 서버사이드 복원 (업로드 우회 #634)
+  listServerBackupFiles: () => api.get('/admin/backup/restore/server-files'),
+  validateServerBackup: (fileName) => api.post('/admin/backup/restore/server-validate', { fileName }),
 };
 
 export const serverAPI = {

--- a/scripts/upload-backup-file.sh
+++ b/scripts/upload-backup-file.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# 백업 .zip 파일을 실행 중인 backend 컨테이너의 /app/backups 로 올린다 (#634).
+# 대용량 백업을 브라우저로 업로드하지 않고, 이 한 줄로 서버에 넣은 뒤
+# 웹 UI(관리자 > 백업/복구 > "서버 백업")에서 선택해 복원한다.
+#
+# 사용법:
+#   ./scripts/upload-backup-file.sh <백업파일.zip>
+#   ./scripts/upload-backup-file.sh --dev <백업파일.zip>   # 개발(docker-compose.yml) 환경
+set -euo pipefail
+
+MODE="prod"
+if [ "${1:-}" = "--dev" ]; then MODE="dev"; shift; fi
+
+FILE="${1:-}"
+if [ -z "$FILE" ]; then
+  echo "사용법: $0 [--dev] <백업파일.zip>"
+  exit 1
+fi
+if [ ! -f "$FILE" ]; then
+  echo "❌ 파일을 찾을 수 없습니다: $FILE"
+  exit 1
+fi
+case "$FILE" in
+  *.zip) ;;
+  *) echo "❌ .zip 백업 파일이어야 합니다: $FILE"; exit 1 ;;
+esac
+
+# repo 루트로 이동 (스크립트 위치 기준)
+cd "$(dirname "$0")/.."
+
+# compose 명령 구성 (prod 우선, 없으면 dev)
+if [ "$MODE" = "prod" ] && [ -f docker-compose.prod.yml ] && [ -f .env.production ]; then
+  COMPOSE=(docker compose -f docker-compose.prod.yml --env-file .env.production)
+else
+  COMPOSE=(docker compose)
+fi
+
+# backend 컨테이너가 떠 있는지 확인
+if ! "${COMPOSE[@]}" ps backend 2>/dev/null | grep -q "Up\|running"; then
+  echo "❌ backend 컨테이너가 실행 중이 아닙니다. 먼저 서비스를 기동하세요 (예: ./scripts/deploy-prod.sh)."
+  exit 1
+fi
+
+BN="$(basename "$FILE")"
+SIZE="$(du -h "$FILE" | cut -f1)"
+echo "📦 백업 파일 업로드: $BN ($SIZE) → backend:/app/backups/"
+"${COMPOSE[@]}" cp "$FILE" "backend:/app/backups/$BN"
+
+echo "✅ 완료했습니다."
+echo "   다음: 웹 UI 관리자 > 백업/복구 > '서버 백업' 탭에서 '$BN' 을 선택해 복원하세요."

--- a/src/routes/backup.js
+++ b/src/routes/backup.js
@@ -275,8 +275,45 @@ router.delete('/:id', requireAdmin, async (req, res) => {
 });
 
 /**
+ * GET /api/admin/backup/restore/server-files
+ * 서버 BACKUP_DIR 에 있는 백업 .zip 목록 (서버사이드 복원용 #634)
+ */
+router.get('/restore/server-files', requireAdmin, async (req, res) => {
+  try {
+    res.json({ success: true, data: { files: backupService.listServerBackupFiles() } });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
+/**
+ * POST /api/admin/backup/restore/server-validate
+ * 서버에 있는 백업 파일을 파일명으로 검증 (업로드 우회 #634). body: { fileName }
+ */
+router.post('/restore/server-validate', requireAdmin, async (req, res) => {
+  try {
+    const { fileName } = req.body;
+    const resolved = backupService.resolveServerBackupPath(fileName);
+    if (!resolved) {
+      return res.status(400).json({ success: false, message: '유효한 서버 백업 파일이 아닙니다.' });
+    }
+    const job = await restoreService.validateBackup(resolved, req.user._id);
+    res.json({
+      success: true,
+      data: {
+        jobId: job._id,
+        validationResult: job.validationResult,
+        backupMetadata: job.backupMetadata
+      }
+    });
+  } catch (error) {
+    res.status(500).json({ success: false, message: error.message });
+  }
+});
+
+/**
  * POST /api/admin/restore/validate
- * 백업 파일 검증
+ * 백업 파일 검증 (업로드 방식)
  */
 router.post('/restore/validate', requireAdmin, upload.single('backup'), async (req, res) => {
   try {
@@ -360,32 +397,34 @@ router.post('/restore', requireAdmin, async (req, res) => {
       });
     }
 
-    // 경로 검증: backup-temp 디렉토리 하위인지 확인
+    // 경로 검증: 업로드 임시 디렉토리(backup-temp) 또는 서버 백업 디렉토리(BACKUP_DIR #634) 하위만 허용
     const resolvedPath = path.resolve(filePath);
     const resolvedUploadDir = path.resolve(UPLOAD_DIR);
-    if (!resolvedPath.startsWith(resolvedUploadDir + path.sep) && resolvedPath !== resolvedUploadDir) {
+    const inUploadTemp = resolvedPath.startsWith(resolvedUploadDir + path.sep) || resolvedPath === resolvedUploadDir;
+    const isServerBackup = backupService.isInBackupDir(resolvedPath);
+    if (!inUploadTemp && !isServerBackup) {
       return res.status(403).json({
         success: false,
         message: 'Access denied'
       });
     }
 
+    // 서버 백업 파일(BACKUP_DIR)은 복원 후에도 보존, 업로드 임시파일만 삭제
+    const cleanupTempFile = () => {
+      if (!isServerBackup && fs.existsSync(filePath)) {
+        fs.unlinkSync(filePath);
+      }
+    };
+
     // 복원 잠금 시작 — 복원 중 동시 쓰기 차단 (#589)
     startRestoreLock(jobId);
 
     // 복구 실행 (비동기로 시작하고 바로 응답)
     restoreService.executeRestore(jobId, filePath, options)
-      .then(() => {
-        // 복구 완료 후 임시 파일 삭제
-        if (fs.existsSync(filePath)) {
-          fs.unlinkSync(filePath);
-        }
-      })
+      .then(cleanupTempFile)
       .catch((err) => {
         console.error('복구 실행 오류:', err);
-        if (fs.existsSync(filePath)) {
-          fs.unlinkSync(filePath);
-        }
+        cleanupTempFile();
       })
       .finally(() => {
         // 복원 완료/실패 시 잠금 해제

--- a/src/services/backupService.js
+++ b/src/services/backupService.js
@@ -452,6 +452,46 @@ async function deleteBackup(jobId) {
 }
 
 /**
+ * BACKUP_DIR 의 백업 .zip 파일 목록 (서버사이드 복원용 #634).
+ * BackupJob 레코드 유무와 무관하게 실제 파일을 스캔 (새 머신에 cp 로 넣은 외부 zip 도 포함).
+ */
+function listServerBackupFiles() {
+  if (!fs.existsSync(BACKUP_DIR)) return [];
+  return fs.readdirSync(BACKUP_DIR, { withFileTypes: true })
+    .filter((e) => e.isFile() && e.name.endsWith('.zip'))
+    .map((e) => {
+      const full = path.join(BACKUP_DIR, e.name);
+      let size = 0; let mtime = null;
+      try { const st = fs.statSync(full); size = st.size; mtime = st.mtime; } catch { /* skip */ }
+      return { fileName: e.name, size, mtime };
+    })
+    .sort((a, b) => (b.mtime || 0) - (a.mtime || 0));
+}
+
+/**
+ * 서버 백업 파일명을 안전한 절대경로로 해석 (path traversal 방지) (#634).
+ * basename 만 허용하고 BACKUP_DIR 직속 .zip 만. 유효치 않으면 null.
+ */
+function resolveServerBackupPath(fileName) {
+  if (!fileName || typeof fileName !== 'string') return null;
+  if (path.basename(fileName) !== fileName) return null; // 디렉토리 구분자/.. 차단
+  if (!fileName.endsWith('.zip')) return null;
+  const full = path.join(BACKUP_DIR, fileName);
+  const resolved = path.resolve(full);
+  const resolvedDir = path.resolve(BACKUP_DIR);
+  if (path.dirname(resolved) !== resolvedDir) return null;
+  if (!fs.existsSync(resolved)) return null;
+  return resolved;
+}
+
+/** 경로가 BACKUP_DIR 하위인지 (복원 후 삭제 skip 판단용) */
+function isInBackupDir(filePath) {
+  if (!filePath) return false;
+  const resolvedDir = path.resolve(BACKUP_DIR);
+  return path.resolve(filePath).startsWith(resolvedDir + path.sep) || path.dirname(path.resolve(filePath)) === resolvedDir;
+}
+
+/**
  * 최근 백업 시간 확인 (rate limiting)
  */
 async function getLastBackupTime(userId) {
@@ -476,6 +516,9 @@ module.exports = {
   getLastBackupTime,
   checkDiskSpace,
   decideDiskSpace,
+  listServerBackupFiles,
+  resolveServerBackupPath,
+  isInBackupDir,
   ENCRYPTION_KEY,
   // 테스트용 내부 헬퍼 (#591)
   processDoc,

--- a/src/tests/restorePathValidation.test.js
+++ b/src/tests/restorePathValidation.test.js
@@ -47,7 +47,11 @@ jest.mock('../services/backupService', () => ({
   getBackupStatus: jest.fn(),
   listBackups: jest.fn(),
   deleteBackup: jest.fn(),
-  getBackupFilePath: jest.fn()
+  getBackupFilePath: jest.fn(),
+  // #634 서버사이드 복원 헬퍼 — 이 테스트의 경로들은 모두 BACKUP_DIR 밖이라 false
+  isInBackupDir: jest.fn(() => false),
+  resolveServerBackupPath: jest.fn(() => null),
+  listServerBackupFiles: jest.fn(() => [])
 }));
 
 // multer mock: upload.single() → req.file 주입

--- a/src/tests/serverSideRestore.test.js
+++ b/src/tests/serverSideRestore.test.js
@@ -1,0 +1,68 @@
+/**
+ * #634 서버사이드 복원 — 경로 안전성(traversal 방지) + 파일 목록 테스트
+ */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+let tmpBackupDir;
+let backupService;
+
+beforeAll(() => {
+  tmpBackupDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vcc-bkdir-'));
+  process.env.BACKUP_PATH = tmpBackupDir;
+  process.env.BACKUP_ENCRYPTION_KEY = 'a'.repeat(64);
+  // BACKUP_DIR 은 모듈 로드시 캡처되므로 env 설정 후 require
+  backupService = require('../services/backupService');
+  // 백업 파일 2개 + 비zip 1개 + 하위 디렉토리 1개
+  fs.writeFileSync(path.join(tmpBackupDir, 'vcc-backup-A.zip'), 'x');
+  fs.writeFileSync(path.join(tmpBackupDir, 'vcc-backup-B.zip'), 'xx');
+  fs.writeFileSync(path.join(tmpBackupDir, 'notes.txt'), 'x');
+  fs.mkdirSync(path.join(tmpBackupDir, 'sub'), { recursive: true });
+});
+afterAll(() => {
+  fs.rmSync(tmpBackupDir, { recursive: true, force: true });
+});
+
+describe('#634 listServerBackupFiles', () => {
+  test('.zip 파일만 목록(비zip/디렉토리 제외)', () => {
+    const files = backupService.listServerBackupFiles().map((f) => f.fileName).sort();
+    expect(files).toEqual(['vcc-backup-A.zip', 'vcc-backup-B.zip']);
+  });
+  test('size 포함', () => {
+    const a = backupService.listServerBackupFiles().find((f) => f.fileName === 'vcc-backup-B.zip');
+    expect(a.size).toBe(2);
+  });
+});
+
+describe('#634 resolveServerBackupPath (traversal 방지)', () => {
+  test('정상 파일명 → 절대경로', () => {
+    const p = backupService.resolveServerBackupPath('vcc-backup-A.zip');
+    expect(p).toBe(path.resolve(tmpBackupDir, 'vcc-backup-A.zip'));
+  });
+  test('경로 구분자/.. 포함 차단', () => {
+    expect(backupService.resolveServerBackupPath('../etc/passwd')).toBeNull();
+    expect(backupService.resolveServerBackupPath('sub/x.zip')).toBeNull();
+    expect(backupService.resolveServerBackupPath('/abs/path.zip')).toBeNull();
+  });
+  test('.zip 아니면 차단', () => {
+    expect(backupService.resolveServerBackupPath('notes.txt')).toBeNull();
+  });
+  test('존재하지 않는 파일 차단', () => {
+    expect(backupService.resolveServerBackupPath('nope.zip')).toBeNull();
+  });
+  test('빈/비문자열 차단', () => {
+    expect(backupService.resolveServerBackupPath('')).toBeNull();
+    expect(backupService.resolveServerBackupPath(null)).toBeNull();
+  });
+});
+
+describe('#634 isInBackupDir', () => {
+  test('BACKUP_DIR 하위는 true', () => {
+    expect(backupService.isInBackupDir(path.join(tmpBackupDir, 'vcc-backup-A.zip'))).toBe(true);
+  });
+  test('다른 경로는 false', () => {
+    expect(backupService.isInBackupDir('/tmp/other/x.zip')).toBe(false);
+    expect(backupService.isInBackupDir('')).toBe(false);
+  });
+});


### PR DESCRIPTION
## 배경
13.4GB 백업을 브라우저 업로드하려다 nginx(50M)/multer(10GB) 초과 + 업로드가 안 끝나 **UI 무한 상태**(본서버 이전 막힘).

## 변경
**백엔드**
- `listServerBackupFiles` / `resolveServerBackupPath`(basename·.zip·존재 검증으로 **traversal 방지**) / `isInBackupDir`
- `GET /restore/server-files`, `POST /restore/server-validate` — 업로드 없이 서버 파일명으로 검증
- `/restore` 경로검증에 BACKUP_DIR 허용 + **BACKUP_DIR 파일은 복원 후 보존**(업로드 임시파일만 삭제)

**프론트**
- 복원 다이얼로그: **'서버 백업(권장)' / '파일 업로드' 탭**. 서버 탭 = 목록 선택 → 검증 → 복원
- 업로드는 **2GB 초과 차단** + 서버 백업 안내 → 무한 상태 예방

**운영**
- `scripts/upload-backup-file.sh <zip>`: 한 줄로 `backend:/app/backups` 업로드 (비개발자/운영자용)
- `BACKUP_RESTORE.md` 흐름·스크립트 반영

## 흐름
`./scripts/upload-backup-file.sh backup.zip` → UI '서버 백업' 탭에서 선택 → 복원. **업로드 한도 무관(13GB+ OK).**

## 검증
- 경로 traversal/목록/isInBackupDir 9건 + 기존 restore 경로검증 mock 보강. 전체 jest **221 green**. 프론트 esbuild OK.

closes #634