### PR TITLE
fix: 복원 시 원본 생성시각 보존 + 완전 복제(clean) 모드 (#646)

### DIFF
--- a/frontend/src/pages/admin/BackupRestorePage.js
+++ b/frontend/src/pages/admin/BackupRestorePage.js
@@ -93,7 +93,9 @@ function BackupRestorePage() {
   const [restoreOptions, setRestoreOptions] = useState({
     overwriteExisting: false,
     skipFiles: false,
-    skipDatabase: false
+    skipDatabase: false,
+    cleanRestore: false, // 완전 교체 모드 (#646)
+    skipSnapshot: false  // 복원 전 자동 스냅샷 생략 (대용량/빈 DB 이전 시) (#646)
   });
   const [uploadedFile, setUploadedFile] = useState(null);
   const [validationResult, setValidationResult] = useState(null);
@@ -450,6 +452,9 @@ function BackupRestorePage() {
                           <TableCell>
                             {restore.options && (
                               <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+                                {restore.options.cleanRestore && (
+                                  <Chip label="완전 교체" color="error" />
+                                )}
                                 {restore.options.overwriteExisting && (
                                   <Chip label="덮어쓰기" />
                                 )}
@@ -458,6 +463,9 @@ function BackupRestorePage() {
                                 )}
                                 {restore.options.skipDatabase && (
                                   <Chip label="DB 제외" />
+                                )}
+                                {restore.options.skipSnapshot && (
+                                  <Chip label="스냅샷 생략" />
                                 )}
                               </Box>
                             )}
@@ -674,7 +682,22 @@ function BackupRestorePage() {
                     <FormControlLabel
                       control={
                         <Checkbox
+                          checked={restoreOptions.cleanRestore}
+                          onChange={(e) => setRestoreOptions({
+                            ...restoreOptions,
+                            cleanRestore: e.target.checked,
+                            // 완전 교체 시 덮어쓰기는 의미 없으므로 함께 해제
+                            overwriteExisting: e.target.checked ? false : restoreOptions.overwriteExisting
+                          })}
+                        />
+                      }
+                      label="기존 데이터를 모두 지우고 완전히 교체 (새 서버 이전 시 권장)"
+                    />
+                    <FormControlLabel
+                      control={
+                        <Checkbox
                           checked={restoreOptions.overwriteExisting}
+                          disabled={restoreOptions.cleanRestore}
                           onChange={(e) => setRestoreOptions({
                             ...restoreOptions,
                             overwriteExisting: e.target.checked
@@ -707,13 +730,35 @@ function BackupRestorePage() {
                       }
                       label="파일 복구 건너뛰기"
                     />
+                    <FormControlLabel
+                      control={
+                        <Checkbox
+                          checked={restoreOptions.skipSnapshot}
+                          onChange={(e) => setRestoreOptions({
+                            ...restoreOptions,
+                            skipSnapshot: e.target.checked
+                          })}
+                        />
+                      }
+                      label="복원 전 자동 스냅샷 생략 (대용량·빈 서버 이전 시 빠름)"
+                    />
 
-                    <Alert severity="warning" sx={{ mt: 2 }}>
-                      <Typography variant="body2">
-                        복구를 실행하면 선택한 옵션에 따라 기존 데이터가 영향을 받을 수 있습니다.
-                        신중하게 진행해주세요.
-                      </Typography>
-                    </Alert>
+                    {restoreOptions.cleanRestore ? (
+                      <Alert severity="error" sx={{ mt: 2 }}>
+                        <Typography variant="subtitle2">완전 교체 모드</Typography>
+                        <Typography variant="body2">
+                          백업에 포함된 컬렉션의 <strong>현재 데이터를 모두 삭제</strong>하고 백업으로 교체합니다.
+                          새 서버로 이전(빈 DB)할 때 사용하세요. 복원 후에는 <strong>백업에 들어있던 계정/비밀번호</strong>로 로그인해야 합니다.
+                        </Typography>
+                      </Alert>
+                    ) : (
+                      <Alert severity="warning" sx={{ mt: 2 }}>
+                        <Typography variant="body2">
+                          복구를 실행하면 선택한 옵션에 따라 기존 데이터가 영향을 받을 수 있습니다.
+                          신중하게 진행해주세요.
+                        </Typography>
+                      </Alert>
+                    )}
                   </Box>
                 )}
               </Box>

--- a/src/models/RestoreJob.js
+++ b/src/models/RestoreJob.js
@@ -29,7 +29,9 @@ const restoreJobSchema = new mongoose.Schema({
   options: {
     overwriteExisting: { type: Boolean, default: false },
     skipFiles: { type: Boolean, default: false },
-    skipDatabase: { type: Boolean, default: false }
+    skipDatabase: { type: Boolean, default: false },
+    cleanRestore: { type: Boolean, default: false }, // 완전 교체 모드 (#646)
+    skipSnapshot: { type: Boolean, default: false }  // 복원 전 자동 스냅샷 생략 (#646)
   },
   progress: {
     current: { type: Number, default: 0 },

--- a/src/services/restoreService.js
+++ b/src/services/restoreService.js
@@ -104,15 +104,18 @@ async function restoreOneDoc(doc, config, options, statistics) {
     }
 
     docId = processedDoc._id;
-    delete processedDoc._id;
 
+    // timestamps: false 로 백업 원본 createdAt/updatedAt 을 보존 (#646).
+    // mongoose timestamps:true 기본 동작이 복원 시점으로 덮어쓰던 버그 수정.
+    // new+save / findByIdAndUpdate 모두 스키마 캐스팅(string→ObjectId/Date)은 그대로 적용됨.
     if (options.overwriteExisting) {
-      await config.model.findByIdAndUpdate(docId, processedDoc, { upsert: true, new: true });
+      const { _id, ...rest } = processedDoc;
+      await config.model.findByIdAndUpdate(docId, rest, { upsert: true, new: true, timestamps: false });
     } else {
       const existing = await config.model.findById(docId);
       if (!existing) {
-        processedDoc._id = docId;
-        await config.model.create(processedDoc);
+        const newDoc = new config.model(processedDoc); // _id 포함
+        await newDoc.save({ timestamps: false });
       } else {
         statistics.skipped++;
       }
@@ -132,9 +135,22 @@ async function restoreOneDoc(doc, config, options, statistics) {
 async function restoreCollection(config, tempExtractDir, options, statistics) {
   const ndjsonPath = path.join(tempExtractDir, 'database', `${config.name}.ndjson`);
   const jsonPath = path.join(tempExtractDir, 'database', `${config.name}.json`);
+  const hasNdjson = fs.existsSync(ndjsonPath);
+  const hasJson = !hasNdjson && fs.existsSync(jsonPath);
   let restoredCount = 0;
 
-  if (fs.existsSync(ndjsonPath)) {
+  if (!hasNdjson && !hasJson) {
+    return null; // 해당 컬렉션 파일 없음 — 건드리지 않음
+  }
+
+  // 완전 복제(clean) 모드 (#646): 백업에 포함된 컬렉션만 복원 직전 비우고 백업으로 교체.
+  // 빈 DB 마이그레이션 시 새로 가입한 계정/그룹과 백업의 unique 충돌 제거 + 소유자(_id) 완전 일치.
+  // 파일이 없는 컬렉션은 위에서 이미 return 했으므로 비우지 않음 (구버전 백업 데이터 손실 방지).
+  if (options.cleanRestore) {
+    await config.model.deleteMany({});
+  }
+
+  if (hasNdjson) {
     // 신버전: 한 줄에 문서 1개 — 라인 스트리밍 (메모리 상수)
     const rl = readline.createInterface({
       input: fs.createReadStream(ndjsonPath),
@@ -154,15 +170,13 @@ async function restoreCollection(config, tempExtractDir, options, statistics) {
       await restoreOneDoc(doc, config, options, statistics);
       restoredCount++;
     }
-  } else if (fs.existsSync(jsonPath)) {
-    // 구버전 호환: 통째 JSON 배열
+  } else {
+    // 구버전 호환: 통째 JSON 배열 (hasJson)
     const data = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
     for (const doc of data) {
       await restoreOneDoc(doc, config, options, statistics);
       restoredCount++;
     }
-  } else {
-    return null; // 해당 컬렉션 파일 없음
   }
 
   return restoredCount;

--- a/src/tests/backupStreaming.test.js
+++ b/src/tests/backupStreaming.test.js
@@ -27,14 +27,22 @@ function makeBackupModel(docs) {
   };
 }
 
+// #646: 복원이 model.create() → new Model(doc).save({timestamps:false}) 로 전환됨.
+// 생성자 호출 + save 를 추적하는 mock 모델.
 function makeRestoreModel() {
   const created = [];
-  return {
-    created,
-    create: jest.fn(async (d) => { created.push(d); return d; }),
-    findById: jest.fn(async () => null),
-    findByIdAndUpdate: jest.fn(async () => ({}))
-  };
+  const saveMock = jest.fn(async function () { return this; });
+  const Model = jest.fn().mockImplementation(function (d) {
+    this._input = d;
+    created.push(d);
+    this.save = saveMock;
+  });
+  Model.created = created;
+  Model.saveMock = saveMock;
+  Model.findById = jest.fn(async () => null);
+  Model.findByIdAndUpdate = jest.fn(async () => ({}));
+  Model.deleteMany = jest.fn(async () => ({ deletedCount: 0 }));
+  return Model;
 }
 
 let tmpDir;
@@ -102,7 +110,7 @@ describe('#591 restoreCollection', () => {
     const count = await restoreCollection({ name: 'Coll', model }, tmpDir, {}, stats);
 
     expect(count).toBe(2);
-    expect(model.create).toHaveBeenCalledTimes(2);
+    expect(model.saveMock).toHaveBeenCalledTimes(2);
     expect(stats.errors).toBe(0);
     // _id 보존
     expect(model.created[0]._id).toBe('1');
@@ -114,7 +122,7 @@ describe('#591 restoreCollection', () => {
     const stats = { collectionsRestored: {}, skipped: 0, errors: 0 };
     const count = await restoreCollection({ name: 'Coll', model }, tmpDir, {}, stats);
     expect(count).toBe(2);
-    expect(model.create).toHaveBeenCalledTimes(2);
+    expect(model.saveMock).toHaveBeenCalledTimes(2);
   });
 
   test('구버전 .json 배열도 복구된다 (하위호환)', async () => {
@@ -123,7 +131,7 @@ describe('#591 restoreCollection', () => {
     const stats = { collectionsRestored: {}, skipped: 0, errors: 0 };
     const count = await restoreCollection({ name: 'Legacy', model }, tmpDir, {}, stats);
     expect(count).toBe(3);
-    expect(model.create).toHaveBeenCalledTimes(3);
+    expect(model.saveMock).toHaveBeenCalledTimes(3);
   });
 
   test('파일 없으면 null', async () => {
@@ -138,7 +146,7 @@ describe('#591 restoreCollection', () => {
     model.findById = jest.fn(async () => ({ _id: '1' })); // 이미 존재
     const stats = { collectionsRestored: {}, skipped: 0, errors: 0 };
     await restoreCollection({ name: 'Coll', model }, tmpDir, { overwriteExisting: false }, stats);
-    expect(model.create).not.toHaveBeenCalled();
+    expect(model.saveMock).not.toHaveBeenCalled();
     expect(stats.skipped).toBe(1);
   });
 
@@ -147,7 +155,7 @@ describe('#591 restoreCollection', () => {
     const model = makeRestoreModel();
     const stats = { collectionsRestored: {}, skipped: 0, errors: 0 };
     await restoreCollection({ name: 'Coll', model }, tmpDir, {}, stats);
-    expect(model.create).toHaveBeenCalledTimes(2);
+    expect(model.saveMock).toHaveBeenCalledTimes(2);
     expect(stats.errors).toBe(1);
   });
 });

--- a/src/tests/restoreFidelity.test.js
+++ b/src/tests/restoreFidelity.test.js
@@ -1,0 +1,116 @@
+/**
+ * #646 복원 충실도 — timestamps 보존 + 완전 복제(clean) 모드
+ *  - restoreOneDoc 이 mongoose timestamps 자동 갱신을 끄는지 (원본 createdAt/updatedAt 보존)
+ *  - restoreCollection 이 cleanRestore 시 백업에 있는 컬렉션만 비우는지
+ */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { restoreOneDoc, restoreCollection } = require('../services/restoreService');
+
+// new Model(doc) 생성자 + 정적 메서드를 흉내내는 mock 모델
+function makeModel() {
+  const saveMock = jest.fn().mockResolvedValue(undefined);
+  const Model = jest.fn().mockImplementation(function (doc) {
+    this._input = doc;
+    this.save = saveMock;
+  });
+  Model.findById = jest.fn();
+  Model.findByIdAndUpdate = jest.fn().mockResolvedValue({});
+  Model.deleteMany = jest.fn().mockResolvedValue({ deletedCount: 0 });
+  Model._saveMock = saveMock;
+  return Model;
+}
+
+function freshStats() {
+  return { errors: 0, dbErrors: 0, fileErrors: 0, errorDetails: [], skipped: 0 };
+}
+
+describe('#646 restoreOneDoc — timestamps 보존', () => {
+  test('신규 문서: new Model(doc) + save({ timestamps:false }) — 원본 _id/createdAt 유지', async () => {
+    const Model = makeModel();
+    Model.findById.mockResolvedValue(null);
+    const stats = freshStats();
+
+    const doc = { _id: 'id-1', title: 'x', createdAt: '2020-01-02T03:04:05.000Z' };
+    const ok = await restoreOneDoc(doc, { name: 'GeneratedImage', model: Model }, { overwriteExisting: false }, stats);
+
+    expect(ok).toBe(true);
+    // 생성자에 _id 포함한 원본 doc 그대로 전달 (캐스팅은 mongoose 가 수행)
+    expect(Model).toHaveBeenCalledWith(expect.objectContaining({ _id: 'id-1', createdAt: '2020-01-02T03:04:05.000Z' }));
+    // 핵심: timestamps:false 로 저장 → 복원 시점으로 덮어쓰지 않음
+    expect(Model._saveMock).toHaveBeenCalledWith({ timestamps: false });
+  });
+
+  test('overwriteExisting: findByIdAndUpdate 에 timestamps:false, _id 제외', async () => {
+    const Model = makeModel();
+    const stats = freshStats();
+
+    const doc = { _id: 'id-2', title: 'y', updatedAt: '2021-05-05T00:00:00.000Z' };
+    await restoreOneDoc(doc, { name: 'Workboard', model: Model }, { overwriteExisting: true }, stats);
+
+    expect(Model.findByIdAndUpdate).toHaveBeenCalledTimes(1);
+    const [id, update, opts] = Model.findByIdAndUpdate.mock.calls[0];
+    expect(id).toBe('id-2');
+    expect(update).not.toHaveProperty('_id'); // _id 는 update 본문에서 제외
+    expect(update).toMatchObject({ title: 'y', updatedAt: '2021-05-05T00:00:00.000Z' });
+    expect(opts).toMatchObject({ upsert: true, timestamps: false });
+    expect(Model._saveMock).not.toHaveBeenCalled();
+  });
+
+  test('overwriteExisting=false 이고 이미 존재하면 skip', async () => {
+    const Model = makeModel();
+    Model.findById.mockResolvedValue({ _id: 'id-3' });
+    const stats = freshStats();
+
+    await restoreOneDoc({ _id: 'id-3' }, { name: 'User', model: Model }, { overwriteExisting: false }, stats);
+
+    expect(stats.skipped).toBe(1);
+    expect(Model._saveMock).not.toHaveBeenCalled();
+    expect(Model).not.toHaveBeenCalled(); // 생성자 미호출
+  });
+});
+
+describe('#646 restoreCollection — 완전 복제(clean) 모드', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rc-'));
+    fs.mkdirSync(path.join(tmpDir, 'database'), { recursive: true });
+  });
+  afterEach(() => { try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* noop */ } });
+
+  test('cleanRestore: 백업에 파일이 있는 컬렉션은 deleteMany({}) 후 복원', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'database', 'GeneratedImage.ndjson'), JSON.stringify({ _id: 'a' }) + '\n');
+    const Model = makeModel();
+    Model.findById.mockResolvedValue(null);
+    const stats = freshStats();
+
+    const count = await restoreCollection({ name: 'GeneratedImage', model: Model }, tmpDir, { cleanRestore: true, overwriteExisting: false }, stats);
+
+    expect(Model.deleteMany).toHaveBeenCalledWith({});
+    expect(count).toBe(1);
+    expect(Model._saveMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('cleanRestore: 백업에 파일이 없는 컬렉션은 비우지 않고 null 반환 (구버전 백업 손실 방지)', async () => {
+    const Model = makeModel();
+    const stats = freshStats();
+
+    const count = await restoreCollection({ name: 'Missing', model: Model }, tmpDir, { cleanRestore: true }, stats);
+
+    expect(count).toBeNull();
+    expect(Model.deleteMany).not.toHaveBeenCalled();
+  });
+
+  test('cleanRestore 미설정 시 deleteMany 호출 안 함', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'database', 'Tag.ndjson'), JSON.stringify({ _id: 'a' }) + '\n');
+    const Model = makeModel();
+    Model.findById.mockResolvedValue(null);
+    const stats = freshStats();
+
+    await restoreCollection({ name: 'Tag', model: Model }, tmpDir, { overwriteExisting: false }, stats);
+
+    expect(Model.deleteMany).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 배경
본서버 이전(빈 DB → 백업 복원)에서 복원은 `completed` 로 끝나고 데이터도 전부 들어왔으나:
1. 시스템 통계의 생성시간이 전부 복원 시점으로 잡힘
2. 내 콘텐츠/작업 히스토리가 안 보임 (소유자 불일치)

## 원인
1. `restoreOneDoc` 이 `model.create()`/`findByIdAndUpdate()` 를 기본(`timestamps:true`)으로 호출 → `createdAt`/`updatedAt` 이 복원 시점으로 덮어써짐. (백업엔 원본 시각 보존돼 있음)
2. 빈 DB 에 admin 이 먼저 가입 → 백업 admin 은 email unique 충돌로 복원 실패 → 콘텐츠 owner `_id` 가 DB 에 없어 안 보임 (errorDetails 에 User dup email, Group dup name "기본" 확인됨)

## 변경
- **timestamps 보존**: `new Model(doc).save({ timestamps:false })` / `findByIdAndUpdate(..., { timestamps:false })`. mongoose 캐스팅(string→ObjectId/Date)은 유지.
- **완전 복제(clean) 모드**: `options.cleanRestore`. 백업에 파일이 있는 컬렉션만 복원 직전 `deleteMany({})` 후 교체 → unique 충돌 제거 + 소유자 완전 일치. 파일 없는 컬렉션은 비우지 않음(구버전 백업 손실 방지).
- `RestoreJob.options` 스키마에 `cleanRestore`/`skipSnapshot` 추가.
- 프론트 복원 다이얼로그: "기존 데이터를 모두 지우고 완전히 교체" + "복원 전 자동 스냅샷 생략" 옵션. 완전 교체 시 강한 경고(백업 계정으로 재로그인 안내). 복구 히스토리에 칩 표시.

## 테스트
- `restoreFidelity.test.js` 신규 6건 (timestamps:false 전달, _id 제외, skip, cleanRestore deleteMany 범위)
- `backupStreaming.test.js` mock 을 `new Model+save` 동작에 맞게 갱신
- 전체 jest 234 green

## 사용법 (본서버 재복원)
새 서버는 빈 DB 이므로 복원 다이얼로그에서 **"완전 교체"** 체크 → 백업으로 깨끗이 교체됨. 복원 후 백업에 들어있던 관리자 계정/비밀번호로 로그인.

closes #646
