### PR TITLE
refactor: 편집기 R1 기반 정리 — dead code·Dialog 껍데기·legacy 계약 소거 (#709)

### DIFF
--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -2,8 +2,6 @@ import React, { useState, useEffect } from 'react';
 import { copyToClipboard } from '../../utils/clipboard';
 import {
   Box,
-  Card,
-  CardContent,
   Typography,
   Grid,
   Button,
@@ -19,7 +17,6 @@ import {
   CircularProgress,
   Chip,
   IconButton,
-  Menu,
   MenuItem,
   Tabs,
   Tab,
@@ -35,17 +32,14 @@ import {
   Add,
   Edit,
   Delete,
-  MoreVert,
   ContentCopy,
   Visibility,
-  VisibilityOff,
   Computer,
   TrendingUp,
   ExpandMore,
   ToggleOn,
   ToggleOff,
   DragIndicator,
-  FileDownload,
   FileUpload,
   Check,
   CheckCircle,
@@ -62,11 +56,6 @@ import MetadataPickerModal from '../common/MetadataPickerModal';
 import { BUILTIN_WORKFLOW_VARIABLES, WORKFLOW_VARIABLE_CATEGORIES, formatValueType } from '../../constants/workflowVariables';
 import { MONO } from '../../theme';
 import { BRAND_GRADIENTS } from '../../utils/brandGradients';
-import {
-  getServerTypeLabel,
-  getOutputFormatLabel,
-  getServerTypeColor,
-} from '../../templates/capabilities';
 
 // admin 의 customField 기본값 입력기 — type=baseModel/lora 일 때 서버 모델 목록 Autocomplete (#391)
 function ServerMetadataDefaultValueInput({ serverId, type, value, onChange, label }) {
@@ -120,171 +109,6 @@ function ServerMetadataDefaultValueInput({ serverId, type, value, onChange, labe
       )}
       size="small"
     />
-  );
-}
-
-function WorkboardCard({ workboard, onEdit, onDelete, onDuplicate, onExport, onView, onToggleActive }) {
-  const [anchorEl, setAnchorEl] = useState(null);
-  const menuOpen = Boolean(anchorEl);
-  const isInactive = !workboard.isActive;
-  const getWorkboardChipLabel = (wb) => {
-    const serverType = getServerTypeLabel(wb.serverId?.serverType || '');
-    const outputLabel = getOutputFormatLabel(wb.outputFormat || 'image');
-    if (!serverType) return outputLabel;
-    return `${serverType} · ${outputLabel}`;
-  };
-  const handleMenuOpen = (event) => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handleMenuClose = () => {
-    setAnchorEl(null);
-  };
-
-  const handleCopyWorkboardId = async () => {
-    try {
-      await copyToClipboard(workboard._id);
-      toast.success('작업판 ID를 복사했습니다.');
-    } catch (error) {
-      toast.error('작업판 ID 복사에 실패했습니다.');
-    }
-  };
-
-  return (
-    <Card
-      sx={{
-        height: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-        ...(isInactive && {
-          opacity: 0.7,
-          bgcolor: 'grey.100',
-          border: '2px dashed',
-          borderColor: 'grey.400'
-        })
-      }}
-    >
-      <CardContent sx={{ flexGrow: 1 }}>
-        <Box display="flex" justifyContent="space-between" alignItems="flex-start" mb={2}>
-          <Box display="flex" alignItems="center" gap={1}>
-            {isInactive && <VisibilityOff fontSize="small" color="disabled" />}
-            <Typography
-              variant="h6"
-              gutterBottom
-              sx={{ color: isInactive ? 'text.disabled' : 'text.primary', mb: 0 }}
-            >
-              {workboard.name}
-            </Typography>
-          </Box>
-          <IconButton size="small" onClick={handleMenuOpen}>
-            <MoreVert />
-          </IconButton>
-        </Box>
-
-        {workboard.description && (
-          <Typography variant="body2" color="text.secondary" paragraph>
-            {workboard.description}
-          </Typography>
-        )}
-
-        <Box display="flex" alignItems="center" gap={1} mb={1}>
-          <Computer fontSize="small" />
-          <Typography variant="caption" color="text.secondary">
-            {workboard.serverId ? 
-              `${workboard.serverId.name} (${workboard.serverId.serverType})` :
-              workboard.serverUrl ? new URL(workboard.serverUrl).hostname : '서버 미설정'
-            }
-          </Typography>
-        </Box>
-
-        <Box display="flex" alignItems="center" gap={1} mb={2}>
-          <TrendingUp fontSize="small" />
-          <Typography variant="caption" color="text.secondary">
-            사용횟수: {workboard.usageCount || 0}회
-          </Typography>
-        </Box>
-
-        <Box display="flex" alignItems="center" gap={0.5} mb={2}>
-          <Typography variant="caption" color="text.secondary" sx={{ fontFamily: MONO }}>
-            ID: {workboard._id}
-          </Typography>
-          <IconButton size="small" onClick={handleCopyWorkboardId} aria-label="작업판 ID 복사">
-            <ContentCopy fontSize="inherit" />
-          </IconButton>
-        </Box>
-
-        <Box display="flex" flexWrap="wrap" gap={1} mb={2}>
-          <Chip
-            label={getWorkboardChipLabel(workboard)}
-            sx={{ bgcolor: getServerTypeColor(workboard.serverId?.serverType), color: 'white' }}
-          />
-          <Chip
-            label={workboard.isActive ? '활성' : '비활성'}
-            color={workboard.isActive ? 'success' : 'default'}
-            variant="outlined"
-          />
-          <Chip
-            label={`v${workboard.version || 1}`}
-            color="info"
-            variant="outlined"
-          />
-        </Box>
-
-        <Typography variant="caption" color="text.secondary">
-          생성자: {workboard.createdBy?.nickname || '알 수 없음'}
-        </Typography>
-        <br />
-        <Typography variant="caption" color="text.secondary">
-          생성일: {new Date(workboard.createdAt).toLocaleDateString()}
-        </Typography>
-      </CardContent>
-
-      <Menu
-        anchorEl={anchorEl}
-        open={menuOpen}
-        onClose={handleMenuClose}
-      >
-        <MenuItem onClick={() => { onView(workboard); handleMenuClose(); }}>
-          <Visibility sx={{ mr: 1 }} fontSize="small" />
-          보기
-        </MenuItem>
-        <MenuItem onClick={() => { onEdit(workboard, 'detailed'); handleMenuClose(); }}>
-          <Edit sx={{ mr: 1 }} fontSize="small" />
-          편집
-        </MenuItem>
-        <MenuItem onClick={() => { onDuplicate(workboard); handleMenuClose(); }}>
-          <ContentCopy sx={{ mr: 1 }} fontSize="small" />
-          복제
-        </MenuItem>
-        <MenuItem onClick={() => { onExport(workboard); handleMenuClose(); }}>
-          <FileDownload sx={{ mr: 1 }} fontSize="small" />
-          내보내기
-        </MenuItem>
-        <MenuItem
-          onClick={() => { onToggleActive(workboard); handleMenuClose(); }}
-          sx={{ color: isInactive ? 'success.main' : 'warning.main' }}
-        >
-          {isInactive ? (
-            <>
-              <ToggleOn sx={{ mr: 1 }} fontSize="small" />
-              활성화
-            </>
-          ) : (
-            <>
-              <ToggleOff sx={{ mr: 1 }} fontSize="small" />
-              비활성화
-            </>
-          )}
-        </MenuItem>
-        <MenuItem
-          onClick={() => { onDelete(workboard); handleMenuClose(); }}
-          sx={{ color: 'error.main' }}
-        >
-          <Delete sx={{ mr: 1 }} fontSize="small" />
-          삭제
-        </MenuItem>
-      </Menu>
-    </Card>
   );
 }
 
@@ -708,11 +532,10 @@ function PreviewField({ field }) {
 }
 
 // 상세 편집을 위한 새로운 다이얼로그 컴포넌트
-// asPage 모드 (#437 Phase A) — Dialog 대신 페이지 안에 인라인 렌더. 데이터 fetch 게이트는
-// open 또는 asPage 가 true 일 때 열림. 페이지 경로는 WorkboardEditorPage 가 wrap.
-export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage = false, onCancel }) {
-  const isOpen = asPage || open;
-  const handleCancel = onCancel || onClose;
+// 작업판 편집기 본체 (#709 에서 Dialog 껍데기 제거·개명 — 구 WorkboardDetailDialog).
+// 페이지 전용: WorkboardEditorPage 가 wrap. sticky 헤더의 저장 버튼은 form="wbEditForm" 으로 연결.
+export function WorkboardEditor({ workboard, onSave, onCancel }) {
+  const handleCancel = onCancel;
   const [tabValue, setTabValue] = useState(0);
   // 5e-3 — 입력 양식 탭의 선택 필드 (인스펙터 패턴)
   const [selectedFieldIdx, setSelectedFieldIdx] = useState(-1);
@@ -754,7 +577,7 @@ export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage
   // ComfyUI 서버의 availableBaseModels (#252) — allowedModelTypes 옵션 풀.
   // ServerModelCache 의 detailed endpoint 에서 derived (limit 1 로 가벼운 호출).
   useEffect(() => {
-    if (!isOpen || !isComfyUI || !watchedServerId) {
+    if (!isComfyUI || !watchedServerId) {
       setAvailableBaseModels([]);
       return;
     }
@@ -763,15 +586,15 @@ export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage
         setAvailableBaseModels(res.data?.data?.availableBaseModels || []);
       })
       .catch(() => setAvailableBaseModels([]));
-  }, [isOpen, isComfyUI, watchedServerId]);
+  }, [isComfyUI, watchedServerId]);
 
   // 그룹 목록 fetch (#198) — 모달 open 시 1회
   useEffect(() => {
-    if (!isOpen) return;
+
     groupAPI.getAll()
       .then((res) => setAvailableGroups(res.data?.data?.groups || []))
       .catch(() => setAvailableGroups([]));
-  }, [isOpen]);
+  }, []);
 
   useEffect(() => {
     return () => {
@@ -817,7 +640,7 @@ export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage
 
   // 관리자 전용 API로 완전한 데이터 로딩
   useEffect(() => {
-    if (workboard && workboard._id && isOpen) {
+    if (workboard && workboard._id) {
       setLoading(true);
       
       workboardAPI.getByIdAdmin(workboard._id)
@@ -863,7 +686,7 @@ export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage
           setLoading(false);
         });
     }
-  }, [workboard?._id, isOpen, reset]);
+  }, [workboard?._id, reset]);
 
   const addArrayItem = (fieldName, defaultItem = { key: '', value: '' }) => {
     const currentItems = watch(fieldName) || [];
@@ -967,31 +790,16 @@ export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage
       loraWhitelist: isComfyUIServer && Array.isArray(data.loraWhitelist) ? data.loraWhitelist : [],
       llmExtraParams: parsedLlmExtraParams,
       isActive: Boolean(data.isActive),
-      // F3: baseInputFields 편집 제거 — 신규/기존 모두 빈 상태로 저장.
-      // 스키마의 required: true (aiModel) 통과 위해 빈 배열 명시.
-      // F4 에서 baseInputFields 스키마 자체 drop 예정.
-      baseInputFields: {
-        aiModel: [],
-        imageSizes: [],
-        referenceImageMethods: [],
-        systemPrompt: '',
-        referenceImages: []
-      },
+      // baseInputFields 는 F4 에서 스키마 제거 완료 — payload 에서도 소거 (#709)
       additionalInputFields
     };
 
     onSave(updateData);
   };
 
-  // asPage (#437 Phase A) — Dialog wrapper 대신 React.Fragment 로 감싸 페이지 안에 그대로 렌더.
-  // 사용자가 외부에서 form submit 할 수 있도록 form 에 id 부여 + sticky header 의 저장 버튼은
-  // form="wbEditForm" 으로 연결.
-  const Wrapper = asPage ? React.Fragment : Dialog;
-  const wrapperProps = asPage ? {} : { open, onClose: handleCancel, maxWidth: 'xl', fullWidth: true };
   return (
-    <Wrapper {...wrapperProps}>
-      {asPage ? (
-        <Box sx={{
+    <>
+      <Box sx={{
           position: 'sticky', top: 0, zIndex: 10,
           bgcolor: 'background.paper', borderBottom: 1, borderColor: 'divider',
           py: 2, mb: 2,
@@ -1009,14 +817,9 @@ export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage
           <Box sx={{ flex: 1 }} />
           <Button onClick={handleCancel}>취소</Button>
           <Button form="wbEditForm" type="submit" variant="contained" disabled={loading}>저장</Button>
-        </Box>
-      ) : (
-        <DialogTitle>
-          작업판 상세 편집 - {workboard?.name}
-        </DialogTitle>
-      )}
+      </Box>
       <form id="wbEditForm" onSubmit={handleSubmit(onSubmit)}>
-        <DialogContent>
+        <Box sx={{ px: 6, py: 5 }}>
           {loading ? (
             <Box display="flex" justifyContent="center" alignItems="center" minHeight="200px">
               <CircularProgress />
@@ -1055,7 +858,7 @@ export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage
               errors={errors}
               showActiveSwitch={true}
               showTypeSelector={true}
-              isDialogOpen={isOpen}
+              isDialogOpen
             />
           )}
 
@@ -1662,23 +1465,15 @@ export function WorkboardDetailDialog({ open, onClose, workboard, onSave, asPage
           )}
             </>
           )}
-      </DialogContent>
-        {!asPage && (
-          <DialogActions>
-            <Button onClick={handleCancel}>취소</Button>
-            <Button type="submit" variant="contained" disabled={loading}>
-              저장
-            </Button>
-          </DialogActions>
-        )}
+      </Box>
       </form>
-    </Wrapper>
+    </>
   );
 }
 
-export function WorkboardCreateDialog({ open, onClose, onSave, asPage = false, onCancel }) {
-  const isOpen = asPage || open;
-  const handleCancel = onCancel || onClose;
+// 새 작업판 생성 폼 (#709 — 구 WorkboardCreateDialog). 페이지 전용: WorkboardCreatePage 가 wrap.
+export function WorkboardCreateForm({ onSave, onCancel }) {
+  const handleCancel = onCancel;
   const { control, handleSubmit, reset, setValue, formState: { errors } } = useForm({
     defaultValues: {
       name: '',
@@ -1691,28 +1486,23 @@ export function WorkboardCreateDialog({ open, onClose, onSave, asPage = false, o
   });
 
   useEffect(() => {
-    if (isOpen) {
-      reset({
-        name: '',
-        description: '',
-        outputFormat: 'image',
-        serverId: '',
-        serverType: '',
-        isActive: true
-      });
-    }
-  }, [isOpen, reset]);
+    reset({
+      name: '',
+      description: '',
+      outputFormat: 'image',
+      serverId: '',
+      serverType: '',
+      isActive: true
+    });
+  }, [reset]);
 
   const onSubmit = (data) => {
     onSave(data);
   };
 
-  const Wrapper = asPage ? React.Fragment : Dialog;
-  const wrapperProps = asPage ? {} : { open, onClose: handleCancel, maxWidth: 'md', fullWidth: true };
   return (
-    <Wrapper {...wrapperProps}>
-      {asPage ? (
-        <Box sx={{
+    <>
+      <Box sx={{
           position: 'sticky', top: 0, zIndex: 10,
           bgcolor: 'background.paper', borderBottom: 1, borderColor: 'divider',
           py: 2, mb: 2,
@@ -1723,34 +1513,25 @@ export function WorkboardCreateDialog({ open, onClose, onSave, asPage = false, o
           <Box sx={{ flex: 1 }} />
           <Button onClick={handleCancel}>취소</Button>
           <Button form="wbCreateForm" type="submit" variant="contained">생성</Button>
-        </Box>
-      ) : (
-        <DialogTitle>새 작업판 생성</DialogTitle>
-      )}
+      </Box>
       <form id="wbCreateForm" onSubmit={handleSubmit(onSubmit)}>
-        <DialogContent>
+        <Box sx={{ px: 6, py: 5 }}>
           <WorkboardBasicInfoForm
             control={control}
             setValue={setValue}
             errors={errors}
             showActiveSwitch={false}
             showTypeSelector={true}
-            isDialogOpen={isOpen}
+            isDialogOpen
           />
 
           <Alert severity="info" sx={{ mt: 2 }}>
             기본 작업판 구조가 생성됩니다. 상세 설정(AI 모델, 입력 필드 등)은
             생성 후 편집에서 추가할 수 있습니다.
           </Alert>
-        </DialogContent>
-        {!asPage && (
-          <DialogActions>
-            <Button onClick={handleCancel}>취소</Button>
-            <Button type="submit" variant="contained">생성</Button>
-          </DialogActions>
-        )}
+        </Box>
       </form>
-    </Wrapper>
+    </>
   );
 }
 

--- a/frontend/src/pages/admin/WorkboardCreatePage.js
+++ b/frontend/src/pages/admin/WorkboardCreatePage.js
@@ -5,7 +5,7 @@ import { Container } from '@mui/material';
 import toast from 'react-hot-toast';
 import { workboardAPI } from '../../services/api';
 import { getWorkboardTemplate } from '../../templates';
-import { WorkboardCreateDialog } from '../../components/admin/WorkboardManagement';
+import { WorkboardCreateForm } from '../../components/admin/WorkboardManagement';
 import { invalidateWorkboardQueries } from '../../utils/queryInvalidation';
 
 // #437 Phase A — WorkboardCreateDialog 를 페이지로. 생성 성공 시 편집 페이지로 이동.
@@ -43,8 +43,7 @@ function WorkboardCreatePage() {
 
   return (
     <Container maxWidth="md" sx={{ mt: 2, mb: 4 }}>
-      <WorkboardCreateDialog
-        asPage
+      <WorkboardCreateForm
         onCancel={() => navigate('/admin/workboards')}
         onSave={handleSave}
       />

--- a/frontend/src/pages/admin/WorkboardEditorPage.js
+++ b/frontend/src/pages/admin/WorkboardEditorPage.js
@@ -4,7 +4,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Container, Box, CircularProgress, Alert } from '@mui/material';
 import toast from 'react-hot-toast';
 import { workboardAPI } from '../../services/api';
-import { WorkboardDetailDialog } from '../../components/admin/WorkboardManagement';
+import { WorkboardEditor } from '../../components/admin/WorkboardManagement';
 import { invalidateWorkboardQueries } from '../../utils/queryInvalidation';
 
 // #437 Phase A — 기존 WorkboardDetailDialog 를 페이지 안에 그대로 렌더 (asPage prop).
@@ -51,8 +51,7 @@ function WorkboardEditorPage() {
 
   return (
     <Container maxWidth="xl" sx={{ mt: 2, mb: 4 }}>
-      <WorkboardDetailDialog
-        asPage
+      <WorkboardEditor
         workboard={workboard}
         onCancel={() => navigate('/admin/workboards')}
         onSave={(updateData) => updateMutation.mutate(updateData)}

--- a/frontend/src/templates/ComfyUI-image.json
+++ b/frontend/src/templates/ComfyUI-image.json
@@ -1,5 +1,4 @@
 {
-  "baseInputFields": {},
   "additionalInputFields": [
     {
       "name": "base_model",
@@ -16,13 +15,34 @@
       "required": true,
       "defaultValue": "1024x1024",
       "options": [
-        { "key": "1024x1024", "value": "1024x1024" },
-        { "key": "896x1152", "value": "896x1152" },
-        { "key": "1152x896", "value": "1152x896" },
-        { "key": "832x1216", "value": "832x1216" },
-        { "key": "1216x832", "value": "1216x832" },
-        { "key": "768x1344", "value": "768x1344" },
-        { "key": "1344x768", "value": "1344x768" }
+        {
+          "key": "1024x1024",
+          "value": "1024x1024"
+        },
+        {
+          "key": "896x1152",
+          "value": "896x1152"
+        },
+        {
+          "key": "1152x896",
+          "value": "1152x896"
+        },
+        {
+          "key": "832x1216",
+          "value": "832x1216"
+        },
+        {
+          "key": "1216x832",
+          "value": "1216x832"
+        },
+        {
+          "key": "768x1344",
+          "value": "768x1344"
+        },
+        {
+          "key": "1344x768",
+          "value": "1344x768"
+        }
       ]
     },
     {
@@ -31,8 +51,14 @@
       "type": "select",
       "required": false,
       "options": [
-        { "key": "Image to Image", "value": "img2img" },
-        { "key": "ControlNet Canny", "value": "controlnet_canny" }
+        {
+          "key": "Image to Image",
+          "value": "img2img"
+        },
+        {
+          "key": "ControlNet Canny",
+          "value": "controlnet_canny"
+        }
       ]
     }
   ],

--- a/frontend/src/templates/ComfyUI-video.json
+++ b/frontend/src/templates/ComfyUI-video.json
@@ -1,5 +1,4 @@
 {
-  "baseInputFields": {},
   "additionalInputFields": [
     {
       "name": "base_model",
@@ -16,13 +15,34 @@
       "required": true,
       "defaultValue": "1024x1024",
       "options": [
-        { "key": "1024x1024", "value": "1024x1024" },
-        { "key": "896x1152", "value": "896x1152" },
-        { "key": "1152x896", "value": "1152x896" },
-        { "key": "832x1216", "value": "832x1216" },
-        { "key": "1216x832", "value": "1216x832" },
-        { "key": "768x1344", "value": "768x1344" },
-        { "key": "1344x768", "value": "1344x768" }
+        {
+          "key": "1024x1024",
+          "value": "1024x1024"
+        },
+        {
+          "key": "896x1152",
+          "value": "896x1152"
+        },
+        {
+          "key": "1152x896",
+          "value": "1152x896"
+        },
+        {
+          "key": "832x1216",
+          "value": "832x1216"
+        },
+        {
+          "key": "1216x832",
+          "value": "1216x832"
+        },
+        {
+          "key": "768x1344",
+          "value": "768x1344"
+        },
+        {
+          "key": "1344x768",
+          "value": "1344x768"
+        }
       ]
     },
     {
@@ -31,8 +51,14 @@
       "type": "select",
       "required": false,
       "options": [
-        { "key": "Image to Image", "value": "img2img" },
-        { "key": "ControlNet Canny", "value": "controlnet_canny" }
+        {
+          "key": "Image to Image",
+          "value": "img2img"
+        },
+        {
+          "key": "ControlNet Canny",
+          "value": "controlnet_canny"
+        }
       ]
     }
   ],

--- a/frontend/src/templates/Gemini-image.json
+++ b/frontend/src/templates/Gemini-image.json
@@ -1,5 +1,4 @@
 {
-  "baseInputFields": {},
   "additionalInputFields": [
     {
       "name": "base_model",
@@ -15,12 +14,30 @@
       "required": true,
       "defaultValue": "1:1",
       "options": [
-        { "key": "정사각 (1:1)", "value": "1:1" },
-        { "key": "가로 와이드 (16:9)", "value": "16:9" },
-        { "key": "세로 와이드 (9:16)", "value": "9:16" },
-        { "key": "가로 (4:3)", "value": "4:3" },
-        { "key": "세로 (3:4)", "value": "3:4" },
-        { "key": "영화 (21:9)", "value": "21:9" }
+        {
+          "key": "정사각 (1:1)",
+          "value": "1:1"
+        },
+        {
+          "key": "가로 와이드 (16:9)",
+          "value": "16:9"
+        },
+        {
+          "key": "세로 와이드 (9:16)",
+          "value": "9:16"
+        },
+        {
+          "key": "가로 (4:3)",
+          "value": "4:3"
+        },
+        {
+          "key": "세로 (3:4)",
+          "value": "3:4"
+        },
+        {
+          "key": "영화 (21:9)",
+          "value": "21:9"
+        }
       ]
     },
     {
@@ -30,9 +47,18 @@
       "required": true,
       "defaultValue": "2K",
       "options": [
-        { "key": "1K (기본)", "value": "1K" },
-        { "key": "2K", "value": "2K" },
-        { "key": "4K", "value": "4K" }
+        {
+          "key": "1K (기본)",
+          "value": "1K"
+        },
+        {
+          "key": "2K",
+          "value": "2K"
+        },
+        {
+          "key": "4K",
+          "value": "4K"
+        }
       ],
       "description": "Gemini 이미지 출력 해상도를 선택합니다."
     }

--- a/frontend/src/templates/Gemini-text.json
+++ b/frontend/src/templates/Gemini-text.json
@@ -1,5 +1,4 @@
 {
-  "baseInputFields": {},
   "additionalInputFields": [
     {
       "name": "base_model",

--- a/frontend/src/templates/OpenAI Compatible-text.json
+++ b/frontend/src/templates/OpenAI Compatible-text.json
@@ -1,5 +1,4 @@
 {
-  "baseInputFields": {},
   "additionalInputFields": [
     {
       "name": "base_model",

--- a/frontend/src/templates/OpenAI-image.json
+++ b/frontend/src/templates/OpenAI-image.json
@@ -1,5 +1,4 @@
 {
-  "baseInputFields": {},
   "additionalInputFields": [
     {
       "name": "base_model",
@@ -15,10 +14,22 @@
       "required": true,
       "defaultValue": "auto",
       "options": [
-        { "key": "자동 (auto)", "value": "auto" },
-        { "key": "1024x1024", "value": "1024x1024" },
-        { "key": "1024x1536", "value": "1024x1536" },
-        { "key": "1536x1024", "value": "1536x1024" }
+        {
+          "key": "자동 (auto)",
+          "value": "auto"
+        },
+        {
+          "key": "1024x1024",
+          "value": "1024x1024"
+        },
+        {
+          "key": "1024x1536",
+          "value": "1024x1536"
+        },
+        {
+          "key": "1536x1024",
+          "value": "1536x1024"
+        }
       ]
     },
     {
@@ -28,10 +39,22 @@
       "required": true,
       "defaultValue": "auto",
       "options": [
-        { "key": "Auto", "value": "auto" },
-        { "key": "Low", "value": "low" },
-        { "key": "Medium", "value": "medium" },
-        { "key": "High", "value": "high" }
+        {
+          "key": "Auto",
+          "value": "auto"
+        },
+        {
+          "key": "Low",
+          "value": "low"
+        },
+        {
+          "key": "Medium",
+          "value": "medium"
+        },
+        {
+          "key": "High",
+          "value": "high"
+        }
       ],
       "description": "GPT Image 생성 품질을 선택합니다."
     },
@@ -42,8 +65,14 @@
       "required": false,
       "defaultValue": "opaque",
       "options": [
-        { "key": "불투명 (opaque)", "value": "opaque" },
-        { "key": "투명 (transparent)", "value": "transparent" }
+        {
+          "key": "불투명 (opaque)",
+          "value": "opaque"
+        },
+        {
+          "key": "투명 (transparent)",
+          "value": "transparent"
+        }
       ],
       "description": "gpt-image-2 전용. 투명 배경으로 출력하려면 transparent. 다른 모델에서는 무시됨."
     },

--- a/frontend/src/templates/OpenAI-text.json
+++ b/frontend/src/templates/OpenAI-text.json
@@ -1,5 +1,4 @@
 {
-  "baseInputFields": {},
   "additionalInputFields": [
     {
       "name": "base_model",

--- a/src/routes/workboards.js
+++ b/src/routes/workboards.js
@@ -349,7 +349,6 @@ router.post('/import', requireAdmin, async (req, res) => {
       outputFormat: wb.outputFormat || 'image',
       serverId: matchedServerId,
       serverUrl: server.serverUrl,
-      baseInputFields: wb.baseInputFields,
       additionalInputFields: wb.additionalInputFields || [],
       workflowData: wb.workflowData || '',
       allowedModelTypes: wb.allowedModelTypes || [],
@@ -437,10 +436,8 @@ router.post('/', requireAdmin, validateBody(workboardCreateSchema), async (req, 
       name,
       description,
       serverId,
-      serverUrl,
       workboardType,
       outputFormat,
-      baseInputFields,
       additionalInputFields,
       workflowData,
       allowedModelTypes,
@@ -455,22 +452,15 @@ router.post('/', requireAdmin, validateBody(workboardCreateSchema), async (req, 
     const resolvedOutputFormat = outputFormat || (workboardType === 'prompt' ? 'text' : 'image');
     const resolvedWorkboardType = workboardType || (resolvedOutputFormat === 'text' ? 'prompt' : 'image');
 
-    // serverId가 제공되지 않았지만 serverUrl이 있는 경우 (기존 호환성)
-    let finalServerId = serverId;
-    if (!serverId && serverUrl) {
-      // 기존 serverUrl 방식 지원 (deprecated)
-      console.warn('Warning: Using deprecated serverUrl. Please use serverId instead.');
-    }
-
-    // serverId 필수 검증
-    if (!finalServerId) {
+    // serverId 필수 검증 (serverUrl 직접 입력 방식은 #709 에서 제거 — 편집기는 serverId 만 전송)
+    if (!serverId) {
       return res.status(400).json({
         message: 'serverId is required. Please select a server.'
       });
     }
 
     // 서버 존재 확인
-    const server = await Server.findById(finalServerId);
+    const server = await Server.findById(serverId);
     if (!server) {
       return res.status(400).json({
         message: 'Selected server not found.'
@@ -495,11 +485,10 @@ router.post('/', requireAdmin, validateBody(workboardCreateSchema), async (req, 
     const workboard = new Workboard({
       name: name.trim(),
       description: description?.trim(),
-      serverId: finalServerId,
+      serverId: serverId,
       serverUrl: server.serverUrl,
       workboardType: resolvedWorkboardType,
       outputFormat: resolvedOutputFormat,
-      baseInputFields,
       additionalInputFields: additionalInputFields || [],
       workflowData: isComfyUI ? workflowData : '',
       allowedModelTypes: isComfyUI ? (allowedModelTypes || []) : [],
@@ -535,10 +524,8 @@ router.put('/:id', requireAdmin, validateBody(workboardUpdateSchema), async (req
       name,
       description,
       serverId,
-      serverUrl,
       workboardType,
       outputFormat,
-      baseInputFields,
       additionalInputFields,
       workflowData,
       allowedModelTypes,
@@ -574,10 +561,6 @@ router.put('/:id', requireAdmin, validateBody(workboardUpdateSchema), async (req
       }
       workboard.serverId = serverId;
       workboard.serverUrl = server.serverUrl; // 서버에서 실제 URL 가져오기
-    } else if (serverUrl) {
-      // 기존 호환성 지원 (deprecated)
-      console.warn('Warning: Using deprecated serverUrl. Please use serverId instead.');
-      workboard.serverUrl = serverUrl.trim();
     }
     if (outputFormat) {
       workboard.outputFormat = outputFormat;
@@ -588,7 +571,6 @@ router.put('/:id', requireAdmin, validateBody(workboardUpdateSchema), async (req
     } else if (outputFormat) {
       workboard.workboardType = outputFormat === 'text' ? 'prompt' : 'image';
     }
-    if (baseInputFields) workboard.baseInputFields = baseInputFields;
     if (additionalInputFields !== undefined) workboard.additionalInputFields = additionalInputFields;
     if (workflowData !== undefined) {
       const wbServer = await Server.findById(workboard.serverId);
@@ -731,7 +713,6 @@ router.post('/:id/duplicate', requireAdmin, async (req, res) => {
       serverUrl: originalWorkboard.serverUrl,
       workboardType: originalWorkboard.workboardType,
       outputFormat: originalWorkboard.outputFormat,
-      baseInputFields: originalWorkboard.baseInputFields,
       additionalInputFields: originalWorkboard.additionalInputFields,
       workflowData: originalWorkboard.workflowData,
       allowedModelTypes: originalWorkboard.allowedModelTypes || [],
@@ -785,7 +766,6 @@ router.get('/:id/export', requireAdmin, async (req, res) => {
         description: workboard.description,
         workboardType: workboard.workboardType,
         outputFormat: workboard.outputFormat,
-        baseInputFields: workboard.baseInputFields,
         additionalInputFields: workboard.additionalInputFields,
         workflowData: workboard.workflowData,
         allowedModelTypes: workboard.allowedModelTypes || [],

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -162,9 +162,6 @@ const workboardCreateSchema = Joi.object({
   description: Joi.string().allow('', null).max(2000),
   workboardType: Joi.string(),
   outputFormat: Joi.string(),
-  // baseInputFields: legacy 필드 — 편집기가 객체를, 구버전 백업이 배열을 보낼 수 있어
-  // 타입을 제약하지 않는다 (모델은 F4 에서 스키마 제거돼 저장 시 strip됨) (#706)
-  baseInputFields: Joi.any(),
   additionalInputFields: Joi.array(),
   allowedModelTypes: Joi.array(),
   allowedGroupIds: Joi.array(),
@@ -181,7 +178,6 @@ const workboardUpdateSchema = Joi.object({
   description: Joi.string().allow('', null).max(2000),
   workboardType: Joi.string(),
   outputFormat: Joi.string(),
-  baseInputFields: Joi.any(), // legacy — 위 create 주석 참고 (#706)
   additionalInputFields: Joi.array(),
   allowedModelTypes: Joi.array(),
   allowedGroupIds: Joi.array(),


### PR DESCRIPTION
closes #709

편집기 전면 재검토 실행안 **R1** (행동 변화 없는 순수 정리). 후속: R2 FieldRenderer 단일화 → R3 3-pane UI → R4 워크플로우 에디터.

## 변경사항
- **dead code 제거**: 구형 `WorkboardCard` 164줄(#465 에서 WorkboardCatalog 로 대체된 잔재) + 전용 capabilities import 3종 + WorkboardCard 만 쓰던 MUI import 6종
- **Dialog 껍데기 제거 + 개명**: 편집기/생성 폼은 #437 페이지 전환 후 asPage 로만 사용 — `Wrapper`/`open`/`onClose`/`asPage` dead 분기 전부 삭제, `DialogContent`→`Box`(동일 패딩 px6/py5), `WorkboardDetailDialog`→**`WorkboardEditor`**, `WorkboardCreateDialog`→**`WorkboardCreateForm`**. 카탈로그의 동명 정보창(`WorkboardDetailDialog`)과의 이름 충돌 해소
- **baseInputFields 완전 소거** (F3/F4 반쪽 마이그레이션 완결 — #706 후속): 편집기 payload 하드코딩, 생성 템플릿 JSON 7종, Joi 스키마, 백엔드 create/put/export/duplicate/import 저장 시도 전부 제거. 모델 스키마는 F4 에서 이미 제거돼 마이그레이션 불필요
- **serverUrl 클라이언트 입력 fallback 제거**: 프론트가 전송하지 않는 deprecated 경로(create 경고 분기, put else-if) — server 기준 `workboard.serverUrl` 동기화(실사용)는 유지

순감소: **-334줄 / +193줄** (WorkboardManagement.js 1,980→1,795줄)

## 동작 보존 검증
- 실브라우저: 편집기 열기→저장(PUT 200)→목록 이동, 생성 페이지 렌더, 콘솔 에러 0, **렌더 픽셀 동일** (정리 전 스크린샷과 대조)
- jest 42 suites / 331 tests, e2e smoke 5/5

🤖 Generated with [Claude Code](https://claude.com/claude-code)