### PR TITLE
fix: User 삭제 시 cascade 누락 모델 보강 (#660)

### DIFF
--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -8,6 +8,7 @@ const UploadedImage = require('../models/UploadedImage');
 const SystemSettings = require('../models/SystemSettings');
 const ApiKey = require('../models/ApiKey');
 const { escapeRegex } = require('../utils/escapeRegex');
+const { deleteUserAndContent } = require('../services/userDeletionService');
 const router = express.Router();
 
 router.get('/users', requireAdmin, async (req, res) => {
@@ -129,14 +130,9 @@ router.delete('/users/:id', requireAdmin, async (req, res) => {
       return res.status(404).json({ message: 'User not found' });
     }
     
-    await Promise.all([
-      ImageGenerationJob.deleteMany({ userId }),
-      GeneratedImage.deleteMany({ userId }),
-      UploadedImage.deleteMany({ userId }),
-      ApiKey.deleteMany({ userId }),
-      User.findByIdAndDelete(userId)
-    ]);
-    
+    // 개인 콘텐츠 cascade 삭제 — 단일 헬퍼로 통합 (영상/대화/텍스트 등 누락 방지, #660)
+    await deleteUserAndContent(userId);
+
     res.json({ message: 'User deleted successfully' });
   } catch (error) {
     res.status(500).json({ message: error.message });

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -2,6 +2,7 @@ const express = require('express');
 const { requireAuth } = require('../middleware/auth');
 const User = require('../models/User');
 const ApiKey = require('../models/ApiKey');
+const { deleteUserAndContent } = require('../services/userDeletionService');
 const router = express.Router();
 
 router.get('/profile', requireAuth, (req, res) => {
@@ -123,17 +124,8 @@ router.get('/stats', requireAuth, async (req, res) => {
 
 router.delete('/account', requireAuth, async (req, res) => {
   try {
-    const ImageGenerationJob = require('../models/ImageGenerationJob');
-    const GeneratedImage = require('../models/GeneratedImage');
-    const UploadedImage = require('../models/UploadedImage');
-    
-    await Promise.all([
-      ImageGenerationJob.deleteMany({ userId: req.user._id }),
-      GeneratedImage.deleteMany({ userId: req.user._id }),
-      UploadedImage.deleteMany({ userId: req.user._id }),
-      ApiKey.deleteMany({ userId: req.user._id }),
-      User.findByIdAndDelete(req.user._id)
-    ]);
+    // 개인 콘텐츠 cascade 삭제 — 단일 헬퍼로 통합 (영상/대화/텍스트 등 누락 방지, #660)
+    await deleteUserAndContent(req.user._id);
 
     res.json({ message: 'Account deleted successfully' });
   } catch (error) {

--- a/src/services/userDeletionService.js
+++ b/src/services/userDeletionService.js
@@ -1,0 +1,48 @@
+/**
+ * User 삭제 + 개인 콘텐츠 cascade 정리 (#660).
+ *
+ * 사용자 본인 삭제(routes/users.js DELETE /account)와 관리자 삭제(routes/admin.js
+ * DELETE /users/:id)가 각자 삭제 목록을 하드코딩하다 drift 가 생겨, 나중에 추가된
+ * 영상/대화/텍스트/업로드텍스트/파이프라인실행이 누락돼 orphan 이 남았다. 단일 헬퍼로 통합.
+ *
+ * 정책:
+ * - User 삭제 시 개인 소유 콘텐츠(userId 기준)는 무조건 전체 삭제 (preferences 미반영).
+ * - 구조 리소스(Project/Workboard/Pipeline/Tag/Server/Group — createdBy)는 소유권 이전
+ *   정책이 별개라 여기 포함하지 않음.
+ * - 새 "개인 콘텐츠" 모델 추가 시 USER_CONTENT_MODELS 에 반드시 추가
+ *   (userDeletionService.test.js 의 modelName 대조 테스트가 누락을 잡아준다).
+ */
+const User = require('../models/User');
+const ImageGenerationJob = require('../models/ImageGenerationJob');
+const ConversationJob = require('../models/ConversationJob');
+const GeneratedImage = require('../models/GeneratedImage');
+const GeneratedVideo = require('../models/GeneratedVideo');
+const GeneratedText = require('../models/GeneratedText');
+const UploadedImage = require('../models/UploadedImage');
+const UploadedText = require('../models/UploadedText');
+const PipelineRun = require('../models/PipelineRun');
+const ApiKey = require('../models/ApiKey');
+
+// userId 로 소유자를 참조하는 개인 콘텐츠/작업 모델 — User 삭제 시 함께 제거.
+const USER_CONTENT_MODELS = [
+  ImageGenerationJob,
+  ConversationJob,
+  GeneratedImage,
+  GeneratedVideo,
+  GeneratedText,
+  UploadedImage,
+  UploadedText,
+  PipelineRun,
+  ApiKey,
+];
+
+/**
+ * 사용자와 그 개인 콘텐츠를 모두 삭제.
+ * 콘텐츠를 먼저 일괄 삭제한 뒤 User 문서를 삭제한다.
+ */
+async function deleteUserAndContent(userId) {
+  await Promise.all(USER_CONTENT_MODELS.map((Model) => Model.deleteMany({ userId })));
+  await User.findByIdAndDelete(userId);
+}
+
+module.exports = { deleteUserAndContent, USER_CONTENT_MODELS };

--- a/src/tests/userDeletionService.test.js
+++ b/src/tests/userDeletionService.test.js
@@ -1,0 +1,35 @@
+/**
+ * #660 User 삭제 cascade — 개인 콘텐츠 모델 누락 방지
+ */
+const svc = require('../services/userDeletionService');
+const User = require('../models/User');
+
+describe('#660 userDeletionService', () => {
+  test('USER_CONTENT_MODELS 가 개인 콘텐츠/작업 모델을 전부 포함 (누락 회귀 방지)', () => {
+    const names = svc.USER_CONTENT_MODELS.map((M) => M.modelName).sort();
+    expect(names).toEqual([
+      'ApiKey',
+      'ConversationJob',
+      'GeneratedImage',
+      'GeneratedText',
+      'GeneratedVideo',
+      'ImageGenerationJob',
+      'PipelineRun',
+      'UploadedImage',
+      'UploadedText',
+    ]);
+  });
+
+  test('deleteUserAndContent 가 모든 콘텐츠 모델 deleteMany({userId}) + User 삭제 호출', async () => {
+    const spies = svc.USER_CONTENT_MODELS.map((M) => jest.spyOn(M, 'deleteMany').mockResolvedValue({ deletedCount: 0 }));
+    const userSpy = jest.spyOn(User, 'findByIdAndDelete').mockResolvedValue({});
+
+    await svc.deleteUserAndContent('uid-123');
+
+    for (const s of spies) expect(s).toHaveBeenCalledWith({ userId: 'uid-123' });
+    expect(userSpy).toHaveBeenCalledWith('uid-123');
+
+    spies.forEach((s) => s.mockRestore());
+    userSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
User 삭제 cascade 에서 ConversationJob/GeneratedVideo/GeneratedText/UploadedText/PipelineRun 누락 → orphan. services/userDeletionService 로 통합(USER_CONTENT_MODELS 9종 + deleteUserAndContent), 두 라우트 공통화. 구조 리소스(createdBy)는 제외. modelName 대조 회귀 테스트 추가. 전체 240 green. closes #660