### PR TITLE
fix: 복원 시 비밀번호 이중해싱 — 신규 삽입을 native insert 로 (#655)

### DIFF
--- a/src/services/restoreService.js
+++ b/src/services/restoreService.js
@@ -105,17 +105,18 @@ async function restoreOneDoc(doc, config, options, statistics) {
 
     docId = processedDoc._id;
 
-    // timestamps: false 로 백업 원본 createdAt/updatedAt 을 보존 (#646).
-    // mongoose timestamps:true 기본 동작이 복원 시점으로 덮어쓰던 버그 수정.
-    // new+save / findByIdAndUpdate 모두 스키마 캐스팅(string→ObjectId/Date)은 그대로 적용됨.
+    // 캐스팅(string→ObjectId/Date)은 mongoose 로, 저장은 native driver 로.
+    // pre('save') 훅(User 비밀번호 bcrypt 재해싱 등)을 우회해 백업 원본을 그대로 보존 (#655).
+    // native insert 라 timestamps 자동설정도 없음 → 원본 createdAt/updatedAt 유지 (#646).
     if (options.overwriteExisting) {
       const { _id, ...rest } = processedDoc;
       await config.model.findByIdAndUpdate(docId, rest, { upsert: true, new: true, timestamps: false });
     } else {
       const existing = await config.model.findById(docId);
       if (!existing) {
-        const newDoc = new config.model(processedDoc); // _id 포함
-        await newDoc.save({ timestamps: false });
+        // new Model() 은 캐스팅/기본값만 적용(저장 아님) → toObject 후 native insert 로 훅 우회
+        const casted = new config.model(processedDoc).toObject({ depopulate: true });
+        await config.model.collection.insertOne(casted);
       } else {
         statistics.skipped++;
       }

--- a/src/tests/backupStreaming.test.js
+++ b/src/tests/backupStreaming.test.js
@@ -27,18 +27,18 @@ function makeBackupModel(docs) {
   };
 }
 
-// #646: 복원이 model.create() → new Model(doc).save({timestamps:false}) 로 전환됨.
-// 생성자 호출 + save 를 추적하는 mock 모델.
+// #655: 복원 신규 삽입이 new Model(doc).save() → new Model(doc).toObject() + collection.insertOne 으로 전환됨
+// (저장 훅 우회로 비밀번호 이중해싱 방지). 생성자 + native insert 를 추적하는 mock 모델.
 function makeRestoreModel() {
-  const created = [];
-  const saveMock = jest.fn(async function () { return this; });
+  const inserted = [];
+  const insertOneMock = jest.fn(async (d) => { inserted.push(d); return { acknowledged: true }; });
   const Model = jest.fn().mockImplementation(function (d) {
     this._input = d;
-    created.push(d);
-    this.save = saveMock;
+    this.toObject = () => ({ ...d });
   });
-  Model.created = created;
-  Model.saveMock = saveMock;
+  Model.inserted = inserted;
+  Model.insertOneMock = insertOneMock;
+  Model.collection = { insertOne: insertOneMock };
   Model.findById = jest.fn(async () => null);
   Model.findByIdAndUpdate = jest.fn(async () => ({}));
   Model.deleteMany = jest.fn(async () => ({ deletedCount: 0 }));
@@ -110,10 +110,10 @@ describe('#591 restoreCollection', () => {
     const count = await restoreCollection({ name: 'Coll', model }, tmpDir, {}, stats);
 
     expect(count).toBe(2);
-    expect(model.saveMock).toHaveBeenCalledTimes(2);
+    expect(model.insertOneMock).toHaveBeenCalledTimes(2);
     expect(stats.errors).toBe(0);
     // _id 보존
-    expect(model.created[0]._id).toBe('1');
+    expect(model.inserted[0]._id).toBe('1');
   });
 
   test('빈 줄은 건너뛴다', async () => {
@@ -122,7 +122,7 @@ describe('#591 restoreCollection', () => {
     const stats = { collectionsRestored: {}, skipped: 0, errors: 0 };
     const count = await restoreCollection({ name: 'Coll', model }, tmpDir, {}, stats);
     expect(count).toBe(2);
-    expect(model.saveMock).toHaveBeenCalledTimes(2);
+    expect(model.insertOneMock).toHaveBeenCalledTimes(2);
   });
 
   test('구버전 .json 배열도 복구된다 (하위호환)', async () => {
@@ -131,7 +131,7 @@ describe('#591 restoreCollection', () => {
     const stats = { collectionsRestored: {}, skipped: 0, errors: 0 };
     const count = await restoreCollection({ name: 'Legacy', model }, tmpDir, {}, stats);
     expect(count).toBe(3);
-    expect(model.saveMock).toHaveBeenCalledTimes(3);
+    expect(model.insertOneMock).toHaveBeenCalledTimes(3);
   });
 
   test('파일 없으면 null', async () => {
@@ -146,7 +146,7 @@ describe('#591 restoreCollection', () => {
     model.findById = jest.fn(async () => ({ _id: '1' })); // 이미 존재
     const stats = { collectionsRestored: {}, skipped: 0, errors: 0 };
     await restoreCollection({ name: 'Coll', model }, tmpDir, { overwriteExisting: false }, stats);
-    expect(model.saveMock).not.toHaveBeenCalled();
+    expect(model.insertOneMock).not.toHaveBeenCalled();
     expect(stats.skipped).toBe(1);
   });
 
@@ -155,7 +155,7 @@ describe('#591 restoreCollection', () => {
     const model = makeRestoreModel();
     const stats = { collectionsRestored: {}, skipped: 0, errors: 0 };
     await restoreCollection({ name: 'Coll', model }, tmpDir, {}, stats);
-    expect(model.saveMock).toHaveBeenCalledTimes(2);
+    expect(model.insertOneMock).toHaveBeenCalledTimes(2);
     expect(stats.errors).toBe(1);
   });
 });

--- a/src/tests/restoreFidelity.test.js
+++ b/src/tests/restoreFidelity.test.js
@@ -1,7 +1,9 @@
 /**
- * #646 복원 충실도 — timestamps 보존 + 완전 복제(clean) 모드
- *  - restoreOneDoc 이 mongoose timestamps 자동 갱신을 끄는지 (원본 createdAt/updatedAt 보존)
- *  - restoreCollection 이 cleanRestore 시 백업에 있는 컬렉션만 비우는지
+ * #646/#655 복원 충실도 — 원본 보존(시각/비밀번호) + 완전 복제(clean) 모드
+ *  - restoreOneDoc 신규 삽입은 native insert(collection.insertOne)로 저장 훅 우회
+ *    → User 비밀번호(이미 bcrypt 해시) 재해싱 방지(이중해싱), createdAt 원본 보존
+ *  - overwriteExisting 은 findByIdAndUpdate(timestamps:false)
+ *  - restoreCollection cleanRestore 는 백업에 있는 컬렉션만 비움
  */
 const fs = require('fs');
 const os = require('os');
@@ -9,17 +11,19 @@ const path = require('path');
 
 const { restoreOneDoc, restoreCollection } = require('../services/restoreService');
 
-// new Model(doc) 생성자 + 정적 메서드를 흉내내는 mock 모델
+// new Model(doc).toObject() + 정적 메서드 + native collection.insertOne 을 흉내내는 mock 모델
 function makeModel() {
-  const saveMock = jest.fn().mockResolvedValue(undefined);
+  const insertOneMock = jest.fn().mockResolvedValue({ acknowledged: true });
   const Model = jest.fn().mockImplementation(function (doc) {
     this._input = doc;
-    this.save = saveMock;
+    // 실제 mongoose 는 캐스팅하지만 테스트에선 입력을 그대로 POJO 로 반환
+    this.toObject = () => ({ ...doc });
   });
+  Model.collection = { insertOne: insertOneMock };
   Model.findById = jest.fn();
   Model.findByIdAndUpdate = jest.fn().mockResolvedValue({});
   Model.deleteMany = jest.fn().mockResolvedValue({ deletedCount: 0 });
-  Model._saveMock = saveMock;
+  Model._insertOne = insertOneMock;
   return Model;
 }
 
@@ -27,20 +31,30 @@ function freshStats() {
   return { errors: 0, dbErrors: 0, fileErrors: 0, errorDetails: [], skipped: 0 };
 }
 
-describe('#646 restoreOneDoc — timestamps 보존', () => {
-  test('신규 문서: new Model(doc) + save({ timestamps:false }) — 원본 _id/createdAt 유지', async () => {
+describe('#655 restoreOneDoc — native insert 로 저장 훅 우회(이중해싱 방지) + 원본 보존', () => {
+  test('신규 문서: collection.insertOne 으로 저장, _id/createdAt/해시 비밀번호 원본 그대로', async () => {
     const Model = makeModel();
     Model.findById.mockResolvedValue(null);
     const stats = freshStats();
 
-    const doc = { _id: 'id-1', title: 'x', createdAt: '2020-01-02T03:04:05.000Z' };
-    const ok = await restoreOneDoc(doc, { name: 'GeneratedImage', model: Model }, { overwriteExisting: false }, stats);
+    const doc = {
+      _id: 'id-1',
+      title: 'x',
+      createdAt: '2020-01-02T03:04:05.000Z',
+      password: '$2b$10$AlreadyHashedValueeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+    };
+    const ok = await restoreOneDoc(doc, { name: 'User', model: Model }, { overwriteExisting: false }, stats);
 
     expect(ok).toBe(true);
-    // 생성자에 _id 포함한 원본 doc 그대로 전달 (캐스팅은 mongoose 가 수행)
-    expect(Model).toHaveBeenCalledWith(expect.objectContaining({ _id: 'id-1', createdAt: '2020-01-02T03:04:05.000Z' }));
-    // 핵심: timestamps:false 로 저장 → 복원 시점으로 덮어쓰지 않음
-    expect(Model._saveMock).toHaveBeenCalledWith({ timestamps: false });
+    // native insert 사용 — mongoose save() 훅 미실행
+    expect(Model._insertOne).toHaveBeenCalledTimes(1);
+    const inserted = Model._insertOne.mock.calls[0][0];
+    expect(inserted).toMatchObject({
+      _id: 'id-1',
+      createdAt: '2020-01-02T03:04:05.000Z',
+      // 이미 해시된 비밀번호가 그대로 — 재해싱(이중해싱) 안 됨
+      password: '$2b$10$AlreadyHashedValueeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+    });
   });
 
   test('overwriteExisting: findByIdAndUpdate 에 timestamps:false, _id 제외', async () => {
@@ -53,13 +67,13 @@ describe('#646 restoreOneDoc — timestamps 보존', () => {
     expect(Model.findByIdAndUpdate).toHaveBeenCalledTimes(1);
     const [id, update, opts] = Model.findByIdAndUpdate.mock.calls[0];
     expect(id).toBe('id-2');
-    expect(update).not.toHaveProperty('_id'); // _id 는 update 본문에서 제외
+    expect(update).not.toHaveProperty('_id');
     expect(update).toMatchObject({ title: 'y', updatedAt: '2021-05-05T00:00:00.000Z' });
     expect(opts).toMatchObject({ upsert: true, timestamps: false });
-    expect(Model._saveMock).not.toHaveBeenCalled();
+    expect(Model._insertOne).not.toHaveBeenCalled();
   });
 
-  test('overwriteExisting=false 이고 이미 존재하면 skip', async () => {
+  test('overwriteExisting=false 이고 이미 존재하면 skip (insert 안 함)', async () => {
     const Model = makeModel();
     Model.findById.mockResolvedValue({ _id: 'id-3' });
     const stats = freshStats();
@@ -67,8 +81,7 @@ describe('#646 restoreOneDoc — timestamps 보존', () => {
     await restoreOneDoc({ _id: 'id-3' }, { name: 'User', model: Model }, { overwriteExisting: false }, stats);
 
     expect(stats.skipped).toBe(1);
-    expect(Model._saveMock).not.toHaveBeenCalled();
-    expect(Model).not.toHaveBeenCalled(); // 생성자 미호출
+    expect(Model._insertOne).not.toHaveBeenCalled();
   });
 });
 
@@ -90,7 +103,7 @@ describe('#646 restoreCollection — 완전 복제(clean) 모드', () => {
 
     expect(Model.deleteMany).toHaveBeenCalledWith({});
     expect(count).toBe(1);
-    expect(Model._saveMock).toHaveBeenCalledTimes(1);
+    expect(Model._insertOne).toHaveBeenCalledTimes(1);
   });
 
   test('cleanRestore: 백업에 파일이 없는 컬렉션은 비우지 않고 null 반환 (구버전 백업 손실 방지)', async () => {


### PR DESCRIPTION
## 증상
완전 교체 복원 후 복원된 관리자로 로그인 시 "비밀번호 틀림". 다른 데이터는 정상.

## 원인
복원 신규 삽입 `new Model(doc).save()` 가 `User` `pre('save')` 훅을 타 **이미 bcrypt 해시인 백업 password 를 한 번 더 해싱**(이중해싱). #646 완전 교체로 admin 이 처음 제대로 복원되며 발현. (overwrite 경로 findByIdAndUpdate 는 save 훅 미실행이라 무관)

## 해결
신규 삽입을 native insert 로:
```js
const casted = new config.model(doc).toObject({ depopulate: true }); // 캐스팅+기본값
await config.model.collection.insertOne(casted); // 저장 훅 우회, timestamps 자동설정 없음 → 원본 보존
```
pre('save') 훅(비밀번호 재해싱 등 모든 저장 부작용)을 우회하면서 캐스팅·생성시각 보존은 유지.

## 테스트
- restoreFidelity: 신규삽입=collection.insertOne, 해시 password 원본 보존, overwrite=findByIdAndUpdate
- backupStreaming mock 갱신. 전체 jest 238 green.

## 운영
본서버는 password 만 영향 → 재복원 없이 admin 비밀번호 리셋으로 즉시 복구 가능.

closes #655