### PR TITLE
feat: LLM(text) 작업판 기본 이미지 입력 필드 + vision 미지원 안내 (#666)

### DIFF
--- a/frontend/src/templates/Gemini-text.json
+++ b/frontend/src/templates/Gemini-text.json
@@ -22,6 +22,16 @@
       "required": false,
       "defaultValue": false,
       "description": "켜면 작업판이 단일 샷 프롬프트 생성기 대신 채팅 UI 로 동작합니다. 사용자에겐 노출되지 않는 관리자 설정입니다."
+    },
+    {
+      "name": "input_images",
+      "label": "이미지 (선택)",
+      "type": "image",
+      "required": false,
+      "imageConfig": {
+        "maxImages": 3
+      },
+      "description": "이미지 인식(vision) 지원 모델에서 이미지를 함께 입력할 수 있습니다. 지원하지 않는 모델에서는 비워두세요."
     }
   ],
   "workflowData": ""

--- a/frontend/src/templates/OpenAI Compatible-text.json
+++ b/frontend/src/templates/OpenAI Compatible-text.json
@@ -22,6 +22,16 @@
       "required": false,
       "defaultValue": false,
       "description": "켜면 작업판이 단일 샷 프롬프트 생성기 대신 채팅 UI 로 동작합니다. 사용자에겐 노출되지 않는 관리자 설정입니다."
+    },
+    {
+      "name": "input_images",
+      "label": "이미지 (선택)",
+      "type": "image",
+      "required": false,
+      "imageConfig": {
+        "maxImages": 3
+      },
+      "description": "이미지 인식(vision) 지원 모델에서 이미지를 함께 입력할 수 있습니다. 지원하지 않는 모델에서는 비워두세요."
     }
   ],
   "workflowData": ""

--- a/frontend/src/templates/OpenAI-text.json
+++ b/frontend/src/templates/OpenAI-text.json
@@ -22,6 +22,16 @@
       "required": false,
       "defaultValue": false,
       "description": "켜면 작업판이 단일 샷 프롬프트 생성기 대신 채팅 UI 로 동작합니다. 사용자에겐 노출되지 않는 관리자 설정입니다."
+    },
+    {
+      "name": "input_images",
+      "label": "이미지 (선택)",
+      "type": "image",
+      "required": false,
+      "imageConfig": {
+        "maxImages": 3
+      },
+      "description": "이미지 인식(vision) 지원 모델에서 이미지를 함께 입력할 수 있습니다. 지원하지 않는 모델에서는 비워두세요."
     }
   ],
   "workflowData": ""

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -662,11 +662,16 @@ router.post('/generate-prompt', requireAuth, async (req, res) => {
       }
     } catch (chatError) {
       clearInterval(heartbeat);
+      // 이미지를 함께 보낸 요청이 실패하면 vision 미지원 모델일 수 있음을 안내 (#666, a안)
+      let errorMessage = chatError.message;
+      if (turnImages.length > 0) {
+        errorMessage += ' (이미지를 함께 보냈습니다 — 선택한 모델이 이미지 입력(vision)을 지원하지 않을 수 있습니다. 모델을 확인하거나 이미지를 빼고 다시 시도해보세요.)';
+      }
       conversation.status = 'failed';
-      conversation.error = { message: chatError.message };
+      conversation.error = { message: errorMessage };
       conversation.completedAt = new Date();
       await conversation.save();
-      sse('error', { message: chatError.message });
+      sse('error', { message: errorMessage });
       finished = true;
       return res.end();
     }

--- a/src/tests/llmTextImageField.test.js
+++ b/src/tests/llmTextImageField.test.js
@@ -1,0 +1,24 @@
+/**
+ * #666 LLM(text) 작업판 기본 이미지 입력 필드
+ * text 템플릿 3종에 선택형 image 입력 필드가 포함돼 있는지 (누락 회귀 방지).
+ */
+const fs = require('fs');
+const path = require('path');
+
+const TEMPLATE_DIR = path.join(__dirname, '../../frontend/src/templates');
+const TEXT_TEMPLATES = ['Gemini-text.json', 'OpenAI-text.json', 'OpenAI Compatible-text.json'];
+
+describe('#666 text 템플릿 이미지 입력 필드', () => {
+  TEXT_TEMPLATES.forEach((file) => {
+    test(`${file} 에 선택형 image 입력 필드 존재`, () => {
+      const data = JSON.parse(fs.readFileSync(path.join(TEMPLATE_DIR, file), 'utf8'));
+      const fields = data.additionalInputFields || [];
+      const imageField = fields.find((f) => f.type === 'image');
+      expect(imageField).toBeTruthy();
+      expect(imageField.required).toBe(false); // 선택 입력 — 비워도 텍스트만으로 동작
+      expect(imageField.imageConfig).toBeTruthy();
+      expect(imageField.imageConfig.maxImages).toBeGreaterThanOrEqual(1);
+      expect(imageField.imageConfig.maxImages).toBeLessThanOrEqual(3); // Workboard 스키마 max 3
+    });
+  });
+});


### PR DESCRIPTION
text 템플릿 3종에 선택형 이미지 입력 필드 기본 추가(#517/#519 의 이미지 입력 기능이 이미 있으나 템플릿에 필드가 없었음). vision 미지원 모델은 이미지 포함 실패 시 친화 안내(a안). 템플릿 회귀 테스트 3건, jest 247 green, frontend 빌드 통과. closes #666