### PR TITLE
fix: 히스토리 이어가기 베이스모델 조건부 prefill + 텍스트 결과 패딩 (#673, #674)

### DIFF
--- a/frontend/src/components/common/JobHistoryPanel.js
+++ b/frontend/src/components/common/JobHistoryPanel.js
@@ -1045,7 +1045,8 @@ function JobHistoryPanel({
       localStorage.setItem('continueJobData', JSON.stringify({
         workboardId,
         inputData: job.inputData,
-        workboard
+        workboard,
+        prevOutputFormat: job.resultVideos?.length ? 'video' : 'image', // #673
       }));
       navigate(`/generate/${workboardId}`);
       toast.success('작업 설정을 불러왔습니다');
@@ -1088,7 +1089,8 @@ function JobHistoryPanel({
       lastGeneratedMedia: {
         image: lastGeneratedImage,
         video: lastGeneratedVideo
-      }
+      },
+      prevOutputFormat: lastGeneratedVideo ? 'video' : 'image', // #673
     }));
 
     setCrossWorkboardOpen(false);

--- a/frontend/src/pages/ImageGeneration.js
+++ b/frontend/src/pages/ImageGeneration.js
@@ -570,6 +570,7 @@ function ImageGeneration() {
       let jobInputData = null;
 
       let lastGeneratedMedia = null;
+      let prevOutputFormat = null; // 이전 작업의 출력 타입 (#673 — base_model prefill 조건 판단용)
 
       if (continueJobData) {
         try {
@@ -579,6 +580,7 @@ function ImageGeneration() {
           if (parsedData.workboardId === workboardData._id) {
             jobInputData = parsedData.inputData;
             lastGeneratedMedia = parsedData.lastGeneratedMedia || null;
+            prevOutputFormat = parsedData.prevOutputFormat || null; // #673
             localStorage.removeItem('continueJobData'); // 사용 후 제거
             console.log('Using continue job data for same workboard');
           } else {
@@ -604,6 +606,12 @@ function ImageGeneration() {
           }
         };
 
+        // #673: 이전 작업의 base_model 을 새 작업판에 prefill 할지 결정.
+        //  ① 출력 타입이 다르면 비호환이라 skip  ② 출력 타입 같아도 작업판에 base_model 기본값이 있으면 skip  ③ 그 외 prefill
+        const bmField = (workboardData.additionalInputFields || []).find((f) => f.type === 'baseModel');
+        const bmHasDefault = bmField && bmField.defaultValue !== undefined && bmField.defaultValue !== null && bmField.defaultValue !== '';
+        const allowBaseModelPrefill = !(prevOutputFormat && prevOutputFormat !== workboardData.outputFormat) && !bmHasDefault;
+
         // F2: 기본 필드 (prompt, negativePrompt) 만 직접 매핑 — aiModel/imageSize 등은 customField 가 처리.
         // legacy job 의 {key,value} 객체 값도 그대로 set 됨 (Controller 가 value 만 추출). 이전 매칭 로직은
         // baseInputFields 의 옵션 풀에 의존했는데, F2 에서 풀이 제거되어 단순화.
@@ -616,6 +624,7 @@ function ImageGeneration() {
         // customField 들은 additionalParams 네임스페이스에서 복원 (jobInputData 도 동일 구조)
         if (jobInputData.additionalParams) {
           Object.entries(jobInputData.additionalParams).forEach(([k, v]) => {
+            if (k === 'base_model' && !allowBaseModelPrefill) return; // #673 비호환/기본값 → 이전 base_model 안 가져옴
             safeSetValue(`additionalParams.${k}`, typeof v === 'object' && v?.value !== undefined ? v.value : v);
           });
         }
@@ -663,6 +672,8 @@ function ImageGeneration() {
                   console.warn(`Option ${JSON.stringify(inputValue)} not found for field ${paramKey}, using default`);
                   safeSetValue(`additionalParams.${paramKey}`, field.defaultValue || field.options[0]?.value);
                 }
+              } else if (field.type === 'baseModel' && !allowBaseModelPrefill) {
+                // #673 비호환/기본값 → 이전 base_model 안 가져옴 (작업판 기본값/빈값 유지)
               } else {
                 // 다른 타입의 경우 그대로 사용
                 safeSetValue(`additionalParams.${paramKey}`, inputValue);

--- a/frontend/src/pages/JobHistory.js
+++ b/frontend/src/pages/JobHistory.js
@@ -281,7 +281,7 @@ function HistoryRow({ item, onOpenMedia, onMenu, onContinue, onCross, onTextCont
               sx={{
                 mt: 1, fontSize: 12, lineHeight: 1.55, color: 'text.secondary',
                 display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden',
-                bgcolor: 'grey.100', borderRadius: 1.5, p: 1.25,
+                bgcolor: 'grey.100', borderRadius: 1.5, px: 2.5, py: 1.25,
               }}
             >
               {item.preview}
@@ -480,7 +480,7 @@ function JobHistory() {
       const wbRes = await workboardAPI.getById(workboardId);
       const workboard = wbRes.data?.workboard;
       if (!workboard || !workboard.isActive) { toast.error('작업판을 사용할 수 없습니다. 작업판 선택 페이지로 이동합니다.'); return fallback(); }
-      localStorage.setItem('continueJobData', JSON.stringify({ workboardId, inputData: job.inputData, workboard }));
+      localStorage.setItem('continueJobData', JSON.stringify({ workboardId, inputData: job.inputData, workboard, prevOutputFormat: job.resultVideos?.length ? 'video' : 'image' }));
       navigate(`/generate/${workboardId}`);
       toast.success('작업 설정을 불러왔습니다');
     } catch (error) {
@@ -498,6 +498,7 @@ function JobHistory() {
     localStorage.setItem('continueJobData', JSON.stringify({
       workboardId: workboard._id, inputData: job.inputData, workboard,
       lastGeneratedMedia: { image: lastImage, video: lastVideo },
+      prevOutputFormat: lastVideo ? 'video' : 'image', // #673
     }));
     setCrossJob(null);
     navigate(`/generate/${workboard._id}`);


### PR DESCRIPTION
#673 계속하기/이어가기 base_model 조건부(출력타입 다름/작업판 기본값 있음 → skip). 저장 4곳 prevOutputFormat 추가 + ImageGeneration prefill 조건. #674 텍스트 결과 박스 좌우 패딩 확보. frontend 빌드 통과, 알파 반영됨. closes #673, closes #674