### PR TITLE
fix: 작업판 편집기 저장/생성 400 회귀 — baseInputFields Joi 타입 해제 (#706)

### DIFF
--- a/src/tests/routeValidation.test.js
+++ b/src/tests/routeValidation.test.js
@@ -125,6 +125,29 @@ describe('스키마 단위 — 기존 허용 본문의 동작 보존 (#698)', ()
     expect(projectUpdateSchema.validate({ coverImage: 'not-object' }).error).toBeDefined();
   });
 
+  test('편집기 실제 payload 형태를 거부하지 않는다 (#706 회귀)', () => {
+    // WorkboardManagement onSubmit 이 보내는 legacy baseInputFields 는 객체
+    const editorPayload = {
+      name: 'Anima - Simple',
+      serverId: 'srv-1',
+      outputFormat: 'image',
+      baseInputFields: {
+        aiModel: [], imageSizes: [], referenceImageMethods: [], systemPrompt: '', referenceImages: [],
+      },
+      additionalInputFields: [{ name: 'base_model', label: '베이스 모델', type: 'baseModel' }],
+      workflowData: '{"46":{}}',
+      isActive: true,
+    };
+    expect(workboardUpdateSchema.validate(editorPayload).error).toBeUndefined();
+
+    const { serverId, ...rest } = editorPayload;
+    expect(
+      require('../utils/validation').workboardCreateSchema.validate({ serverId, ...rest }).error
+    ).toBeUndefined();
+    // 구버전 백업 등 배열 형태도 허용 (타입 무제약)
+    expect(workboardUpdateSchema.validate({ baseInputFields: [] }).error).toBeUndefined();
+  });
+
   test('llmExtraParams 는 객체/null 허용, 문자열 거부 (#493 계약)', () => {
     expect(workboardUpdateSchema.validate({ llmExtraParams: { max_tokens: 8 } }).error).toBeUndefined();
     expect(workboardUpdateSchema.validate({ llmExtraParams: null }).error).toBeUndefined();

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -162,7 +162,9 @@ const workboardCreateSchema = Joi.object({
   description: Joi.string().allow('', null).max(2000),
   workboardType: Joi.string(),
   outputFormat: Joi.string(),
-  baseInputFields: Joi.array(),
+  // baseInputFields: legacy 필드 — 편집기가 객체를, 구버전 백업이 배열을 보낼 수 있어
+  // 타입을 제약하지 않는다 (모델은 F4 에서 스키마 제거돼 저장 시 strip됨) (#706)
+  baseInputFields: Joi.any(),
   additionalInputFields: Joi.array(),
   allowedModelTypes: Joi.array(),
   allowedGroupIds: Joi.array(),
@@ -179,7 +181,7 @@ const workboardUpdateSchema = Joi.object({
   description: Joi.string().allow('', null).max(2000),
   workboardType: Joi.string(),
   outputFormat: Joi.string(),
-  baseInputFields: Joi.array(),
+  baseInputFields: Joi.any(), // legacy — 위 create 주석 참고 (#706)
   additionalInputFields: Joi.array(),
   allowedModelTypes: Joi.array(),
   allowedGroupIds: Joi.array(),


### PR DESCRIPTION
closes #706

## 회귀 내용
v3.9.0(#698)이 workboard Joi 스키마에 `baseInputFields: Joi.array()` 를 넣었는데, 실제 프론트는:
- 편집기 저장: legacy **객체** `{aiModel:[], imageSizes:[], ...}` 하드코딩 전송
- 생성: 템플릿의 `baseInputFields: {}` 전송

→ v3.9.0 이후 **작업판 저장(PUT)·생성(POST)이 400** `"baseInputFields" must be an array` 로 전부 거부. 편집기 전면 재검토 감사 중 발견, 로컬에서 재현 확인.

## 수정
- `baseInputFields: Joi.any()` — legacy 필드라 타입 제약 안 함 (모델은 F4 에서 스키마 제거돼 strip — 어떤 값이든 저장에 영향 없음)
- 편집기 실제 payload 형태(객체 baseInputFields + 배열 형태 백업)의 스키마 회귀 테스트 추가

## 검증
- 실 backend: PUT 200 / POST 201 (workflowData 포함 실 생성 → 삭제) 복구 확인
- jest 42 suites / 331 tests

## 교훈 / 후속
- #698 의 "동작 보존" 검증이 실제 편집기 payload 로는 안 이뤄졌던 것 — 스키마 타이핑은 실 클라이언트 payload 캡처 기반으로
- `baseInputFields` 는 반쪽 마이그레이션(F3/F4) 잔재 — 프론트 payload·템플릿·Joi·route 에서의 완전 제거는 편집기 재검토 라운드에서 진행

🤖 Generated with [Claude Code](https://claude.com/claude-code)