### PR TITLE
test: provider 서비스·주요 라우트 인가 테스트 확충 (#691)

### DIFF
--- a/src/tests/comfyUIModelLists.test.js
+++ b/src/tests/comfyUIModelLists.test.js
@@ -1,0 +1,71 @@
+/**
+ * comfyUIService 모델 목록 조회 순수 로직 테스트 (#691)
+ *
+ * axios mock 으로 object_info 응답 파싱(중첩 경로 · 정렬 · 빈/이상 응답)을 검증한다.
+ */
+
+jest.mock('axios');
+jest.mock('ws', () => jest.fn()); // comfyUIService 가 require 하는 WebSocket — 이 테스트에서 미사용
+
+const axios = require('axios');
+const comfyUIService = require('../services/comfyUIService');
+
+describe('comfyUIService.getLoraModels', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('object_info 의 lora_name 목록을 대소문자 무시 정렬로 반환', async () => {
+    axios.get.mockResolvedValue({
+      data: {
+        LoraLoader: {
+          input: { required: { lora_name: [['zeta.safetensors', 'Alpha.safetensors', 'beta.safetensors']] } },
+        },
+      },
+    });
+
+    const models = await comfyUIService.getLoraModels('http://comfy');
+
+    expect(models).toEqual(['Alpha.safetensors', 'beta.safetensors', 'zeta.safetensors']);
+    expect(axios.get).toHaveBeenCalledWith('http://comfy/object_info/LoraLoader');
+  });
+
+  test('구조가 다르거나 목록이 없으면 빈 배열', async () => {
+    axios.get.mockResolvedValue({ data: { LoraLoader: { input: { required: {} } } } });
+    expect(await comfyUIService.getLoraModels('http://comfy')).toEqual([]);
+
+    axios.get.mockResolvedValue({ data: {} });
+    expect(await comfyUIService.getLoraModels('http://comfy')).toEqual([]);
+  });
+
+  test('요청 실패는 컨텍스트 있는 에러로 래핑', async () => {
+    axios.get.mockRejectedValue(new Error('timeout'));
+    await expect(comfyUIService.getLoraModels('http://comfy')).rejects.toThrow(
+      'Failed to get LoRA models: timeout'
+    );
+  });
+});
+
+describe('comfyUIService.getCheckpointModels', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('CheckpointLoaderSimple 의 ckpt_name 목록을 정렬해 반환', async () => {
+    axios.get.mockResolvedValue({
+      data: {
+        CheckpointLoaderSimple: {
+          input: { required: { ckpt_name: [['sdxl.safetensors', 'anima.safetensors']] } },
+        },
+      },
+    });
+
+    const models = await comfyUIService.getCheckpointModels('http://comfy');
+
+    expect(models).toEqual(['anima.safetensors', 'sdxl.safetensors']);
+    expect(axios.get).toHaveBeenCalledWith('http://comfy/object_info/CheckpointLoaderSimple');
+  });
+
+  test('요청 실패는 컨텍스트 있는 에러로 래핑', async () => {
+    axios.get.mockRejectedValue(new Error('ECONNREFUSED'));
+    await expect(comfyUIService.getCheckpointModels('http://comfy')).rejects.toThrow(
+      'Failed to get checkpoint models: ECONNREFUSED'
+    );
+  });
+});

--- a/src/tests/geminiService.test.js
+++ b/src/tests/geminiService.test.js
@@ -1,0 +1,165 @@
+/**
+ * geminiService 순수 로직 테스트 (#691)
+ *
+ * axios 를 mock 해 실 API 호출 없이 요청 조립(파트 구성 · imageConfig 필터링 ·
+ * extraParams merge)과 응답 파싱(inlineData → buffer, usage 정규화)을 검증한다.
+ */
+
+jest.mock('axios');
+const axios = require('axios');
+const geminiService = require('../services/geminiService');
+
+const imageResponse = (parts) => ({
+  data: { candidates: [{ content: { parts } }], usageMetadata: { totalTokenCount: 10 } },
+});
+
+describe('geminiService.generateImage', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('apiKey 없으면 throw', async () => {
+    await expect(geminiService.generateImage(null, '', 'a cat')).rejects.toThrow(
+      'Gemini API key is required'
+    );
+  });
+
+  test('inlineData 파트를 이미지 buffer 로 파싱한다', async () => {
+    const pngBase64 = Buffer.from('fake-png').toString('base64');
+    axios.post.mockResolvedValue(
+      imageResponse([
+        { text: 'here is your image' },
+        { inlineData: { data: pngBase64, mimeType: 'image/png' } },
+      ])
+    );
+
+    const result = await geminiService.generateImage(null, 'key', 'a cat');
+
+    expect(result.images).toHaveLength(1);
+    expect(result.images[0].buffer.toString()).toBe('fake-png');
+    expect(result.images[0].filename).toMatch(/\.png$/);
+    expect(result.usage).toEqual({ totalTokenCount: 10 });
+  });
+
+  test('이미지 파트가 없으면 throw', async () => {
+    axios.post.mockResolvedValue(imageResponse([{ text: 'no image, sorry' }]));
+
+    await expect(geminiService.generateImage(null, 'key', 'a cat')).rejects.toThrow(
+      'No image returned from Gemini'
+    );
+  });
+
+  test('요청 파트: 첨부 이미지는 inline_data, 프롬프트 텍스트는 마지막', async () => {
+    axios.post.mockResolvedValue(
+      imageResponse([{ inlineData: { data: 'aGk=', mimeType: 'image/png' } }])
+    );
+
+    await geminiService.generateImage(null, 'key', 'edit this', {
+      images: [
+        { buffer: Buffer.from('img1'), mimeType: 'image/jpeg' },
+        { buffer: null }, // buffer 없는 항목은 skip
+      ],
+    });
+
+    const body = axios.post.mock.calls[0][1];
+    const parts = body.contents[0].parts;
+    expect(parts).toHaveLength(2);
+    expect(parts[0].inline_data.mime_type).toBe('image/jpeg');
+    expect(parts[1]).toEqual({ text: 'edit this' });
+  });
+
+  test('imageConfig: 지원 목록의 비율/해상도만 전송, 미지원 값은 제외', async () => {
+    axios.post.mockResolvedValue(
+      imageResponse([{ inlineData: { data: 'aGk=' } }])
+    );
+
+    await geminiService.generateImage(null, 'key', 'p', {
+      aspectRatio: '16:9',
+      resolution: '8K', // 미지원 — 제외돼야 함
+    });
+
+    const body = axios.post.mock.calls[0][1];
+    expect(body.generationConfig.imageConfig).toEqual({ aspectRatio: '16:9' });
+  });
+
+  test('serverUrl 미지정 시 기본 Google 엔드포인트 + 모델 경로', async () => {
+    axios.post.mockResolvedValue(
+      imageResponse([{ inlineData: { data: 'aGk=' } }])
+    );
+
+    await geminiService.generateImage(null, 'key', 'p', { model: { value: 'my-model' } });
+
+    const url = axios.post.mock.calls[0][0];
+    expect(url).toBe(
+      'https://generativelanguage.googleapis.com/v1beta/models/my-model:generateContent'
+    );
+  });
+});
+
+describe('geminiService.complete (Chat)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const chatResponse = (text) => ({
+    data: {
+      candidates: [{ content: { parts: [{ text }] } }],
+      usageMetadata: { promptTokenCount: 3, candidatesTokenCount: 5, totalTokenCount: 8 },
+    },
+  });
+
+  test('model / apiKey / messages 필수 검증', async () => {
+    await expect(geminiService.complete(null, 'k', [], {})).rejects.toThrow('model is required');
+    await expect(
+      geminiService.complete(null, '', [{ role: 'user', content: 'hi' }], { model: 'm' })
+    ).rejects.toThrow('api key is required');
+    await expect(geminiService.complete(null, 'k', [], { model: 'm' })).rejects.toThrow(
+      'messages is empty'
+    );
+  });
+
+  test('assistant 역할은 model 로 매핑, 이미지는 inline_data 파트로', async () => {
+    axios.post.mockResolvedValue(chatResponse('ok'));
+
+    await geminiService.complete(
+      null,
+      'k',
+      [
+        { role: 'user', content: 'look', images: [{ base64: 'aWs=', mimeType: 'image/png' }] },
+        { role: 'assistant', content: 'I see' },
+      ],
+      { model: 'gemini-x' }
+    );
+
+    const body = axios.post.mock.calls[0][1];
+    expect(body.contents[0].role).toBe('user');
+    expect(body.contents[0].parts).toEqual([
+      { text: 'look' },
+      { inline_data: { mime_type: 'image/png', data: 'aWs=' } },
+    ]);
+    expect(body.contents[1].role).toBe('model');
+  });
+
+  test('extraParams 는 generationConfig 에 merge 된다 (#493)', async () => {
+    axios.post.mockResolvedValue(chatResponse('ok'));
+
+    await geminiService.complete(null, 'k', [{ role: 'user', content: 'hi' }], {
+      model: 'm',
+      extraParams: { temperature: 0.2 },
+    });
+
+    const body = axios.post.mock.calls[0][1];
+    expect(body.generationConfig.temperature).toBe(0.2);
+    expect(body.generationConfig.responseModalities).toEqual(['TEXT']);
+  });
+
+  test('빈 응답이면 throw, 정상 응답은 usage 정규화', async () => {
+    axios.post.mockResolvedValue({ data: { candidates: [{ content: { parts: [] } }] } });
+    await expect(
+      geminiService.complete(null, 'k', [{ role: 'user', content: 'hi' }], { model: 'm' })
+    ).rejects.toThrow('빈 응답');
+
+    axios.post.mockResolvedValue(chatResponse('answer'));
+    const result = await geminiService.complete(null, 'k', [{ role: 'user', content: 'hi' }], {
+      model: 'm',
+    });
+    expect(result.content).toBe('answer');
+    expect(result.usage).toEqual({ promptTokens: 3, completionTokens: 5, totalTokens: 8 });
+  });
+});

--- a/src/tests/gptImageService.test.js
+++ b/src/tests/gptImageService.test.js
@@ -1,0 +1,83 @@
+/**
+ * gptImageService 순수 로직 테스트 (#691)
+ *
+ * axios mock 으로 요청 조립(기본값 · 선택 필드 조건부 포함)과
+ * 응답 파싱(b64_json → buffer) · 에러 매핑을 검증한다.
+ */
+
+jest.mock('axios');
+const axios = require('axios');
+const gptImageService = require('../services/gptImageService');
+
+const okResponse = (entries, usage = null) => ({ data: { data: entries, usage } });
+
+describe('gptImageService.generateImage', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('apiKey 없으면 throw', async () => {
+    await expect(gptImageService.generateImage(null, '', 'a cat')).rejects.toThrow(
+      'GPT Image API key is required'
+    );
+  });
+
+  test('기본값: 모델/사이즈/품질/포맷 + 기본 OpenAI 엔드포인트', async () => {
+    axios.post.mockResolvedValue(okResponse([{ b64_json: 'aGk=' }]));
+
+    await gptImageService.generateImage(null, 'key', 'a cat');
+
+    const [url, body] = axios.post.mock.calls[0];
+    expect(url).toBe('https://api.openai.com/v1/images/generations');
+    expect(body).toEqual({
+      model: 'gpt-image-1.5',
+      prompt: 'a cat',
+      n: 1,
+      size: '1024x1024',
+      quality: 'medium',
+      output_format: 'png',
+    });
+  });
+
+  test('background / output_compression 은 유효할 때만 포함 (숫자 변환)', async () => {
+    axios.post.mockResolvedValue(okResponse([{ b64_json: 'aGk=' }]));
+
+    await gptImageService.generateImage(null, 'key', 'p', {
+      background: 'transparent',
+      outputCompression: '80',
+    });
+    let body = axios.post.mock.calls[0][1];
+    expect(body.background).toBe('transparent');
+    expect(body.output_compression).toBe(80);
+
+    await gptImageService.generateImage(null, 'key', 'p', { outputCompression: 'abc' });
+    body = axios.post.mock.calls[1][1];
+    expect(body.output_compression).toBeUndefined();
+    expect(body.background).toBeUndefined();
+  });
+
+  test('b64_json 파싱 — 유효 항목만 buffer 로, 없으면 throw', async () => {
+    axios.post.mockResolvedValue(
+      okResponse([{ b64_json: Buffer.from('img').toString('base64') }, { url: 'http://x' }], { total_tokens: 5 })
+    );
+    const result = await gptImageService.generateImage(null, 'key', 'p');
+    expect(result.images).toHaveLength(1);
+    expect(result.images[0].buffer.toString()).toBe('img');
+    expect(result.usage).toEqual({ total_tokens: 5 });
+
+    axios.post.mockResolvedValue(okResponse([]));
+    await expect(gptImageService.generateImage(null, 'key', 'p')).rejects.toThrow(
+      'No image returned from GPT Image'
+    );
+  });
+
+  test('에러 매핑: 조직 인증 안내 / 일반 API 메시지', async () => {
+    axios.post.mockRejectedValue({
+      response: { data: { error: { message: 'Your organization must be verified.' } } },
+    });
+    await expect(gptImageService.generateImage(null, 'key', 'p')).rejects.toThrow(/조직 인증/);
+
+    axios.post.mockRejectedValue({ response: { data: { error: { message: 'billing issue' } } } });
+    await expect(gptImageService.generateImage(null, 'key', 'p')).rejects.toThrow(
+      'OpenAI: billing issue'
+    );
+  });
+});

--- a/src/tests/jobsRouteAuth.test.js
+++ b/src/tests/jobsRouteAuth.test.js
@@ -1,0 +1,115 @@
+/**
+ * jobs 라우트 인가(소유권) 회귀 테스트 (#691)
+ *
+ * 미들웨어/모델/큐 서비스를 mock 해 라우트 레벨의 소유권 검사
+ * (본인 또는 admin 만 조회/삭제) 와 등록 순서(/my 가 /:id 에 안 가림)를 검증한다.
+ */
+
+const express = require('express');
+const request = require('supertest');
+
+let mockCurrentUser;
+
+jest.mock('../middleware/auth', () => ({
+  requireAuth: (req, res, next) => {
+    req.user = mockCurrentUser;
+    next();
+  },
+  userHasWorkboardAccess: jest.fn().mockResolvedValue(true),
+}));
+
+// queueService 는 bull/redis 를 물고 있어 모듈째 mock
+jest.mock('../services/queueService', () => ({
+  addImageGenerationJob: jest.fn(),
+  getQueueStats: jest.fn(),
+  cancelQueueJob: jest.fn(),
+  abortActiveJob: jest.fn(),
+}));
+
+jest.mock('../models/ImageGenerationJob', () => ({
+  findById: jest.fn(),
+  find: jest.fn(),
+  countDocuments: jest.fn(),
+}));
+
+const ImageGenerationJob = require('../models/ImageGenerationJob');
+
+// findById().populate()...(체이닝) 뒤 await 되는 mongoose query 흉내
+function chainable(result) {
+  const chain = {};
+  chain.populate = () => chain;
+  chain.select = () => chain;
+  chain.sort = () => chain;
+  chain.skip = () => chain;
+  chain.limit = () => chain;
+  chain.lean = () => chain;
+  chain.then = (resolve, reject) => Promise.resolve(result).then(resolve, reject);
+  return chain;
+}
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/jobs', require('../routes/jobs'));
+  return app;
+}
+
+describe('jobs 라우트 소유권 검사 (#691)', () => {
+  let app;
+
+  beforeAll(() => {
+    app = createApp();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCurrentUser = { _id: 'user-1', isAdmin: false };
+  });
+
+  const ownJob = { _id: 'job-1', userId: 'user-1', status: 'completed' };
+  const otherJob = { _id: 'job-2', userId: 'user-2', status: 'completed' };
+
+  test('GET /:id — 본인 작업은 200', async () => {
+    ImageGenerationJob.findById.mockReturnValue(chainable(ownJob));
+
+    const res = await request(app).get('/api/jobs/job-1');
+    expect(res.status).toBe(200);
+    expect(res.body.job._id).toBe('job-1');
+  });
+
+  test('GET /:id — 타인 작업은 403', async () => {
+    ImageGenerationJob.findById.mockReturnValue(chainable(otherJob));
+
+    const res = await request(app).get('/api/jobs/job-2');
+    expect(res.status).toBe(403);
+  });
+
+  test('GET /:id — admin 은 타인 작업도 200', async () => {
+    mockCurrentUser = { _id: 'admin-1', isAdmin: true };
+    ImageGenerationJob.findById.mockReturnValue(chainable(otherJob));
+
+    const res = await request(app).get('/api/jobs/job-2');
+    expect(res.status).toBe(200);
+  });
+
+  test('GET /:id — 없는 작업은 404', async () => {
+    ImageGenerationJob.findById.mockReturnValue(chainable(null));
+
+    const res = await request(app).get('/api/jobs/nope');
+    expect(res.status).toBe(404);
+  });
+
+  test('GET /my — /:id 에 가리지 않고 본인 필터 목록으로 동작 (등록 순서 회귀 방지)', async () => {
+    ImageGenerationJob.find.mockReturnValue(chainable([]));
+    ImageGenerationJob.countDocuments.mockResolvedValue(0);
+
+    const res = await request(app).get('/api/jobs/my');
+
+    expect(res.status).toBe(200);
+    // /:id 로 샜다면 findById('my') 가 호출된다
+    expect(ImageGenerationJob.findById).not.toHaveBeenCalled();
+    expect(ImageGenerationJob.find).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-1' })
+    );
+  });
+});

--- a/src/tests/modelMetadataProviders.test.js
+++ b/src/tests/modelMetadataProviders.test.js
@@ -1,0 +1,152 @@
+/**
+ * modelMetadataService provider 로직 테스트 (#691)
+ *
+ * axios / 모델 mock 으로 provider 모델 목록 파싱 + outputFormat 추론(#354),
+ * OpenAI Compatible 미분류 노출 회귀(#487)를 검증한다.
+ */
+
+jest.mock('axios');
+jest.mock('../models/ServerModelCache', () => ({ findOne: jest.fn() }));
+jest.mock('../models/SystemSettings', () => ({ findOne: jest.fn() }));
+
+const axios = require('axios');
+const ServerModelCache = require('../models/ServerModelCache');
+const modelMetadataService = require('../services/modelMetadataService');
+
+describe('getOpenAIProviderModels — 파싱 + outputFormat 추론', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('모델 종류별 outputFormats 추론 (#354)', async () => {
+    axios.get.mockResolvedValue({
+      data: {
+        data: [
+          { id: 'gpt-4o', owned_by: 'openai' },
+          { id: 'dall-e-3' },
+          { id: 'gpt-image-1.5' },
+          { id: 'o3-mini' },
+          { id: 'whisper-1' },
+          { id: 'text-embedding-3-small' },
+        ],
+      },
+    });
+
+    const models = await modelMetadataService.getOpenAIProviderModels('http://api', 'k');
+    const byId = Object.fromEntries(models.map((m) => [m.id, m.outputFormats]));
+
+    expect(byId['gpt-4o']).toEqual(['text']);
+    expect(byId['dall-e-3']).toEqual(['image']);
+    expect(byId['gpt-image-1.5']).toEqual(['image']);
+    expect(byId['o3-mini']).toEqual(['text']);
+    // whisper / embedding 은 워크플로 미지원 — 미분류(빈 배열)
+    expect(byId['whisper-1']).toEqual([]);
+    expect(byId['text-embedding-3-small']).toEqual([]);
+  });
+
+  test('로컬 LLM 임의 모델명(llama 등)은 미분류로 파싱된다', async () => {
+    axios.get.mockResolvedValue({
+      data: { data: [{ id: 'llama-3.3-70b-instruct' }, { id: 'qwen3-32b' }] },
+    });
+
+    const models = await modelMetadataService.getOpenAIProviderModels('http://local:1234');
+    expect(models.every((m) => m.outputFormats.length === 0)).toBe(true);
+    // apiKey 미전달 시 Authorization 헤더 없음 (로컬 서버)
+    expect(axios.get.mock.calls[0][1].headers.Authorization).toBeUndefined();
+  });
+
+  test('요청 실패는 컨텍스트 있는 에러로 래핑', async () => {
+    axios.get.mockRejectedValue(new Error('ECONNREFUSED'));
+    await expect(
+      modelMetadataService.getOpenAIProviderModels('http://api', 'k')
+    ).rejects.toThrow('Failed to fetch OpenAI models: ECONNREFUSED');
+  });
+});
+
+describe('getGeminiProviderModels — 파싱 + outputFormat 추론', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('generateContent=text, predict=image, image 키워드+generateContent=image, embed=미분류', async () => {
+    axios.get.mockResolvedValue({
+      data: {
+        models: [
+          {
+            name: 'models/gemini-2.5-pro',
+            displayName: 'Gemini 2.5 Pro',
+            supportedGenerationMethods: ['generateContent'],
+            inputTokenLimit: 1000000,
+          },
+          {
+            name: 'models/imagen-4.0',
+            supportedGenerationMethods: ['predict'],
+          },
+          {
+            // multimodal image 모델은 이름만으로는 판별 불가 — 실제 API 처럼
+            // displayName/description 의 image 키워드로 판별된다 (#354)
+            name: 'models/gemini-2.5-flash-image',
+            displayName: 'Nano Banana',
+            description: 'State-of-the-art image generation model',
+            supportedGenerationMethods: ['generateContent'],
+          },
+          {
+            name: 'models/text-embedding-004',
+            supportedGenerationMethods: ['embedContent'],
+          },
+        ],
+      },
+    });
+
+    const models = await modelMetadataService.getGeminiProviderModels('http://gem', 'k');
+    const byId = Object.fromEntries(models.map((m) => [m.id, m]));
+
+    // 'models/' prefix 제거 확인
+    expect(byId['gemini-2.5-pro']).toBeDefined();
+    expect(byId['gemini-2.5-pro'].outputFormats).toEqual(['text']);
+    expect(byId['gemini-2.5-pro'].name).toBe('Gemini 2.5 Pro');
+    expect(byId['gemini-2.5-pro'].contextWindow).toBe(1000000);
+    expect(byId['imagen-4.0'].outputFormats).toEqual(['image']);
+    expect(byId['gemini-2.5-flash-image'].outputFormats).toEqual(['image']);
+    expect(byId['text-embedding-004'].outputFormats).toEqual([]);
+  });
+});
+
+describe('searchServerModels — outputFormat 필터의 미분류 처리 (#487 회귀)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const cacheWith = (models) => ({ status: 'ready', lastFetched: null, lastMetadataSync: null, hashNodeAvailable: false, models });
+
+  const providerModels = [
+    { filename: 'gpt-4o', provider: { found: true, outputFormats: ['text'] } },
+    { filename: 'dall-e-3', provider: { found: true, outputFormats: ['image'] } },
+    { filename: 'llama-3.3-70b', provider: { found: true, outputFormats: [] } }, // 미분류 (로컬)
+  ];
+
+  test('OpenAI Compatible 서버는 미분류 모델을 text 필터에서도 노출한다', async () => {
+    ServerModelCache.findOne.mockResolvedValue(cacheWith(providerModels));
+
+    const result = await modelMetadataService.searchServerModels('srv1', {
+      outputFormat: 'text',
+      serverType: 'OpenAI Compatible',
+    });
+
+    const names = result.models.map((m) => m.filename).sort();
+    expect(names).toEqual(['gpt-4o', 'llama-3.3-70b']);
+  });
+
+  test('OpenAI 공식 서버는 미분류 모델을 숨긴다 (whisper 류 클러터 방지)', async () => {
+    ServerModelCache.findOne.mockResolvedValue(cacheWith(providerModels));
+
+    const result = await modelMetadataService.searchServerModels('srv1', {
+      outputFormat: 'text',
+      serverType: 'OpenAI',
+    });
+
+    expect(result.models.map((m) => m.filename)).toEqual(['gpt-4o']);
+  });
+
+  test('캐시가 없으면 빈 결과', async () => {
+    ServerModelCache.findOne.mockResolvedValue(null);
+
+    const result = await modelMetadataService.searchServerModels('srv-none', {});
+    expect(result.models).toEqual([]);
+    expect(result.pagination.total).toBe(0);
+  });
+});

--- a/src/tests/openAIChatService.test.js
+++ b/src/tests/openAIChatService.test.js
@@ -1,0 +1,198 @@
+/**
+ * openAIChatService 순수 로직 테스트 (#691)
+ *
+ * axios mock 으로 요청 조립(vision 직렬화 · extraParams 덮어쓰기 방지)과
+ * 응답/에러 처리, SSE 스트림 파싱(청크 경계 · usage · [DONE])을 검증한다.
+ */
+
+jest.mock('axios');
+const { EventEmitter } = require('events');
+const axios = require('axios');
+const openAIChatService = require('../services/openAIChatService');
+
+const okResponse = (content, usage) => ({
+  data: {
+    choices: [{ message: { content } }],
+    usage,
+  },
+});
+
+describe('openAIChatService.complete', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('serverUrl / model 필수 검증', async () => {
+    await expect(openAIChatService.complete('', 'k', [], { model: 'm' })).rejects.toThrow(
+      'serverUrl is required'
+    );
+    await expect(openAIChatService.complete('http://llm', 'k', [], {})).rejects.toThrow(
+      'model is required'
+    );
+  });
+
+  test('이미지 없는 메시지는 문자열 content 유지, 이미지는 data URL 로 직렬화 (#517)', async () => {
+    axios.post.mockResolvedValue(okResponse('ok'));
+
+    await openAIChatService.complete(
+      'http://llm',
+      'k',
+      [
+        { role: 'system', content: 'be nice' },
+        { role: 'user', content: 'what is this', images: [{ base64: 'aWs=', mimeType: 'image/png' }] },
+      ],
+      { model: 'gpt-x' }
+    );
+
+    const body = axios.post.mock.calls[0][1];
+    expect(body.messages[0]).toEqual({ role: 'system', content: 'be nice' });
+    expect(body.messages[1].content).toEqual([
+      { type: 'text', text: 'what is this' },
+      { type: 'image_url', image_url: { url: 'data:image/png;base64,aWs=' } },
+    ]);
+  });
+
+  test('extraParams 는 passthrough 되지만 model/messages 는 덮어쓸 수 없다 (#493)', async () => {
+    axios.post.mockResolvedValue(okResponse('ok'));
+
+    await openAIChatService.complete(
+      'http://llm',
+      'k',
+      [{ role: 'user', content: 'hi' }],
+      { model: 'real-model', extraParams: { max_tokens: 8, model: 'evil-model', messages: [] } }
+    );
+
+    const body = axios.post.mock.calls[0][1];
+    expect(body.max_tokens).toBe(8);
+    expect(body.model).toBe('real-model');
+    expect(body.messages).toHaveLength(1);
+  });
+
+  test('apiKey 있으면 Bearer 헤더, 없으면 미포함 (로컬 LLM)', async () => {
+    axios.post.mockResolvedValue(okResponse('ok'));
+
+    await openAIChatService.complete('http://llm', 'secret', [{ role: 'user', content: 'a' }], { model: 'm' });
+    expect(axios.post.mock.calls[0][2].headers.Authorization).toBe('Bearer secret');
+
+    await openAIChatService.complete('http://llm', '', [{ role: 'user', content: 'a' }], { model: 'm' });
+    expect(axios.post.mock.calls[1][2].headers.Authorization).toBeUndefined();
+  });
+
+  test('API 에러 메시지 매핑: 조직 인증 필요 안내 / 일반 메시지 / 빈 choices / 빈 content', async () => {
+    axios.post.mockRejectedValue({
+      response: { data: { error: { message: 'Your organization must be verified to use this model' } } },
+    });
+    await expect(
+      openAIChatService.complete('http://llm', 'k', [{ role: 'user', content: 'a' }], { model: 'gpt-9' })
+    ).rejects.toThrow(/조직 인증/);
+
+    axios.post.mockRejectedValue({ response: { data: { error: { message: 'rate limited' } } } });
+    await expect(
+      openAIChatService.complete('http://llm', 'k', [{ role: 'user', content: 'a' }], { model: 'm' })
+    ).rejects.toThrow('OpenAI: rate limited');
+
+    axios.post.mockResolvedValue({ data: { choices: [] } });
+    await expect(
+      openAIChatService.complete('http://llm', 'k', [{ role: 'user', content: 'a' }], { model: 'm' })
+    ).rejects.toThrow('유효한 응답');
+
+    axios.post.mockResolvedValue(okResponse(''));
+    await expect(
+      openAIChatService.complete('http://llm', 'k', [{ role: 'user', content: 'a' }], { model: 'm' })
+    ).rejects.toThrow('빈 응답');
+  });
+
+  test('usage 정규화 (미제공 시 0)', async () => {
+    axios.post.mockResolvedValue(
+      okResponse('hi', { prompt_tokens: 2, completion_tokens: 4, total_tokens: 6 })
+    );
+    let result = await openAIChatService.complete(
+      'http://llm', 'k', [{ role: 'user', content: 'a' }], { model: 'm' }
+    );
+    expect(result.usage).toEqual({ promptTokens: 2, completionTokens: 4, totalTokens: 6 });
+
+    axios.post.mockResolvedValue(okResponse('hi'));
+    result = await openAIChatService.complete(
+      'http://llm', 'k', [{ role: 'user', content: 'a' }], { model: 'm' }
+    );
+    expect(result.usage).toEqual({ promptTokens: 0, completionTokens: 0, totalTokens: 0 });
+  });
+});
+
+describe('openAIChatService.completeStream — SSE 파싱 (#490)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const sseChunk = (delta) =>
+    `data: ${JSON.stringify({ choices: [{ delta: { content: delta } }] })}\n`;
+
+  const streamWith = (emitFn) => {
+    const stream = new EventEmitter();
+    axios.post.mockResolvedValue({ data: stream });
+    // completeStream 이 리스너를 등록한 다음 틱에 이벤트를 흘려보낸다
+    setImmediate(() => emitFn(stream));
+    return stream;
+  };
+
+  test('토큰 delta 누적 + onToken 콜백 + 마지막 청크 usage', async () => {
+    streamWith((s) => {
+      s.emit('data', Buffer.from(sseChunk('Hel') + sseChunk('lo')));
+      s.emit(
+        'data',
+        Buffer.from(
+          `data: ${JSON.stringify({ choices: [], usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 } })}\n` +
+            'data: [DONE]\n'
+        )
+      );
+      s.emit('end');
+    });
+
+    const tokens = [];
+    const result = await openAIChatService.completeStream(
+      'http://llm', 'k', [{ role: 'user', content: 'a' }], { model: 'm' },
+      (t) => tokens.push(t)
+    );
+
+    expect(result.content).toBe('Hello');
+    expect(tokens).toEqual(['Hel', 'lo']);
+    expect(result.usage).toEqual({ promptTokens: 1, completionTokens: 2, totalTokens: 3 });
+  });
+
+  test('청크 경계에서 잘린 SSE 줄을 이어 붙여 파싱한다', async () => {
+    const line = sseChunk('whole-token');
+    streamWith((s) => {
+      s.emit('data', Buffer.from(line.slice(0, 20)));
+      s.emit('data', Buffer.from(line.slice(20)));
+      s.emit('end');
+    });
+
+    const result = await openAIChatService.completeStream(
+      'http://llm', 'k', [{ role: 'user', content: 'a' }], { model: 'm' }
+    );
+
+    expect(result.content).toBe('whole-token');
+  });
+
+  test('usage 미제공 서버는 0 으로 degrade, 요청에 stream 옵션 포함', async () => {
+    streamWith((s) => {
+      s.emit('data', Buffer.from(sseChunk('x') + 'data: [DONE]\n'));
+      s.emit('end');
+    });
+
+    const result = await openAIChatService.completeStream(
+      'http://llm', 'k', [{ role: 'user', content: 'a' }], { model: 'm' }
+    );
+
+    expect(result.usage).toEqual({ promptTokens: 0, completionTokens: 0, totalTokens: 0 });
+    const body = axios.post.mock.calls[0][1];
+    expect(body.stream).toBe(true);
+    expect(body.stream_options).toEqual({ include_usage: true });
+  });
+
+  test('스트림 error 이벤트는 reject 로 전파', async () => {
+    streamWith((s) => {
+      s.emit('error', new Error('socket hang up'));
+    });
+
+    await expect(
+      openAIChatService.completeStream('http://llm', 'k', [{ role: 'user', content: 'a' }], { model: 'm' })
+    ).rejects.toThrow('socket hang up');
+  });
+});

--- a/src/tests/serversRouteAuth.test.js
+++ b/src/tests/serversRouteAuth.test.js
@@ -1,0 +1,121 @@
+/**
+ * servers 라우트 인가(admin 게이트) 회귀 테스트 (#691)
+ *
+ * 목록 조회는 일반 사용자 허용(작업판 picker 용), 상세/CUD 는 admin 전용,
+ * 목록 응답에서 API 키 필드 제외를 검증한다.
+ */
+
+const express = require('express');
+const request = require('supertest');
+
+let mockCurrentUser;
+
+jest.mock('../middleware/auth', () => ({
+  verifyJWT: (req, res, next) => {
+    req.user = mockCurrentUser;
+    next();
+  },
+  requireAdmin: (req, res, next) => {
+    if (!mockCurrentUser?.isAdmin) {
+      return res.status(403).json({ success: false, message: '관리자 권한이 필요합니다.' });
+    }
+    req.user = mockCurrentUser;
+    next();
+  },
+  userHasWorkboardAccess: jest.fn().mockResolvedValue(true),
+}));
+
+jest.mock('../models/Server', () => ({
+  find: jest.fn(),
+  findById: jest.fn(),
+  findOne: jest.fn(),
+}));
+jest.mock('../models/ServerLoraCache', () => ({ findOne: jest.fn() }));
+jest.mock('../models/ServerModelCache', () => ({ findOne: jest.fn() }));
+jest.mock('../models/Workboard', () => ({ findById: jest.fn() }));
+// 무거운 서비스 의존은 모듈째 mock (이 테스트에서 호출 안 됨)
+jest.mock('../services/loraMetadataService', () => ({}));
+jest.mock('../services/modelMetadataService', () => ({}));
+jest.mock('../services/comfyUIService', () => ({}));
+
+const Server = require('../models/Server');
+
+function chainable(result) {
+  const chain = {};
+  chain.populate = () => chain;
+  chain.select = jest.fn(() => chain);
+  chain.sort = () => chain;
+  chain.lean = () => chain;
+  chain.then = (resolve, reject) => Promise.resolve(result).then(resolve, reject);
+  return chain;
+}
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/servers', require('../routes/servers'));
+  return app;
+}
+
+describe('servers 라우트 admin 게이트 (#691)', () => {
+  let app;
+
+  beforeAll(() => {
+    app = createApp();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCurrentUser = { _id: 'user-1', isAdmin: false };
+  });
+
+  test('GET / — 일반 사용자도 목록 조회 가능, API 키는 select 에서 제외', async () => {
+    const chain = chainable([{ _id: 's1', name: 'ComfyUI-1' }]);
+    Server.find.mockReturnValue(chain);
+
+    const res = await request(app).get('/api/servers');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.servers).toHaveLength(1);
+    expect(chain.select).toHaveBeenCalledWith('-configuration.apiKey');
+  });
+
+  test('GET / — 기본은 활성 서버만, includeInactive=true 면 필터 해제', async () => {
+    Server.find.mockReturnValue(chainable([]));
+
+    await request(app).get('/api/servers');
+    expect(Server.find).toHaveBeenCalledWith(expect.objectContaining({ isActive: true }));
+
+    await request(app).get('/api/servers').query({ includeInactive: 'true' });
+    expect(Server.find).toHaveBeenLastCalledWith(
+      expect.not.objectContaining({ isActive: true })
+    );
+  });
+
+  test('GET /:id — 일반 사용자는 403 (admin 전용 상세)', async () => {
+    const res = await request(app).get('/api/servers/s1');
+    expect(res.status).toBe(403);
+    expect(Server.findById).not.toHaveBeenCalled();
+  });
+
+  test('POST / — 일반 사용자는 403, 모델 접근 자체가 없어야 함', async () => {
+    const res = await request(app)
+      .post('/api/servers')
+      .send({ name: 'x', serverType: 'ComfyUI', serverUrl: 'http://c' });
+
+    expect(res.status).toBe(403);
+  });
+
+  test('POST / — admin 은 게이트 통과 (필수 필드 검증 단계 도달)', async () => {
+    mockCurrentUser = { _id: 'admin-1', isAdmin: true };
+
+    // 필수 필드 누락으로 400 — requireAdmin 게이트를 통과해 핸들러에 도달했다는 증거
+    const res = await request(app).post('/api/servers').send({ name: 'only-name' });
+    expect(res.status).toBe(400);
+  });
+
+  test('DELETE /:id — 일반 사용자는 403', async () => {
+    const res = await request(app).delete('/api/servers/s1');
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
closes #691

2026-07-12 전면 점검 후속 — backup/restore 편중이던 테스트를 provider 연동·라우트 인가로 확장. 실 API 호출 없이 axios/모델/큐 전부 mock (순수 로직 검증).

## 추가된 테스트 (7 suites / 48 tests)

| 파일 | 검증 내용 |
|---|---|
| `geminiService.test.js` | generateImage 요청 조립(첨부 inline_data·imageConfig 허용값 필터)·inlineData 파싱, complete 역할 매핑(assistant→model)·extraParams merge(#493)·usage 정규화 |
| `openAIChatService.test.js` | vision data-URL 직렬화(#517), extraParams passthrough 시 model/messages 덮어쓰기 방지(#493), 조직인증/일반 에러 매핑, **completeStream SSE 파싱**(#490 — 청크 경계 이어붙임·[DONE]·마지막 usage·onToken) |
| `gptImageService.test.js` | 기본값(모델/사이즈/품질/포맷), background·output_compression 조건부 포함, b64 파싱, 에러 매핑 |
| `comfyUIModelLists.test.js` | object_info 의 LoRA/checkpoint 목록 추출·대소문자 무시 정렬·이상 응답·에러 래핑 |
| `modelMetadataProviders.test.js` | OpenAI/Gemini `/models` 파싱 + outputFormat 추론(#354 — dall-e/gpt/whisper/imagen/embed 분기), **searchServerModels 의 OpenAI Compatible 미분류 노출(#487) 회귀** |
| `jobsRouteAuth.test.js` | `GET /:id` 소유권(본인 200/타인 403/admin 200/404), `GET /my` 등록 순서 회귀 |
| `serversRouteAuth.test.js` | 목록은 일반 사용자 허용 + `-configuration.apiKey` select 확인(#594), 상세/POST/DELETE admin 게이트 |

## 결과
- 31 → **38 suites**, 259 → **307 tests** 전부 green
- #687 conversations 셰도잉 같은 라우트 등록 순서·인가 회귀가 이제 jest 에서 잡힘

🤖 Generated with [Claude Code](https://claude.com/claude-code)