### PR TITLE
feat: 프로젝트 export P0 — 프로젝트 자산 단일 JSON 내보내기 (#404)

### DIFF
--- a/frontend/src/pages/ProjectDetail.js
+++ b/frontend/src/pages/ProjectDetail.js
@@ -39,7 +39,8 @@ import {
   Close,
   DeleteSweep,
   SelectAll,
-  Deselect
+  Deselect,
+  FileDownload,
 } from '@mui/icons-material';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
@@ -57,6 +58,8 @@ import JobHistoryPanel from '../components/common/JobHistoryPanel';
 import TagInput from '../components/common/TagInput';
 import ProjectEditDialog from '../components/common/ProjectEditDialog';
 import { BRAND_GRADIENTS } from '../utils/brandGradients';
+import { downloadBlob } from '../utils/download';
+import { useAuth } from '../contexts/AuthContext';
 
 // 이미지/비디오 편집 다이얼로그
 function ImageEditDialog({ image, open, onClose, isVideo = false, projectId }) {
@@ -743,7 +746,7 @@ function JobsTab({ projectId }) {
 }
 
 // 프로젝트 헤더 — gradient avatar tile + 제목/설명/메타 / 데스크탑 액션 버튼 (Phase 5a).
-function ProjectHero({ project, isMobile, onEdit, onDelete, onToggleFavorite, onViewWorkboards }) {
+function ProjectHero({ project, isMobile, onEdit, onDelete, onToggleFavorite, onViewWorkboards, onExport }) {
   const initial = (project.name?.trim()?.[0] || '?').toUpperCase();
   const isFav = project.isFavorite;
   const hasCover = !!project.coverImage?.url;
@@ -831,6 +834,11 @@ function ProjectHero({ project, isMobile, onEdit, onDelete, onToggleFavorite, on
           <Button variant="outlined" startIcon={<ViewModule />} onClick={onViewWorkboards}>
             작업판 보기
           </Button>
+          {onExport && (
+            <Button variant="outlined" startIcon={<FileDownload />} onClick={onExport}>
+              내보내기
+            </Button>
+          )}
           <Tooltip title="삭제">
             <IconButton color="error" onClick={onDelete}><Delete /></IconButton>
           </Tooltip>
@@ -913,6 +921,20 @@ function ProjectDetail() {
         toast.error(error.response?.data?.message || '삭제 실패');
       } });
 
+  const { isAdmin } = useAuth();
+
+  // 프로젝트 export (#404 P0) — admin 전용 (작업판 풀 정의 포함)
+  const handleExport = async () => {
+    try {
+      const res = await projectAPI.export(id);
+      const filename = `${(project?.name || 'project').replace(/[^a-zA-Z0-9가-힣_-]/g, '_')}_project.json`;
+      downloadBlob(new Blob([JSON.stringify(res.data, null, 2)], { type: 'application/json' }), filename);
+      toast.success('프로젝트를 내보냈습니다');
+    } catch (e) {
+      toast.error(e.response?.data?.message || '프로젝트 내보내기에 실패했습니다');
+    }
+  };
+
   const favoriteMutation = useMutation({ mutationFn: () => projectAPI.toggleFavorite(id),
       onSuccess: (response) => {
         queryClient.invalidateQueries({ queryKey: ['project', id] });
@@ -965,6 +987,7 @@ function ProjectDetail() {
         onDelete={() => setDeleteOpen(true)}
         onToggleFavorite={() => favoriteMutation.mutate()}
         onViewWorkboards={() => navigate(`/workboards?projectId=${id}`)}
+        onExport={isAdmin ? handleExport : undefined}
       />
 
       {isMobile && (

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -262,6 +262,7 @@ export const updatelogAPI = {
 
 export const projectAPI = {
   getAll: (params) => api.get('/projects', { params }),
+  export: (id) => api.get(`/projects/${id}/export`), // admin 전용 (#404)
   getById: (id) => api.get(`/projects/${id}`),
   getByTag: (tagId) => api.get(`/projects/by-tag/${tagId}`),
   create: (data) => api.post('/projects', data),

--- a/src/routes/projects.js
+++ b/src/routes/projects.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { requireAuth } = require('../middleware/auth');
+const { requireAuth, requireAdmin } = require('../middleware/auth');
 const { reverseSignedUrl } = require('../utils/signedUrl');
 const Project = require('../models/Project');
 const Tag = require('../models/Tag');
@@ -10,6 +10,7 @@ const PromptData = require('../models/PromptData');
 const ImageGenerationJob = require('../models/ImageGenerationJob');
 const { escapeRegex } = require('../utils/escapeRegex');
 const { validateBody, projectCreateSchema, projectUpdateSchema } = require('../utils/validation');
+const { WORKBOARD_EXPORT_VERSION, APP_VERSION, buildWorkboardExportEntry } = require('../utils/workboardExport');
 const router = express.Router();
 
 // GET /favorites - 즐겨찾기 프로젝트 목록 (대시보드용) - 구체적 경로를 /:id 위에 배치
@@ -571,6 +572,106 @@ router.get('/:id/conversations', requireAuth, async (req, res) => {
   } catch (error) {
     console.error('Get project conversations error:', error);
     res.status(500).json({ success: false, message: error.message });
+  }
+});
+
+
+// ── 프로젝트 export (#404 P0) ────────────────────────────────────
+// 프로젝트 자산(작업판 풀 정의·세계관/문서·파이프라인·태그)을 단일 JSON 으로.
+// admin 전용 — export 에 작업판 풀 정의(workflowData 포함)가 들어가는데
+// 작업판은 admin 관리 자산이라 일반 사용자에게 정의를 노출하지 않는다.
+// binary(이미지/영상)는 v1 규격에서 제외 (기획 결정).
+router.get('/:id/export', requireAdmin, async (req, res) => {
+  try {
+    const Workboard = require('../models/Workboard');
+    const Server = require('../models/Server');
+    const Pipeline = require('../models/Pipeline');
+    const UploadedText = require('../models/UploadedText');
+
+    const project = await Project.findOne({ _id: req.params.id, userId: req.user._id }).populate('tagId');
+    if (!project) {
+      return res.status(404).json({ success: false, message: '프로젝트를 찾을 수 없습니다' });
+    }
+
+    const pipelines = await Pipeline.find({ projectId: project._id }).sort({ createdAt: 1 }).lean();
+
+    // 작업판 수집 — 프로젝트 소속 + 파이프라인 단계가 참조하는 것의 합집합.
+    // export 안에서는 배열 index 가 참조 키 (ObjectId 는 instance 간 매칭 불가).
+    const workboardIdSet = new Set((project.workboardIds || []).map(String));
+    for (const pl of pipelines) {
+      for (const step of pl.steps || []) {
+        if (step.workboardId) workboardIdSet.add(String(step.workboardId));
+      }
+    }
+    const workboardIds = [...workboardIdSet];
+    const workboards = await Workboard.find({ _id: { $in: workboardIds } }).lean();
+    const servers = await Server.find({ _id: { $in: workboards.map((w) => w.serverId).filter(Boolean) } }).lean();
+    const serverById = new Map(servers.map((sv) => [String(sv._id), sv]));
+    // index 안정화: 수집 순서 기준
+    const wbIndexById = new Map();
+    const workboardEntries = workboardIds
+      .map((id) => workboards.find((w) => String(w._id) === id))
+      .filter(Boolean)
+      .map((wb, idx) => {
+        wbIndexById.set(String(wb._id), idx);
+        return buildWorkboardExportEntry(wb, wb.serverId ? serverById.get(String(wb.serverId)) : null);
+      });
+
+    // 문서 — 프로젝트 태그가 붙은 UploadedText. 태그는 이름으로 export (import 시 이름 매핑).
+    const docs = await UploadedText.find({ userId: req.user._id, tags: project.tagId._id })
+      .populate('tags', 'name')
+      .sort({ createdAt: 1 })
+      .lean();
+    const docIndexById = new Map();
+    const documents = docs.map((d, idx) => {
+      docIndexById.set(String(d._id), idx);
+      return {
+        title: d.title,
+        content: d.content,
+        // 프로젝트 전용 태그는 제외 — import 시 새 프로젝트 태그가 대신 부여됨
+        tagNames: (d.tags || []).map((t) => t.name).filter((n) => n && n !== project.tagId.name),
+      };
+    });
+
+    const pipelineEntries = pipelines.map((pl) => ({
+      name: pl.name,
+      description: pl.description || '',
+      steps: (pl.steps || []).map((step) => ({
+        workboardIndex: wbIndexById.has(String(step.workboardId)) ? wbIndexById.get(String(step.workboardId)) : null,
+        autoInject: step.autoInject !== false,
+        inputs: step.inputs || {},
+        contextDocIndexes: (step.contextDocIds || [])
+          .map((id) => docIndexById.get(String(id)))
+          .filter((i) => i !== undefined),
+        systemPromptDocIndex: step.systemPromptDocId !== undefined && docIndexById.has(String(step.systemPromptDocId))
+          ? docIndexById.get(String(step.systemPromptDocId))
+          : null,
+        note: step.note || '',
+      })),
+    }));
+
+    const exportData = {
+      projectExportVersion: 1,
+      workboardExportVersion: WORKBOARD_EXPORT_VERSION,
+      appVersion: APP_VERSION,
+      exportedAt: new Date().toISOString(),
+      project: {
+        name: project.name,
+        description: project.description || '',
+        tagColor: project.tagId?.color,
+      },
+      workboards: workboardEntries,
+      documents,
+      pipelines: pipelineEntries,
+    };
+
+    const filename = `${project.name.replace(/[^a-zA-Z0-9가-힣_-]/g, '_')}_project.json`;
+    res.setHeader('Content-Disposition', `attachment; filename*=UTF-8''${encodeURIComponent(filename)}`);
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    res.json(exportData);
+  } catch (error) {
+    console.error('Project export error:', error);
+    res.status(500).json({ success: false, message: '프로젝트 내보내기에 실패했습니다.' });
   }
 });
 

--- a/src/routes/workboards.js
+++ b/src/routes/workboards.js
@@ -15,8 +15,7 @@ const { escapeRegex } = require('../utils/escapeRegex');
 const { validateBody, workboardCreateSchema, workboardUpdateSchema } = require('../utils/validation');
 const router = express.Router();
 
-const EXPORT_VERSION = 1;
-const APP_VERSION = { major: 1, minor: 3 };
+const { WORKBOARD_EXPORT_VERSION: EXPORT_VERSION, APP_VERSION, buildWorkboardExportEntry } = require('../utils/workboardExport');
 
 // 옛 환경에서 export 한 작업판 백업의 server.serverType 을 신규 enum 으로 폴백 매핑.
 // Phase 2 (#181, #182) 마이그레이션과 동일 매핑. import 자동 매칭 1차 실패 시 시도.
@@ -761,23 +760,7 @@ router.get('/:id/export', requireAdmin, async (req, res) => {
       _exportVersion: EXPORT_VERSION,
       appVersion: APP_VERSION,
       exportedAt: new Date().toISOString(),
-      workboard: {
-        name: workboard.name,
-        description: workboard.description,
-        workboardType: workboard.workboardType,
-        outputFormat: workboard.outputFormat,
-        additionalInputFields: workboard.additionalInputFields,
-        workflowData: workboard.workflowData,
-        allowedModelTypes: workboard.allowedModelTypes || [],
-        // allowedGroupIds 는 export 에서 제외 — ObjectId 가 instance 간 매칭 안 됨.
-        // import 시 기본 그룹 자동 할당으로 안전한 default 적용.
-        modelExposurePolicy: workboard.modelExposurePolicy || 'full',
-        modelWhitelist: workboard.modelWhitelist || [],
-        loraExposurePolicy: workboard.loraExposurePolicy || 'full',
-        loraWhitelist: workboard.loraWhitelist || [],
-        version: workboard.version
-      },
-      server: serverInfo
+      ...buildWorkboardExportEntry(workboard, serverInfo && { name: serverInfo.name, serverType: serverInfo.serverType }),
     };
 
     const filename = `${workboard.name.replace(/[^a-zA-Z0-9가-힣_-]/g, '_')}_backup.json`;

--- a/src/tests/projectExport.test.js
+++ b/src/tests/projectExport.test.js
@@ -1,0 +1,130 @@
+/**
+ * 프로젝트 export 라우트 테스트 (#404 P0)
+ *
+ * admin 게이트·소유권, 그리고 export 규격의 핵심인 참조 재배선
+ * (작업판 ObjectId → 배열 index, 문서 ObjectId → index)을 검증한다.
+ */
+const express = require('express');
+const request = require('supertest');
+
+let mockCurrentUser;
+
+jest.mock('../middleware/auth', () => ({
+  requireAuth: (req, res, next) => { req.user = mockCurrentUser; next(); },
+  requireAdmin: (req, res, next) => {
+    if (!mockCurrentUser?.isAdmin) return res.status(403).json({ success: false, message: '관리자 권한이 필요합니다.' });
+    req.user = mockCurrentUser; next();
+  },
+}));
+jest.mock('../utils/signedUrl', () => ({ reverseSignedUrl: (u) => u, convertToSignedUrls: (x) => x, generateSignedUrl: (u) => u }));
+
+const chainable = (result) => {
+  const chain = {};
+  chain.populate = () => chain;
+  chain.sort = () => chain;
+  chain.lean = () => chain;
+  chain.then = (res, rej) => Promise.resolve(result).then(res, rej);
+  return chain;
+};
+
+jest.mock('../models/Project', () => ({ findOne: jest.fn() }));
+jest.mock('../models/Tag', () => ({ findOne: jest.fn() }));
+jest.mock('../models/User', () => ({}));
+jest.mock('../models/GeneratedImage', () => ({}));
+jest.mock('../models/GeneratedVideo', () => ({}));
+jest.mock('../models/PromptData', () => ({}));
+jest.mock('../models/ImageGenerationJob', () => ({}));
+jest.mock('../models/Workboard', () => ({ find: jest.fn() }));
+jest.mock('../models/Server', () => ({ find: jest.fn() }));
+jest.mock('../models/Pipeline', () => ({ find: jest.fn() }));
+jest.mock('../models/UploadedText', () => ({ find: jest.fn() }));
+
+const Project = require('../models/Project');
+const Workboard = require('../models/Workboard');
+const Server = require('../models/Server');
+const Pipeline = require('../models/Pipeline');
+const UploadedText = require('../models/UploadedText');
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/projects', require('../routes/projects'));
+  return app;
+}
+
+describe('프로젝트 export (#404 P0)', () => {
+  let app;
+
+  beforeAll(() => { app = createApp(); });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCurrentUser = { _id: 'admin-1', isAdmin: true };
+
+    Project.findOne.mockReturnValue(chainable({
+      _id: 'proj-1',
+      name: '뱀파이어 NYC',
+      description: '테스트',
+      userId: 'admin-1',
+      tagId: { _id: 'tag-proj', name: 'vampires', color: '#7c4dff' },
+      workboardIds: ['wb-1'],
+    }));
+    Pipeline.find.mockReturnValue(chainable([{
+      name: '텍스트→이미지',
+      description: '',
+      steps: [
+        { workboardId: 'wb-1', autoInject: true, inputs: {}, contextDocIds: ['doc-2'], systemPromptDocId: 'doc-1', note: '' },
+        { workboardId: 'wb-2', autoInject: false, inputs: { image_size: '1024x1024' }, contextDocIds: [], note: 'step2' },
+      ],
+    }]));
+    Workboard.find.mockReturnValue(chainable([
+      { _id: 'wb-1', name: '장면 LLM', outputFormat: 'text', serverId: 'srv-1', additionalInputFields: [] },
+      { _id: 'wb-2', name: '이미지 생성', outputFormat: 'image', serverId: 'srv-1', additionalInputFields: [] },
+    ]));
+    Server.find.mockReturnValue(chainable([{ _id: 'srv-1', name: 'GPT', serverType: 'OpenAI' }]));
+    UploadedText.find.mockReturnValue(chainable([
+      { _id: 'doc-1', title: '작업 지침', content: 'sys', tags: [{ name: 'vampires' }, { name: '시스템 프롬프트' }] },
+      { _id: 'doc-2', title: '세계관', content: 'lore', tags: [{ name: 'vampires' }, { name: '세계관' }] },
+    ]));
+  });
+
+  test('일반 사용자는 403 (작업판 정의 노출 차단)', async () => {
+    mockCurrentUser = { _id: 'user-1', isAdmin: false };
+    const res = await request(app).get('/api/projects/proj-1/export');
+    expect(res.status).toBe(403);
+  });
+
+  test('export 규격 — 인덱스 재배선·태그 이름·프로젝트 태그 제외', async () => {
+    const res = await request(app).get('/api/projects/proj-1/export');
+    expect(res.status).toBe(200);
+    const data = res.body;
+
+    expect(data.projectExportVersion).toBe(1);
+    expect(data.project.name).toBe('뱀파이어 NYC');
+
+    // 작업판: 프로젝트 소속(wb-1) + 파이프라인만 참조(wb-2)의 합집합, 풀 정의 인라인
+    expect(data.workboards).toHaveLength(2);
+    expect(data.workboards[0].workboard.name).toBe('장면 LLM');
+    expect(data.workboards[0].server).toEqual({ name: 'GPT', serverType: 'OpenAI' });
+
+    // 문서: 프로젝트 전용 태그(vampires)는 제외, 분류 태그만
+    expect(data.documents).toHaveLength(2);
+    expect(data.documents[0].tagNames).toEqual(['시스템 프롬프트']);
+    expect(data.documents[1].tagNames).toEqual(['세계관']);
+
+    // 파이프라인: ObjectId → index 재배선
+    const steps = data.pipelines[0].steps;
+    expect(steps[0].workboardIndex).toBe(0);
+    expect(steps[0].contextDocIndexes).toEqual([1]);
+    expect(steps[0].systemPromptDocIndex).toBe(0);
+    expect(steps[1].workboardIndex).toBe(1);
+    expect(steps[1].inputs).toEqual({ image_size: '1024x1024' });
+    expect(steps[1].systemPromptDocIndex).toBeNull();
+  });
+
+  test('타인 프로젝트/없는 프로젝트는 404', async () => {
+    Project.findOne.mockReturnValue(chainable(null));
+    const res = await request(app).get('/api/projects/other/export');
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/utils/workboardExport.js
+++ b/src/utils/workboardExport.js
@@ -1,0 +1,29 @@
+// 작업판 export 규격 — 단일 소스 (#404 P0 에서 workboards.js 인라인에서 추출).
+// 작업판 단건 export(routes/workboards.js)와 프로젝트 export(routes/projects.js)가 공용.
+
+const WORKBOARD_EXPORT_VERSION = 1;
+const APP_VERSION = { major: 1, minor: 3 };
+
+// 작업판 문서 → export entry. allowedGroupIds 는 제외 — ObjectId 가 instance 간
+// 매칭되지 않아 import 시 기본 그룹 자동 할당이 안전한 default (#기존 규격 유지).
+function buildWorkboardExportEntry(workboard, server) {
+  return {
+    workboard: {
+      name: workboard.name,
+      description: workboard.description,
+      workboardType: workboard.workboardType,
+      outputFormat: workboard.outputFormat,
+      additionalInputFields: workboard.additionalInputFields,
+      workflowData: workboard.workflowData,
+      allowedModelTypes: workboard.allowedModelTypes || [],
+      modelExposurePolicy: workboard.modelExposurePolicy || 'full',
+      modelWhitelist: workboard.modelWhitelist || [],
+      loraExposurePolicy: workboard.loraExposurePolicy || 'full',
+      loraWhitelist: workboard.loraWhitelist || [],
+      version: workboard.version,
+    },
+    server: server ? { name: server.name, serverType: server.serverType } : null,
+  };
+}
+
+module.exports = { WORKBOARD_EXPORT_VERSION, APP_VERSION, buildWorkboardExportEntry };


### PR DESCRIPTION
#404 P0 (기획안 승인 반영: 작업판 풀 정의 인라인 / binary 제외 / 파일 공유 / version 1). P1 import, P2 템플릿 UX 후속 — 이슈는 유지.

## 규격 (projectExportVersion 1)
- project 메타 (name/description/tagColor)
- workboards[]: **풀 정의 인라인** — 소속 작업판 ∪ 파이프라인 단계 참조 합집합, 기존 작업판 export 형태 재사용 (`utils/workboardExport` 로 추출해 단건 export 와 단일 소스화)
- documents[]: UploadedText title/content + 분류 태그 **이름** (프로젝트 전용 태그 제외 — import 시 새 프로젝트 태그로 대체)
- pipelines[]: steps 의 workboardId/contextDocIds/systemPromptDocId 를 **export 내 index 로 재배선** (ObjectId 는 instance 간 무의미)

## 보안
- **admin 전용** — export 에 workflowData 포함 작업판 풀 정의가 들어가는데, 작업판은 admin 관리 자산이라 일반 사용자에게 정의 비노출 + 소유자 본인 프로젝트만

## 검증
- jest 43 suites / 334 tests (신규 3)
- 실데이터 'Mages' 프로젝트: 작업판 4 · 문서 4(세계관 1+시스템 프롬프트 3) · 파이프라인 3 — 단계별 인덱스 재배선 정확성 확인
- 브라우저: ProjectDetail "내보내기" → `Mages_project.json` 다운로드 + 토스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)