### PR TITLE
feat: 복원 진행 모달 + 완료 후 캐시/큐 무효화 (#650)

### DIFF
--- a/frontend/src/pages/admin/BackupRestorePage.js
+++ b/frontend/src/pages/admin/BackupRestorePage.js
@@ -37,7 +37,7 @@ import {
   Pending,
   Refresh
 } from '@mui/icons-material';
-import { useQuery, useMutation } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { backupAPI } from '../../services/api';
 import Pagination from '../../components/common/Pagination';
@@ -102,6 +102,9 @@ function BackupRestorePage() {
   const [activeJobId, setActiveJobId] = useState(null);
   // 진행 중인 작업 종류 — 폴링 대상 API 를 현재 탭이 아니라 작업 종류로 결정 (#648)
   const [activeJobType, setActiveJobType] = useState(null); // 'backup' | 'restore'
+  const [activeJobProgress, setActiveJobProgress] = useState(null); // {current,total,stage} 복원 진행 모달용 (#650)
+  const cleanRestoreRef = useRef(false); // 마지막 복원이 완전 교체였는지 (완료 후 안내 분기) (#650)
+  const queryClient = useQueryClient();
   const [restoreMode, setRestoreMode] = useState('server'); // 'server' | 'upload' (#634)
   const [selectedServerFile, setSelectedServerFile] = useState('');
   const fileInputRef = useRef(null);
@@ -127,9 +130,33 @@ function BackupRestorePage() {
           : await backupAPI.getRestoreStatus(activeJobId);
 
         const job = response.data.data;
+        // 복원 진행 모달용 진행률 갱신 (#650)
+        if (activeJobType === 'restore') {
+          setActiveJobProgress({
+            current: job.progress?.current,
+            total: job.progress?.total,
+            stage: job.progress?.stage
+          });
+        }
+
         if (job.status === 'completed' || job.status === 'failed') {
           setActiveJobId(null);
           setActiveJobType(null);
+
+          // 복원 완료: 캐시를 비우고 페이지 리로드 (#650).
+          // 완전 교체였으면 계정 _id 가 백업 것으로 바뀌어 리로드 후 첫 요청이 401 → 자동 /login.
+          if (activeJobType === 'restore' && job.status === 'completed') {
+            queryClient.clear();
+            toast.success(
+              cleanRestoreRef.current
+                ? '복원 완료! 잠시 후 새로고침되며, 백업에 든 계정으로 다시 로그인해주세요.'
+                : '복구 완료! 잠시 후 새로고침됩니다.'
+            );
+            setTimeout(() => window.location.reload(), 1800);
+            return;
+          }
+
+          setActiveJobProgress(null);
           if (job.status === 'completed') {
             toast.success(activeJobType === 'backup' ? '백업이 완료되었습니다!' : '복구가 완료되었습니다!');
           } else {
@@ -145,7 +172,7 @@ function BackupRestorePage() {
 
     const interval = setInterval(checkStatus, 2000);
     return () => clearInterval(interval);
-  }, [activeJobId, activeJobType, refetchBackups, refetchRestores]);
+  }, [activeJobId, activeJobType, queryClient, refetchBackups, refetchRestores]);
 
   // 백업 생성
   const createBackupMutation = useMutation({ mutationFn: () => backupAPI.create(),
@@ -265,6 +292,8 @@ function BackupRestorePage() {
   const handleRestoreExecute = () => {
     if (!validationResult) return;
 
+    cleanRestoreRef.current = !!restoreOptions.cleanRestore; // 완료 후 안내 분기용 (#650)
+    setActiveJobProgress(null);
     restoreMutation.mutate({
       jobId: validationResult.jobId,
       options: restoreOptions
@@ -793,6 +822,41 @@ function BackupRestorePage() {
             복구 실행
           </Button>
         </DialogActions>
+      </Dialog>
+
+      {/* 복원 진행 모달 (#650) — 닫기 불가, 완료 시 캐시 비우고 자동 리로드 */}
+      <Dialog
+        open={activeJobType === 'restore' && !!activeJobId}
+        disableEscapeKeyDown
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Restore />
+            복원 진행 중
+          </Box>
+        </DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" sx={{ mb: 2 }}>
+            데이터를 복원하고 있습니다. 완료될 때까지 이 창을 닫거나 새로고침하지 마세요.
+            {cleanRestoreRef.current && ' 완료 후 백업에 든 계정으로 다시 로그인하게 됩니다.'}
+          </Typography>
+          <LinearProgress
+            variant={activeJobProgress?.total ? 'determinate' : 'indeterminate'}
+            value={
+              activeJobProgress?.total
+                ? Math.min(100, (activeJobProgress.current / activeJobProgress.total) * 100)
+                : undefined
+            }
+          />
+          <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
+            {activeJobProgress?.stage || '준비 중...'}
+            {activeJobProgress?.total
+              ? ` (${activeJobProgress.current || 0}/${activeJobProgress.total})`
+              : ''}
+          </Typography>
+        </DialogContent>
       </Dialog>
     </Box>
   );

--- a/src/services/backupCollections.js
+++ b/src/services/backupCollections.js
@@ -43,6 +43,10 @@ const GeneratedText = require('../models/GeneratedText');
 const PipelineRun = require('../models/PipelineRun');
 const ApiKey = require('../models/ApiKey');
 const SystemSettings = require('../models/SystemSettings');
+// 백업 비대상 캐시 컬렉션 (재생성 가능) — 완전 교체 복원 시 비워 새 DB 와의 불일치 방지 (#650)
+const LoraCache = require('../models/LoraCache');
+const ServerLoraCache = require('../models/ServerLoraCache');
+const ServerModelCache = require('../models/ServerModelCache');
 
 const BACKUP_COLLECTIONS = [
   // 참조 대상 (사용자 / 그룹 / 태그 / 서버)
@@ -69,4 +73,12 @@ const BACKUP_COLLECTIONS = [
   { name: 'SystemSettings', model: SystemSettings, encryptFields: ['external.civitaiApiKey', 'lora.civitaiApiKey'] },
 ];
 
-module.exports = { BACKUP_COLLECTIONS };
+// 백업 비대상 캐시 컬렉션 (#650). 완전 교체(cleanRestore) 복원 시에만 비운다.
+// 서버 모델/LoRA 동기화로 재생성되며, 옛 캐시가 복원된 새 Server 와 불일치하는 것을 방지.
+const CACHE_COLLECTIONS = [
+  { name: 'LoraCache', model: LoraCache },
+  { name: 'ServerLoraCache', model: ServerLoraCache },
+  { name: 'ServerModelCache', model: ServerModelCache },
+];
+
+module.exports = { BACKUP_COLLECTIONS, CACHE_COLLECTIONS };

--- a/src/services/pipelineRunService.js
+++ b/src/services/pipelineRunService.js
@@ -338,9 +338,23 @@ const closePipelineRunQueue = async () => {
   console.log('🛑 Pipeline run queue closed');
 };
 
+// 복원 완료 후 큐 전체 비우기 (#650) — best-effort.
+const clearPipelineRunQueue = async () => {
+  if (!pipelineRunQueue) return { cleared: false, reason: 'not-initialized' };
+  try {
+    await pipelineRunQueue.obliterate({ force: true });
+    console.log('🧹 pipeline run 큐 정리 완료 (복원 후)');
+    return { cleared: true };
+  } catch (error) {
+    console.error('pipeline run 큐 정리 실패:', error.message);
+    return { cleared: false, error: error.message };
+  }
+};
+
 module.exports = {
   initPipelineRunQueue,
   startPipelineRun,
   retryPipelineRun,
   closePipelineRunQueue,
+  clearPipelineRunQueue,
 };

--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -1127,6 +1127,20 @@ const closeQueues = async () => {
   console.log('🛑 Image generation queue closed');
 };
 
+// 복원 완료 후 큐 전체 비우기 (#650) — 복원 중 전면 차단(backupLock)이라 in-flight 없음.
+// 옛 작업/이력이 복원된 새 DB 의 _id 와 안 맞으므로 정리. best-effort.
+const clearImageGenerationQueue = async () => {
+  if (!imageGenerationQueue) return { cleared: false, reason: 'not-initialized' };
+  try {
+    await imageGenerationQueue.obliterate({ force: true });
+    console.log('🧹 image generation 큐 정리 완료 (복원 후)');
+    return { cleared: true };
+  } catch (error) {
+    console.error('image generation 큐 정리 실패:', error.message);
+    return { cleared: false, error: error.message };
+  }
+};
+
 module.exports = {
   initializeQueues,
   addImageGenerationJob,
@@ -1134,5 +1148,6 @@ module.exports = {
   cancelQueueJob,
   abortActiveJob,
   closeQueues,
+  clearImageGenerationQueue,
   imageGenerationQueue
 };

--- a/src/services/restoreService.js
+++ b/src/services/restoreService.js
@@ -9,7 +9,7 @@ const { ENCRYPTION_KEY } = backupService;
 
 // 복원 대상 컬렉션 — backup/restore 공유 단일 소스 (#588).
 // 복호화 대상은 백업 시 암호화한 필드(encryptFields)와 동일하게 적용.
-const { BACKUP_COLLECTIONS } = require('./backupCollections');
+const { BACKUP_COLLECTIONS, CACHE_COLLECTIONS } = require('./backupCollections');
 
 const UPLOAD_DIR = process.env.UPLOAD_PATH || './uploads';
 const TEMP_DIR = process.env.TEMP_PATH || path.join(UPLOAD_DIR, 'restore-temp');
@@ -425,6 +425,28 @@ async function executeRestore(jobId, zipPath, options = {}) {
 
     // 임시 디렉토리 정리
     fs.rmSync(tempExtractDir, { recursive: true, force: true });
+
+    // 완전 교체(clean) 복원: 백업 비대상 캐시 컬렉션도 비워 새 DB 와 불일치 방지 (#650).
+    // best-effort — 실패해도 복원 자체는 성공으로 처리. 서버 모델/LoRA 동기화로 재생성됨.
+    if (options.cleanRestore && !options.skipDatabase) {
+      for (const c of CACHE_COLLECTIONS) {
+        try {
+          await c.model.deleteMany({});
+          console.log(`🧹 캐시 컬렉션 비움(완전 교체): ${c.name}`);
+        } catch (cacheErr) {
+          console.error(`캐시 컬렉션 ${c.name} 정리 실패:`, cacheErr.message);
+        }
+      }
+    }
+
+    // 복원 후 작업 큐 비우기 (#650) — 복원 중 전면 차단이라 in-flight 없음.
+    // 옛 큐 작업/이력이 복원된 새 DB 와 안 맞으므로 정리. best-effort, 지연 require 로 순환 회피.
+    try {
+      await require('./queueService').clearImageGenerationQueue();
+      await require('./pipelineRunService').clearPipelineRunQueue();
+    } catch (queueErr) {
+      console.error('복원 후 큐 정리 실패:', queueErr.message);
+    }
 
     await job.complete(statistics);
 

--- a/src/tests/restoreCleanup.test.js
+++ b/src/tests/restoreCleanup.test.js
@@ -1,0 +1,33 @@
+/**
+ * #650 복원 완료 후 정리 — 캐시 컬렉션 구성 + 큐 정리 안전성
+ */
+const { BACKUP_COLLECTIONS, CACHE_COLLECTIONS } = require('../services/backupCollections');
+const queueService = require('../services/queueService');
+const pipelineRunService = require('../services/pipelineRunService');
+
+describe('#650 CACHE_COLLECTIONS', () => {
+  test('3개 캐시 모델(LoraCache/ServerLoraCache/ServerModelCache), name/model 보유', () => {
+    expect(CACHE_COLLECTIONS.map((c) => c.name).sort()).toEqual(['LoraCache', 'ServerLoraCache', 'ServerModelCache']);
+    CACHE_COLLECTIONS.forEach((c) => {
+      expect(c.model).toBeTruthy();
+      expect(typeof c.model.deleteMany).toBe('function');
+    });
+  });
+
+  test('백업 대상(BACKUP_COLLECTIONS)과 겹치지 않음 (캐시는 백업 비대상)', () => {
+    const backupNames = new Set(BACKUP_COLLECTIONS.map((c) => c.name));
+    CACHE_COLLECTIONS.forEach((c) => expect(backupNames.has(c.name)).toBe(false));
+  });
+});
+
+describe('#650 복원 후 큐 정리 (미초기화 시 안전)', () => {
+  test('clearImageGenerationQueue 는 큐 미초기화 상태에서 던지지 않고 cleared:false', async () => {
+    const r = await queueService.clearImageGenerationQueue();
+    expect(r.cleared).toBe(false);
+  });
+
+  test('clearPipelineRunQueue 는 큐 미초기화 상태에서 던지지 않고 cleared:false', async () => {
+    const r = await pipelineRunService.clearPipelineRunQueue();
+    expect(r.cleared).toBe(false);
+  });
+});


### PR DESCRIPTION
## 범위
복원(DB 전체 교체) UX 정비. #648(폴링 종류 기반)에 이어:

### 프론트엔드
- 복원 시작 시 **진행 전용 모달**(닫기 불가, 진행률 막대 + 단계). RestoreJob.progress 폴링 표시.
- 완료 시 `queryClient.clear()` + 페이지 리로드. 완전 교체였으면 리로드 후 첫 요청 401 → 자동 `/login`. 토스트만 완전교체/일반 분기.

### 백엔드 (복원 완료 후, best-effort)
- Bull 큐 2개(`image generation`/`pipeline run`) `obliterate` — 복원 중 전면 차단이라 in-flight 없음.
- 완전 교체 시 백업 비대상 캐시 컬렉션(LoraCache/ServerLoraCache/ServerModelCache) 비움 → 모델 동기화로 재생성. `CACHE_COLLECTIONS` 단일 소스.

## 테스트
- `restoreCleanup.test.js` 4건(캐시 컬렉션 구성·BACKUP과 중복배제, 큐 정리 미초기화 안전)
- 전체 jest 238 green, frontend `--no-cache` 빌드 통과

closes #650