### PR TITLE
fix: 파이프라인 이미지→LLM 400 + 단계 버튼 UI 깨짐 (#684, #683)

### DIFF
--- a/frontend/src/components/common/PipelinePanel.js
+++ b/frontend/src/components/common/PipelinePanel.js
@@ -588,6 +588,7 @@ function StepLaneCard({
         onClick={(e) => e.stopPropagation()}
         sx={{
           display: 'flex',
+          flexWrap: 'wrap', // 좁을 때 버튼 단위로 줄바꿈 (텍스트 wrap 방지, #683)
           gap: 1,
           px: 2,
           py: 1.5,
@@ -605,7 +606,7 @@ function StepLaneCard({
             variant="outlined"
             startIcon={<SettingsIcon />}
             onClick={onOpenInputs}
-            sx={{ justifyContent: 'flex-start', flex: 1 }}
+            sx={{ justifyContent: 'flex-start', flex: 1, whiteSpace: 'nowrap', minWidth: 'fit-content' }}
           >
             입력 설정
             {inputsCount > 0 && <Chip label={inputsCount} sx={{ ml: 'auto', height: 18 }} />}
@@ -617,7 +618,7 @@ function StepLaneCard({
             fullWidth
             variant="outlined"
             onClick={onOpenDocs}
-            sx={{ justifyContent: 'flex-start', flex: 1 }}
+            sx={{ justifyContent: 'flex-start', flex: 1, whiteSpace: 'nowrap', minWidth: 'fit-content' }}
           >
             문서
             {docsCount > 0 && <Chip label={docsCount} sx={{ ml: 'auto', height: 18 }} />}

--- a/src/utils/visionImages.js
+++ b/src/utils/visionImages.js
@@ -1,5 +1,6 @@
 const sharp = require('sharp');
 const UploadedImage = require('../models/UploadedImage');
+const GeneratedImage = require('../models/GeneratedImage');
 
 // 비전 LLM 첨부 이미지 처리 (#517).
 // imageId 배열 → 비전 콘텐츠용 base64 이미지 배열로 변환한다.
@@ -16,8 +17,12 @@ async function loadVisionImages(imageIds, userId) {
   const ids = imageIds.filter(Boolean).slice(0, MAX_IMAGES);
   if (ids.length === 0) return [];
 
-  const docs = await UploadedImage.find({ _id: { $in: ids }, userId });
-  const byId = new Map(docs.map((d) => [String(d._id), d]));
+  // 업로드 이미지 + 생성 이미지 둘 다 조회 — 파이프라인 앞 단계 산출물(GeneratedImage)도 vision 입력으로 (#684).
+  const [uploaded, generated] = await Promise.all([
+    UploadedImage.find({ _id: { $in: ids }, userId }),
+    GeneratedImage.find({ _id: { $in: ids }, userId }),
+  ]);
+  const byId = new Map([...uploaded, ...generated].map((d) => [String(d._id), d]));
 
   const out = [];
   for (const id of ids) {


### PR DESCRIPTION
#684 loadVisionImages 가 UploadedImage 만 조회→GeneratedImage(파이프라인 산출물) 미지원으로 400. 둘 다 조회하도록 수정. 알파 검증: 생성이미지로 재현→qwen 이미지 인식+SDXL 프롬프트 생성(400 해결). #683 파이프라인 단계 버튼 flexWrap+nowrap. jest 256 green. closes #684, closes #683