### PR TITLE
feat: 데이터 정합성 진단·정제 서비스 + CLI — #662 P0/P1

### DIFF
--- a/src/scripts/integrityCheck.js
+++ b/src/scripts/integrityCheck.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * 데이터 정합성 점검·정제 CLI (#662 P0/P1).
+ *
+ * 사용법 (backend 컨테이너 안에서 — 이미지에 src/ 로 포함됨):
+ *   docker compose exec backend node src/scripts/integrityCheck.js              # 진단 리포트 (읽기전용)
+ *   docker compose exec backend node src/scripts/integrityCheck.js --files      # 파일↔DB 정합성 포함 (느릴 수 있음)
+ *   docker compose exec backend node src/scripts/integrityCheck.js --fix-owner-orphans           # 정제 dry-run
+ *   docker compose exec backend node src/scripts/integrityCheck.js --fix-owner-orphans --apply   # 실제 삭제
+ *
+ * 정책:
+ * - 기본은 전부 읽기전용. --apply 없이는 어떤 것도 삭제하지 않는다.
+ * - 정제 대상은 개인 콘텐츠(소유자 orphan)만 — 구조 리소스/끊긴 jobId 는 리포트 전용.
+ * - 삭제 전 백업 권장 (백업에는 orphan 이 그대로 담기므로 되돌림 안전망이 된다).
+ */
+require('dotenv').config();
+const mongoose = require('mongoose');
+const {
+  checkOwnerOrphans,
+  cleanupOwnerOrphans,
+  checkDanglingJobRefs,
+  checkFileIntegrity,
+} = require('../services/integrityService');
+
+const args = process.argv.slice(2);
+const FLAG_FILES = args.includes('--files');
+const FLAG_FIX = args.includes('--fix-owner-orphans');
+const FLAG_APPLY = args.includes('--apply');
+
+function printSection(title) {
+  console.log(`\n═══ ${title} ═══`);
+}
+
+function printOrphanRows(rows) {
+  for (const r of rows) {
+    const mark = r.count > 0 ? '⚠️ ' : '  ';
+    console.log(`${mark}${r.collection.padEnd(20)} ${String(r.count).padStart(6)}건` +
+      (r.orphanOwners.length ? `  (orphan 소유자 ${r.orphanOwners.length}명)` : ''));
+    for (const s of r.sample || []) {
+      console.log(`     · ${s._id}  owner=${s[r.field]}  ${s.createdAt ? new Date(s.createdAt).toISOString() : s.name || ''}`);
+    }
+  }
+}
+
+async function main() {
+  const uri = process.env.MONGODB_URI;
+  if (!uri) {
+    console.error('MONGODB_URI 환경변수가 필요합니다. (backend 컨테이너 안에서 실행하세요)');
+    process.exit(1);
+  }
+  await mongoose.connect(uri);
+
+  try {
+    printSection('소유자 orphan (개인 콘텐츠 — 정제 대상)');
+    const owners = await checkOwnerOrphans();
+    printOrphanRows(owners.userContent);
+    console.log(`  합계: ${owners.totalOrphanDocs}건`);
+
+    printSection('소유자 orphan (구조 리소스 — 리포트 전용, 소유권 이전 정책 별개)');
+    printOrphanRows(owners.structural);
+
+    printSection('끊긴 jobId 참조 (리포트 전용 — jobId:null 은 보존 설계라 정상)');
+    const dangling = await checkDanglingJobRefs();
+    for (const r of dangling) {
+      const mark = r.count > 0 ? '⚠️ ' : '  ';
+      console.log(`${mark}${r.collection.padEnd(20)} ${String(r.count).padStart(6)}건`);
+    }
+
+    if (FLAG_FILES) {
+      printSection('파일↔DB 정합성 (P1)');
+      const files = await checkFileIntegrity();
+      console.log(`  DB→디스크 누락(missing): ${files.missingCount}건`);
+      for (const m of files.missing.slice(0, 10)) {
+        console.log(`     · ${m.collection} ${m.id} ${m.field}=${m.url}`);
+      }
+      console.log(`  디스크 고아 파일(DB 참조 없음): ${files.orphanFileCount}건`);
+      for (const f of files.orphanFiles.slice(0, 10)) {
+        console.log(`     · ${f}`);
+      }
+    }
+
+    if (FLAG_FIX) {
+      printSection(FLAG_APPLY ? '소유자 orphan 정제 — 실제 삭제 (--apply)' : '소유자 orphan 정제 — dry-run (--apply 없음)');
+      const cleanup = await cleanupOwnerOrphans({ apply: FLAG_APPLY });
+      for (const r of cleanup.results) {
+        console.log(`  ${r.collection.padEnd(20)} matched ${String(r.matched).padStart(6)}  deleted ${String(r.deleted).padStart(6)}`);
+      }
+      if (!FLAG_APPLY) {
+        console.log('\n  실제 삭제하려면 --apply 를 붙이세요. 삭제 전 백업을 권장합니다.');
+      }
+    }
+  } finally {
+    await mongoose.disconnect();
+  }
+}
+
+main().catch((err) => {
+  console.error('integrity check failed:', err);
+  process.exit(1);
+});

--- a/src/services/integrityService.js
+++ b/src/services/integrityService.js
@@ -1,0 +1,230 @@
+/**
+ * 데이터 정합성 진단·정제 서비스 (#662 P0/P1).
+ *
+ * 백업은 "있는 그대로의 스냅샷"이라 정합성 문제를 고치지 않는다(의도) — 정합성은
+ * 백업과 분리된 이 서비스가 담당한다. 진단(읽기전용)과 정제(dry-run 기본)를 제공.
+ *
+ * - 소유자 orphan: 현존하지 않는 User 를 가리키는 개인 콘텐츠 (USER_CONTENT_MODELS
+ *   — #660 단일 소스 재사용). 정제 대상.
+ * - 구조 리소스 orphan: Project/Tag/Workboard/Pipeline/Server/Group 의 소유 필드가
+ *   끊긴 경우. 소유권 이전 정책이 별개라 **리포트만** 하고 정제하지 않는다.
+ * - 끊긴 jobId: GeneratedImage/Video 의 jobId 가 없는 Job 을 가리키는 경우.
+ *   정상 삭제 플로우는 jobId 를 $unset 하므로(routes/jobs.js) 값이 남아 있는데
+ *   Job 이 없으면 비정상 — 리포트만 (jobId:null 은 보존 설계라 정상).
+ * - 파일↔DB (P1): DB 가 가리키는 파일의 디스크 부재 / DB 참조 없는 고아 파일.
+ */
+const fs = require('fs');
+const path = require('path');
+const User = require('../models/User');
+const ImageGenerationJob = require('../models/ImageGenerationJob');
+const GeneratedImage = require('../models/GeneratedImage');
+const GeneratedVideo = require('../models/GeneratedVideo');
+const UploadedImage = require('../models/UploadedImage');
+const Project = require('../models/Project');
+const Tag = require('../models/Tag');
+const Workboard = require('../models/Workboard');
+const Pipeline = require('../models/Pipeline');
+const Server = require('../models/Server');
+const Group = require('../models/Group');
+const { USER_CONTENT_MODELS } = require('./userDeletionService');
+
+// 구조 리소스 — 소유 필드가 끊겨도 삭제하지 않는다 (소유권 이전 정책 별개, 리포트 전용)
+const STRUCTURAL_CHECKS = [
+  { Model: Project, field: 'userId' },
+  { Model: Tag, field: 'userId' },
+  { Model: Workboard, field: 'createdBy' },
+  { Model: Pipeline, field: 'userId' },
+  { Model: Server, field: 'createdBy' },
+  { Model: Group, field: 'createdBy' },
+];
+
+const SAMPLE_LIMIT = 5;
+
+async function loadExistingUserIdSet() {
+  const users = await User.find({}, { _id: 1 }).lean();
+  return new Set(users.map((u) => String(u._id)));
+}
+
+async function findOrphanOwnersForModel(Model, field, userIdSet) {
+  const owners = await Model.distinct(field);
+  return owners
+    .filter((id) => id && !userIdSet.has(String(id)))
+    .map((id) => String(id));
+}
+
+/**
+ * 소유자 orphan 진단 (개인 콘텐츠 + 구조 리소스).
+ * @returns {{ userContent: Array, structural: Array, totalOrphanDocs: number }}
+ */
+async function checkOwnerOrphans() {
+  const userIdSet = await loadExistingUserIdSet();
+
+  const userContent = [];
+  for (const Model of USER_CONTENT_MODELS) {
+    const orphanOwners = await findOrphanOwnersForModel(Model, 'userId', userIdSet);
+    let count = 0;
+    let sample = [];
+    if (orphanOwners.length > 0) {
+      count = await Model.countDocuments({ userId: { $in: orphanOwners } });
+      sample = await Model.find(
+        { userId: { $in: orphanOwners } },
+        { _id: 1, userId: 1, createdAt: 1 }
+      ).limit(SAMPLE_LIMIT).lean();
+    }
+    userContent.push({ collection: Model.modelName, field: 'userId', orphanOwners, count, sample });
+  }
+
+  const structural = [];
+  for (const { Model, field } of STRUCTURAL_CHECKS) {
+    const orphanOwners = await findOrphanOwnersForModel(Model, field, userIdSet);
+    let count = 0;
+    let sample = [];
+    if (orphanOwners.length > 0) {
+      count = await Model.countDocuments({ [field]: { $in: orphanOwners } });
+      sample = await Model.find(
+        { [field]: { $in: orphanOwners } },
+        { _id: 1, [field]: 1, name: 1 }
+      ).limit(SAMPLE_LIMIT).lean();
+    }
+    structural.push({ collection: Model.modelName, field, orphanOwners, count, sample });
+  }
+
+  const totalOrphanDocs = userContent.reduce((sum, r) => sum + r.count, 0);
+  return { userContent, structural, totalOrphanDocs };
+}
+
+/**
+ * 개인 콘텐츠 소유자 orphan 정제. 기본 dry-run — apply:true 일 때만 실제 삭제.
+ * 구조 리소스는 대상에서 제외 (리포트 전용 정책).
+ * @returns {{ apply: boolean, results: Array<{collection, matched, deleted}> }}
+ */
+async function cleanupOwnerOrphans({ apply = false } = {}) {
+  const userIdSet = await loadExistingUserIdSet();
+  const results = [];
+
+  for (const Model of USER_CONTENT_MODELS) {
+    const orphanOwners = await findOrphanOwnersForModel(Model, 'userId', userIdSet);
+    if (orphanOwners.length === 0) {
+      results.push({ collection: Model.modelName, matched: 0, deleted: 0 });
+      continue;
+    }
+    const filter = { userId: { $in: orphanOwners } };
+    const matched = await Model.countDocuments(filter);
+    let deleted = 0;
+    if (apply && matched > 0) {
+      const r = await Model.deleteMany(filter);
+      deleted = r.deletedCount || 0;
+    }
+    results.push({ collection: Model.modelName, matched, deleted });
+  }
+
+  return { apply, results };
+}
+
+/**
+ * 끊긴 jobId 진단 — jobId 값이 있는데 해당 ImageGenerationJob 이 없는 콘텐츠.
+ * (jobId 미보유는 히스토리 삭제 시 콘텐츠 보존 설계라 정상 — 검사 제외)
+ */
+async function checkDanglingJobRefs() {
+  const jobIds = await ImageGenerationJob.distinct('_id');
+  const jobIdSet = new Set(jobIds.map((id) => String(id)));
+
+  const results = [];
+  for (const Model of [GeneratedImage, GeneratedVideo]) {
+    const refs = await Model.distinct('jobId');
+    const dangling = refs
+      .filter((id) => id && !jobIdSet.has(String(id)))
+      .map((id) => String(id));
+    let count = 0;
+    let sample = [];
+    if (dangling.length > 0) {
+      count = await Model.countDocuments({ jobId: { $in: dangling } });
+      sample = await Model.find(
+        { jobId: { $in: dangling } },
+        { _id: 1, jobId: 1, filename: 1 }
+      ).limit(SAMPLE_LIMIT).lean();
+    }
+    results.push({ collection: Model.modelName, danglingJobIds: dangling, count, sample });
+  }
+  return results;
+}
+
+// ── P1: 파일↔DB 정합성 ─────────────────────────────────────────
+
+// DB 의 /uploads/... 경로를 디스크 경로로 변환. uploads 밖(비정상)은 null.
+function uploadUrlToDiskPath(url, uploadRoot) {
+  if (!url || typeof url !== 'string') return null;
+  const normalized = url.split('?')[0];
+  if (!normalized.startsWith('/uploads/')) return null;
+  const rel = normalized.slice('/uploads/'.length);
+  if (rel.includes('..') || rel.includes('\0')) return null;
+  return path.join(uploadRoot, rel);
+}
+
+function walkFiles(dir, out = []) {
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walkFiles(full, out);
+    else out.push(full);
+  }
+  return out;
+}
+
+// 파일 정합성 대상 — 미디어 콘텐츠 (url + 파생 파일)
+const FILE_CHECKS = [
+  { Model: GeneratedImage, urlFields: ['url'] },
+  { Model: GeneratedVideo, urlFields: ['url', 'thumbnailUrl'] },
+  { Model: UploadedImage, urlFields: ['url'] },
+];
+
+// uploads 하위 중 파일 정합성 검사 대상 서브디렉토리 (임시/백업 디렉토리는 제외)
+const CHECKED_SUBDIRS = ['generated', 'reference', 'videos'];
+
+/**
+ * 파일↔DB 정합성 진단 (P1).
+ * - missing: DB 가 가리키는데 디스크에 없는 파일
+ * - orphanFiles: 검사 대상 서브디렉토리에 있는데 DB 어디에도 참조가 없는 파일
+ */
+async function checkFileIntegrity({ uploadRoot = process.env.UPLOAD_PATH || './uploads' } = {}) {
+  const known = new Set();
+  const missing = [];
+
+  for (const { Model, urlFields } of FILE_CHECKS) {
+    const projection = Object.fromEntries(urlFields.map((f) => [f, 1]));
+    const docs = await Model.find({}, { _id: 1, ...projection }).lean();
+    for (const doc of docs) {
+      for (const field of urlFields) {
+        const diskPath = uploadUrlToDiskPath(doc[field], uploadRoot);
+        if (!diskPath) continue;
+        known.add(path.resolve(diskPath));
+        if (!fs.existsSync(diskPath)) {
+          missing.push({ collection: Model.modelName, id: String(doc._id), field, url: doc[field] });
+        }
+      }
+    }
+  }
+
+  const orphanFiles = [];
+  for (const sub of CHECKED_SUBDIRS) {
+    for (const file of walkFiles(path.join(uploadRoot, sub))) {
+      if (!known.has(path.resolve(file))) orphanFiles.push(file);
+    }
+  }
+
+  return {
+    missingCount: missing.length,
+    missing: missing.slice(0, 50),
+    orphanFileCount: orphanFiles.length,
+    orphanFiles: orphanFiles.slice(0, 50),
+  };
+}
+
+module.exports = {
+  checkOwnerOrphans,
+  cleanupOwnerOrphans,
+  checkDanglingJobRefs,
+  checkFileIntegrity,
+  uploadUrlToDiskPath,
+  STRUCTURAL_CHECKS,
+};

--- a/src/tests/integrityService.test.js
+++ b/src/tests/integrityService.test.js
@@ -1,0 +1,168 @@
+/**
+ * integrityService 테스트 (#662 P0/P1)
+ *
+ * 모델을 mock 해 orphan 탐지/정제(dry-run vs apply)와 파일↔DB 정합성의
+ * 순수 로직을 검증한다. 실제 DB/디스크 대신 fixture 사용 (파일 검사는 임시 디렉토리).
+ */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// 테스트용 mock 모델 팩토리 — distinct/countDocuments/find/deleteMany 만 흉내
+function mockModel(name) {
+  const m = {
+    modelName: name,
+    distinct: jest.fn().mockResolvedValue([]),
+    countDocuments: jest.fn().mockResolvedValue(0),
+    find: jest.fn(() => ({ limit: () => ({ lean: () => Promise.resolve([]) }), lean: () => Promise.resolve([]) })),
+    deleteMany: jest.fn().mockResolvedValue({ deletedCount: 0 }),
+  };
+  return m;
+}
+
+const MockUser = mockModel('User');
+const MockJob = mockModel('ImageGenerationJob');
+const MockGenImage = mockModel('GeneratedImage');
+const MockGenVideo = mockModel('GeneratedVideo');
+const MockUploadedImage = mockModel('UploadedImage');
+
+jest.mock('../models/User', () => MockUser);
+jest.mock('../models/ImageGenerationJob', () => MockJob);
+jest.mock('../models/GeneratedImage', () => MockGenImage);
+jest.mock('../models/GeneratedVideo', () => MockGenVideo);
+jest.mock('../models/UploadedImage', () => MockUploadedImage);
+jest.mock('../models/Project', () => mockModel('Project'));
+jest.mock('../models/Tag', () => mockModel('Tag'));
+jest.mock('../models/Workboard', () => mockModel('Workboard'));
+jest.mock('../models/Pipeline', () => mockModel('Pipeline'));
+jest.mock('../models/Server', () => mockModel('Server'));
+jest.mock('../models/Group', () => mockModel('Group'));
+jest.mock('../services/userDeletionService', () => ({
+  USER_CONTENT_MODELS: [MockJob, MockGenImage],
+}));
+
+const {
+  checkOwnerOrphans,
+  cleanupOwnerOrphans,
+  checkDanglingJobRefs,
+  checkFileIntegrity,
+  uploadUrlToDiskPath,
+} = require('../services/integrityService');
+
+function setUserIds(ids) {
+  MockUser.find.mockReturnValue({ lean: () => Promise.resolve(ids.map((id) => ({ _id: id }))) });
+}
+
+function setFindSample(model, docs) {
+  model.find.mockReturnValue({ limit: () => ({ lean: () => Promise.resolve(docs) }), lean: () => Promise.resolve(docs) });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setUserIds(['user-a', 'user-b']);
+  for (const m of [MockJob, MockGenImage, MockGenVideo, MockUploadedImage]) {
+    m.distinct.mockResolvedValue([]);
+    m.countDocuments.mockResolvedValue(0);
+    setFindSample(m, []);
+    m.deleteMany.mockResolvedValue({ deletedCount: 0 });
+  }
+});
+
+describe('checkOwnerOrphans', () => {
+  test('현존 사용자만 있으면 orphan 0', async () => {
+    MockJob.distinct.mockResolvedValue(['user-a']);
+    MockGenImage.distinct.mockResolvedValue(['user-b']);
+
+    const result = await checkOwnerOrphans();
+    expect(result.totalOrphanDocs).toBe(0);
+    expect(result.userContent.every((r) => r.count === 0)).toBe(true);
+  });
+
+  test('삭제된 사용자를 가리키는 문서를 orphan 으로 집계 (#660 사례)', async () => {
+    MockJob.distinct.mockResolvedValue(['user-a', 'ghost-user']);
+    MockJob.countDocuments.mockResolvedValue(17);
+    setFindSample(MockJob, [{ _id: 'j1', userId: 'ghost-user' }]);
+    MockGenImage.distinct.mockResolvedValue(['ghost-user']);
+    MockGenImage.countDocuments.mockResolvedValue(10);
+
+    const result = await checkOwnerOrphans();
+    const jobRow = result.userContent.find((r) => r.collection === 'ImageGenerationJob');
+    expect(jobRow.orphanOwners).toEqual(['ghost-user']);
+    expect(jobRow.count).toBe(17);
+    expect(result.totalOrphanDocs).toBe(27);
+    // count 쿼리는 orphan 소유자만 대상으로
+    expect(MockJob.countDocuments).toHaveBeenCalledWith({ userId: { $in: ['ghost-user'] } });
+  });
+});
+
+describe('cleanupOwnerOrphans — dry-run 기본', () => {
+  beforeEach(() => {
+    MockJob.distinct.mockResolvedValue(['ghost-user']);
+    MockJob.countDocuments.mockResolvedValue(17);
+    MockJob.deleteMany.mockResolvedValue({ deletedCount: 17 });
+  });
+
+  test('apply 없이는 어떤 것도 삭제하지 않는다', async () => {
+    const result = await cleanupOwnerOrphans();
+    const jobRow = result.results.find((r) => r.collection === 'ImageGenerationJob');
+    expect(jobRow.matched).toBe(17);
+    expect(jobRow.deleted).toBe(0);
+    expect(MockJob.deleteMany).not.toHaveBeenCalled();
+  });
+
+  test('apply:true 일 때만 orphan 소유자 대상 deleteMany 실행', async () => {
+    const result = await cleanupOwnerOrphans({ apply: true });
+    const jobRow = result.results.find((r) => r.collection === 'ImageGenerationJob');
+    expect(jobRow.deleted).toBe(17);
+    expect(MockJob.deleteMany).toHaveBeenCalledWith({ userId: { $in: ['ghost-user'] } });
+  });
+});
+
+describe('checkDanglingJobRefs', () => {
+  test('jobId 값이 있는데 Job 이 없으면 비정상으로 집계 (null 은 검사 제외)', async () => {
+    MockJob.distinct.mockResolvedValue(['job-1']);
+    MockGenImage.distinct.mockResolvedValue(['job-1', 'gone-job', null]);
+    MockGenImage.countDocuments.mockResolvedValue(3);
+    MockGenVideo.distinct.mockResolvedValue([null]);
+
+    const result = await checkDanglingJobRefs();
+    const imgRow = result.find((r) => r.collection === 'GeneratedImage');
+    expect(imgRow.danglingJobIds).toEqual(['gone-job']);
+    expect(imgRow.count).toBe(3);
+    const vidRow = result.find((r) => r.collection === 'GeneratedVideo');
+    expect(vidRow.count).toBe(0);
+  });
+});
+
+describe('checkFileIntegrity (P1)', () => {
+  test('uploadUrlToDiskPath — /uploads 경로만 변환, traversal 차단', () => {
+    expect(uploadUrlToDiskPath('/uploads/generated/a.png', '/root')).toBe(path.join('/root', 'generated/a.png'));
+    expect(uploadUrlToDiskPath('/uploads/videos/v.mp4?expires=1', '/root')).toBe(path.join('/root', 'videos/v.mp4'));
+    expect(uploadUrlToDiskPath('/etc/passwd', '/root')).toBeNull();
+    expect(uploadUrlToDiskPath('/uploads/../etc/x', '/root')).toBeNull();
+    expect(uploadUrlToDiskPath(null, '/root')).toBeNull();
+  });
+
+  test('DB→디스크 누락과 디스크 고아 파일을 각각 집계', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vcc-integrity-'));
+    fs.mkdirSync(path.join(root, 'generated'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'generated/exists.png'), 'x');
+    fs.writeFileSync(path.join(root, 'generated/orphan.png'), 'x');
+
+    setFindSample(MockGenImage, [
+      { _id: 'i1', url: '/uploads/generated/exists.png' },
+      { _id: 'i2', url: '/uploads/generated/missing.png' },
+    ]);
+    setFindSample(MockGenVideo, []);
+    setFindSample(MockUploadedImage, []);
+
+    const result = await checkFileIntegrity({ uploadRoot: root });
+
+    expect(result.missingCount).toBe(1);
+    expect(result.missing[0]).toMatchObject({ collection: 'GeneratedImage', id: 'i2' });
+    expect(result.orphanFileCount).toBe(1);
+    expect(result.orphanFiles[0]).toContain('orphan.png');
+
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
#662 Epic 의 P0(진단 서비스 + CLI + orphan 정제) / P1(파일↔DB 정합성) 구현. Epic 은 P2(관리자 화면) 남아 있어 열어 둠.

## 구성
- **`services/integrityService.js`** — 진단은 전부 읽기전용, 정제는 dry-run 기본
  - 소유자 orphan: 개인 콘텐츠는 #660 의 `USER_CONTENT_MODELS` 를 단일 소스로 재사용 (새 모델 추가 시 자동 편입). 구조 리소스 6종은 소유권 이전 정책이 별개라 **리포트 전용**
  - 끊긴 jobId: 정상 삭제 플로우가 `$unset` 하므로 값이 남은 채 Job 부재 = 비정상 (jobId:null 은 보존 설계라 정상 — 검사 제외)
  - 파일↔DB (P1): DB→디스크 누락 + 디스크 고아 파일 (uploads 의 generated/reference/videos 만, 임시/백업 디렉토리 제외, traversal 가드)
- **`src/scripts/integrityCheck.js`** — `docker compose exec backend node src/scripts/integrityCheck.js [--files] [--fix-owner-orphans [--apply]]`. src/ 에 둬 이미지에 포함 (별도 마운트 불필요)

## 실데이터 검증 (로컬 = 실데이터 복원 사본)
- 이슈에 기록된 **orphan 27건을 정확히 탐지** — ImageGenerationJob 17 + GeneratedImage 10, 삭제된 사용자 1명(69e36bcd…)
- dry-run: matched 27 / deleted 0 (deleteMany 미호출) → `--apply`: 27건 삭제 → 재점검: 0건
- 추가 발견: **Server 'GPT' 의 createdBy orphan 1건** (같은 삭제 유저) — 구조 리소스라 정책대로 리포트만
- 정제로 DB 참조가 사라진 이미지 파일 10건이 P1 고아 파일 검사에 잡히는 것까지 확인 (두 검사의 정합)

## 운영 절차 (알파/본서버)
1. 배포 후 `integrityCheck.js` (읽기전용 리포트) → 2. 백업 → 3. `--fix-owner-orphans` (dry-run) → 4. `--apply`

## 테스트
- jest 41 suites / 325 tests (신규 7 — orphan 집계 / dry-run vs apply / dangling / 파일 정합 픽스처)

🤖 Generated with [Claude Code](https://claude.com/claude-code)