### PR TITLE
fix: 백업/복원 진행 폴링을 작업 종류 기준으로 (#648)

### DIFF
--- a/frontend/src/pages/admin/BackupRestorePage.js
+++ b/frontend/src/pages/admin/BackupRestorePage.js
@@ -100,6 +100,8 @@ function BackupRestorePage() {
   const [uploadedFile, setUploadedFile] = useState(null);
   const [validationResult, setValidationResult] = useState(null);
   const [activeJobId, setActiveJobId] = useState(null);
+  // 진행 중인 작업 종류 — 폴링 대상 API 를 현재 탭이 아니라 작업 종류로 결정 (#648)
+  const [activeJobType, setActiveJobType] = useState(null); // 'backup' | 'restore'
   const [restoreMode, setRestoreMode] = useState('server'); // 'server' | 'upload' (#634)
   const [selectedServerFile, setSelectedServerFile] = useState('');
   const fileInputRef = useRef(null);
@@ -119,15 +121,17 @@ function BackupRestorePage() {
 
     const checkStatus = async () => {
       try {
-        const response = tabValue === 0
+        // 폴링 대상은 현재 탭이 아니라 진행 중인 작업의 종류로 결정 (#648)
+        const response = activeJobType === 'backup'
           ? await backupAPI.getStatus(activeJobId)
           : await backupAPI.getRestoreStatus(activeJobId);
 
         const job = response.data.data;
         if (job.status === 'completed' || job.status === 'failed') {
           setActiveJobId(null);
+          setActiveJobType(null);
           if (job.status === 'completed') {
-            toast.success(tabValue === 0 ? '백업이 완료되었습니다!' : '복구가 완료되었습니다!');
+            toast.success(activeJobType === 'backup' ? '백업이 완료되었습니다!' : '복구가 완료되었습니다!');
           } else {
             toast.error(job.error?.message || '작업이 실패했습니다.');
           }
@@ -141,13 +145,14 @@ function BackupRestorePage() {
 
     const interval = setInterval(checkStatus, 2000);
     return () => clearInterval(interval);
-  }, [activeJobId, tabValue, refetchBackups, refetchRestores]);
+  }, [activeJobId, activeJobType, refetchBackups, refetchRestores]);
 
   // 백업 생성
   const createBackupMutation = useMutation({ mutationFn: () => backupAPI.create(),
       onSuccess: (response) => {
         const jobId = response.data.data.jobId;
         setActiveJobId(jobId);
+        setActiveJobType('backup');
         toast.success('백업이 시작되었습니다.');
         refetchBackups();
       },
@@ -187,6 +192,7 @@ function BackupRestorePage() {
       onSuccess: (response) => {
         const jobId = response.data.data.jobId;
         setActiveJobId(jobId);
+        setActiveJobType('restore');
         toast.success('복구가 시작되었습니다.');
         setRestoreDialogOpen(false);
         setUploadedFile(null);


### PR DESCRIPTION
## 증상
복원 실행 시 "백업 작업을 찾을 수 없습니다" 404 토스트가 2초마다 무한 반복(새로고침해야 멈춤). 작업 자체는 정상 완료.

## 원인
폴링이 현재 탭(`tabValue`)으로 status API 를 선택 → "백업 목록" 탭에서 복원 실행 시 복원 jobId 로 백업 status 호출 → 404. activeJobId 해제도 안 돼 폴링 지속, axios 에러 인터셉터가 토스트 스팸.

## 해결
`activeJobType`('backup'|'restore') 상태 추가. 백업/복원 시작 시 종류 설정, 폴링·완료 토스트·상태 해제를 모두 작업 종류 기준으로. tabValue 의존 제거.

## 검증
- frontend `--no-cache` 빌드 통과. 알파 recreate 후 실 UI 재테스트 예정.
- 프론트 단위 테스트 인프라 없음(e2e 만) → 알파 실사용 확인.

closes #648