### PR TITLE
feat: 관리자 데이터 정합성 화면 — #662 P2

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -39,6 +39,7 @@ import {
   ServerManagementPage,
   SystemStatsPage,
   BackupRestorePage,
+  IntegrityPage,
   MetadataManagementPage,
   GroupManagementPage
 } from './pages/admin';
@@ -249,6 +250,14 @@ function MainLayout() {
               element={
                 <AdminRoute>
                   <BackupRestorePage />
+                </AdminRoute>
+              }
+            />
+            <Route
+              path="/admin/integrity"
+              element={
+                <AdminRoute>
+                  <IntegrityPage />
                 </AdminRoute>
               }
             />

--- a/frontend/src/components/Sidebar.js
+++ b/frontend/src/components/Sidebar.js
@@ -25,6 +25,7 @@ import {
   LocalOffer,
   Settings,
   Backup,
+  FactCheck,
   AutoFixHigh,
   FolderSpecial,
   Group
@@ -58,6 +59,7 @@ const adminMenuItems = [
   { text: '그룹 관리', path: '/admin/groups', icon: <Group /> },
   { text: '시스템 통계', path: '/admin/stats', icon: <BarChart /> },
   { text: '백업 / 복구', path: '/admin/backup', icon: <Backup /> },
+  { text: '데이터 정합성', path: '/admin/integrity', icon: <FactCheck /> },
 ];
 
 const settingsItem = { text: '설정', path: '/settings', icon: <Settings /> };

--- a/frontend/src/components/admin/IntegrityReport.js
+++ b/frontend/src/components/admin/IntegrityReport.js
@@ -1,0 +1,258 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Paper,
+  Typography,
+  Button,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Alert,
+  CircularProgress,
+  FormControlLabel,
+  Switch,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+} from '@mui/material';
+import {
+  Refresh as RefreshIcon,
+  CleaningServices as CleanupIcon,
+} from '@mui/icons-material';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
+import { adminAPI } from '../../services/api';
+import PageHeader from '../common/PageHeader';
+import ToneChip from '../common/ToneChip';
+import { MONO } from '../../theme';
+
+// 데이터 정합성 리포트 + 정제 (#662 P2).
+// 진단은 읽기전용 — 버튼을 눌러야 실행 (자동 조회 없음, DB 전 컬렉션 스캔이라).
+// 정제는 개인 콘텐츠 orphan 만 — dry-run 결과 확인 후 경고 모달 거쳐 실행.
+function IntegrityReport() {
+  const [includeFiles, setIncludeFiles] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [cleanupResult, setCleanupResult] = useState(null);
+
+  const {
+    data: reportData,
+    isFetching,
+    refetch,
+  } = useQuery({
+    queryKey: ['adminIntegrity', includeFiles],
+    queryFn: () => adminAPI.getIntegrity({ files: includeFiles }),
+    enabled: false, // 수동 실행 전용
+  });
+  const report = reportData?.data?.data;
+
+  const dryRunMutation = useMutation({
+    mutationFn: () => adminAPI.cleanupOwnerOrphans(false),
+    onSuccess: (res) => {
+      setCleanupResult(res.data.data);
+      const total = res.data.data.results.reduce((s, r) => s + r.matched, 0);
+      if (total === 0) {
+        toast.success('정제할 orphan 이 없습니다.');
+      } else {
+        setConfirmOpen(true);
+      }
+    },
+    onError: (err) => toast.error(err.response?.data?.message || '정제 dry-run 실패'),
+  });
+
+  const applyMutation = useMutation({
+    mutationFn: () => adminAPI.cleanupOwnerOrphans(true),
+    onSuccess: (res) => {
+      setCleanupResult(res.data.data);
+      setConfirmOpen(false);
+      const total = res.data.data.results.reduce((s, r) => s + r.deleted, 0);
+      toast.success(`orphan ${total}건을 정리했습니다.`);
+      refetch();
+    },
+    onError: (err) => toast.error(err.response?.data?.message || 'orphan 정제 실패'),
+  });
+
+  const userContentTotal = report
+    ? report.owners.userContent.reduce((s, r) => s + r.count, 0)
+    : 0;
+  const dryRunTotal = cleanupResult
+    ? cleanupResult.results.reduce((s, r) => s + r.matched, 0)
+    : 0;
+
+  const renderOrphanTable = (rows, ownerLabel) => (
+    <Table size="small">
+      <TableHead>
+        <TableRow>
+          <TableCell>컬렉션</TableCell>
+          <TableCell align="right">orphan 문서</TableCell>
+          <TableCell>{ownerLabel}</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {rows.map((r) => (
+          <TableRow key={`${r.collection}-${r.field}`}>
+            <TableCell sx={{ fontFamily: MONO }}>{r.collection}</TableCell>
+            <TableCell align="right">
+              {r.count > 0 ? <ToneChip tone="warning" label={`${r.count}건`} /> : '0건'}
+            </TableCell>
+            <TableCell sx={{ fontFamily: MONO, fontSize: 12, color: 'text.secondary' }}>
+              {r.orphanOwners.slice(0, 3).join(', ') || '—'}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+
+  return (
+    <Box>
+      <PageHeader
+        title="데이터 정합성"
+        description="삭제된 사용자를 가리키는 문서, 끊긴 참조, 파일↔DB 불일치를 점검하고 정리합니다."
+      />
+
+      <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 2, flexWrap: 'wrap', rowGap: 1 }}>
+        <Button
+          variant="contained"
+          startIcon={isFetching ? <CircularProgress size={16} /> : <RefreshIcon />}
+          onClick={() => refetch()}
+          disabled={isFetching}
+        >
+          진단 실행
+        </Button>
+        <FormControlLabel
+          control={
+            <Switch
+              size="small"
+              checked={includeFiles}
+              onChange={(e) => setIncludeFiles(e.target.checked)}
+            />
+          }
+          label={<Typography variant="caption">파일↔DB 정합성 포함 (파일이 많으면 느림)</Typography>}
+        />
+        <Box sx={{ flexGrow: 1 }} />
+        <Button
+          variant="outlined"
+          color="warning"
+          startIcon={<CleanupIcon />}
+          onClick={() => dryRunMutation.mutate()}
+          disabled={dryRunMutation.isPending || applyMutation.isPending}
+        >
+          orphan 정제
+        </Button>
+      </Stack>
+
+      <Alert severity="info" sx={{ mb: 2 }}>
+        진단은 읽기전용입니다. 정제는 <strong>개인 콘텐츠의 소유자 orphan 만</strong> 대상이며,
+        실행 전 대상 수를 확인하는 단계를 거칩니다. 정제 전 백업을 권장합니다
+        (백업에는 orphan 이 그대로 담기므로 되돌림 안전망이 됩니다).
+      </Alert>
+
+      {!report && !isFetching && (
+        <Paper variant="outlined" sx={{ p: 4, textAlign: 'center' }}>
+          <Typography variant="body2" color="text.secondary">
+            "진단 실행"을 눌러 정합성 점검을 시작하세요.
+          </Typography>
+        </Paper>
+      )}
+
+      {report && (
+        <Stack spacing={2}>
+          <Paper variant="outlined" sx={{ p: 2 }}>
+            <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+              <Typography variant="subtitle2">개인 콘텐츠 — 소유자 orphan</Typography>
+              {userContentTotal > 0
+                ? <ToneChip tone="warning" label={`총 ${userContentTotal}건`} />
+                : <ToneChip tone="success" label="이상 없음" />}
+            </Stack>
+            {renderOrphanTable(report.owners.userContent, 'orphan 소유자 (일부)')}
+          </Paper>
+
+          <Paper variant="outlined" sx={{ p: 2 }}>
+            <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+              <Typography variant="subtitle2">구조 리소스 — 소유자 orphan</Typography>
+              <ToneChip tone="neutral" label="리포트 전용" />
+            </Stack>
+            <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1 }}>
+              작업판·서버·그룹 등은 소유권 이전 정책이 별개라 자동 정제하지 않습니다.
+              발견 시 소유자 재지정 또는 개별 판단이 필요합니다.
+            </Typography>
+            {renderOrphanTable(report.owners.structural, 'orphan 소유자 (일부)')}
+          </Paper>
+
+          <Paper variant="outlined" sx={{ p: 2 }}>
+            <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+              <Typography variant="subtitle2">끊긴 작업 참조 (jobId)</Typography>
+              <ToneChip tone="neutral" label="리포트 전용" />
+            </Stack>
+            <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1 }}>
+              작업 삭제 시 콘텐츠를 보존하는 설계에서 참조는 정상적으로 해제(null)됩니다 —
+              값이 남은 채 작업이 없으면 비정상입니다.
+            </Typography>
+            {report.danglingJobRefs.map((r) => (
+              <Typography key={r.collection} variant="body2" sx={{ fontFamily: MONO }}>
+                {r.collection}: {r.count > 0 ? `⚠️ ${r.count}건` : '0건'}
+              </Typography>
+            ))}
+          </Paper>
+
+          {report.files && (
+            <Paper variant="outlined" sx={{ p: 2 }}>
+              <Typography variant="subtitle2" sx={{ mb: 1 }}>파일↔DB 정합성</Typography>
+              <Typography variant="body2">
+                DB가 가리키는데 디스크에 없는 파일: {report.files.missingCount > 0 ? `⚠️ ${report.files.missingCount}건` : '0건'}
+              </Typography>
+              <Typography variant="body2">
+                DB 참조 없는 고아 파일: {report.files.orphanFileCount > 0 ? `⚠️ ${report.files.orphanFileCount}건` : '0건'}
+              </Typography>
+              {report.files.orphanFileCount > 0 && (
+                <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 0.5 }}>
+                  고아 파일 정리는 CLI(src/scripts/integrityCheck.js --files)로 목록 확인 후 수동으로 진행하세요.
+                </Typography>
+              )}
+            </Paper>
+          )}
+
+          <Typography variant="caption" color="text.secondary">
+            점검 시각: {report.checkedAt ? new Date(report.checkedAt).toLocaleString('ko-KR') : '—'}
+          </Typography>
+        </Stack>
+      )}
+
+      <Dialog open={confirmOpen} onClose={() => setConfirmOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>orphan 정제 실행</DialogTitle>
+        <DialogContent>
+          <DialogContentText component="div">
+            삭제된 사용자를 가리키는 개인 콘텐츠 <strong>{dryRunTotal}건</strong>을 삭제합니다.
+            <br /><br />
+            {cleanupResult?.results.filter((r) => r.matched > 0).map((r) => (
+              <Typography key={r.collection} variant="body2" sx={{ fontFamily: MONO }}>
+                · {r.collection}: {r.matched}건
+              </Typography>
+            ))}
+            <br />
+            이 작업은 되돌릴 수 없습니다. <strong>정제 전 백업을 권장합니다.</strong> 계속할까요?
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmOpen(false)} disabled={applyMutation.isPending}>취소</Button>
+          <Button
+            color="error"
+            variant="contained"
+            onClick={() => applyMutation.mutate()}
+            disabled={applyMutation.isPending}
+            startIcon={applyMutation.isPending ? <CircularProgress size={16} /> : <CleanupIcon />}
+          >
+            {dryRunTotal}건 삭제
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}
+
+export default IntegrityReport;

--- a/frontend/src/pages/admin/IntegrityPage.js
+++ b/frontend/src/pages/admin/IntegrityPage.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Container } from '@mui/material';
+import IntegrityReport from '../../components/admin/IntegrityReport';
+
+function IntegrityPage() {
+  return (
+    <Container maxWidth="lg" sx={{ mb: 8 }}>
+      <IntegrityReport />
+    </Container>
+  );
+}
+
+export default IntegrityPage;

--- a/frontend/src/pages/admin/index.js
+++ b/frontend/src/pages/admin/index.js
@@ -10,3 +10,4 @@ export { default as LoraManagementPage } from './LoraManagementPage';
 export { default as ModelManagementPage } from './ModelManagementPage';
 export { default as MetadataManagementPage } from './MetadataManagementPage';
 export { default as GroupManagementPage } from './GroupManagementPage';
+export { default as IntegrityPage } from './IntegrityPage';

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -181,6 +181,9 @@ export const adminAPI = {
   rejectUser: (id) => api.post(`/admin/users/${id}/reject`),
   getStats: () => api.get('/admin/stats'),
   getJobs: (params) => api.get('/admin/jobs', { params }),
+  // 데이터 정합성 (#662 P2)
+  getIntegrity: (params) => api.get('/admin/integrity', { params }),
+  cleanupOwnerOrphans: (apply) => api.post('/admin/integrity/cleanup-owner-orphans', { apply }),
   // LoRA 설정 API
   getLoraSettings: () => api.get('/admin/settings/lora'),
   updateLoraSettings: (data) => api.put('/admin/settings/lora', data),

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -6,6 +6,7 @@ const ImageGenerationJob = require('../models/ImageGenerationJob');
 const GeneratedImage = require('../models/GeneratedImage');
 const UploadedImage = require('../models/UploadedImage');
 const SystemSettings = require('../models/SystemSettings');
+const integrityService = require('../services/integrityService');
 const ApiKey = require('../models/ApiKey');
 const { escapeRegex } = require('../utils/escapeRegex');
 const { deleteUserAndContent } = require('../services/userDeletionService');
@@ -294,6 +295,37 @@ router.put('/settings/lora', requireAdmin, async (req, res) => {
       success: false,
       message: error.message
     });
+  }
+});
+
+// ── 데이터 정합성 (#662 P2) ────────────────────────────────────
+
+// 진단 리포트 (읽기전용). ?files=true 면 파일↔DB 정합성 포함 (파일 수에 따라 느릴 수 있음)
+router.get('/integrity', requireAdmin, async (req, res) => {
+  try {
+    const includeFiles = req.query.files === 'true';
+    const [owners, danglingJobRefs] = await Promise.all([
+      integrityService.checkOwnerOrphans(),
+      integrityService.checkDanglingJobRefs(),
+    ]);
+    const files = includeFiles ? await integrityService.checkFileIntegrity() : null;
+    res.json({ success: true, data: { owners, danglingJobRefs, files, checkedAt: new Date() } });
+  } catch (error) {
+    console.error('Integrity check error:', error);
+    res.status(500).json({ success: false, message: '정합성 점검에 실패했습니다.' });
+  }
+});
+
+// 소유자 orphan 정제 — body.apply === true 일 때만 실제 삭제 (기본 dry-run).
+// 구조 리소스/끊긴 jobId 는 대상 아님 (리포트 전용 정책 — services/integrityService 참고)
+router.post('/integrity/cleanup-owner-orphans', requireAdmin, async (req, res) => {
+  try {
+    const apply = req.body?.apply === true;
+    const result = await integrityService.cleanupOwnerOrphans({ apply });
+    res.json({ success: true, data: result });
+  } catch (error) {
+    console.error('Integrity cleanup error:', error);
+    res.status(500).json({ success: false, message: 'orphan 정제에 실패했습니다.' });
   }
 });
 

--- a/src/tests/integrityRoute.test.js
+++ b/src/tests/integrityRoute.test.js
@@ -1,0 +1,97 @@
+/**
+ * admin 정합성 라우트 테스트 (#662 P2)
+ *
+ * admin 게이트, 파일 검사 opt-in, cleanup 의 apply 플래그가
+ * 서비스로 정확히 전달되는지(기본 dry-run) 검증.
+ */
+const express = require('express');
+const request = require('supertest');
+
+let mockCurrentUser;
+
+jest.mock('../middleware/auth', () => ({
+  requireAdmin: (req, res, next) => {
+    if (!mockCurrentUser?.isAdmin) {
+      return res.status(403).json({ success: false, message: '관리자 권한이 필요합니다.' });
+    }
+    req.user = mockCurrentUser;
+    next();
+  },
+}));
+
+jest.mock('../services/integrityService', () => ({
+  checkOwnerOrphans: jest.fn(),
+  checkDanglingJobRefs: jest.fn(),
+  checkFileIntegrity: jest.fn(),
+  cleanupOwnerOrphans: jest.fn(),
+}));
+
+// admin.js 가 물고 있는 모델들 — 이 테스트에서 호출 안 됨
+jest.mock('../models/User', () => ({}));
+jest.mock('../models/Workboard', () => ({}));
+jest.mock('../models/ImageGenerationJob', () => ({}));
+jest.mock('../models/GeneratedImage', () => ({}));
+jest.mock('../models/UploadedImage', () => ({}));
+jest.mock('../models/SystemSettings', () => ({}));
+
+const integrityService = require('../services/integrityService');
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/admin', require('../routes/admin'));
+  return app;
+}
+
+describe('admin 정합성 라우트 (#662 P2)', () => {
+  let app;
+
+  beforeAll(() => {
+    app = createApp();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCurrentUser = { _id: 'admin-1', isAdmin: true };
+    integrityService.checkOwnerOrphans.mockResolvedValue({ userContent: [], structural: [], totalOrphanDocs: 0 });
+    integrityService.checkDanglingJobRefs.mockResolvedValue([]);
+    integrityService.checkFileIntegrity.mockResolvedValue({ missingCount: 0, orphanFileCount: 0 });
+    integrityService.cleanupOwnerOrphans.mockResolvedValue({ apply: false, results: [] });
+  });
+
+  test('GET /integrity — 일반 사용자는 403', async () => {
+    mockCurrentUser = { _id: 'user-1', isAdmin: false };
+    const res = await request(app).get('/api/admin/integrity');
+    expect(res.status).toBe(403);
+    expect(integrityService.checkOwnerOrphans).not.toHaveBeenCalled();
+  });
+
+  test('GET /integrity — 기본은 파일 검사 제외', async () => {
+    const res = await request(app).get('/api/admin/integrity');
+    expect(res.status).toBe(200);
+    expect(res.body.data.files).toBeNull();
+    expect(integrityService.checkFileIntegrity).not.toHaveBeenCalled();
+  });
+
+  test('GET /integrity?files=true — 파일 검사 포함', async () => {
+    const res = await request(app).get('/api/admin/integrity').query({ files: 'true' });
+    expect(res.status).toBe(200);
+    expect(res.body.data.files).toEqual({ missingCount: 0, orphanFileCount: 0 });
+    expect(integrityService.checkFileIntegrity).toHaveBeenCalled();
+  });
+
+  test('POST /cleanup-owner-orphans — 기본은 dry-run (apply:false)', async () => {
+    const res = await request(app).post('/api/admin/integrity/cleanup-owner-orphans').send({});
+    expect(res.status).toBe(200);
+    expect(integrityService.cleanupOwnerOrphans).toHaveBeenCalledWith({ apply: false });
+  });
+
+  test('POST /cleanup-owner-orphans — apply 는 boolean true 일 때만', async () => {
+    await request(app).post('/api/admin/integrity/cleanup-owner-orphans').send({ apply: true });
+    expect(integrityService.cleanupOwnerOrphans).toHaveBeenLastCalledWith({ apply: true });
+
+    // 문자열 'true' 등 유사값은 dry-run 으로 강등 (안전)
+    await request(app).post('/api/admin/integrity/cleanup-owner-orphans').send({ apply: 'true' });
+    expect(integrityService.cleanupOwnerOrphans).toHaveBeenLastCalledWith({ apply: false });
+  });
+});


### PR DESCRIPTION
closes #662

Epic #662 마지막 단계 (P0/P1 은 PR #703). 관리자 화면에서 정합성 진단·정제를 수행.

## 구성
- **admin API**
  - `GET /admin/integrity` — 진단 리포트 (읽기전용). `?files=true` 로 파일↔DB 검사 opt-in (전 파일 스캔이라 기본 제외)
  - `POST /admin/integrity/cleanup-owner-orphans` — `body.apply` 가 **boolean `true` 일 때만** 실제 삭제, 그 외 전부 dry-run 강등 (안전 기본값)
- **관리자 페이지 `/admin/integrity`** (사이드바 '데이터 정합성')
  - 진단은 버튼 눌러 수동 실행 (자동 조회 없음 — 전 컬렉션 스캔)
  - 카드 4종: 개인 콘텐츠 orphan(정제 대상) / 구조 리소스 orphan(리포트 전용 배지 + 소유권 이전 안내) / 끊긴 jobId / 파일↔DB (고아 파일은 CLI 안내)
  - **정제 플로우**: dry-run 호출 → 대상 수·컬렉션별 내역 모달 (되돌릴 수 없음 + 백업 권장 경고) → 확인 시 apply → 토스트 + 자동 재진단
  - v2 디자인 컴포넌트 (PageHeader/ToneChip/outlined Paper)

## 검증
- jest 42 suites / 330 tests — 라우트 5건 신규 (admin 게이트 403 / files opt-in / apply boolean 강제)
- e2e smoke 5/5
- **실브라우저 전체 플로우**: 로컬 DB 에 합성 orphan 2건 심고 → 진단(경고 칩 '총 2건') → 정제 모달(ImageGenerationJob: 2건 명시) → 삭제 → 성공 토스트 + 자동 재진단 '이상 없음' 칩 확인, 콘솔 에러 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)