### PR TITLE
feat: E2E admin 시크릿 헤더 — 승인 게이트 테스트 흐름 재설계 (#381)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,3 +83,8 @@ MCP_PORT=4136
 # 서버별 키가 항상 있다면 설정 불필요.
 # GEMINI_API_KEY=
 # OPENAI_IMAGE_API_KEY=
+
+# E2E Test Admin Secret (#381) — Local development ONLY
+# 설정 시 e2e 테스트가 X-E2E-Admin-Secret 헤더로 admin+approved 계정을 만들 수 있음.
+# 미설정 시 완전 비활성. 알파 등 외부 노출 환경에는 절대 설정하지 말 것.
+# E2E_ADMIN_SECRET=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,10 @@ critical user journey 자동 회귀 검증. `e2e/` 디렉토리 + `playwright.co
 # 첫 실행 — Playwright 브라우저 다운로드
 npx playwright install chromium
 
+# 전체 실행에는 .env 에 E2E_ADMIN_SECRET 설정 필요 (#381) — 미설정 시
+# 승인/admin 필요한 테스트는 skip 됨. 알파 등 외부 노출 환경에는 절대 설정 금지.
+# (playwright.config 가 .env 에서 자동 로드, 백엔드는 docker-compose 가 주입)
+
 # 헤드리스 실행 (docker-compose 가 떠 있어야 함)
 npm run test:e2e
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,8 +80,10 @@ services:
       SIGNED_URL_ROUND_SECONDS: ${SIGNED_URL_ROUND_SECONDS:-1440}
       # dev / e2e 환경 — signup rate limit 완화 (#359). 명시 설정 시만 적용 (#379).
       SIGNUP_RATE_LIMIT_MAX: ${SIGNUP_RATE_LIMIT_MAX:-}
-      # NOTE: TEST_AUTO_ADMIN_DOMAIN 백도어는 #379 에서 완전 제거. E2E 테스트는 후속 작업에서
-      # 안전한 admin 부여 방식 (시크릿 헤더 / DB seed 등) 으로 재설계 필요.
+      # E2E 테스트 admin 부여 시크릿 (#381) — 미설정 시 완전 비활성.
+      # 로컬 개발 전용. 알파 등 외부 노출 환경의 .env 에는 절대 설정하지 말 것.
+      # (TEST_AUTO_ADMIN_DOMAIN 백도어는 #379 에서 제거 — 이 시크릿 헤더 방식으로 대체)
+      E2E_ADMIN_SECRET: ${E2E_ADMIN_SECRET:-}
     ports:
       - "${BACKEND_PORT:-3136}:3000"
     volumes:

--- a/e2e/helpers/auth.js
+++ b/e2e/helpers/auth.js
@@ -22,8 +22,15 @@ async function signupViaAPI(request, overrides = {}) {
   const email = overrides.email || uniqueEmail();
   const password = overrides.password || 'TestPass!23';
   const nickname = overrides.nickname || uniqueNickname();
+  // E2E_ADMIN_SECRET 이 설정돼 있으면 admin + approved 로 생성 (#381).
+  // 백엔드도 같은 값을 가져야 함 (.env → docker-compose 로 주입, playwright.config 가 .env 로드).
+  const headers = {};
+  if (process.env.E2E_ADMIN_SECRET) {
+    headers['X-E2E-Admin-Secret'] = process.env.E2E_ADMIN_SECRET;
+  }
   const response = await request.post('/api/auth/signup', {
-    data: { email, password, confirmPassword: password, nickname }
+    data: { email, password, confirmPassword: password, nickname },
+    headers
   });
   if (!response.ok()) {
     const body = await response.text();

--- a/e2e/smoke.spec.js
+++ b/e2e/smoke.spec.js
@@ -24,6 +24,9 @@ test.describe('Anonymous', () => {
 });
 
 test.describe('Authenticated user', () => {
+  // E2E_ADMIN_SECRET 미설정 시 signup 계정이 승인 대기(pending) 상태라 페이지 접근이 막힘 (#381)
+  test.skip(!process.env.E2E_ADMIN_SECRET, 'E2E_ADMIN_SECRET 미설정 — 가입 승인 게이트로 skip (#381)');
+
   test.beforeEach(async ({ context, baseURL }) => {
     const url = new URL(baseURL || 'http://localhost:8136');
     await context.addCookies([{
@@ -49,10 +52,11 @@ test.describe('Authenticated user', () => {
     expect(page.url()).toContain('/workboards');
   });
 
-  test('내 이미지 페이지 접근', async ({ page }) => {
+  test('내 컨텐츠 페이지 접근 (레거시 /images 리다이렉트 포함)', async ({ page }) => {
+    // /images 는 콘텐츠 라이브러리 통합으로 /content 로 리다이렉트된다 (App.js)
     await page.goto('/images');
     await page.waitForLoadState('networkidle');
-    expect(page.url()).toContain('/images');
+    expect(page.url()).toContain('/content');
   });
 });
 

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -7,6 +7,16 @@ const { defineConfig, devices } = require('@playwright/test');
 
 const BASE_URL = process.env.E2E_BASE_URL || 'http://localhost:8136';
 
+// E2E_ADMIN_SECRET (#381) 을 리포 .env 에서 로드 (process.env 우선).
+// 백엔드는 docker-compose 가 같은 .env 값을 주입하므로 양쪽이 자동으로 일치한다.
+if (!process.env.E2E_ADMIN_SECRET) {
+  try {
+    const envFile = require('fs').readFileSync(require('path').join(__dirname, '.env'), 'utf8');
+    const match = envFile.match(/^E2E_ADMIN_SECRET=(.+)$/m);
+    if (match) process.env.E2E_ADMIN_SECRET = match[1].trim();
+  } catch (_) { /* .env 없으면 무시 — 시크릿 없는 상태로 진행 */ }
+}
+
 module.exports = defineConfig({
   testDir: './e2e',
   timeout: 30 * 1000,

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -10,6 +10,19 @@ const { sendPasswordResetEmail } = require('../services/emailService');
 const { isValidPassword, PASSWORD_POLICY_MESSAGE } = require('../utils/passwordPolicy');
 const router = express.Router();
 
+// E2E admin 시크릿 헤더 검증 (#381) — 타이밍 공격 방지를 위해 timingSafeEqual 사용.
+const isE2EAdminRequest = (req) => {
+  const expected = process.env.E2E_ADMIN_SECRET;
+  if (!expected) return false;
+  const provided = req.header('X-E2E-Admin-Secret') || '';
+  const expectedBuf = Buffer.from(expected);
+  const providedBuf = Buffer.from(provided);
+  return (
+    providedBuf.length === expectedBuf.length &&
+    crypto.timingSafeEqual(providedBuf, expectedBuf)
+  );
+};
+
 // Rate limit for forgot password - 3 requests per hour per IP
 const forgotPasswordRateLimit = rateLimit({
   windowMs: 60 * 60 * 1000, // 1 hour
@@ -110,6 +123,18 @@ router.post('/signup', signupRateLimit, validate(signupSchema), async (req, res)
     });
 
     await newUser.updateAdminStatus();
+
+    // E2E 테스트용 admin 부여 (#381) — `E2E_ADMIN_SECRET` 환경변수가 설정된 환경에서만
+    // 동작하며, signup 요청의 `X-E2E-Admin-Secret` 헤더가 일치하면 admin + approved 로 생성.
+    // 시크릿 미설정 시 완전 비활성. 알파/본서버 등 외부 노출 환경의 .env 에는 절대 설정 금지.
+    // (이후 signin 시 updateAdminStatus 가 ADMIN_EMAILS 기준으로 재계산해 강등시키는 것은
+    //  의도된 방어 — e2e 는 signup 응답의 토큰을 그대로 쓰므로 영향 없음.)
+    if (isE2EAdminRequest(req)) {
+      newUser.isAdmin = true;
+      newUser.approvalStatus = 'approved';
+      newUser.approvedAt = new Date();
+    }
+
     // admin 으로 승격된 경우 그룹 클리어 (admin 은 그룹 무관)
     if (newUser.isAdmin) {
       newUser.groupIds = [];

--- a/src/tests/e2eAdminSignup.test.js
+++ b/src/tests/e2eAdminSignup.test.js
@@ -1,0 +1,110 @@
+/**
+ * E2E admin 시크릿 signup 게이트 테스트 (#381)
+ *
+ * E2E_ADMIN_SECRET 이 설정된 환경에서 X-E2E-Admin-Secret 헤더가 일치하는 signup 만
+ * admin + approved 로 생성되고, 미설정/불일치 시 기존과 동일하게 pending 인지 검증.
+ */
+
+const express = require('express');
+const request = require('supertest');
+
+jest.mock('../middleware/auth', () => ({
+  generateJWT: jest.fn(() => 'test-token'),
+  requireAuth: (req, res, next) => next(),
+  verifyJWT: (req, res, next) => next(),
+  authRateLimit: (req, res, next) => next(),
+  signupRateLimit: (req, res, next) => next(),
+}));
+
+jest.mock('../models/User', () => {
+  function MockUser(data) {
+    Object.assign(this, data);
+    this.isAdmin = false;
+    this.approvalStatus = 'pending';
+    MockUser.__last = this;
+  }
+  MockUser.prototype.updateAdminStatus = function () {
+    // 실제 구현은 ADMIN_EMAILS 검사 — 테스트에선 항상 비-admin
+    return Promise.resolve(this);
+  };
+  MockUser.prototype.save = function () {
+    this._id = 'user-new';
+    return Promise.resolve(this);
+  };
+  MockUser.findOne = jest.fn().mockResolvedValue(null);
+  return MockUser;
+});
+
+jest.mock('../models/Group', () => ({
+  findDefault: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('../services/emailService', () => ({
+  sendPasswordResetEmail: jest.fn(),
+}));
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/auth', require('../routes/auth'));
+  return app;
+}
+
+const VALID_BODY = {
+  email: 'e2e-user@example.com',
+  password: 'TestPass!23',
+  confirmPassword: 'TestPass!23',
+  nickname: 'e2euser',
+};
+
+describe('signup E2E admin 시크릿 게이트 (#381)', () => {
+  let app;
+
+  beforeAll(() => {
+    app = createApp();
+  });
+
+  afterEach(() => {
+    delete process.env.E2E_ADMIN_SECRET;
+  });
+
+  test('시크릿 미설정 — 헤더를 보내도 pending (기능 완전 비활성)', async () => {
+    const res = await request(app)
+      .post('/api/auth/signup')
+      .set('X-E2E-Admin-Secret', 'anything')
+      .send(VALID_BODY);
+
+    expect(res.status).toBe(201);
+    expect(res.body.user.approvalStatus).toBe('pending');
+    expect(res.body.user.isAdmin).toBe(false);
+  });
+
+  test('시크릿 설정 + 헤더 일치 — admin + approved 로 생성', async () => {
+    process.env.E2E_ADMIN_SECRET = 'test-secret-381';
+
+    const res = await request(app)
+      .post('/api/auth/signup')
+      .set('X-E2E-Admin-Secret', 'test-secret-381')
+      .send(VALID_BODY);
+
+    expect(res.status).toBe(201);
+    expect(res.body.user.approvalStatus).toBe('approved');
+    expect(res.body.user.isAdmin).toBe(true);
+  });
+
+  test('시크릿 설정 + 헤더 불일치/누락 — pending 유지', async () => {
+    process.env.E2E_ADMIN_SECRET = 'test-secret-381';
+
+    let res = await request(app)
+      .post('/api/auth/signup')
+      .set('X-E2E-Admin-Secret', 'wrong-secret-!!')
+      .send(VALID_BODY);
+    expect(res.status).toBe(201);
+    expect(res.body.user.approvalStatus).toBe('pending');
+    expect(res.body.user.isAdmin).toBe(false);
+
+    res = await request(app).post('/api/auth/signup').send(VALID_BODY);
+    expect(res.status).toBe(201);
+    expect(res.body.user.approvalStatus).toBe('pending');
+  });
+});


### PR DESCRIPTION
closes #381

#379 에서 TEST_AUTO_ADMIN_DOMAIN 백도어 제거 후 깨져 있던 e2e admin/approved 흐름을 이슈의 **옵션 1 (시크릿 헤더 + 환경변수)** 로 재설계.

## 동작
- `E2E_ADMIN_SECRET` 환경변수가 설정된 백엔드에서, signup 요청의 `X-E2E-Admin-Secret` 헤더가 일치하면 그 계정을 admin + approved 로 생성
- **시크릿 미설정 시 완전 비활성** — 코드가 배포돼도 환경변수 없으면 그냥 일반 signup
- 비교는 `crypto.timingSafeEqual` (타이밍 공격 방지)
- signin 시 `updateAdminStatus` 가 ADMIN_EMAILS 기준으로 재계산해 강등시키는 기존 동작은 **의도적으로 유지** (방어층) — e2e 는 signup 응답 토큰을 그대로 사용하므로 무관

## 배선
- e2e helper: `E2E_ADMIN_SECRET` 있으면 헤더 자동 첨부
- playwright.config: 리포 `.env` 에서 시크릿 자동 로드 (백엔드는 docker-compose dev 가 같은 .env 값 주입 — 양쪽 자동 일치)
- 시크릿 미설정 환경: 승인 게이트 걸리는 테스트는 명시적 skip (빨간불 대신 안내)
- `.env.example`·CLAUDE.md 문서화 — **알파 등 외부 노출 환경 .env 에 설정 금지 경고 포함**
- prod compose 에는 미배선 (의도)

## 부수 — smoke spec 현행화
- `내 이미지 페이지 접근` 테스트가 `/images` URL 잔존을 기대했으나, 실제 앱은 콘텐츠 라이브러리 통합으로 `/images → /content` 리다이렉트 (App.js:161, 의도된 동작 확인) → spec 을 실동작 기준으로 갱신 (레거시 리다이렉트 검증 포함)

## 검증
- jest 43 suites / 321 tests (게이트 단위 3건 신규: 미설정 비활성 / 일치 승격 / 불일치 pending)
- **e2e smoke 5/5 전체 통과** — #379 이후 처음으로 all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)