### PR TITLE
feat: 백업 저장소 호스트 경로 분리 옵션 (BACKUP_HOST_PATH) (#637)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,11 @@ BACKUP_PATH=./backups
 # 64자리 hex 문자열 (32바이트 AES-256 키). openssl rand -hex 32 로 생성 가능
 BACKUP_ENCRYPTION_KEY=
 
+# 백업 .zip 저장 위치 (#637). 비워두면 Docker named volume(backups_data) 사용.
+# 호스트 절대경로를 넣으면 그 경로로 bind mount → 외부/별도 디스크에 저장 (Docker 가상 디스크 절약).
+# 예: BACKUP_HOST_PATH=/mnt/backup-disk/vcc-backups
+BACKUP_HOST_PATH=
+
 # Provider API 키 at-rest 암호화 키 (#594). 선택 — 미설정 시 BACKUP_ENCRYPTION_KEY 를 재사용.
 # 별도 키로 분리하고 싶을 때만 설정 (64자리 hex). 키를 잃으면 암호화된 provider 키 복구 불가.
 CONFIG_ENCRYPTION_KEY=

--- a/.env.production.example
+++ b/.env.production.example
@@ -41,6 +41,11 @@ BACKUP_PATH=/app/backups
 # 중요: 이 키를 잃어버리면 암호화된 API 키를 복구할 수 없습니다
 BACKUP_ENCRYPTION_KEY=CHANGE_THIS_TO_64_HEX_CHARS_KEY
 
+# 백업 .zip 저장 위치 (#637). 비워두면 Docker named volume(backups_data) 사용.
+# 호스트 절대경로를 넣으면 bind mount → 외부/별도 디스크에 저장 (Docker/OrbStack 가상 디스크 절약 + DB 디스크 보호).
+# 예: BACKUP_HOST_PATH=/mnt/backup-disk/vcc-backups  (해당 디렉토리는 미리 생성해 두세요)
+BACKUP_HOST_PATH=
+
 # Provider API 키 at-rest 암호화 키 (#594). 선택 — 미설정 시 위 BACKUP_ENCRYPTION_KEY 를 재사용.
 # 별도 키로 분리할 때만 설정 (64자리 hex). 키를 잃으면 DB의 provider 키 복호화 불가.
 CONFIG_ENCRYPTION_KEY=

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -84,7 +84,8 @@ services:
       - "${BACKEND_PORT:-3136}:3000"
     volumes:
       - uploads_data:/app/uploads
-      - backups_data:/app/backups
+      # BACKUP_HOST_PATH 미설정 시 named volume(backups_data), 절대경로 설정 시 host bind mount (#637)
+      - ${BACKUP_HOST_PATH:-backups_data}:/app/backups
     depends_on:
       - mongodb
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,8 @@ services:
       - "${BACKEND_PORT:-3136}:3000"
     volumes:
       - uploads_data:/app/uploads
-      - backups_data:/app/backups
+      # BACKUP_HOST_PATH 미설정 시 named volume(backups_data), 절대경로 설정 시 host bind mount (#637)
+      - ${BACKUP_HOST_PATH:-backups_data}:/app/backups
     depends_on:
       - mongodb
       - redis

--- a/docs/BACKUP_RESTORE.md
+++ b/docs/BACKUP_RESTORE.md
@@ -63,6 +63,20 @@ backend:
 
 > `backups_data`·`uploads_data`·`mongodb` 볼륨은 같은 디스크(Docker 데이터 루트)를 공유합니다. 백업이 디스크를 채우면 DB까지 위험하므로, 백업 시작 전 디스크 여유를 자동 점검합니다(아래).
 
+### 백업을 외부/별도 디스크로 분리 (선택, 권장)
+백업이 Docker/OrbStack 가상 디스크나 DB와 같은 디스크를 먹지 않게 하려면, `.env`(.env.production)에 `BACKUP_HOST_PATH`로 호스트 경로를 지정하세요:
+```bash
+# 비워두면 기존 named volume(backups_data) 사용 — 동작 동일
+# 호스트 절대경로를 넣으면 그 경로로 bind mount → 외부/별도 디스크에 저장
+BACKUP_HOST_PATH=/mnt/backup-disk/vcc-backups
+```
+- 지정한 디렉토리는 **미리 만들어 두세요** (`mkdir -p /mnt/backup-disk/vcc-backups`).
+- 적용: `.env` 수정 후 재배포(`./scripts/deploy-prod.sh`).
+- **기존 백업 이전**(named volume → 새 경로로 옮길 때): 재배포 전에 기존 볼륨의 파일을 새 경로로 복사
+  ```bash
+  docker cp $(docker compose ps -q backend):/app/backups/. /mnt/backup-disk/vcc-backups/
+  ```
+
 ## 백업 생성
 
 ### 백업 중 시스템 동작

--- a/src/tests/backupHostPath.test.js
+++ b/src/tests/backupHostPath.test.js
@@ -1,0 +1,52 @@
+/**
+ * #637 BACKUP_HOST_PATH — backups 마운트가 named volume ↔ host bind 로 전환되는지 검증.
+ * docker compose config 출력을 파싱해 마운트 타입을 확인 (docker 없으면 skip).
+ */
+const { execSync } = require('child_process');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const ENV = path.join(ROOT, '.env.production.example');
+
+function hasDocker() {
+  try { execSync('docker compose version', { stdio: 'ignore' }); return true; }
+  catch { return false; }
+}
+
+function backupsMountType(extraEnv) {
+  const out = execSync(
+    `docker compose -f docker-compose.prod.yml --env-file ${ENV} config`,
+    { cwd: ROOT, env: { ...process.env, ...extraEnv }, encoding: 'utf8' }
+  );
+  // backups 마운트 블록에서 target: /app/backups 직전의 type/source 추출
+  const lines = out.split('\n');
+  const idx = lines.findIndex((l) => l.includes('target: /app/backups'));
+  if (idx < 0) return null;
+  const block = lines.slice(Math.max(0, idx - 3), idx + 1).join('\n');
+  const type = (block.match(/type:\s*(\w+)/) || [])[1];
+  const source = (block.match(/source:\s*(\S+)/) || [])[1];
+  return { type, source };
+}
+
+const d = hasDocker();
+const maybe = d ? describe : describe.skip;
+
+maybe('#637 BACKUP_HOST_PATH 마운트 전환', () => {
+  test('미설정 → named volume(backups_data)', () => {
+    const m = backupsMountType({ BACKUP_HOST_PATH: '' });
+    expect(m.type).toBe('volume');
+    expect(m.source).toBe('backups_data');
+  });
+
+  test('절대경로 설정 → host bind mount', () => {
+    const m = backupsMountType({ BACKUP_HOST_PATH: '/mnt/backup-disk/vcc-backups' });
+    expect(m.type).toBe('bind');
+    expect(m.source).toBe('/mnt/backup-disk/vcc-backups');
+  });
+});
+
+if (!d) {
+  test('docker 미설치 — compose 전환 테스트 skip', () => {
+    expect(true).toBe(true);
+  });
+}


### PR DESCRIPTION
## 배경
백업(`backups_data`)이 named volume 이라 Docker/OrbStack 가상 디스크를 먹고, DB/uploads 와 같은 디스크 공유 → 백업이 차면 DB 위험.

## 변경
- compose(dev/prod): backups 마운트를 `${BACKUP_HOST_PATH:-backups_data}:/app/backups`
  - **미설정 → named volume 유지(하위호환)**
  - **절대경로 → host bind mount** (외부/별도 디스크, 가상 디스크 절약 + DB 디스크 보호)
- `.env(.production).example` BACKUP_HOST_PATH 문서화
- `BACKUP_RESTORE.md` 분리 설정 + 기존 백업 이전(`docker cp`) 안내

## 검증
- compose config 파싱으로 named↔bind 전환 2건(docker 없으면 skip). 전체 jest **223 green**.
- 미설정: `type: volume / source: backups_data` / 설정: `type: bind / source: <경로>` 확인

closes #637