### PR TITLE
feat: customField 렌더러 단일화 — 실행 2곳·프리뷰 drift 해소 (#711)

### DIFF
--- a/frontend/src/components/PromptGeneratorPanel.js
+++ b/frontend/src/components/PromptGeneratorPanel.js
@@ -31,7 +31,7 @@ import { useDropzone } from 'react-dropzone';
 import toast from 'react-hot-toast';
 import { workboardAPI, imageAPI } from '../services/api';
 import { useStreamingPrompt } from '../hooks/useStreamingPrompt';
-import MetadataFieldInput from './common/MetadataFieldInput';
+import CustomFieldControl from './common/CustomFieldControl';
 import { MONO } from '../theme';
 
 function ImageUploadField({ label, description, images, onImagesChange, maxImages = 1 }) {
@@ -296,70 +296,23 @@ function PromptGeneratorPanel({
                   #391: conversation_mode 는 admin 전용 설정이라 사용자 폼에선 숨김 */}
               {workboard.additionalInputFields?.filter((f) => f.name !== 'conversation_mode').map((field) => (
                 <Box key={field.name} sx={{ mb: 2 }}>
-                  {field.type === 'string' && (
-                    <Controller
-                      name={field.name}
-                      control={control}
-                      rules={{ required: field.required ? `${field.label}을(를) 입력해주세요` : false }}
-                      render={({ field: formField }) => (
-                        <TextField
-                          {...formField}
-                          fullWidth
-                          size={compact ? 'small' : 'medium'}
-                          label={field.label}
-                          placeholder={field.placeholder}
-                          multiline={field.name.includes('prompt')}
-                          rows={field.name.includes('prompt') ? 2 : 1}
-                          error={!!errors[field.name]}
-                          helperText={errors[field.name]?.message || field.description}
-                        />
-                      )}
-                    />
-                  )}
-                  {field.type === 'select' && (
-                    <Controller
-                      name={field.name}
-                      control={control}
-                      rules={{ required: field.required ? `${field.label}을(를) 선택해주세요` : false }}
-                      render={({ field: formField }) => (
-                        <FormControl fullWidth error={!!errors[field.name]} size={compact ? 'small' : 'medium'}>
-                          <InputLabel>{field.label}</InputLabel>
-                          <Select {...formField} label={field.label}>
-                            {field.options?.map((opt) => (
-                              <MenuItem key={opt.value} value={opt.value}>
-                                {opt.key}
-                              </MenuItem>
-                            ))}
-                          </Select>
-                        </FormControl>
-                      )}
-                    />
-                  )}
-                  {(field.type === 'baseModel' || field.type === 'lora') && (
-                    <Controller
-                      name={field.name}
-                      control={control}
-                      rules={{ required: field.required ? `${field.label}을(를) 선택해주세요` : false }}
-                      render={({ field: formField }) => (
-                        <MetadataFieldInput
-                          kind={field.type === 'baseModel' ? 'model' : 'lora'}
-                          field={field}
-                          value={formField.value || ''}
-                          onChange={formField.onChange}
-                          workboardId={workboard._id}
-                          serverId={workboard?.serverId?._id || workboard?.serverId}
-                        />
-                      )}
-                    />
-                  )}
-                  {/* 이미지 입력 (#519) — image 타입 필드. 첨부 시 비전 입력으로 사용 */}
-                  {field.type === 'image' && (
+                  {field.type === 'image' ? (
+                    /* 이미지 입력 (#519) — image 타입 필드. 첨부 시 비전 입력으로 사용 */
                     <ImageUploadField
                       label={field.label}
                       description={field.description || '이미지를 첨부하면 모델이 분석에 참고합니다. (비전 모델 전용)'}
                       images={referenceImages[field.name] || []}
                       onImagesChange={(imgs) => setReferenceImages((prev) => ({ ...prev, [field.name]: imgs }))}
-                      maxImages={field.imageConfig?.maxImages || 4}
+                      maxImages={field.imageConfig?.maxImages || 3}
+                    />
+                  ) : (
+                    // 공용 렌더러 (#711) — number/boolean 도 렌더 (기존엔 소멸), required 일관 강제
+                    <CustomFieldControl
+                      field={field}
+                      control={control}
+                      size={compact ? 'small' : 'medium'}
+                      workboardId={workboard._id}
+                      serverId={workboard?.serverId?._id || workboard?.serverId}
                     />
                   )}
                 </Box>

--- a/frontend/src/components/admin/WorkboardManagement.js
+++ b/frontend/src/components/admin/WorkboardManagement.js
@@ -52,6 +52,7 @@ import { useForm, Controller } from 'react-hook-form';
 import toast from 'react-hot-toast';
 import { workboardAPI, serverAPI, groupAPI } from '../../services/api';
 import WorkboardBasicInfoForm from './WorkboardBasicInfoForm';
+import CustomFieldControl from '../common/CustomFieldControl';
 import MetadataPickerModal from '../common/MetadataPickerModal';
 import { BUILTIN_WORKFLOW_VARIABLES, WORKFLOW_VARIABLE_CATEGORIES, formatValueType } from '../../constants/workflowVariables';
 import { MONO } from '../../theme';
@@ -430,105 +431,24 @@ function CustomFieldsPreview({ fields }) {
   );
 }
 
+// 프리뷰 필드 — 실행 화면과 동일한 공용 렌더러의 preview 모드 사용 (#711).
+// 별도 목업 구현이 실행과 어긋나던 문제(boolean/string multiline 등)를 원천 차단.
 function PreviewField({ field }) {
-  const label = (
-    <Typography variant="caption" sx={{ display: 'block', fontWeight: 500, mb: 0.5 }}>
-      {field.label || field.name}
-      {field.required && <Box component="span" sx={{ color: 'error.main', ml: 0.5 }}>*</Box>}
-    </Typography>
-  );
-
-  if (field.type === 'string') {
-    const multi = field.name?.includes('prompt');
-    return (
-      <Box>
-        {label}
-        <TextField
-          fullWidth disabled placeholder={field.placeholder}
-          multiline={multi} rows={multi ? 2 : 1}
-          defaultValue={field.defaultValue || ''}
-        />
-        {field.description && (
-          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.25 }}>
-            {field.description}
-          </Typography>
-        )}
-      </Box>
-    );
-  }
-  if (field.type === 'number') {
-    return (
-      <Box>
-        {label}
-        <TextField fullWidth disabled type="number" defaultValue={field.defaultValue || ''} />
-      </Box>
-    );
-  }
-  if (field.type === 'boolean') {
-    return (
-      <FormControlLabel
-        disabled
-        control={<Switch defaultChecked={!!field.defaultValue} />}
-        label={field.label || field.name}
-      />
-    );
-  }
-  if (field.type === 'select') {
-    return (
-      <Box>
-        {label}
-        <TextField
-          fullWidth disabled select SelectProps={{ native: true }}
-          defaultValue={field.defaultValue || ''}
-          InputLabelProps={{ shrink: true }}
-        >
-          <option value="">— 선택 없음 —</option>
-          {(field.options || []).map((opt, i) => (
-            <option key={i} value={opt.value}>{opt.key || opt.value}</option>
-          ))}
-        </TextField>
-      </Box>
-    );
-  }
-  if (field.type === 'baseModel') {
-    return (
-      <Box>
-        {label}
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, px: 1.5, py: 1, border: 1, borderColor: 'divider', borderRadius: 1, bgcolor: 'action.hover' }}>
-          <Box sx={{ width: 22, height: 22, borderRadius: 0.5, background: BRAND_GRADIENTS[0], color: 'white', display: 'grid', placeItems: 'center', fontSize: 11 }}>
-            M
-          </Box>
-          <Typography variant="caption" sx={{ flex: 1 }}>모델 선택…</Typography>
-        </Box>
-      </Box>
-    );
-  }
-  if (field.type === 'lora') {
-    return (
-      <Box>
-        {label}
-        <Box sx={{ border: '1px dashed', borderColor: 'divider', borderRadius: 1, p: 1.5, bgcolor: 'action.hover', minHeight: 40, display: 'flex', alignItems: 'center' }}>
-          <Typography variant="caption" color="text.secondary">LoRA 슬롯 — 사용자가 추가</Typography>
-        </Box>
-      </Box>
-    );
-  }
   if (field.type === 'image') {
     return (
       <Box>
-        {label}
-        <Box sx={{ border: '1px dashed', borderColor: 'divider', borderRadius: 1, p: 2.5, textAlign: 'center', bgcolor: 'action.hover' }}>
-          <Typography variant="caption" color="text.secondary">이미지를 드래그하거나 클릭해서 선택</Typography>
+        <Typography variant="body2" sx={{ fontWeight: 600, mb: 0.5 }}>
+          {field.label}{field.required ? ' *' : ''}
+        </Typography>
+        <Box sx={{ border: '2px dashed', borderColor: 'divider', borderRadius: 1, p: 2, textAlign: 'center' }}>
+          <Typography variant="caption" color="text.secondary">
+            이미지 업로드 (최대 {field.imageConfig?.maxImages || 3}개)
+          </Typography>
         </Box>
       </Box>
     );
   }
-  return (
-    <Box>
-      {label}
-      <Typography variant="caption" color="text.secondary">(타입 {field.type} preview 미지원)</Typography>
-    </Box>
-  );
+  return <CustomFieldControl field={field} preview />;
 }
 
 // 상세 편집을 위한 새로운 다이얼로그 컴포넌트

--- a/frontend/src/components/common/CustomFieldControl.js
+++ b/frontend/src/components/common/CustomFieldControl.js
@@ -1,0 +1,192 @@
+import React from 'react';
+import {
+  TextField,
+  FormControl,
+  FormControlLabel,
+  FormHelperText,
+  InputLabel,
+  Select,
+  MenuItem,
+  Switch,
+} from '@mui/material';
+import { Controller } from 'react-hook-form';
+import MetadataFieldInput from './MetadataFieldInput';
+
+/**
+ * customField 공용 렌더러 (#711 R2).
+ *
+ * 이미지 실행(ImageGeneration)·텍스트 실행(PromptGeneratorPanel)·편집기 라이브 프리뷰가
+ * 각자 필드 렌더를 재구현하면서 "편집기에서 정의한 필드가 실행에서 다르게 보이거나
+ * 아예 안 보이는" drift 가 누적됐다 (boolean 이 TextField 로 렌더, number 미렌더,
+ * required 미강제 등 — #440 전면 재검토). 이 컴포넌트가 단일 소스.
+ *
+ * - string / number / select / boolean / baseModel / lora 를 처리
+ * - image 타입은 컨텍스트별 업로드 플로우(참조 이미지 vs 비전 첨부)가 달라 호출부가 렌더
+ * - required 는 react-hook-form rules 로 일관 강제 (에러 메시지 = "{표시명}을(를) 입력/선택해주세요")
+ * - preview 모드: 폼 없이 disabled 로 동일 UI 렌더 — 프리뷰가 정의상 실행과 같은 모습
+ */
+
+const isPromptLike = (field) => (field.name || '').includes('prompt');
+
+function requiredMessage(field) {
+  const verb = ['select', 'baseModel', 'lora', 'boolean'].includes(field.type) ? '선택' : '입력';
+  return `${field.label}을(를) ${verb}해주세요`;
+}
+
+// 실제 입력 UI — 폼 유무와 무관한 표현 계층
+function FieldBody({ field, value, onChange, error, size, disabled, serverId, workboardId, allowedModelTypes }) {
+  switch (field.type) {
+    case 'number':
+      return (
+        <TextField
+          type="number"
+          fullWidth
+          size={size}
+          label={field.label}
+          required={field.required}
+          placeholder={field.placeholder}
+          value={value ?? ''}
+          onChange={(e) => onChange(e.target.value)}
+          error={!!error}
+          helperText={error?.message || field.description}
+          disabled={disabled}
+        />
+      );
+
+    case 'select':
+      return (
+        <FormControl fullWidth size={size} error={!!error} disabled={disabled}>
+          <InputLabel required={field.required}>{field.label}</InputLabel>
+          <Select
+            value={value ?? ''}
+            label={field.label}
+            onChange={(e) => onChange(e.target.value)}
+          >
+            {field.options?.map((option) => (
+              <MenuItem key={option.value} value={option.value}>
+                {option.key}
+              </MenuItem>
+            ))}
+          </Select>
+          {(error?.message || field.description) && (
+            <FormHelperText>{error?.message || field.description}</FormHelperText>
+          )}
+        </FormControl>
+      );
+
+    case 'boolean':
+      return (
+        <FormControl error={!!error} disabled={disabled}>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={value === true || value === 'true'}
+                onChange={(e) => onChange(e.target.checked)}
+              />
+            }
+            label={field.label}
+          />
+          {(error?.message || field.description) && (
+            <FormHelperText sx={{ mt: -0.5 }}>{error?.message || field.description}</FormHelperText>
+          )}
+        </FormControl>
+      );
+
+    case 'baseModel':
+    case 'lora':
+      return (
+        <MetadataFieldInput
+          kind={field.type === 'baseModel' ? 'model' : 'lora'}
+          field={field}
+          value={value || ''}
+          onChange={onChange}
+          workboardId={workboardId}
+          serverId={serverId}
+          allowedModelTypes={field.type === 'baseModel' ? allowedModelTypes : undefined}
+          disabled={disabled}
+          error={!!error}
+          errorMessage={error?.message}
+        />
+      );
+
+    case 'string':
+    default:
+      return (
+        <TextField
+          fullWidth
+          size={size}
+          label={field.label}
+          required={field.required}
+          placeholder={field.placeholder}
+          multiline={isPromptLike(field)}
+          rows={isPromptLike(field) ? 2 : 1}
+          value={value ?? ''}
+          onChange={(e) => onChange(e.target.value)}
+          error={!!error}
+          helperText={error?.message || field.description}
+          disabled={disabled}
+        />
+      );
+  }
+}
+
+function CustomFieldControl({
+  field,
+  control,
+  name,
+  size = 'medium',
+  serverId,
+  workboardId,
+  allowedModelTypes,
+  preview = false,
+}) {
+  // 프리뷰(편집기 "사용자 시점") — 폼 없이 기본값을 disabled 로 표시
+  if (preview || !control) {
+    return (
+      <FieldBody
+        field={field}
+        value={field.defaultValue ?? (field.type === 'boolean' ? false : '')}
+        onChange={() => {}}
+        size={size}
+        disabled
+        serverId={serverId}
+        workboardId={workboardId}
+        allowedModelTypes={allowedModelTypes}
+      />
+    );
+  }
+
+  const defaultValue =
+    field.type === 'boolean'
+      ? (field.defaultValue === true || field.defaultValue === 'true')
+      : field.type === 'select'
+        ? (field.defaultValue || field.options?.[0]?.value || '')
+        : (field.defaultValue || '');
+
+  return (
+    <Controller
+      name={name || field.name}
+      control={control}
+      defaultValue={defaultValue}
+      rules={{
+        required: field.required ? requiredMessage(field) : false,
+        // boolean 필수는 "켜짐 강제"가 아니라 "값 존재"라 rules 미적용 (Switch 는 항상 값 보유)
+        ...(field.type === 'boolean' ? { required: false } : {}),
+      }}
+      render={({ field: formField, fieldState }) => (
+        <FieldBody
+          field={field}
+          value={formField.value}
+          onChange={formField.onChange}
+          error={fieldState.error}
+          size={size}
+          serverId={serverId}
+          workboardId={workboardId}
+          allowedModelTypes={allowedModelTypes}
+        />
+      )}
+    />
+  );
+}
+
+export default CustomFieldControl;

--- a/frontend/src/components/common/MetadataFieldInput.js
+++ b/frontend/src/components/common/MetadataFieldInput.js
@@ -13,7 +13,7 @@ import MetadataPickerModal from './MetadataPickerModal';
 // 다른 customField (select / number / string) 와 동일하게 TextField 의 floating label 사용해 디자인 통일.
 // 표시는 Civitai 모델 이름 (있으면) 또는 파일 basename — 경로는 tooltip / helperText.
 // 내부 form value 는 그대로 filename (workflow injection 용).
-function MetadataFieldInput({ kind, field, value, onChange, workboardId, serverId, allowedModelTypes }) {
+function MetadataFieldInput({ kind, field, value, onChange, workboardId, serverId, allowedModelTypes, disabled = false, error = false, errorMessage }) {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [displayName, setDisplayName] = useState('');
   const [displayValue, setDisplayValue] = useState('');
@@ -37,12 +37,14 @@ function MetadataFieldInput({ kind, field, value, onChange, workboardId, serverI
           required={field.required}
           value={shown}
           fullWidth
+          disabled={disabled}
+          error={error}
           placeholder={placeholder}
           InputProps={{
             readOnly: true,
             endAdornment: (
               <InputAdornment position="end">
-                {value && (
+                {value && !disabled && (
                   <Tooltip title="해제">
                     <IconButton onClick={() => { onChange(''); setDisplayName(''); }}>
                       <ClearIcon fontSize="small" />
@@ -53,7 +55,7 @@ function MetadataFieldInput({ kind, field, value, onChange, workboardId, serverI
                   variant="text"
                   startIcon={<SearchIcon />}
                   onClick={() => setPickerOpen(true)}
-                  disabled={!serverId && !workboardId}
+                  disabled={disabled || (!serverId && !workboardId)}
                   sx={{ ml: 0.5 }}
                 >
                   선택
@@ -61,7 +63,7 @@ function MetadataFieldInput({ kind, field, value, onChange, workboardId, serverI
               </InputAdornment>
             )
           }}
-          helperText={value && value !== shown ? value : field.description}
+          helperText={errorMessage || (value && value !== shown ? value : field.description)}
         />
       </Tooltip>
       <MetadataPickerModal

--- a/frontend/src/pages/ImageGeneration.js
+++ b/frontend/src/pages/ImageGeneration.js
@@ -48,7 +48,7 @@ import toast from 'react-hot-toast';
 import { workboardAPI, jobAPI, imageAPI, promptDataAPI, userAPI, projectAPI } from '../services/api';
 import { copyToClipboard } from '../utils/clipboard';
 import MetadataPickerModal from '../components/common/MetadataPickerModal';
-import MetadataFieldInput from '../components/common/MetadataFieldInput';
+import CustomFieldControl from '../components/common/CustomFieldControl';
 import { extractLoraName, insertLoraTag, insertTriggerWordWithLora } from '../utils/promptUtils';
 import Pagination from '../components/common/Pagination';
 import ImageSelectDialog from '../components/common/ImageSelectDialog';
@@ -994,68 +994,32 @@ function ImageGeneration() {
                 <Grid container spacing={3.5} sx={{ p: 4 }}>
                   {workboardData.additionalInputFields.map((field) => (
                     <Grid item xs={12} sm={field.type === 'image' ? 12 : 6} key={field.name}>
-                      <Controller
-                        name={`additionalParams.${field.name}`}
-                        control={control}
-                        defaultValue={field.type === 'select' ?
-                          (field.defaultValue || field.options?.[0]?.value || '') :
-                          field.type === 'image' ? [] :
-                          (field.defaultValue || '')
-                        }
-                        render={({ field: formField }) => (
-                          field.type === 'select' ? (
-                            <FormControl fullWidth>
-                              <InputLabel>{field.label}</InputLabel>
-                              <Select
-                                {...formField}
-                                value={formField.value || field.defaultValue || field.options?.[0]?.value || ''}
-                                label={field.label}
-                              >
-                                {field.options?.map((option) => (
-                                  <MenuItem key={option.value} value={option.value}>
-                                    {option.key}
-                                  </MenuItem>
-                                ))}
-                              </Select>
-                            </FormControl>
-                          ) : field.type === 'number' ? (
-                            <TextField
-                              {...formField}
-                              type="number"
-                              fullWidth
-                              label={field.label}
-                              placeholder={field.placeholder}
-                              helperText={field.description}
-                            />
-                          ) : field.type === 'image' ? (
+                      {field.type === 'image' ? (
+                        <Controller
+                          name={`additionalParams.${field.name}`}
+                          control={control}
+                          defaultValue={[]}
+                          render={({ field: formField }) => (
                             <CustomImageField
                               field={field}
                               value={formField.value || []}
                               onChange={formField.onChange}
-                              maxImages={field.imageConfig?.maxImages || 1}
+                              maxImages={field.imageConfig?.maxImages || 3}
                               isComfyUI={workboardData?.serverId?.serverType === 'ComfyUI'}
                             />
-                          ) : field.type === 'baseModel' || field.type === 'lora' ? (
-                            <MetadataFieldInput
-                              kind={field.type === 'baseModel' ? 'model' : 'lora'}
-                              field={field}
-                              value={formField.value || ''}
-                              onChange={formField.onChange}
-                              workboardId={id}
-                              serverId={workboardData?.serverId?._id || workboardData?.serverId}
-                              allowedModelTypes={field.type === 'baseModel' ? workboardData?.allowedModelTypes : undefined}
-                            />
-                          ) : (
-                            <TextField
-                              {...formField}
-                              fullWidth
-                              label={field.label}
-                              placeholder={field.placeholder}
-                              helperText={field.description}
-                            />
-                          )
-                        )}
-                      />
+                          )}
+                        />
+                      ) : (
+                        // 공용 렌더러 (#711) — required 강제 포함. 편집기 프리뷰와 동일 렌더 보장
+                        <CustomFieldControl
+                          field={field}
+                          control={control}
+                          name={`additionalParams.${field.name}`}
+                          workboardId={id}
+                          serverId={workboardData?.serverId?._id || workboardData?.serverId}
+                          allowedModelTypes={workboardData?.allowedModelTypes}
+                        />
+                      )}
                     </Grid>
                   ))}
                 </Grid>


### PR DESCRIPTION
closes #711

편집기 전면 재검토 실행안 **R2**. 필드 렌더가 세 곳(이미지 실행/텍스트 실행/편집기 프리뷰)에 각각 재구현돼 있던 것을 공용 `CustomFieldControl` 하나로 통합 — drift 계열 결함의 구조적 원천 제거.

## 고쳐지는 실동작 (#440 감사 High 3건 포함)
| 감사 항목 | 전 | 후 |
|---|---|---|
| 2-A | boolean 필드가 이미지 실행에서 **일반 텍스트 입력**으로 렌더 (프리뷰는 Switch — 정반대) | Switch (전 화면 동일) |
| 2-B | number/boolean 이 텍스트 실행에서 **아예 미렌더** (입력 UI 소멸) | 렌더 |
| 2-C | required 가 이미지 실행에서 **미강제** (텍스트 실행은 강제 — 경로 불일치) | rules 로 일관 강제 + 에러 메시지 |
| 2-D | select 의 설명(description) 미표시 | helperText 표시 |
| 4-B | prompt 류 string 이 이미지 실행에서만 단일행 (프리뷰·텍스트는 multiline) | multiline 통일 |
| 2-F | image maxImages 미설정 기본값 1 vs 4 로 화면마다 다름 | 3 으로 통일 (편집기 옵션·템플릿 기준) |

## 구성
- `components/common/CustomFieldControl.js` — string/number/select/boolean/baseModel/lora + required rules. `preview` 모드는 폼 없이 disabled 로 동일 UI 렌더 → **프리뷰가 정의상 실행과 동일**해지고 기본값도 실제 값으로 표시
- image 타입은 컨텍스트별 업로드 플로우(참조 이미지 vs 비전 첨부)가 달라 호출부 유지
- `MetadataFieldInput` 에 disabled/error/errorMessage 지원 추가

## 검증 (실브라우저)
- 기본값 자동 적용 → 제출 성공 (잡 생성, base_model/image_size 정상 주입)
- base_model 해제 후 제출 → **required 에러 표시 + POST 차단 + 페이지 유지**
- 편집기 라이브 프리뷰 정상 렌더 (기본값 표시), 콘솔 에러 0
- jest 42/331, e2e smoke 5/5

## 릴리스 노트 참고 (사용자 가시 변화)
- 필수로 지정된 입력을 비우고 생성하면 이제 안내와 함께 막힙니다 (기존엔 무시하고 진행)
- 체크박스/숫자 입력이 모든 실행 화면에서 올바르게 표시됩니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)