### PR TITLE
feat: 비밀번호 변경 기능 + '개인정보 설정' 라벨 (#663)

### DIFF
--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -238,7 +238,7 @@ function Header({ onMobileToggle, onOpenPalette }) {
                 <ListItemIcon>
                   <Settings fontSize="small" />
                 </ListItemIcon>
-                <ListItemText>프로필 설정</ListItemText>
+                <ListItemText>개인정보 설정</ListItemText>
               </MenuItem>
 
               {isAdmin && (

--- a/frontend/src/components/common/CommandPalette.js
+++ b/frontend/src/components/common/CommandPalette.js
@@ -113,7 +113,7 @@ export default function CommandPalette({ open, onClose }) {
       {
         group: '명령',
         icon: <PersonIcon fontSize="small" />,
-        name: '프로필 / 설정',
+        name: '개인정보 설정',
         kbd: ['⌘', ','],
         action: () => navigate('/profile'),
       },

--- a/frontend/src/pages/Profile.js
+++ b/frontend/src/pages/Profile.js
@@ -223,6 +223,79 @@ function AccountSettings() {
   );
 }
 
+function PasswordChange() {
+  const { user } = useAuth();
+  const { register, handleSubmit, watch, reset, formState: { errors } } = useForm();
+
+  const changeMutation = useMutation({
+    mutationFn: userAPI.changePassword,
+    onSuccess: () => { toast.success('비밀번호가 변경되었습니다'); reset(); },
+    onError: (error) => { toast.error(error.response?.data?.message || '비밀번호 변경에 실패했습니다'); }
+  });
+
+  // 소셜 로그인 계정은 비밀번호가 없어 변경 불가 — 표시하지 않음 (#663)
+  if (user?.authProvider && user.authProvider !== 'local') return null;
+
+  const newPassword = watch('newPassword');
+  const onSubmit = (data) => changeMutation.mutate({ currentPassword: data.currentPassword, newPassword: data.newPassword });
+
+  return (
+    <Paper variant="outlined" sx={{ p: 4 }}>
+      <Typography variant="h6" gutterBottom>
+        비밀번호 변경
+      </Typography>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <Grid container spacing={2}>
+          <Grid item xs={12}>
+            <TextField
+              fullWidth
+              type="password"
+              label="현재 비밀번호"
+              error={!!errors.currentPassword}
+              helperText={errors.currentPassword?.message}
+              {...register('currentPassword', { required: '현재 비밀번호를 입력해주세요' })}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6}>
+            <TextField
+              fullWidth
+              type="password"
+              label="새 비밀번호"
+              error={!!errors.newPassword}
+              helperText={errors.newPassword?.message}
+              {...register('newPassword', {
+                required: '새 비밀번호를 입력해주세요',
+                pattern: {
+                  value: /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*]).{8,}$/,
+                  message: '8자 이상, 대·소문자·숫자·특수문자(!@#$%^&*) 포함'
+                }
+              })}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6}>
+            <TextField
+              fullWidth
+              type="password"
+              label="새 비밀번호 확인"
+              error={!!errors.confirmPassword}
+              helperText={errors.confirmPassword?.message}
+              {...register('confirmPassword', {
+                required: '새 비밀번호를 다시 입력해주세요',
+                validate: (v) => v === newPassword || '새 비밀번호가 일치하지 않습니다'
+              })}
+            />
+          </Grid>
+        </Grid>
+        <Box mt={3}>
+          <Button type="submit" variant="contained" disabled={changeMutation.isPending}>
+            {changeMutation.isPending ? '변경 중...' : '비밀번호 변경'}
+          </Button>
+        </Box>
+      </form>
+    </Paper>
+  );
+}
+
 function SecuritySettings() {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [createKeyDialogOpen, setCreateKeyDialogOpen] = useState(false);
@@ -617,6 +690,9 @@ function Profile() {
       </Grid>
 
       <AccountSettings />
+      <Box mt={3}>
+        <PasswordChange />
+      </Box>
       <Box mt={3}>
         <SecuritySettings />
       </Box>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -78,6 +78,7 @@ export const authAPI = {
 export const userAPI = {
   getProfile: () => api.get('/users/profile'),
   updateProfile: (data) => api.put('/users/profile', data),
+  changePassword: (data) => api.put('/users/password', data), // #663
   getStats: () => api.get('/users/stats'),
   deleteAccount: () => api.delete('/users/account'),
 };

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -7,6 +7,7 @@ const { validate, signupSchema, signinSchema } = require('../utils/validation');
 const User = require('../models/User');
 const Group = require('../models/Group');
 const { sendPasswordResetEmail } = require('../services/emailService');
+const { isValidPassword, PASSWORD_POLICY_MESSAGE } = require('../utils/passwordPolicy');
 const router = express.Router();
 
 // Rate limit for forgot password - 3 requests per hour per IP
@@ -367,12 +368,9 @@ router.post('/reset-password', async (req, res) => {
       });
     }
 
-    // Validate password strength
-    const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*]).{8,}$/;
-    if (!passwordRegex.test(password)) {
-      return res.status(400).json({
-        message: '비밀번호는 8자 이상이며, 대문자, 소문자, 숫자, 특수문자(!@#$%^&*)를 포함해야 합니다'
-      });
+    // Validate password strength (#663 단일 소스)
+    if (!isValidPassword(password)) {
+      return res.status(400).json({ message: PASSWORD_POLICY_MESSAGE });
     }
 
     // Hash the token to compare with stored hash

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -3,6 +3,7 @@ const { requireAuth } = require('../middleware/auth');
 const User = require('../models/User');
 const ApiKey = require('../models/ApiKey');
 const { deleteUserAndContent } = require('../services/userDeletionService');
+const { isValidPassword, PASSWORD_POLICY_MESSAGE } = require('../utils/passwordPolicy');
 const router = express.Router();
 
 router.get('/profile', requireAuth, (req, res) => {
@@ -79,6 +80,43 @@ router.put('/profile', requireAuth, async (req, res) => {
     });
   } catch (error) {
     res.status(400).json({ message: error.message });
+  }
+});
+
+// 비밀번호 변경 (로그인 상태, 현재 비번 확인 → 새 비번) (#663)
+router.put('/password', requireAuth, async (req, res) => {
+  try {
+    const { currentPassword, newPassword } = req.body;
+    if (!currentPassword || !newPassword) {
+      return res.status(400).json({ message: '현재 비밀번호와 새 비밀번호를 입력해주세요' });
+    }
+
+    const user = await User.findById(req.user._id);
+    if (!user) {
+      return res.status(404).json({ message: '사용자를 찾을 수 없습니다' });
+    }
+    // 소셜 로그인 계정은 비밀번호가 없어 변경 불가
+    if (user.authProvider !== 'local') {
+      return res.status(400).json({ message: '소셜 로그인 계정은 비밀번호를 변경할 수 없습니다' });
+    }
+
+    const isCurrentValid = await user.comparePassword(currentPassword);
+    if (!isCurrentValid) {
+      return res.status(400).json({ message: '현재 비밀번호가 올바르지 않습니다' });
+    }
+    if (currentPassword === newPassword) {
+      return res.status(400).json({ message: '새 비밀번호가 현재 비밀번호와 같습니다' });
+    }
+    if (!isValidPassword(newPassword)) {
+      return res.status(400).json({ message: PASSWORD_POLICY_MESSAGE });
+    }
+
+    user.password = newPassword; // pre-save 미들웨어가 bcrypt 해시
+    await user.save();
+
+    res.json({ message: '비밀번호가 변경되었습니다' });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
   }
 });
 

--- a/src/tests/passwordPolicy.test.js
+++ b/src/tests/passwordPolicy.test.js
@@ -1,0 +1,33 @@
+/**
+ * #663 비밀번호 정책 단일 소스
+ */
+const { isValidPassword, PASSWORD_REGEX, PASSWORD_POLICY_MESSAGE } = require('../utils/passwordPolicy');
+
+describe('#663 passwordPolicy', () => {
+  test('정책 충족(8자+, 대/소문자·숫자·특수문자) → 통과', () => {
+    expect(isValidPassword('Abcdef1!')).toBe(true);
+    expect(isValidPassword('StrongP@ss2026')).toBe(true);
+    expect(isValidPassword('AlphaReset2026!')).toBe(true);
+  });
+
+  test('정책 미달 → 거부', () => {
+    expect(isValidPassword('short1!A')).toBe(true); // 8자 경계(통과 케이스 확인)
+    expect(isValidPassword('abc123!a')).toBe(false); // 대문자 없음
+    expect(isValidPassword('ABC123!A')).toBe(false); // 소문자 없음
+    expect(isValidPassword('Abcdefg!')).toBe(false); // 숫자 없음
+    expect(isValidPassword('Abcdefg1')).toBe(false); // 특수문자 없음
+    expect(isValidPassword('Ab1!')).toBe(false);     // 8자 미만
+    expect(isValidPassword('')).toBe(false);
+  });
+
+  test('문자열 아닌 입력 → 거부(throw 안 함)', () => {
+    expect(isValidPassword(null)).toBe(false);
+    expect(isValidPassword(undefined)).toBe(false);
+    expect(isValidPassword(12345678)).toBe(false);
+  });
+
+  test('정책 메시지·정규식 export', () => {
+    expect(typeof PASSWORD_POLICY_MESSAGE).toBe('string');
+    expect(PASSWORD_REGEX.test('Abcdef1!')).toBe(true);
+  });
+});

--- a/src/utils/passwordPolicy.js
+++ b/src/utils/passwordPolicy.js
@@ -1,0 +1,13 @@
+/**
+ * 비밀번호 정책 단일 소스 (#663).
+ * signup/reset-password/change 가 각자 정규식을 두면 drift 가 생기므로 한 곳에서 관리.
+ * 정책: 8자 이상 + 소문자 + 대문자 + 숫자 + 특수문자(!@#$%^&*).
+ */
+const PASSWORD_REGEX = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*]).{8,}$/;
+const PASSWORD_POLICY_MESSAGE = '비밀번호는 8자 이상이며, 대문자, 소문자, 숫자, 특수문자(!@#$%^&*)를 포함해야 합니다';
+
+function isValidPassword(password) {
+  return typeof password === 'string' && PASSWORD_REGEX.test(password);
+}
+
+module.exports = { PASSWORD_REGEX, PASSWORD_POLICY_MESSAGE, isValidPassword };


### PR DESCRIPTION
로그인 상태 비밀번호 변경 기능 추가(백엔드 PUT /users/password + 개인정보 페이지 카드). 비번 정책 단일 소스(utils/passwordPolicy)로 통합 + 테스트. 메뉴 라벨 '프로필 설정'→'개인정보 설정'. 소셜 계정 거부. jest 244 green, frontend 빌드 통과. closes #663