### PR TITLE
refactor: 메타데이터 어댑터·동기화 폴링 공용화 + 다운로드 유틸 추출 (#697)

### DIFF
--- a/frontend/src/components/admin/MetadataManagementBody.js
+++ b/frontend/src/components/admin/MetadataManagementBody.js
@@ -39,56 +39,12 @@ import MetadataItemCard from '../common/MetadataItemCard';
 import MetadataItemGrid from '../common/MetadataItemGrid';
 import MetadataDetailDialog from '../common/MetadataDetailDialog';
 import MetadataImageListItem from './MetadataImageListItem';
-import { normalizeLora, normalizeModel } from '../../utils/metadataItem';
-import { serverAPI } from '../../services/api';
+import { METADATA_ADAPTERS } from '../../utils/metadataAdapters';
+import useMetadataSyncPolling, { checkInitialSyncStatus } from '../../hooks/useMetadataSyncPolling';
 import { MONO } from '../../theme';
 
 const VIEW_MODE_KEY_PREFIX = 'vcc.metadataAdmin.viewMode.';
 const PAGE_SIZE = 24;
-
-// kind 별 API / 정규화 / 라벨 어댑터 (#344)
-const ADAPTERS = {
-  model: {
-    fetch: (serverId, params) => serverAPI.getDetailedModels(serverId, params),
-    sync: (serverId) => serverAPI.syncModels(serverId, { forceRefresh: true }),
-    getStatus: (serverId) => serverAPI.getModelsSyncStatus(serverId),
-    resetSync: (serverId) => serverAPI.resetModelsSync(serverId),
-    clearCache: (serverId) => serverAPI.clearModelCache(serverId),
-    extractList: (data) => data?.models || [],
-    extractPagination: (data) => data?.pagination || { current: 1, pages: 0, total: 0 },
-    extractCacheInfo: (data) => data?.cacheInfo || null,
-    extractAvailableBaseModels: (data) => data?.availableBaseModels || [],
-    extractTotal: (status, pagination) => status?.totalModels || pagination?.total || 0,
-    extractMetaCount: (status) => status?.modelsWithMetadata,
-    extractLastSync: (info, status) => info?.lastMetadataSync || status?.lastMetadataSync,
-    normalize: (raw, serverType) => normalizeModel(raw, { serverType }),
-    label: '베이스 모델',
-    searchPlaceholder: '모델 검색...',
-    cacheDialogTitle: '베이스 모델 캐시 완전 삭제',
-    cacheDialogBody: '선택한 서버의 모델 캐시를 모두 비웁니다. 다음 동기화부터 hash 부터 재계산됩니다.',
-    emptyMessage: '베이스 모델이 없습니다.',
-  },
-  lora: {
-    fetch: (serverId, params) => serverAPI.getLoras(serverId, params),
-    sync: (serverId) => serverAPI.syncLoras(serverId, { forceRefresh: true }),
-    getStatus: (serverId) => serverAPI.getLorasSyncStatus(serverId),
-    resetSync: (serverId) => serverAPI.resetLorasSync(serverId),
-    clearCache: (serverId) => serverAPI.clearLoraCache(serverId),
-    extractList: (data) => data?.loraModels || [],
-    extractPagination: (data) => data?.pagination || { current: 1, pages: 0, total: 0 },
-    extractCacheInfo: (data) => data?.cacheInfo || null,
-    extractAvailableBaseModels: (data) => data?.availableBaseModels || [],
-    extractTotal: (status, pagination) => status?.totalLoras || pagination?.total || 0,
-    extractMetaCount: (status) => status?.lorasWithMetadata,
-    extractLastSync: (info, status) => info?.lastCivitaiSync || status?.lastCivitaiSync,
-    normalize: (raw) => normalizeLora(raw),
-    label: 'LoRA',
-    searchPlaceholder: 'LoRA 검색...',
-    cacheDialogTitle: 'LoRA 캐시 완전 삭제',
-    cacheDialogBody: '선택한 서버의 LoRA 캐시를 모두 비웁니다. 다음 동기화부터 hash 부터 재계산됩니다.',
-    emptyMessage: 'LoRA 가 없습니다.',
-  }
-};
 
 function formatDate(dateString) {
   if (!dateString) return '없음';
@@ -98,8 +54,8 @@ function formatDate(dateString) {
 // 베이스 모델 / LoRA admin 페이지 공용 본문 (#344).
 // 검색 + view mode 토글 + 동기화 / 캐시 삭제 / 리셋 + 캐시 info + 결과 (3종 view mode).
 function MetadataManagementBody({ kind, selectedServerId, selectedServer, nsfwModelFilter = true }) {
-  // adapter 가 없으면 빈 객체로 fallback — hook order 보존을 위해 조건부 return 사용 안 함.
-  const adapter = ADAPTERS[kind] || ADAPTERS.model;
+  // adapter 가 없으면 model 로 fallback — hook order 보존을 위해 조건부 return 사용 안 함.
+  const adapter = METADATA_ADAPTERS[kind] || METADATA_ADAPTERS.model;
 
   const [items, setItems] = useState([]);
   const [pagination, setPagination] = useState({ current: 1, pages: 0, total: 0 });
@@ -126,7 +82,8 @@ function MetadataManagementBody({ kind, selectedServerId, selectedServer, nsfwMo
     setLoading(true);
     setError(null);
     try {
-      const response = await adapter.fetch(selectedServerId, {
+      const response = await adapter.fetch({
+        serverId: selectedServerId,
         search: searchQuery,
         baseModel: baseModelFilter,
         page,
@@ -136,8 +93,8 @@ function MetadataManagementBody({ kind, selectedServerId, selectedServer, nsfwMo
       setItems(adapter.extractList(data));
       setPagination(adapter.extractPagination(data));
       setCacheInfo(adapter.extractCacheInfo(data));
-      const avail = adapter.extractAvailableBaseModels(data);
-      if (avail) setAvailableBaseModels(avail);
+      // 응답에 목록이 없으면 빈 배열로 초기화 (서버 전환 시 이전 서버 필터 잔존 방지)
+      setAvailableBaseModels(adapter.extractAvailableBaseModels(data) || []);
     } catch (err) {
       console.error(`Failed to fetch ${kind}:`, err);
       setError(err.response?.data?.message || `${adapter.label} 목록을 가져오는데 실패했습니다.`);
@@ -147,30 +104,15 @@ function MetadataManagementBody({ kind, selectedServerId, selectedServer, nsfwMo
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedServerId, searchQuery, baseModelFilter, kind]);
 
-  // sync 폴링
-  useEffect(() => {
-    if (!syncing || !selectedServerId) return undefined;
-    const interval = setInterval(async () => {
-      try {
-        const r = await adapter.getStatus(selectedServerId);
-        const status = r.data.data;
-        setSyncStatus(status);
-        if (['completed', 'failed', 'idle'].includes(status.status)) {
-          setSyncing(false);
-          if (status.status === 'completed') {
-            toast.success(`${adapter.label} 동기화가 완료되었습니다.`);
-            fetchItems(1);
-          } else if (status.status === 'failed') {
-            toast.error(`동기화 실패: ${status.errorMessage || '알 수 없는 오류'}`);
-          }
-        }
-      } catch (err) {
-        console.error('Failed to get sync status:', err);
-      }
-    }, 2000);
-    return () => clearInterval(interval);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [syncing, selectedServerId, kind]);
+  // sync 폴링 — 공용 hook (#697)
+  useMetadataSyncPolling({
+    adapter,
+    serverId: selectedServerId,
+    syncing,
+    setSyncing,
+    setSyncStatus,
+    onCompleted: () => fetchItems(1),
+  });
 
   // 서버 변경 시 reset + fetch
   useEffect(() => {
@@ -183,13 +125,7 @@ function MetadataManagementBody({ kind, selectedServerId, selectedServer, nsfwMo
       return;
     }
     fetchItems(1);
-    adapter.getStatus(selectedServerId)
-      .then((r) => {
-        const status = r.data.data;
-        setSyncStatus(status);
-        if (status.status === 'fetching') setSyncing(true);
-      })
-      .catch(console.error);
+    checkInitialSyncStatus(adapter, selectedServerId, { setSyncStatus, setSyncing });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedServerId, kind]);
 

--- a/frontend/src/components/common/ImageViewerDialog.js
+++ b/frontend/src/components/common/ImageViewerDialog.js
@@ -11,6 +11,7 @@ import {
 } from '@mui/material';
 import { Download, Close } from '@mui/icons-material';
 import toast from 'react-hot-toast';
+import { downloadFromUrl } from '../../utils/download';
 
 function ImageViewerDialog({ 
   images = [], 
@@ -51,22 +52,8 @@ function ImageViewerDialog({
   
   const handleDownload = async () => {
     try {
-      const response = await fetch(currentImage.url);
-      const blob = await response.blob();
-      const blobUrl = window.URL.createObjectURL(blob);
-      
-      const link = document.createElement('a');
-      link.href = blobUrl;
-      link.download = currentImage.originalName || `image_${safeIndex + 1}.png`;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
+      await downloadFromUrl(currentImage.url, currentImage.originalName || `image_${safeIndex + 1}.png`);
       toast.success('다운로드 완료');
-      
-      setTimeout(() => {
-        window.URL.revokeObjectURL(blobUrl);
-      }, 1000);
-      
     } catch (error) {
       console.error('Download error:', error);
       toast.error('다운로드 실패. 잠시 후 다시 시도해주세요.');

--- a/frontend/src/components/common/MediaGrid.js
+++ b/frontend/src/components/common/MediaGrid.js
@@ -35,6 +35,7 @@ import {
 import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { imageAPI } from '../../services/api';
+import { downloadBlob, downloadFromUrl } from '../../utils/download';
 import Pagination from './Pagination';
 import VideoViewerDialog from './VideoViewerDialog';
 import ProjectTagChip from './ProjectTagChip';
@@ -46,37 +47,16 @@ function ImageDetailDialog({ image, open, onClose, type }) {
     if (type === 'generated') {
       try {
         const response = await imageAPI.downloadGenerated(image._id);
-        const blob = new Blob([response.data]);
-        const blobUrl = window.URL.createObjectURL(blob);
-
-        const link = document.createElement('a');
-        link.href = blobUrl;
-        link.download = image.originalName;
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
+        downloadBlob(new Blob([response.data]), image.originalName);
         toast.success('다운로드 완료');
-
-        setTimeout(() => { window.URL.revokeObjectURL(blobUrl); }, 1000);
       } catch (error) {
         console.error('Download error:', error);
         toast.error('다운로드 실패. 잠시 후 다시 시도해주세요.');
       }
     } else {
       try {
-        const response = await fetch(image.url);
-        const blob = await response.blob();
-        const blobUrl = window.URL.createObjectURL(blob);
-
-        const link = document.createElement('a');
-        link.href = blobUrl;
-        link.download = image.originalName;
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
+        await downloadFromUrl(image.url, image.originalName);
         toast.success('다운로드 완료');
-
-        setTimeout(() => { window.URL.revokeObjectURL(blobUrl); }, 1000);
       } catch (error) {
         console.error('Download error:', error);
         toast.error('다운로드 실패. 잠시 후 다시 시도해주세요.');
@@ -125,17 +105,8 @@ function ImageCard({ image, type, onEdit, onDelete, onView, readOnly = false, sh
     if (type === 'generated') {
       try {
         const response = await imageAPI.downloadGenerated(image._id);
-        const blob = new Blob([response.data]);
-        const blobUrl = window.URL.createObjectURL(blob);
-
-        const link = document.createElement('a');
-        link.href = blobUrl;
-        link.download = image.originalName;
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
+        downloadBlob(new Blob([response.data]), image.originalName);
         toast.success('다운로드 완료');
-        setTimeout(() => { window.URL.revokeObjectURL(blobUrl); }, 1000);
       } catch (error) {
         toast.error('다운로드 실패. 잠시 후 다시 시도해주세요.');
       }
@@ -231,16 +202,8 @@ function VideoCard({ video, onEdit, onDelete, onView, readOnly = false, showTags
   const handleDownload = async () => {
     try {
       const response = await imageAPI.downloadVideo(video._id);
-      const blob = new Blob([response.data]);
-      const blobUrl = window.URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.href = blobUrl;
-      link.download = video.originalName;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
+      downloadBlob(new Blob([response.data]), video.originalName);
       toast.success('다운로드 완료');
-      setTimeout(() => { window.URL.revokeObjectURL(blobUrl); }, 1000);
     } catch (error) {
       toast.error('다운로드 실패');
     }

--- a/frontend/src/components/common/MetadataPickerModal.js
+++ b/frontend/src/components/common/MetadataPickerModal.js
@@ -34,83 +34,20 @@ import {
   ViewStream as ImageListIcon
 } from '@mui/icons-material';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import toast from 'react-hot-toast';
-import { serverAPI, workboardAPI, userAPI } from '../../services/api';
+import { userAPI } from '../../services/api';
 import Pagination from './Pagination';
 import MetadataItemCard from './MetadataItemCard';
 import MetadataItemGrid from './MetadataItemGrid';
 import MetadataDetailDialog from './MetadataDetailDialog';
 import MetadataImageListItem from '../admin/MetadataImageListItem';
-import { normalizeLora, normalizeModel } from '../../utils/metadataItem';
+import { METADATA_ADAPTERS } from '../../utils/metadataAdapters';
+import useMetadataSyncPolling, { checkInitialSyncStatus } from '../../hooks/useMetadataSyncPolling';
 
 const VIEW_MODE_KEY_PREFIX = 'vcc.picker.viewMode.';
 
-// ─── Per-kind API adapters ────────────────────────────────────────
-// kind 별 fetch / sync / status / normalize / 응답 필드명을 한 곳에서 관리.
 // 안정적인 빈 배열 reference — `allowedModelTypes = []` default 가 매 render 마다 새 array 를
 // 만들어 useCallback / useEffect 의존성을 깨면서 무한 fetch loop 를 일으키던 버그 수정.
 const EMPTY_ALLOWED_MODEL_TYPES = Object.freeze([]);
-
-const KIND_ADAPTERS = {
-  lora: {
-    fetch: ({ serverId, workboardId, search, baseModel, page, limit }) => {
-      if (serverId) {
-        // workboardId 전달 시 backend 가 작업판의 loraExposurePolicy / loraWhitelist 적용 (#198 Phase D)
-        const params = { search, baseModel, page, limit };
-        if (workboardId) params.workboardId = workboardId;
-        return serverAPI.getLoras(serverId, params);
-      }
-      return workboardAPI.getLoraModels(workboardId);
-    },
-    extractList: (responseData) => responseData?.loraModels || [],
-    extractPagination: (responseData) => responseData?.pagination || { current: 1, pages: 0, total: 0 },
-    extractCacheInfo: (responseData, fallback = false) => {
-      if (fallback) {
-        return {
-          lastFetched: responseData?.lastFetched,
-          lastCivitaiSync: responseData?.lastCivitaiSync,
-          hashNodeAvailable: responseData?.loraInfoNodeAvailable
-        };
-      }
-      return responseData?.cacheInfo || null;
-    },
-    extractAvailableBaseModels: (responseData) => responseData?.availableBaseModels || null,
-    // 동기화 버튼은 항상 forceRefresh — 기존 hash 는 재사용되고 civitai 메타만 새로 받음 (#335)
-    sync: (serverId) => serverAPI.syncLoras(serverId, { forceRefresh: true }),
-    getStatus: (serverId) => serverAPI.getLorasSyncStatus(serverId),
-    normalize: normalizeLora,
-    label: 'LoRA',
-    listLabel: 'LoRA',
-    nsfwItemPreference: 'nsfwModelFilter',  // 사용자 preferences key — NSFW 모델 (LoRA 포함) 숨김 (#346)
-    nsfwItemLabel: 'NSFW 모델 숨기기',
-  },
-  model: {
-    fetch: ({ serverId, workboardId, search, baseModel, allowedBaseModels, outputFormat, page, limit }) => {
-      const params = { search, baseModel, page, limit };
-      if (allowedBaseModels && allowedBaseModels.length > 0) {
-        params.allowedBaseModels = allowedBaseModels;
-      }
-      // workboardId 전달 시 backend 가 작업판의 modelExposurePolicy / modelWhitelist 적용 (#198 Phase D)
-      // 추가로 workboard.outputFormat 으로 provider outputFormats 자동 필터 (#354)
-      if (workboardId) params.workboardId = workboardId;
-      // outputFormat 명시 전달 — workboardId 없이 admin 페이지에서 작업판 폼의 값으로 호출하는 경우 (#354)
-      if (outputFormat) params.outputFormat = outputFormat;
-      return serverAPI.getDetailedModels(serverId, params);
-    },
-    extractList: (responseData) => responseData?.models || [],
-    extractPagination: (responseData) => responseData?.pagination || { current: 1, pages: 0, total: 0 },
-    extractCacheInfo: (responseData) => responseData?.cacheInfo || null,
-    extractAvailableBaseModels: (responseData) => responseData?.availableBaseModels || null,
-    // 동기화 버튼은 항상 forceRefresh (#335)
-    sync: (serverId) => serverAPI.syncModels(serverId, { forceRefresh: true }),
-    getStatus: (serverId) => serverAPI.getModelsSyncStatus(serverId),
-    normalize: normalizeModel,
-    label: '베이스 모델',
-    listLabel: '베이스 모델',
-    nsfwItemPreference: 'nsfwModelFilter',  // 베이스 모델에도 NSFW 모델 숨김 적용 (#346)
-    nsfwItemLabel: 'NSFW 모델 숨기기',
-  }
-};
 
 /**
  * 공통 메타데이터 picker modal — LoRA / Model 양쪽 사용.
@@ -145,10 +82,10 @@ function MetadataPickerModal({
   allowedModelTypes = EMPTY_ALLOWED_MODEL_TYPES,
   title
 }) {
-  // 잘못된 kind 는 internal API 위반 — KIND_ADAPTERS 에 없으면 빈 객체로 fallback,
+  // 잘못된 kind 는 internal API 위반 — METADATA_ADAPTERS 에 없으면 빈 객체로 fallback,
   // hook order 보장 위해 early return 사용 안 함. 호출자가 잘못된 kind 를 넘기면
   // adapter.fetch 등 호출이 실패하면서 사용자에게 에러로 표시됨.
-  const adapter = KIND_ADAPTERS[kind] || {};
+  const adapter = METADATA_ADAPTERS[kind] || {};
 
   const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -224,44 +161,22 @@ function MetadataPickerModal({
     [serverId, workboardId, searchQuery, baseModelFilter, allowedModelTypes, outputFormat, kind, adapter]
   );
 
-  // sync 폴링
-  useEffect(() => {
-    let interval;
-    if (syncing && serverId) {
-      interval = setInterval(async () => {
-        try {
-          const response = await adapter.getStatus(serverId);
-          const status = response.data.data;
-          setSyncStatus(status);
-          if (status.status === 'completed' || status.status === 'failed' || status.status === 'idle') {
-            setSyncing(false);
-            if (status.status === 'completed') {
-              toast.success(`${adapter.label} 동기화가 완료되었습니다.`);
-              fetchItems();
-            } else if (status.status === 'failed') {
-              toast.error(`동기화 실패: ${status.errorMessage || '알 수 없는 오류'}`);
-            }
-          }
-        } catch (err) {
-          console.error('Failed to get sync status:', err);
-        }
-      }, 2000);
-    }
-    return () => clearInterval(interval);
-  }, [syncing, serverId, adapter, fetchItems]);
+  // sync 폴링 — 공용 hook (#697)
+  useMetadataSyncPolling({
+    adapter,
+    serverId,
+    syncing,
+    setSyncing,
+    setSyncStatus,
+    onCompleted: () => fetchItems(),
+  });
 
   // 모달 open 시 fetch + 진행 중 sync 확인
   useEffect(() => {
     if (open && (serverId || workboardId)) {
       fetchItems();
       if (serverId) {
-        adapter.getStatus(serverId)
-          .then((response) => {
-            const status = response.data.data;
-            setSyncStatus(status);
-            if (status.status === 'fetching') setSyncing(true);
-          })
-          .catch(console.error);
+        checkInitialSyncStatus(adapter, serverId, { setSyncStatus, setSyncing });
       }
     }
   }, [open, serverId, workboardId, fetchItems, adapter]);

--- a/frontend/src/components/common/VideoViewerDialog.js
+++ b/frontend/src/components/common/VideoViewerDialog.js
@@ -11,6 +11,7 @@ import {
 import { Close, Download, NavigateBefore, NavigateNext } from '@mui/icons-material';
 import toast from 'react-hot-toast';
 import { imageAPI } from '../../services/api';
+import { downloadBlob } from '../../utils/download';
 
 function VideoViewerDialog({ 
   videos = [], 
@@ -48,19 +49,8 @@ function VideoViewerDialog({
         throw new Error('No video source available');
       }
       
-      const blobUrl = window.URL.createObjectURL(blob);
-      
-      const link = document.createElement('a');
-      link.href = blobUrl;
-      link.download = currentVideo.originalName || `video_${Date.now()}.mp4`;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
+      downloadBlob(blob, currentVideo.originalName || `video_${Date.now()}.mp4`);
       toast.success('다운로드 완료');
-      
-      setTimeout(() => {
-        window.URL.revokeObjectURL(blobUrl);
-      }, 1000);
     } catch (error) {
       console.error('Download error:', error);
       toast.error('다운로드 실패');

--- a/frontend/src/hooks/useMetadataSyncPolling.js
+++ b/frontend/src/hooks/useMetadataSyncPolling.js
@@ -1,0 +1,59 @@
+import { useEffect, useRef } from 'react';
+import toast from 'react-hot-toast';
+
+// 메타데이터 동기화 상태 2초 폴링 — MetadataPickerModal / MetadataManagementBody 공용 (#697).
+// syncing 이 true 인 동안 adapter.getStatus 를 폴링하고, 종료 상태(completed/failed/idle)에서
+// syncing 을 내리며 완료 토스트 + onCompleted(목록 재조회) 를 호출한다.
+//
+// adapter / onCompleted 는 ref 로 들고 있어 의존성 변화로 폴링이 재시작되지 않는다
+// (기존 양쪽 구현 모두 syncing/serverId 외 의존성은 사실상 고정이었음).
+export default function useMetadataSyncPolling({
+  adapter,
+  serverId,
+  syncing,
+  setSyncing,
+  setSyncStatus,
+  onCompleted,
+}) {
+  const adapterRef = useRef(adapter);
+  adapterRef.current = adapter;
+  const onCompletedRef = useRef(onCompleted);
+  onCompletedRef.current = onCompleted;
+
+  useEffect(() => {
+    if (!syncing || !serverId) return undefined;
+    const interval = setInterval(async () => {
+      try {
+        const response = await adapterRef.current.getStatus(serverId);
+        const status = response.data.data;
+        setSyncStatus(status);
+        if (['completed', 'failed', 'idle'].includes(status.status)) {
+          setSyncing(false);
+          if (status.status === 'completed') {
+            toast.success(`${adapterRef.current.label} 동기화가 완료되었습니다.`);
+            if (onCompletedRef.current) onCompletedRef.current();
+          } else if (status.status === 'failed') {
+            toast.error(`동기화 실패: ${status.errorMessage || '알 수 없는 오류'}`);
+          }
+        }
+      } catch (err) {
+        console.error('Failed to get sync status:', err);
+      }
+    }, 2000);
+    return () => clearInterval(interval);
+    // adapter/onCompleted 는 ref 경유 — 의도적으로 의존성 제외
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [syncing, serverId, setSyncing, setSyncStatus]);
+}
+
+// 서버 선택/모달 open 시 진행 중이던 동기화를 이어받기 — 양쪽 공용 초기 상태 확인 (#697).
+export async function checkInitialSyncStatus(adapter, serverId, { setSyncStatus, setSyncing }) {
+  try {
+    const response = await adapter.getStatus(serverId);
+    const status = response.data.data;
+    setSyncStatus(status);
+    if (status.status === 'fetching') setSyncing(true);
+  } catch (err) {
+    console.error(err);
+  }
+}

--- a/frontend/src/utils/download.js
+++ b/frontend/src/utils/download.js
@@ -1,0 +1,24 @@
+// 브라우저 파일 다운로드 공용 유틸 (#697) — 뷰어/카드 5곳에 흩어져 있던
+// createObjectURL + <a download> 클릭 패턴 통합. toast 등 UX 피드백은 호출부 책임.
+
+// Blob 을 filename 으로 저장. objectURL 은 클릭 처리 후 revoke (기존 1초 지연 유지 —
+// 일부 브라우저에서 즉시 revoke 시 다운로드가 끊기는 문제 회피).
+export function downloadBlob(blob, filename) {
+  const blobUrl = window.URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = blobUrl;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  setTimeout(() => {
+    window.URL.revokeObjectURL(blobUrl);
+  }, 1000);
+}
+
+// URL 을 fetch 해 Blob 으로 저장 (signed URL 등 same-origin 미디어용)
+export async function downloadFromUrl(url, filename) {
+  const response = await fetch(url);
+  const blob = await response.blob();
+  downloadBlob(blob, filename);
+}

--- a/frontend/src/utils/metadataAdapters.js
+++ b/frontend/src/utils/metadataAdapters.js
@@ -1,0 +1,89 @@
+// 메타데이터(베이스 모델 / LoRA) kind 별 API 어댑터 — 단일 소스 (#697).
+// MetadataPickerModal(사용자 picker)과 MetadataManagementBody(admin 관리 화면)가
+// 각자 들고 있던 KIND_ADAPTERS / ADAPTERS 를 통합한 슈퍼셋.
+// - picker 전용: fetch 의 workboardId fallback / nsfwItemPreference / listLabel
+// - admin 전용: resetSync / clearCache / extractTotal / extractMetaCount /
+//   extractLastSync / cacheDialog* / emptyMessage / searchPlaceholder
+import { serverAPI, workboardAPI } from '../services/api';
+import { normalizeLora, normalizeModel } from './metadataItem';
+
+export const METADATA_ADAPTERS = {
+  lora: {
+    // serverId 있으면 서버 경유 (workboardId 전달 시 backend 가 작업판의
+    // loraExposurePolicy / loraWhitelist 적용, #198 Phase D).
+    // serverId 없는 사용자 컨텍스트는 workboardAPI fallback.
+    fetch: ({ serverId, workboardId, search, baseModel, page, limit }) => {
+      if (serverId) {
+        const params = { search, baseModel, page, limit };
+        if (workboardId) params.workboardId = workboardId;
+        return serverAPI.getLoras(serverId, params);
+      }
+      return workboardAPI.getLoraModels(workboardId);
+    },
+    // 동기화 버튼은 항상 forceRefresh — 기존 hash 는 재사용되고 civitai 메타만 새로 받음 (#335)
+    sync: (serverId) => serverAPI.syncLoras(serverId, { forceRefresh: true }),
+    getStatus: (serverId) => serverAPI.getLorasSyncStatus(serverId),
+    resetSync: (serverId) => serverAPI.resetLorasSync(serverId),
+    clearCache: (serverId) => serverAPI.clearLoraCache(serverId),
+    extractList: (data) => data?.loraModels || [],
+    extractPagination: (data) => data?.pagination || { current: 1, pages: 0, total: 0 },
+    // fallback=true 는 workboardAPI 응답(캐시 정보가 최상위 필드) 경로 (picker 전용)
+    extractCacheInfo: (data, fallback = false) => {
+      if (fallback) {
+        return {
+          lastFetched: data?.lastFetched,
+          lastCivitaiSync: data?.lastCivitaiSync,
+          hashNodeAvailable: data?.loraInfoNodeAvailable,
+        };
+      }
+      return data?.cacheInfo || null;
+    },
+    extractAvailableBaseModels: (data) => data?.availableBaseModels || null,
+    extractTotal: (status, pagination) => status?.totalLoras || pagination?.total || 0,
+    extractMetaCount: (status) => status?.lorasWithMetadata,
+    extractLastSync: (info, status) => info?.lastCivitaiSync || status?.lastCivitaiSync,
+    normalize: (raw) => normalizeLora(raw),
+    label: 'LoRA',
+    listLabel: 'LoRA',
+    nsfwItemPreference: 'nsfwModelFilter', // 사용자 preferences key — NSFW 모델 (LoRA 포함) 숨김 (#346)
+    nsfwItemLabel: 'NSFW 모델 숨기기',
+    searchPlaceholder: 'LoRA 검색...',
+    cacheDialogTitle: 'LoRA 캐시 완전 삭제',
+    cacheDialogBody: '선택한 서버의 LoRA 캐시를 모두 비웁니다. 다음 동기화부터 hash 부터 재계산됩니다.',
+    emptyMessage: 'LoRA 가 없습니다.',
+  },
+  model: {
+    fetch: ({ serverId, workboardId, search, baseModel, allowedBaseModels, outputFormat, page, limit }) => {
+      const params = { search, baseModel, page, limit };
+      if (allowedBaseModels && allowedBaseModels.length > 0) {
+        params.allowedBaseModels = allowedBaseModels;
+      }
+      // workboardId 전달 시 backend 가 작업판의 modelExposurePolicy / modelWhitelist 적용 (#198 Phase D)
+      // 추가로 workboard.outputFormat 으로 provider outputFormats 자동 필터 (#354)
+      if (workboardId) params.workboardId = workboardId;
+      // outputFormat 명시 전달 — workboardId 없이 admin 페이지에서 작업판 폼의 값으로 호출하는 경우 (#354)
+      if (outputFormat) params.outputFormat = outputFormat;
+      return serverAPI.getDetailedModels(serverId, params);
+    },
+    sync: (serverId) => serverAPI.syncModels(serverId, { forceRefresh: true }),
+    getStatus: (serverId) => serverAPI.getModelsSyncStatus(serverId),
+    resetSync: (serverId) => serverAPI.resetModelsSync(serverId),
+    clearCache: (serverId) => serverAPI.clearModelCache(serverId),
+    extractList: (data) => data?.models || [],
+    extractPagination: (data) => data?.pagination || { current: 1, pages: 0, total: 0 },
+    extractCacheInfo: (data) => data?.cacheInfo || null,
+    extractAvailableBaseModels: (data) => data?.availableBaseModels || null,
+    extractTotal: (status, pagination) => status?.totalModels || pagination?.total || 0,
+    extractMetaCount: (status) => status?.modelsWithMetadata,
+    extractLastSync: (info, status) => info?.lastMetadataSync || status?.lastMetadataSync,
+    normalize: (raw, serverType) => normalizeModel(raw, { serverType }),
+    label: '베이스 모델',
+    listLabel: '베이스 모델',
+    nsfwItemPreference: 'nsfwModelFilter', // 베이스 모델에도 NSFW 모델 숨김 적용 (#346)
+    nsfwItemLabel: 'NSFW 모델 숨기기',
+    searchPlaceholder: '모델 검색...',
+    cacheDialogTitle: '베이스 모델 캐시 완전 삭제',
+    cacheDialogBody: '선택한 서버의 모델 캐시를 모두 비웁니다. 다음 동기화부터 hash 부터 재계산됩니다.',
+    emptyMessage: '베이스 모델이 없습니다.',
+  },
+};


### PR DESCRIPTION
closes #697

점검 후속 리팩토링 1/2 (동작 보존). v3.9.0 대상.

## 변경사항
### 메타데이터 어댑터 통합
- `utils/metadataAdapters.js` — picker(`KIND_ADAPTERS`)와 admin(`ADAPTERS`)이 각자 들고 있던 model/lora fetch·sync·getStatus·normalize·extract* 를 슈퍼셋 하나로 통합. fetch 시그니처는 picker 형태(단일 객체 인자)로 표준화 — admin 호출부는 `fetch({serverId, ...})` 로 전환.
- `hooks/useMetadataSyncPolling.js` — 양쪽에 중복이던 2초 동기화 폴링 + 초기 상태 이어받기(`checkInitialSyncStatus`)를 공용 hook 으로. adapter/onCompleted 는 ref 로 고정해 의존성 배열 안정화 (기존 두 파일의 exhaustive-deps 억제 2건도 함께 소멸).
- 부수 개선: admin 화면에서 서버 전환 시 이전 서버의 베이스모델 필터 목록이 잔존할 수 있던 것을 빈 배열 초기화로 방지.

### 다운로드 유틸
- `utils/download.js` — `downloadBlob` / `downloadFromUrl`. ImageViewerDialog·VideoViewerDialog·MediaGrid(×3)의 createObjectURL+`<a download>` 5중복 제거. toast 피드백은 호출부 유지 (기존 메시지 그대로).

순감소: 8 files, +214 / -251

## 동작 보존 검증
- jest 38 suites / 307 tests, vite 빌드, docker-compose 재빌드 + e2e smoke (기존 #381 2건 외 통과)
- **실 브라우저 검증(Playwright)**: 일반 사용자로 작업판 실행 화면 → "LoRA 추가" → picker 다이얼로그 오픈 → 공용 어댑터 fetch 200 → 목록/빈 상태 정상 렌더, 콘솔 에러 0. (admin 메타데이터 페이지는 로컬에서 admin 계정 확보 불가(#381 제약)로 직접 실행 못 했으나, 동일 공용 어댑터·hook 경로를 사용하며 admin 전용 핸들러는 어댑터 참조 교체 외 무변경)

🤖 Generated with [Claude Code](https://claude.com/claude-code)