### PR TITLE
feat: Joi 입력 검증 확대 — servers/workboards/projects/tags 쓰기 라우트 (#698)

### DIFF
--- a/src/routes/projects.js
+++ b/src/routes/projects.js
@@ -9,6 +9,7 @@ const GeneratedVideo = require('../models/GeneratedVideo');
 const PromptData = require('../models/PromptData');
 const ImageGenerationJob = require('../models/ImageGenerationJob');
 const { escapeRegex } = require('../utils/escapeRegex');
+const { validateBody, projectCreateSchema, projectUpdateSchema } = require('../utils/validation');
 const router = express.Router();
 
 // GET /favorites - 즐겨찾기 프로젝트 목록 (대시보드용) - 구체적 경로를 /:id 위에 배치
@@ -110,7 +111,7 @@ router.get('/', requireAuth, async (req, res) => {
 });
 
 // POST / - 프로젝트 생성 (전용 태그 자동 생성)
-router.post('/', requireAuth, async (req, res) => {
+router.post('/', requireAuth, validateBody(projectCreateSchema), async (req, res) => {
   try {
     const { name, description, tagName } = req.body;
 
@@ -198,7 +199,7 @@ router.get('/:id', requireAuth, async (req, res) => {
 });
 
 // PUT /:id - 프로젝트 수정
-router.put('/:id', requireAuth, async (req, res) => {
+router.put('/:id', requireAuth, validateBody(projectUpdateSchema), async (req, res) => {
   try {
     const { name, description, coverImage } = req.body;
 

--- a/src/routes/servers.js
+++ b/src/routes/servers.js
@@ -9,6 +9,7 @@ const loraMetadataService = require('../services/loraMetadataService');
 const modelMetadataService = require('../services/modelMetadataService');
 const comfyUIService = require('../services/comfyUIService');
 const { encryptSecret } = require('../utils/secretCrypto');
+const { validateBody, serverCreateSchema, serverUpdateSchema } = require('../utils/validation');
 
 // 서버 목록 조회 (일반 사용자도 접근 가능)
 router.get('/', verifyJWT, async (req, res) => {
@@ -72,7 +73,7 @@ router.get('/:id', requireAdmin, async (req, res) => {
 });
 
 // 서버 생성 (관리자만)
-router.post('/', requireAdmin, async (req, res) => {
+router.post('/', requireAdmin, validateBody(serverCreateSchema), async (req, res) => {
   try {
     const {
       name,
@@ -156,7 +157,7 @@ router.post('/', requireAdmin, async (req, res) => {
 });
 
 // 서버 수정 (관리자만)
-router.put('/:id', requireAdmin, async (req, res) => {
+router.put('/:id', requireAdmin, validateBody(serverUpdateSchema), async (req, res) => {
   try {
     const {
       name,

--- a/src/routes/tags.js
+++ b/src/routes/tags.js
@@ -23,6 +23,7 @@ async function ensureBuiltinTag(userId, name, color = '#1976d2') {
 }
 
 const { BUILTIN_TAG_NAMES, BUILTIN_TAG_META } = require('../constants/builtinTags');
+const { validateBody, tagCreateSchema, tagUpdateSchema } = require('../utils/validation');
 
 // 세계관 역할 태그 (#396) — 이제는 단순히 name="세계관" 인 태그 조회/생성 (#400 일반화)
 router.get('/worldview', requireAuth, async (req, res) => {
@@ -80,7 +81,7 @@ router.get('/', requireAuth, async (req, res) => {
   }
 });
 
-router.post('/', requireAuth, async (req, res) => {
+router.post('/', requireAuth, validateBody(tagCreateSchema), async (req, res) => {
   try {
     const { name, color } = req.body;
     
@@ -111,7 +112,7 @@ router.post('/', requireAuth, async (req, res) => {
   }
 });
 
-router.put('/:id', requireAuth, async (req, res) => {
+router.put('/:id', requireAuth, validateBody(tagUpdateSchema), async (req, res) => {
   try {
     const { name, color } = req.body;
     

--- a/src/routes/workboards.js
+++ b/src/routes/workboards.js
@@ -12,6 +12,7 @@ const openAIChatService = require('../services/openAIChatService');
 const geminiService = require('../services/geminiService');
 const { decryptSecret } = require('../utils/secretCrypto');
 const { escapeRegex } = require('../utils/escapeRegex');
+const { validateBody, workboardCreateSchema, workboardUpdateSchema } = require('../utils/validation');
 const router = express.Router();
 
 const EXPORT_VERSION = 1;
@@ -430,7 +431,7 @@ router.get('/admin/:id', requireAdmin, async (req, res) => {
   }
 });
 
-router.post('/', requireAdmin, async (req, res) => {
+router.post('/', requireAdmin, validateBody(workboardCreateSchema), async (req, res) => {
   try {
     const {
       name,
@@ -528,7 +529,7 @@ router.post('/', requireAdmin, async (req, res) => {
   }
 });
 
-router.put('/:id', requireAdmin, async (req, res) => {
+router.put('/:id', requireAdmin, validateBody(workboardUpdateSchema), async (req, res) => {
   try {
     const {
       name,
@@ -550,12 +551,6 @@ router.put('/:id', requireAdmin, async (req, res) => {
       isActive
     } = req.body;
 
-    console.log('Workboard update request:', {
-      id: req.params.id,
-      additionalInputFields,
-      baseInputFields
-    });
-    
     const workboard = await Workboard.findById(req.params.id);
     if (!workboard) {
       return res.status(404).json({ message: 'Workboard not found' });

--- a/src/tests/routeValidation.test.js
+++ b/src/tests/routeValidation.test.js
@@ -1,0 +1,133 @@
+/**
+ * 리소스 라우트 Joi 검증 테스트 (#698)
+ *
+ * 1) 통합: validateBody 미들웨어가 라우트 앞단에서 잘못된 본문을 400 으로 거부하고,
+ *    기존 수동 검증과 동일한 메시지를 반환하는지 (핸들러/DB 도달 전 차단)
+ * 2) 단위: 스키마가 기존에 허용되던 본문(부분 업데이트의 빈 문자열, 추가 필드 등)을
+ *    계속 허용하는지 — 동작 보존 회귀 방지
+ */
+
+const express = require('express');
+const request = require('supertest');
+
+jest.mock('../middleware/auth', () => ({
+  requireAuth: (req, res, next) => {
+    req.user = { _id: 'user-1', isAdmin: false };
+    next();
+  },
+  requireAdmin: (req, res, next) => {
+    req.user = { _id: 'admin-1', isAdmin: true };
+    next();
+  },
+  verifyJWT: (req, res, next) => {
+    req.user = { _id: 'user-1', isAdmin: false };
+    next();
+  },
+  buildWorkboardAccessFilter: jest.fn(),
+  userHasWorkboardAccess: jest.fn().mockResolvedValue(true),
+}));
+
+// 라우트가 물고 있는 무거운 의존은 모듈째 mock (검증 단계 테스트라 호출 안 됨)
+jest.mock('../services/loraMetadataService', () => ({}));
+jest.mock('../services/modelMetadataService', () => ({}));
+jest.mock('../services/comfyUIService', () => ({}));
+jest.mock('../services/workflowConverterService', () => ({}));
+
+const {
+  serverCreateSchema,
+  serverUpdateSchema,
+  workboardUpdateSchema,
+  projectUpdateSchema,
+  tagUpdateSchema,
+} = require('../utils/validation');
+
+function mount(path, routerModule) {
+  const app = express();
+  app.use(express.json());
+  app.use(path, require(routerModule));
+  return app;
+}
+
+describe('validateBody 통합 — 잘못된 본문은 핸들러 도달 전 400 (#698)', () => {
+  test('servers POST — 필수 필드 누락 / 잘못된 서버 타입', async () => {
+    const app = mount('/api/servers', '../routes/servers');
+
+    let res = await request(app).post('/api/servers').send({ name: 'x' });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe('필수 필드가 누락되었습니다.');
+
+    res = await request(app)
+      .post('/api/servers')
+      .send({ name: 'x', serverType: 'GPT Image', serverUrl: 'http://a' });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe('지원하지 않는 서버 타입입니다.');
+
+    // 타입 위반 (문자열 자리에 객체)
+    res = await request(app)
+      .post('/api/servers')
+      .send({ name: { $gt: '' }, serverType: 'ComfyUI', serverUrl: 'http://a' });
+    expect(res.status).toBe(400);
+  });
+
+  test('workboards POST — serverId 누락', async () => {
+    const app = mount('/api/workboards', '../routes/workboards');
+
+    const res = await request(app).post('/api/workboards').send({ name: '작업판' });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe('serverId is required. Please select a server.');
+  });
+
+  test('projects POST — 이름/태그명 누락 (공백 포함)', async () => {
+    const app = mount('/api/projects', '../routes/projects');
+
+    let res = await request(app).post('/api/projects').send({ tagName: 't' });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe('프로젝트 이름은 필수입니다');
+
+    res = await request(app).post('/api/projects').send({ name: 'p', tagName: '   ' });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe('태그명은 필수입니다');
+  });
+
+  test('tags POST — 이름 누락', async () => {
+    const app = mount('/api/tags', '../routes/tags');
+
+    const res = await request(app).post('/api/tags').send({ color: '#123456' });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe('Tag name is required');
+  });
+});
+
+describe('스키마 단위 — 기존 허용 본문의 동작 보존 (#698)', () => {
+  test('생성 스키마는 유효 본문 + 알 수 없는 필드를 허용', () => {
+    const { error } = serverCreateSchema.validate({
+      name: 'ComfyUI-1',
+      serverType: 'ComfyUI',
+      serverUrl: 'http://192.168.1.10:8188',
+      configuration: { apiKey: 'k', anything: 1 },
+      someFutureField: true,
+    });
+    expect(error).toBeUndefined();
+  });
+
+  test('업데이트 스키마는 부분 본문·빈 문자열을 허용 (기존 핸들러가 무시/통과)', () => {
+    expect(serverUpdateSchema.validate({ isActive: false }).error).toBeUndefined();
+    expect(serverUpdateSchema.validate({ name: '' }).error).toBeUndefined();
+    expect(workboardUpdateSchema.validate({ additionalInputFields: [] }).error).toBeUndefined();
+    expect(projectUpdateSchema.validate({ coverImage: null }).error).toBeUndefined();
+    expect(projectUpdateSchema.validate({ name: '' }).error).toBeUndefined();
+    expect(tagUpdateSchema.validate({ color: null }).error).toBeUndefined();
+  });
+
+  test('업데이트 스키마도 타입 위반은 거부', () => {
+    expect(serverUpdateSchema.validate({ isActive: 'maybe' }).error).toBeDefined();
+    expect(workboardUpdateSchema.validate({ additionalInputFields: 'not-array' }).error).toBeDefined();
+    expect(projectUpdateSchema.validate({ coverImage: 'not-object' }).error).toBeDefined();
+  });
+
+  test('llmExtraParams 는 객체/null 허용, 문자열 거부 (#493 계약)', () => {
+    expect(workboardUpdateSchema.validate({ llmExtraParams: { max_tokens: 8 } }).error).toBeUndefined();
+    expect(workboardUpdateSchema.validate({ llmExtraParams: null }).error).toBeUndefined();
+    expect(workboardUpdateSchema.validate({ llmExtraParams: '{"a":1}' }).error).toBeDefined();
+  });
+});

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -117,10 +117,148 @@ const validate = (schema) => {
   };
 };
 
+// ─── 리소스 라우트 스키마 (#698) ─────────────────────────────────
+// 타입/필수/enum 만 검증하는 앞단 게이트 — DB 중복 검사·동적 기본값 등 도메인 검증은
+// 핸들러에 그대로 둔다. 클라이언트가 추가 필드를 보내는 기존 계약을 깨지 않도록
+// unknown 키는 허용. 에러 메시지는 기존 핸들러의 수동 검증 메시지와 동일하게 유지.
+
+const SERVER_TYPES = ['ComfyUI', 'OpenAI', 'OpenAI Compatible', 'Gemini'];
+
+const REQUIRED_FIELD_MESSAGES = {
+  'any.required': '필수 필드가 누락되었습니다.',
+  'string.empty': '필수 필드가 누락되었습니다.',
+};
+
+const serverCreateSchema = Joi.object({
+  name: Joi.string().trim().min(1).max(200).required().messages(REQUIRED_FIELD_MESSAGES),
+  description: Joi.string().allow('', null).max(2000),
+  serverType: Joi.string().valid(...SERVER_TYPES).required().messages({
+    ...REQUIRED_FIELD_MESSAGES,
+    'any.only': '지원하지 않는 서버 타입입니다.',
+  }),
+  serverUrl: Joi.string().trim().min(1).required().messages(REQUIRED_FIELD_MESSAGES),
+  configuration: Joi.object().unknown(true),
+}).unknown(true);
+
+// PUT 은 부분 업데이트 — 빈 문자열 등 기존에 핸들러가 무시/통과시키던 값을
+// 막지 않도록 타입만 본다 (min 제약 없음).
+const serverUpdateSchema = Joi.object({
+  name: Joi.string().allow('').max(200),
+  description: Joi.string().allow('', null).max(2000),
+  serverType: Joi.string().valid(...SERVER_TYPES)
+    .messages({ 'any.only': '지원하지 않는 서버 타입입니다.' }),
+  serverUrl: Joi.string().allow(''),
+  configuration: Joi.object().unknown(true),
+  isActive: Joi.boolean(),
+}).unknown(true);
+
+const workboardCreateSchema = Joi.object({
+  serverId: Joi.string().required()
+    .messages({
+      'any.required': 'serverId is required. Please select a server.',
+      'string.empty': 'serverId is required. Please select a server.',
+    }),
+  name: Joi.string().trim().max(200),
+  description: Joi.string().allow('', null).max(2000),
+  workboardType: Joi.string(),
+  outputFormat: Joi.string(),
+  baseInputFields: Joi.array(),
+  additionalInputFields: Joi.array(),
+  allowedModelTypes: Joi.array(),
+  allowedGroupIds: Joi.array(),
+  modelExposurePolicy: Joi.string(),
+  modelWhitelist: Joi.array(),
+  loraExposurePolicy: Joi.string(),
+  loraWhitelist: Joi.array(),
+  llmExtraParams: Joi.object().unknown(true).allow(null),
+}).unknown(true);
+
+const workboardUpdateSchema = Joi.object({
+  serverId: Joi.string(),
+  name: Joi.string().allow('').max(200),
+  description: Joi.string().allow('', null).max(2000),
+  workboardType: Joi.string(),
+  outputFormat: Joi.string(),
+  baseInputFields: Joi.array(),
+  additionalInputFields: Joi.array(),
+  allowedModelTypes: Joi.array(),
+  allowedGroupIds: Joi.array(),
+  modelExposurePolicy: Joi.string(),
+  modelWhitelist: Joi.array(),
+  loraExposurePolicy: Joi.string(),
+  loraWhitelist: Joi.array(),
+  llmExtraParams: Joi.object().unknown(true).allow(null),
+  isActive: Joi.boolean(),
+}).unknown(true);
+
+const projectCreateSchema = Joi.object({
+  name: Joi.string().trim().min(1).required()
+    .messages({
+      'any.required': '프로젝트 이름은 필수입니다',
+      'string.empty': '프로젝트 이름은 필수입니다',
+    }),
+  tagName: Joi.string().trim().min(1).required()
+    .messages({
+      'any.required': '태그명은 필수입니다',
+      'string.empty': '태그명은 필수입니다',
+    }),
+  description: Joi.string().allow('', null),
+}).unknown(true);
+
+const projectUpdateSchema = Joi.object({
+  name: Joi.string().allow(''),
+  description: Joi.string().allow('', null),
+  coverImage: Joi.object().unknown(true).allow(null),
+}).unknown(true);
+
+const tagCreateSchema = Joi.object({
+  name: Joi.string().trim().min(1).required()
+    .messages({
+      'any.required': 'Tag name is required',
+      'string.empty': 'Tag name is required',
+    }),
+  color: Joi.string().allow('', null).max(50),
+}).unknown(true);
+
+const tagUpdateSchema = Joi.object({
+  name: Joi.string().allow(''),
+  color: Joi.string().allow('', null).max(50),
+}).unknown(true);
+
+// 리소스 라우트용 검증 미들웨어 — 기존 라우트 에러 형식({ success: false, message })에 맞춤.
+// message 는 첫 번째 위반 항목 (abortEarly:false 로 전체 수집, errors 에 나열).
+const validateBody = (schema) => {
+  return (req, res, next) => {
+    const { error } = schema.validate(req.body, { abortEarly: false });
+
+    if (error) {
+      return res.status(400).json({
+        success: false,
+        message: error.details[0].message,
+        errors: error.details.map((detail) => ({
+          field: detail.path.join('.'),
+          message: detail.message,
+        })),
+      });
+    }
+
+    next();
+  };
+};
+
 module.exports = {
   signupSchema,
   signinSchema,
   profileUpdateSchema,
   passwordChangeSchema,
-  validate
+  serverCreateSchema,
+  serverUpdateSchema,
+  workboardCreateSchema,
+  workboardUpdateSchema,
+  projectCreateSchema,
+  projectUpdateSchema,
+  tagCreateSchema,
+  tagUpdateSchema,
+  validate,
+  validateBody
 };


### PR DESCRIPTION
closes #698

점검 후속 리팩토링 2/2. v3.9.0 대상. auth 에만 있던 Joi 스키마 검증을 주요 쓰기 라우트로 확장.

## 변경사항
- `utils/validation.js` — 스키마 8종 (server/workboard/project/tag × create/update) + `validateBody` 미들웨어 추가
  - 에러 형식은 기존 라우트 관례(`{ success: false, message }`) 유지, **메시지도 기존 수동 검증과 동일** ('필수 필드가 누락되었습니다.' / '지원하지 않는 서버 타입입니다.' / '프로젝트 이름은 필수입니다' / 'Tag name is required' 등)
  - 타입/필수/enum 만 앞단 게이트 — DB 중복 검사·동적 기본값 등 도메인 검증은 핸들러 유지
  - unknown 키 허용 (기존 클라이언트가 추가 필드를 보내는 계약 보존)
  - 업데이트 스키마는 부분 본문·빈 문자열 허용 — 기존 핸들러가 무시하던 값을 새로 차단하지 않음 (동작 보존)
- 적용: `servers`(admin CUD), `workboards`(admin CUD), `projects`, `tags` 의 POST/PUT
- 부수: workboards PUT 이 폼 데이터 전체를 서버 로그로 덤프하던 console.log 제거

## 검증
- jest 39 suites / **315 tests** (신규 8: 미들웨어 통합 400 + 스키마 수용범위 단위)
- **실 backend 검증**: 유효 본문 → 201 생성 성공(happy path 통과), 빈 이름/누락 → 400 + 기존과 동일 메시지
- docker-compose 재빌드 + e2e smoke (기존 #381 2건 외 통과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)