### PR TITLE
fix: 부팅 고아정리가 외부 복원용 백업 zip 삭제 (#640)

### DIFF
--- a/src/migrations/cleanupOrphanBackupFiles.js
+++ b/src/migrations/cleanupOrphanBackupFiles.js
@@ -1,33 +1,29 @@
 const fs = require('fs');
 const path = require('path');
-const BackupJob = require('../models/BackupJob');
 
-// #624: 백업 디렉토리의 고아 파일 정리.
-// 크래시(디스크 부족 등)로 백업이 죽으면 ① 스트리밍 임시 디렉토리(.db-tmp-*)의 정리가
-// 실행되지 못해 남고, ② 완료 안 된 백업의 부분 zip 은 job.filePath 에 안 박혀 UI 삭제로도
-// 안 지워진다 → 디스크를 영구 점유. 부팅 시점엔 진행 중 백업이 없으므로(=in-memory 락 +
-// #620 stuck 정리 이후) BackupJob 에 참조되지 않는 zip 은 안전하게 고아로 간주해 삭제한다.
+// #624 / #640: 백업 디렉토리의 임시(transient) 잔재만 정리.
+// 크래시(디스크 부족 등)로 백업이 죽으면 스트리밍 임시 디렉토리(.db-tmp-*) / 추출 임시(restore-temp)가
+// 정리되지 못해 남는다 — 이것들만 삭제한다.
+//
+// ⚠️ zip 파일은 삭제하지 않는다 (#640): 외부에서 복원용으로 넣은 백업(서버사이드 복원 #634)은
+// BackupJob 레코드가 없어 "미참조"이지만 정당한 파일이다. 이전엔 미참조 zip 을 고아로 삭제했는데,
+// 그게 복원용 백업을 구동/재시작 시 지워버렸다. 부분 zip(크래시 잔재) 회수 이득보다 위험이 커서 제거.
+// 부분 zip 은 디스크 사전점검(#622) + UI 수동삭제로 완화.
 
 const BACKUP_DIR = process.env.BACKUP_PATH || './backups';
 const UPLOAD_DIR = process.env.UPLOAD_PATH || './uploads';
 const RESTORE_TEMP_DIR = process.env.TEMP_PATH || path.join(UPLOAD_DIR, 'restore-temp');
 
 /**
- * 순수 로직: 디렉토리 엔트리 + 참조된 파일명 집합 → 삭제 대상 분류.
+ * 순수 로직: 디렉토리 엔트리 → 삭제 대상(임시 디렉토리만). zip 은 절대 포함하지 않는다 (#640).
  * @param {{name:string,isDir:boolean}[]} entries
- * @param {Set<string>} referenced  BackupJob 가 참조하는 basename 집합
  */
-function selectOrphans(entries, referenced) {
+function selectOrphans(entries) {
   const tmpDirs = [];
-  const zips = [];
   for (const e of entries) {
-    if (e.isDir) {
-      if (e.name.startsWith('.db-tmp-')) tmpDirs.push(e.name);
-    } else if (e.name.endsWith('.zip') && !referenced.has(e.name)) {
-      zips.push(e.name);
-    }
+    if (e.isDir && e.name.startsWith('.db-tmp-')) tmpDirs.push(e.name);
   }
-  return { tmpDirs, zips };
+  return { tmpDirs };
 }
 
 async function cleanupOrphanBackupFiles() {
@@ -40,16 +36,9 @@ async function cleanupOrphanBackupFiles() {
     const dirents = fs.readdirSync(BACKUP_DIR, { withFileTypes: true });
     const entries = dirents.map((d) => ({ name: d.name, isDir: d.isDirectory() }));
 
-    const jobs = await BackupJob.find({}).select('fileName filePath').lean();
-    const referenced = new Set();
-    for (const j of jobs) {
-      if (j.fileName) referenced.add(j.fileName);
-      if (j.filePath) referenced.add(path.basename(j.filePath));
-    }
-
-    const { tmpDirs, zips } = selectOrphans(entries, referenced);
+    // 임시 디렉토리(.db-tmp-*)만 삭제. zip 은 절대 건드리지 않음 (#640).
+    const { tmpDirs } = selectOrphans(entries);
     for (const d of tmpDirs) fs.rmSync(path.join(BACKUP_DIR, d), { recursive: true, force: true });
-    for (const z of zips) fs.rmSync(path.join(BACKUP_DIR, z), { force: true });
 
     // restore 추출 임시 디렉토리(항상 transient)도 정리
     let restoreTemps = 0;
@@ -62,11 +51,11 @@ async function cleanupOrphanBackupFiles() {
       }
     }
 
-    const total = tmpDirs.length + zips.length + restoreTemps;
+    const total = tmpDirs.length + restoreTemps;
     if (total > 0) {
-      console.log(`[Migration] 고아 백업 파일 정리: 임시디렉토리 ${tmpDirs.length} + 미참조 zip ${zips.length} + 복원임시 ${restoreTemps}`);
+      console.log(`[Migration] 백업 임시 잔재 정리: .db-tmp ${tmpDirs.length} + 복원임시 ${restoreTemps} (zip 은 보존)`);
     } else {
-      console.log('[Migration] 고아 백업 파일 정리 불필요 (대상 없음)');
+      console.log('[Migration] 백업 임시 잔재 정리 불필요 (대상 없음)');
     }
   } catch (error) {
     console.error('[Migration] 고아 백업 파일 정리 오류:', error.message);

--- a/src/tests/cleanupOrphanBackupFiles.test.js
+++ b/src/tests/cleanupOrphanBackupFiles.test.js
@@ -1,40 +1,39 @@
 /**
- * #624 백업 디렉토리 고아 파일 선택 로직 테스트 (순수 함수)
+ * #624 / #640 백업 임시 잔재 정리 — selectOrphans 는 .db-tmp-* 디렉토리만 삭제 대상.
+ * zip 은 (미참조여도) 절대 삭제하지 않는다 (#640: 외부 복원용 백업 보존).
  */
 const cleanupOrphanBackupFiles = require('../migrations/cleanupOrphanBackupFiles');
 const { selectOrphans } = cleanupOrphanBackupFiles;
 
-test('.db-tmp-* 디렉토리는 항상 삭제 대상', () => {
+test('.db-tmp-* 디렉토리는 삭제 대상', () => {
   const entries = [
     { name: '.db-tmp-abc', isDir: true },
     { name: '.db-tmp-def', isDir: true },
   ];
-  const { tmpDirs } = selectOrphans(entries, new Set());
+  const { tmpDirs } = selectOrphans(entries);
   expect(tmpDirs.sort()).toEqual(['.db-tmp-abc', '.db-tmp-def']);
 });
 
-test('참조된 zip 은 보존, 미참조 zip 만 삭제', () => {
+test('zip 은 미참조여도 삭제 대상이 아님 (#640 — 외부 복원 백업 보존)', () => {
   const entries = [
-    { name: 'vcc-backup-keep.zip', isDir: false },
-    { name: 'vcc-backup-orphan.zip', isDir: false },
-    { name: 'vcc-presnapshot-orphan.zip', isDir: false },
+    { name: 'vcc-backup-external.zip', isDir: false },
+    { name: 'vcc-presnapshot-x.zip', isDir: false },
+    { name: '.db-tmp-keep', isDir: true },
   ];
-  const referenced = new Set(['vcc-backup-keep.zip']);
-  const { zips } = selectOrphans(entries, referenced);
-  expect(zips.sort()).toEqual(['vcc-backup-orphan.zip', 'vcc-presnapshot-orphan.zip']);
+  const result = selectOrphans(entries);
+  expect(result.tmpDirs).toEqual(['.db-tmp-keep']);
+  expect(result.zips).toBeUndefined(); // zips 개념 자체가 제거됨
 });
 
-test('zip 이 아닌 일반 파일/디렉토리는 건드리지 않음', () => {
+test('zip/일반 디렉토리만 있으면 삭제 대상 없음', () => {
   const entries = [
-    { name: 'metadata.json', isDir: false },
+    { name: 'vcc-backup-A.zip', isDir: false },
     { name: 'somedir', isDir: true },
-    { name: 'note.txt', isDir: false },
+    { name: 'notes.txt', isDir: false },
   ];
-  const { tmpDirs, zips } = selectOrphans(entries, new Set());
-  expect(tmpDirs).toEqual([]);
-  expect(zips).toEqual([]);
+  expect(selectOrphans(entries).tmpDirs).toEqual([]);
 });
 
 test('빈 입력', () => {
-  expect(selectOrphans([], new Set())).toEqual({ tmpDirs: [], zips: [] });
+  expect(selectOrphans([])).toEqual({ tmpDirs: [] });
 });


### PR DESCRIPTION
## 증상
서버사이드 복원(#634)용 백업 zip 을 `/app/backups`(또는 BACKUP_HOST_PATH 폴더)에 넣어도 구동/재시작 시 사라짐.

## 원인
#624 `cleanupOrphanBackupFiles` 가 부팅 시 **BackupJob 미참조 zip 을 고아로 삭제**. 외부에서 넣은 복원 백업은 BackupJob 없어 미참조 → 삭제. #624↔#634 충돌.

## 수정
- 미참조 zip 자동삭제 **제거**. `.db-tmp-*` + `restore-temp` 만 정리(확실히 transient).
- 외부 복원 백업 보존이 우선. 부분 zip 잔재는 #622 디스크점검 + UI 수동삭제로 완화.

## 검증
- selectOrphans 가 zip 미반환. 테스트 4건(zip 보존 명시). 전체 jest **223 green**.

closes #640