### PR TITLE
fix: 인스펙터 기본값 select — displayEmpty 와 label 겹침 (#718)

### DIFF
--- a/frontend/src/components/admin/workboardEditor/FieldInspector.js
+++ b/frontend/src/components/admin/workboardEditor/FieldInspector.js
@@ -199,7 +199,10 @@ function InspectorForm({ control, watch, selectedIdx, serverId, onRemove }) {
                   size="small"
                   select
                   label="기본값 (선택)"
+                  // displayEmpty 는 값이 ''여도 "선택 없음"을 렌더하므로 label 을 항상 띄운다
+                  // — 안 그러면 내려온 label 과 겹침 (#718)
                   SelectProps={{ displayEmpty: true }}
+                  InputLabelProps={{ shrink: true }}
                 >
                   <MenuItem value="">선택 없음</MenuItem>
                   {options.map((opt, i) => (


### PR DESCRIPTION
closes #718

사용자 보고 (스크린샷 재현 확인). 편집기 인스펙터의 "기본값 (선택)" select 에서 값이 비어 있을 때 floating label 이 내려온 채 displayEmpty 의 "선택 없음" 텍스트와 겹침.

- `InputLabelProps={{ shrink: true }}` 명시 — displayEmpty 표준 패턴 (label 상단 고정, TextField 가 notch 자동 처리)
- 코드베이스 전체에서 displayEmpty 는 이 한 곳뿐임을 확인 (전수 grep)
- 검증: 재현 스크립트로 수정 전 겹침 검출 → 수정 후 shrink=true + 분리 표시 스크린샷 확인, jest 331

🤖 Generated with [Claude Code](https://claude.com/claude-code)