### PR TITLE
fix: 4GB 초과(ZIP64) 백업 검증/복원 실패 (#643)

### DIFF
--- a/src/services/restoreService.js
+++ b/src/services/restoreService.js
@@ -169,31 +169,50 @@ async function restoreCollection(config, tempExtractDir, options, statistics) {
 }
 
 /**
- * ZIP 파일에서 메타데이터 추출
+ * ZIP 파일에서 메타데이터 추출.
+ * unzipper.Open.file (central directory 기반)로 읽어 4GB 초과(ZIP64) 백업도 처리 (#643).
+ * (기존 unzipper.Parse 스트리밍은 대용량/ZIP64 에서 metadata 를 못 찾았음.)
  */
 async function extractMetadata(zipPath) {
-  return new Promise((resolve, reject) => {
-    let metadata = null;
+  const directory = await unzipper.Open.file(zipPath);
+  const entry = directory.files.find((f) => f.path === 'metadata.json');
+  if (!entry) {
+    throw new Error('metadata.json을 찾을 수 없습니다.');
+  }
+  const content = await entry.buffer();
+  return JSON.parse(content.toString());
+}
 
-    fs.createReadStream(zipPath)
-      .pipe(unzipper.Parse())
-      .on('entry', async (entry) => {
-        if (entry.path === 'metadata.json') {
-          const content = await entry.buffer();
-          metadata = JSON.parse(content.toString());
-        } else {
-          entry.autodrain();
-        }
-      })
-      .on('close', () => {
-        if (metadata) {
-          resolve(metadata);
-        } else {
-          reject(new Error('metadata.json을 찾을 수 없습니다.'));
-        }
-      })
-      .on('error', reject);
-  });
+/**
+ * 추출 대상 경로가 기준 디렉토리 하위인지 검증 (zip-slip 방어, #643). 안전하면 절대경로 반환, 아니면 null.
+ */
+function safeExtractPath(baseDir, entryPath) {
+  const dest = path.resolve(baseDir, entryPath);
+  const base = path.resolve(baseDir);
+  if (dest !== base && !dest.startsWith(base + path.sep)) return null;
+  return dest;
+}
+
+/**
+ * ZIP 을 디렉토리로 추출 — Open.file 기반 entry 별 stream (ZIP64/대용량 안전) (#643).
+ */
+async function extractZipToDir(zipPath, destDir) {
+  const directory = await unzipper.Open.file(zipPath);
+  for (const entry of directory.files) {
+    if (entry.type !== 'File') continue; // 디렉토리 엔트리 skip
+    const dest = safeExtractPath(destDir, entry.path);
+    if (!dest) {
+      console.error('zip-slip 차단:', entry.path);
+      continue;
+    }
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    await new Promise((resolve, reject) => {
+      entry.stream()
+        .pipe(fs.createWriteStream(dest))
+        .on('finish', resolve)
+        .on('error', reject);
+    });
+  }
 }
 
 /**
@@ -326,15 +345,11 @@ async function executeRestore(jobId, zipPath, options = {}) {
   }
 
   try {
-    // ZIP 추출
+    // ZIP 추출 — Open.file(central directory) 기반 entry 별 추출로 4GB 초과(ZIP64) 백업 처리 (#643).
+    // (기존 unzipper.Extract 스트리밍은 대용량/ZIP64 에서 실패.)
     await job.updateProgress(currentStep, totalSteps, 'ZIP 파일 추출 중...');
 
-    await new Promise((resolve, reject) => {
-      fs.createReadStream(zipPath)
-        .pipe(unzipper.Extract({ path: tempExtractDir }))
-        .on('close', resolve)
-        .on('error', reject);
-    });
+    await extractZipToDir(zipPath, tempExtractDir);
 
     // 데이터베이스 복구
     if (!options.skipDatabase) {
@@ -448,8 +463,10 @@ module.exports = {
   executeRestore,
   getRestoreStatus,
   listRestores,
-  // 테스트용 내부 헬퍼 (#591, #631)
+  // 테스트용 내부 헬퍼 (#591, #631, #643)
   restoreOneDoc,
   restoreCollection,
-  recordError
+  recordError,
+  extractMetadata,
+  safeExtractPath
 };

--- a/src/tests/zip64Restore.test.js
+++ b/src/tests/zip64Restore.test.js
@@ -1,0 +1,63 @@
+/**
+ * #643 ZIP64/대용량 복원 — safeExtractPath(zip-slip 방어) + extractMetadata(Open.file) 테스트
+ */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const archiver = require('archiver');
+
+const { safeExtractPath, extractMetadata } = require('../services/restoreService');
+
+describe('#643 safeExtractPath (zip-slip 방어)', () => {
+  const base = '/tmp/restore-xyz';
+  test('정상 entry → 기준 디렉토리 하위 절대경로', () => {
+    expect(safeExtractPath(base, 'database/User.ndjson')).toBe(path.resolve(base, 'database/User.ndjson'));
+    expect(safeExtractPath(base, 'metadata.json')).toBe(path.resolve(base, 'metadata.json'));
+  });
+  test('상위 탈출(../) 차단 → null', () => {
+    expect(safeExtractPath(base, '../evil.sh')).toBeNull();
+    expect(safeExtractPath(base, '../../etc/passwd')).toBeNull();
+    expect(safeExtractPath(base, 'database/../../x')).toBeNull();
+  });
+  test('절대경로 entry 차단', () => {
+    expect(safeExtractPath(base, '/etc/passwd')).toBeNull();
+  });
+});
+
+describe('#643 extractMetadata (Open.file)', () => {
+  let tmpZip;
+  beforeAll(async () => {
+    tmpZip = path.join(os.tmpdir(), `meta-test-${process.pid}.zip`);
+    await new Promise((resolve, reject) => {
+      const out = fs.createWriteStream(tmpZip);
+      const archive = archiver('zip', { zlib: { level: 0 } });
+      out.on('close', resolve);
+      archive.on('error', reject);
+      archive.pipe(out);
+      archive.append(JSON.stringify({ version: '1.0', collections: { User: 3 } }), { name: 'metadata.json' });
+      archive.append('{"_id":"1"}\n', { name: 'database/User.ndjson' });
+      archive.finalize();
+    });
+  });
+  afterAll(() => { try { fs.unlinkSync(tmpZip); } catch { /* noop */ } });
+
+  test('metadata.json 을 읽어 파싱', async () => {
+    const meta = await extractMetadata(tmpZip);
+    expect(meta.version).toBe('1.0');
+    expect(meta.collections.User).toBe(3);
+  });
+
+  test('metadata 없는 zip 은 throw', async () => {
+    const noMeta = path.join(os.tmpdir(), `nometa-${process.pid}.zip`);
+    await new Promise((resolve, reject) => {
+      const out = fs.createWriteStream(noMeta);
+      const archive = archiver('zip');
+      out.on('close', resolve); archive.on('error', reject);
+      archive.pipe(out);
+      archive.append('x', { name: 'other.txt' });
+      archive.finalize();
+    });
+    await expect(extractMetadata(noMeta)).rejects.toThrow(/metadata/);
+    fs.unlinkSync(noMeta);
+  });
+});


### PR DESCRIPTION
## 증상
13.4GB 백업 복원 시 '백업 파일 형식이 올바르지 않습니다' (본서버 이전 중 발견).

## 원인
4GB 초과 zip = **ZIP64**. `extractMetadata`(`unzipper.Parse` 스트리밍)·`executeRestore` 추출(`unzipper.Extract`)이 ZIP64 에서 실패. `unzipper.Open.file`(central directory)로는 13.4GB metadata+18컬렉션+entry 정상.

## 수정
- extractMetadata → `Open.file`
- 추출 → Open.file entry 별 stream(`extractZipToDir`) + **zip-slip 방어**(`safeExtractPath`)

## 검증
- 테스트 +5(traversal/metadata). 전체 jest **228 green**. 알파 실 13.4GB 로 Open.file 읽힘 확인(metadata version 1.0, 18컬렉션, entry buffer OK).

본서버 이전 직결 — 긴급. closes #643