### PR TITLE
feat: 동영상 첫 프레임 썸네일 생성으로 프리뷰 속도 개선 (#672)

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -2,6 +2,9 @@ FROM node:22-alpine
 
 WORKDIR /app
 
+# 동영상 썸네일(첫 프레임) 추출용 ffmpeg (#672). CLI 로만 호출(앱 코드에 링크하지 않음)
+RUN apk add --no-cache ffmpeg
+
 # pnpm 활성화 (v11+ — minimumReleaseAge 1440 기본값으로 신규 release 24h cooldown)
 RUN corepack enable && corepack prepare pnpm@latest --activate
 

--- a/frontend/src/components/common/JobHistoryPanel.js
+++ b/frontend/src/components/common/JobHistoryPanel.js
@@ -452,6 +452,9 @@ function JobCard({ job, onView, onRetry, onCancel, onDelete, onImageView, onCont
                 >
                   <video
                     src={video.url}
+                    poster={video.thumbnailUrl || undefined}
+                    preload="metadata"
+                    playsInline
                     style={{ width: '100%', height: '100%', objectFit: 'cover' }}
                     muted
                   />
@@ -812,7 +815,7 @@ export function JobDetailDialog({ job, open, onClose, onImageView }) {
                       '&:hover': { transform: 'scale(1.02)', boxShadow: '0 4px 8px rgba(0,0,0,0.2)' }
                     }}
                   >
-                    <video src={video.url} style={{ width: '100%', height: '120px', objectFit: 'cover' }} muted />
+                    <video src={video.url} poster={video.thumbnailUrl || undefined} preload="metadata" playsInline style={{ width: '100%', height: '120px', objectFit: 'cover' }} muted />
                     <Box sx={{ position: 'absolute', bottom: 4, right: 4, bgcolor: 'rgba(0,0,0,0.6)', borderRadius: 0.5, p: 0.5 }}>
                       <Videocam sx={{ color: 'white', fontSize: 16 }} />
                     </Box>

--- a/frontend/src/components/common/MediaGrid.js
+++ b/frontend/src/components/common/MediaGrid.js
@@ -277,6 +277,9 @@ function VideoCard({ video, onEdit, onDelete, onView, readOnly = false, showTags
       >
         <video
           src={video.url}
+          poster={video.thumbnailUrl || undefined}
+          preload="metadata"
+          playsInline
           style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }}
           muted
           onMouseEnter={(e) => e.target.play()}

--- a/frontend/src/pages/JobHistory.js
+++ b/frontend/src/pages/JobHistory.js
@@ -126,6 +126,7 @@ function jobToItem(job) {
     duration: isVideo ? results?.[0]?.metadata?.duration : null,
     status: mapStatus(job.status),
     thumb: results?.[0]?.url || null,
+    videoThumb: isVideo ? (results?.[0]?.thumbnailUrl || null) : null, // #672 동영상 첫프레임 썸네일
     results: results || [],
     isVideo,
     raw: job,
@@ -177,8 +178,12 @@ function RowVisual({ item }) {
             bgcolor: 'grey.100', display: 'grid', placeItems: 'center',
           }}
         >
-          {item.thumb ? (
-            // 동영상은 mp4 URL 이라 <img> 로 못 그림 → <video> 첫 프레임으로 프리뷰 (#669)
+          {item.type === 'video' && item.videoThumb ? (
+            // 동영상 썸네일(첫 프레임 jpg) 우선 — 빠름 (#672)
+            <Box component="img" src={item.videoThumb} alt="" loading="lazy"
+              sx={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+          ) : item.thumb ? (
+            // 썸네일 없으면: 동영상은 <video> 첫 프레임 fallback (#669), 이미지는 <img>
             item.type === 'video' ? (
               <Box component="video" src={`${item.thumb}#t=0.1`} muted playsInline preload="metadata"
                 sx={{ width: '100%', height: '100%', objectFit: 'cover' }} />
@@ -369,7 +374,10 @@ function HistoryCard({ item, onOpenMedia, onMenu, onContinue, onCross, onTextCon
     >
       {/* 미디어 / 프리뷰 영역 */}
       <Box sx={{ position: 'relative', aspectRatio: '4 / 3', bgcolor: 'grey.100', display: 'grid', placeItems: 'center', overflow: 'hidden' }}>
-        {(item.type === 'image' || item.type === 'video') && item.thumb ? (
+        {item.type === 'video' && item.videoThumb ? (
+          <Box component="img" src={item.videoThumb} alt="" loading="lazy"
+            sx={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+        ) : (item.type === 'image' || item.type === 'video') && item.thumb ? (
           item.type === 'video' ? (
             <Box component="video" src={`${item.thumb}#t=0.1`} muted playsInline preload="metadata"
               sx={{ width: '100%', height: '100%', objectFit: 'cover' }} />

--- a/src/migrations/backfillVideoThumbnails.js
+++ b/src/migrations/backfillVideoThumbnails.js
@@ -1,0 +1,45 @@
+/**
+ * 기존 동영상 썸네일 백필 (#672).
+ * thumbnailUrl 이 없는 GeneratedVideo 를 순회해 ffmpeg 로 첫 프레임 jpg 를 생성하고 채운다.
+ * idempotent: 이미 thumbnailUrl 이 있으면 대상에서 빠지므로 재부팅 시 재실행 비용 최소.
+ * best-effort: 개별 실패/파일 없음은 skip, 부팅을 막지 않는다.
+ */
+const path = require('path');
+const fs = require('fs');
+const GeneratedVideo = require('../models/GeneratedVideo');
+const { generateVideoThumbnail, thumbnailPathFor } = require('../utils/videoThumbnail');
+
+module.exports = async function backfillVideoThumbnails() {
+  const UPLOAD_PATH = process.env.UPLOAD_PATH || './uploads';
+
+  const targets = await GeneratedVideo.find({
+    $or: [{ thumbnailUrl: { $exists: false } }, { thumbnailUrl: null }, { thumbnailUrl: '' }],
+  }).select('_id url');
+
+  if (!targets.length) return;
+  console.log(`[Migration] 동영상 썸네일 백필: ${targets.length}건 대상`);
+
+  let ok = 0;
+  let skip = 0;
+  for (const doc of targets) {
+    try {
+      if (!doc.url) { skip++; continue; }
+      const rel = doc.url.replace(/^\/uploads\//, ''); // videos/xxx.mp4
+      const videoPath = path.join(UPLOAD_PATH, rel);
+      if (!fs.existsSync(videoPath)) { skip++; continue; } // 원본 파일 없으면 skip
+
+      const thumbPath = thumbnailPathFor(videoPath);
+      await generateVideoThumbnail(videoPath, thumbPath);
+      const subDir = path.dirname(rel); // videos
+      await GeneratedVideo.updateOne(
+        { _id: doc._id },
+        { $set: { thumbnailUrl: `/uploads/${subDir}/${path.basename(thumbPath)}` } }
+      );
+      ok++;
+    } catch (err) {
+      skip++;
+      console.warn(`[Migration] 썸네일 백필 실패 ${doc._id}:`, err.message);
+    }
+  }
+  console.log(`[Migration] 동영상 썸네일 백필 완료: 생성 ${ok}, skip/실패 ${skip}`);
+};

--- a/src/models/GeneratedVideo.js
+++ b/src/models/GeneratedVideo.js
@@ -25,6 +25,11 @@ const generatedVideoSchema = new mongoose.Schema({
     type: String,
     required: true
   },
+  // 첫 프레임 썸네일 (#672). /uploads/videos/*.jpg 원본 경로 저장 → 응답 시 signed URL 자동 변환.
+  // 없으면(구 데이터/생성 실패) 프론트가 <video> 첫 프레임으로 fallback.
+  thumbnailUrl: {
+    type: String
+  },
   userId: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'User',

--- a/src/server.js
+++ b/src/server.js
@@ -50,6 +50,7 @@ const encryptExistingSecrets = require('./migrations/encryptExistingSecrets');
 const ensureWorldviewTag = require('./migrations/ensureWorldviewTag');
 const backfillConversationTags = require('./migrations/backfillConversationTags');
 const alignTagColorsV2 = require('./migrations/alignTagColorsV2');
+const backfillVideoThumbnails = require('./migrations/backfillVideoThumbnails');
 
 dotenv.config();
 
@@ -258,6 +259,7 @@ const startServer = async () => {
     await ensureWorldviewTag();
     await backfillConversationTags();
     await alignTagColorsV2();
+    await backfillVideoThumbnails(); // #672 기존 동영상 썸네일 백필 (best-effort)
 
     // Initialize job queues after database connection
     console.log('Initializing job queues...');

--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -920,6 +920,20 @@ const saveGeneratedMedia = async (jobId, mediaItems, inputData, mediaType, workb
         }
       }
       
+      // 동영상 첫 프레임 썸네일 생성 (#672, best-effort — 실패해도 동영상 저장은 계속)
+      let thumbnailUrl = null;
+      if (mediaType === 'video') {
+        try {
+          const { generateVideoThumbnail, thumbnailPathFor } = require('../utils/videoThumbnail');
+          const thumbPath = thumbnailPathFor(filePath);
+          await generateVideoThumbnail(filePath, thumbPath);
+          thumbnailUrl = `/uploads/${subDir}/${path.basename(thumbPath)}`;
+          console.log(`🖼️ 동영상 썸네일 생성: ${thumbnailUrl}`);
+        } catch (thumbErr) {
+          console.warn('동영상 썸네일 생성 실패 (프리뷰는 <video> 첫 프레임으로 fallback):', thumbErr.message);
+        }
+      }
+
       const mediaTags = inputData.tags || [];
 
       const generatedData = {
@@ -929,6 +943,7 @@ const saveGeneratedMedia = async (jobId, mediaItems, inputData, mediaType, workb
         size: itemData.buffer.length,
         path: filePath,
         url: `/uploads/${subDir}/${filename}`,
+        ...(thumbnailUrl ? { thumbnailUrl } : {}),
         userId: inputData.userId,
         jobId,
         orderIndex: i,

--- a/src/tests/videoThumbnail.test.js
+++ b/src/tests/videoThumbnail.test.js
@@ -1,0 +1,23 @@
+/**
+ * #672 동영상 썸네일 유틸 — 경로 규칙 (순수 함수).
+ * 실제 ffmpeg 첫 프레임 추출은 ffmpeg 설치된 컨테이너에서 e2e 로 검증.
+ */
+const path = require('path');
+const { thumbnailPathFor, THUMB_WIDTH } = require('../utils/videoThumbnail');
+
+describe('#672 videoThumbnail', () => {
+  test('thumbnailPathFor: 같은 디렉토리에 <name>_thumb.jpg', () => {
+    expect(thumbnailPathFor('/app/uploads/videos/generated_123_0.mp4'))
+      .toBe(path.join('/app/uploads/videos', 'generated_123_0_thumb.jpg'));
+  });
+
+  test('thumbnailPathFor: 확장자 무관하게 .jpg 로', () => {
+    expect(thumbnailPathFor('/x/y/clip.webm')).toBe(path.join('/x/y', 'clip_thumb.jpg'));
+    expect(thumbnailPathFor('/x/y/clip.mov')).toBe(path.join('/x/y', 'clip_thumb.jpg'));
+  });
+
+  test('THUMB_WIDTH 는 합리적 프리뷰 폭', () => {
+    expect(THUMB_WIDTH).toBeGreaterThan(0);
+    expect(THUMB_WIDTH).toBeLessThanOrEqual(640);
+  });
+});

--- a/src/utils/videoThumbnail.js
+++ b/src/utils/videoThumbnail.js
@@ -1,0 +1,48 @@
+/**
+ * 동영상 첫 프레임 썸네일 생성 (#672).
+ * ffmpeg 를 CLI(별도 프로세스)로만 호출한다 — 앱 코드에 링크하지 않아 LGPL/GPL 전파 없음.
+ * best-effort: 실패해도 호출측이 동영상 저장을 계속하도록 에러를 던지되 얇게 감싼다.
+ */
+const { execFile } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const FFMPEG_TIMEOUT_MS = 30000;
+const THUMB_WIDTH = 480; // 프리뷰용 축소 폭 (높이는 비율 유지, 짝수 보정 -2)
+
+/**
+ * videoPath 의 첫 프레임을 jpg 로 추출해 thumbPath 에 저장.
+ * @returns {Promise<string>} thumbPath (성공 시)
+ */
+function generateVideoThumbnail(videoPath, thumbPath) {
+  return new Promise((resolve, reject) => {
+    // -ss 0 을 -i 앞에 두어 빠른 seek. 첫 프레임 1장, 폭 480 리사이즈, 품질 q:v 4.
+    const args = [
+      '-y',
+      '-ss', '0',
+      '-i', videoPath,
+      '-frames:v', '1',
+      '-vf', `scale=${THUMB_WIDTH}:-2`,
+      '-q:v', '4',
+      thumbPath,
+    ];
+    execFile('ffmpeg', args, { timeout: FFMPEG_TIMEOUT_MS }, (err) => {
+      if (err) return reject(err);
+      // 산출 파일 존재 확인 (일부 코덱/손상 입력은 exit 0 이어도 파일이 없을 수 있음)
+      fs.promises.access(thumbPath, fs.constants.R_OK)
+        .then(() => resolve(thumbPath))
+        .catch(() => reject(new Error('썸네일 파일이 생성되지 않았습니다')));
+    });
+  });
+}
+
+/**
+ * 동영상 파일 경로로부터 같은 디렉토리에 `<name>_thumb.jpg` 썸네일 경로를 만든다.
+ */
+function thumbnailPathFor(videoFilePath) {
+  const dir = path.dirname(videoFilePath);
+  const base = path.basename(videoFilePath).replace(/\.[^.]+$/, '');
+  return path.join(dir, `${base}_thumb.jpg`);
+}
+
+module.exports = { generateVideoThumbnail, thumbnailPathFor, THUMB_WIDTH };


### PR DESCRIPTION
동영상 저장 시 ffmpeg 로 첫 프레임 jpg 썸네일 생성 → 목록에서 즉시 표시(mp4 안 받음). Dockerfile ffmpeg(CLI 호출, 라이선스 무관) + queueService 훅 + GeneratedVideo.thumbnailUrl + 백필 마이그레이션 + 프론트 썸네일 우선 렌더. jest 250 green, 알파에서 ffmpeg 설치·백필 실동작(2건 썸네일 생성) 검증. closes #672