### PR TITLE
feat: 워크플로 변환기 UI 포맷 지원 — 서브그래프 재귀 확장 포함 (#609 P3)

### DIFF
--- a/frontend/src/components/admin/WorkflowImportDialog.js
+++ b/frontend/src/components/admin/WorkflowImportDialog.js
@@ -10,7 +10,7 @@ import { workboardAPI, serverAPI } from '../../services/api';
 import { MONO } from '../../theme';
 
 /**
- * ComfyUI 워크플로(API 포맷)를 붙여넣어 작업판 초안을 생성하고,
+ * ComfyUI 워크플로(API 포맷 또는 일반 저장 UI 포맷 — #609 P3)를 붙여넣어 작업판 초안을 생성하고,
  * 생성된 작업판 편집기로 이동한다 (#612 — Epic #609 프론트 연결).
  */
 export default function WorkflowImportDialog({ open, onClose }) {
@@ -43,6 +43,12 @@ export default function WorkflowImportDialog({ open, onClose }) {
       parsed = JSON.parse(workflowText);
     } catch {
       toast.error('워크플로 JSON 파싱 실패 — 올바른 JSON 인지 확인하세요.');
+      return;
+    }
+    // UI 포맷(일반 저장)은 서버의 노드 정보가 있어야 변환 가능 (#609 P3)
+    const isUiFormat = Array.isArray(parsed?.nodes) && 'links' in (parsed || {});
+    if (isUiFormat && !serverId) {
+      toast.error('일반 저장(UI 포맷) 워크플로는 변환을 위해 ComfyUI 서버를 먼저 선택해야 합니다.');
       return;
     }
     setLoading(true);
@@ -100,7 +106,9 @@ export default function WorkflowImportDialog({ open, onClose }) {
         {step === 'input' && (
           <Stack spacing={2} sx={{ mt: 1 }}>
             <Alert severity="info">
-              ComfyUI 에서 <strong>"Save (API Format)"</strong> 로 저장한 워크플로 JSON 을 붙여넣으세요.
+              ComfyUI 워크플로 JSON 을 붙여넣으세요 — <strong>"Save (API Format)"</strong> 파일과
+              <strong>일반 저장(UI 포맷)</strong> 파일 모두 지원합니다. UI 포맷은 자동으로 API 포맷으로
+              변환되며, 이 경우 서버 선택이 필요합니다.
               필요한 입력이 자동으로 변수로 추출된 작업판 초안이 만들어집니다.
             </Alert>
             <TextField
@@ -117,7 +125,7 @@ export default function WorkflowImportDialog({ open, onClose }) {
               ))}
             </TextField>
             <TextField
-              label="워크플로 JSON (API 포맷)"
+              label="워크플로 JSON (API 또는 UI 포맷)"
               value={workflowText}
               onChange={(e) => setWorkflowText(e.target.value)}
               placeholder='{ "3": { "class_type": "KSampler", "inputs": { ... } }, ... }'

--- a/src/routes/workboards.js
+++ b/src/routes/workboards.js
@@ -94,6 +94,24 @@ router.get('/', requireAuth, async (req, res) => {
 });
 
 // ComfyUI 워크플로 분석 (관리자 전용) — 파싱 + 필요/빠진 커스텀 노드 감지 (#607)
+
+// UI 포맷 감지·변환 전처리 (#609 P3) — UI 포맷이면 objectInfo 필수.
+function prepareWorkflowInput(workflow, objectInfo) {
+  let obj = workflow;
+  if (typeof workflow === 'string') {
+    try { obj = JSON.parse(workflow); } catch (e) { throw new Error(`워크플로 JSON 파싱 실패: ${e.message}`); }
+  }
+  const format = workflowConverter.detectFormat(obj);
+  if (format !== 'ui') {
+    return { effectiveWorkflow: workflow, sourceFormat: format, conversionWarnings: [] };
+  }
+  if (!objectInfo) {
+    throw new Error('UI 포맷(일반 저장) 워크플로입니다 — 변환하려면 ComfyUI 서버를 선택해주세요. (또는 "Save (API Format)" 파일 사용)');
+  }
+  const { apiWorkflow, warnings } = workflowConverter.convertUiToApi(obj, objectInfo);
+  return { effectiveWorkflow: JSON.stringify(apiWorkflow, null, 2), sourceFormat: 'ui', conversionWarnings: warnings };
+}
+
 router.post('/analyze-workflow', requireAdmin, async (req, res) => {
   try {
     const { workflow, serverId } = req.body;
@@ -101,15 +119,7 @@ router.post('/analyze-workflow', requireAdmin, async (req, res) => {
       return res.status(400).json({ success: false, message: '워크플로 JSON 이 필요합니다.' });
     }
 
-    // 1) 파싱 (서버 없이도 가능). 포맷/파싱 오류는 400.
-    let parsed;
-    try {
-      parsed = workflowConverter.parseWorkflow(workflow);
-    } catch (e) {
-      return res.status(400).json({ success: false, message: e.message });
-    }
-
-    // 2) serverId 가 있으면 /object_info 로 빠진 노드 비교 (선택, 실패해도 분석은 반환)
+    // serverId 가 있으면 /object_info 확보 (빠진 노드 비교 + UI 포맷 변환용)
     let objectInfo = null;
     let serverWarning = null;
     if (serverId) {
@@ -124,11 +134,33 @@ router.post('/analyze-workflow', requireAdmin, async (req, res) => {
       }
     }
 
+    // UI 포맷이면 API 포맷으로 변환 후 기존 파이프라인 진행 (#609 P3)
+    let effectiveWorkflow = workflow;
+    let sourceFormat = null;
+    let conversionWarnings = [];
+    try {
+      const pre = prepareWorkflowInput(workflow, objectInfo);
+      effectiveWorkflow = pre.effectiveWorkflow;
+      sourceFormat = pre.sourceFormat;
+      conversionWarnings = pre.conversionWarnings;
+    } catch (e) {
+      return res.status(400).json({ success: false, message: e.message });
+    }
+
+    let parsed;
+    try {
+      parsed = workflowConverter.parseWorkflow(effectiveWorkflow);
+    } catch (e) {
+      return res.status(400).json({ success: false, message: e.message });
+    }
+
     const nodeAnalysis = workflowConverter.analyzeNodes(parsed, objectInfo);
     res.json({
       success: true,
       data: {
-        format: parsed.format,
+        format: sourceFormat || parsed.format,
+        converted: sourceFormat === 'ui',
+        conversionWarnings,
         nodeCount: parsed.nodes.length,
         literalInputCount: parsed.literalInputs.length,
         ...nodeAnalysis,
@@ -149,14 +181,7 @@ router.post('/draft-from-workflow', requireAdmin, async (req, res) => {
       return res.status(400).json({ success: false, message: '워크플로 JSON 이 필요합니다.' });
     }
 
-    let parsed;
-    try {
-      parsed = workflowConverter.parseWorkflow(workflow);
-    } catch (e) {
-      return res.status(400).json({ success: false, message: e.message });
-    }
-
-    // 빠진 노드 검사 (서버 연결 시, 선택)
+    // 빠진 노드 검사 + UI 포맷 변환용 /object_info (서버 연결 시)
     let objectInfo = null;
     let serverWarning = null;
     if (serverId) {
@@ -168,6 +193,26 @@ router.post('/draft-from-workflow', requireAdmin, async (req, res) => {
           serverWarning = `서버 노드 목록을 불러오지 못해 빠진 노드 검사를 건너뜁니다: ${e.message}`;
         }
       }
+    }
+
+    // UI 포맷이면 API 포맷으로 변환 — 초안의 workflowData 에도 변환본이 들어간다 (#609 P3)
+    let effectiveWorkflow = workflow;
+    let conversionWarnings = [];
+    let sourceFormat = null;
+    try {
+      const pre = prepareWorkflowInput(workflow, objectInfo);
+      effectiveWorkflow = pre.effectiveWorkflow;
+      sourceFormat = pre.sourceFormat;
+      conversionWarnings = pre.conversionWarnings;
+    } catch (e) {
+      return res.status(400).json({ success: false, message: e.message });
+    }
+
+    let parsed;
+    try {
+      parsed = workflowConverter.parseWorkflow(effectiveWorkflow);
+    } catch (e) {
+      return res.status(400).json({ success: false, message: e.message });
     }
 
     const nodeAnalysis = workflowConverter.analyzeNodes(parsed, objectInfo);
@@ -197,7 +242,10 @@ router.post('/draft-from-workflow', requireAdmin, async (req, res) => {
       llmNote = 'AI 보조를 쓰려면 LLM 모델도 지정해야 합니다 — 기본 추출만 적용했습니다.';
     }
 
-    const draft = workflowConverter.buildDraftFromPicks(parsed, workflow, allPicks);
+    const draft = workflowConverter.buildDraftFromPicks(parsed, effectiveWorkflow, allPicks);
+    if (sourceFormat === 'ui') {
+      draft.notes = [`UI 포맷 워크플로를 API 포맷으로 변환했습니다${conversionWarnings.length ? ` (경고 ${conversionWarnings.length}건)` : ''}.`, ...conversionWarnings, ...draft.notes];
+    }
     if (llmNote) draft.notes = [llmNote, ...draft.notes];
 
     res.json({

--- a/src/services/workflowConverterService.js
+++ b/src/services/workflowConverterService.js
@@ -419,7 +419,217 @@ async function proposeLlmPicks({ parsed, existingPicks = [], llmComplete, maxCan
   return picks;
 }
 
+
+// ── UI 포맷 → API 포맷 변환 (#609 P3) ─────────────────────────────
+// ComfyUI 일반 저장(UI 포맷: nodes/links 그래프 + definitions.subgraphs)을 실행용
+// API 포맷으로 변환. 서브그래프는 API export 와 동일한 "인스턴스ID:내부ID" 규칙으로
+// 재귀 확장한다. widgets_values → 입력명 매핑에 /object_info 스키마(순서)가 필요.
+
+const WIDGET_PRIMITIVES = new Set(['INT', 'FLOAT', 'STRING', 'BOOLEAN']);
+const CONTROL_AFTER_GENERATE_VALUES = new Set(['fixed', 'increment', 'decrement', 'randomize']);
+// LiteGraph mode: 0=normal, 2=muted(never), 4=bypass
+const VIRTUAL_NODE_TYPES = new Set(['Note', 'MarkdownNote', 'Reroute', 'PrimitiveNode']);
+const SUBGRAPH_INPUT_NODE_ID = '-10';
+const SUBGRAPH_OUTPUT_NODE_ID = '-20';
+
+function isWidgetSpec(spec) {
+  if (!Array.isArray(spec)) return false;
+  const t = spec[0];
+  if (Array.isArray(t)) return true; // combo (선택지 배열)
+  if (typeof t === 'string' && (WIDGET_PRIMITIVES.has(t) || t === 'COMBO')) return true;
+  return false;
+}
+
+// 서브그래프 입력 정의가 위젯으로 승격되는 타입인지 (인스턴스 widgets_values 소비 순서 결정)
+function isWidgetPromotedInput(inputDef) {
+  const t = String(inputDef.type || '');
+  return t.split(',').some((part) => WIDGET_PRIMITIVES.has(part.trim()));
+}
+
+function convertUiToApi(uiObj, objectInfo) {
+  if (!objectInfo || typeof objectInfo !== 'object') {
+    throw new Error('UI 포맷 변환에는 ComfyUI 서버의 노드 정보(/object_info)가 필요합니다. 서버를 선택해주세요.');
+  }
+  const warnings = [];
+  const subgraphById = new Map((uiObj.definitions?.subgraphs || []).map((sg) => [sg.id, sg]));
+  const apiWorkflow = {};
+
+  // 그래프(top-level 또는 서브그래프 내부) 하나의 실행 컨텍스트
+  function makeCtx(graph, prefix, boundary) {
+    const nodesById = new Map((graph.nodes || []).map((n) => [String(n.id), n]));
+    const linksById = new Map();
+    for (const l of graph.links || []) {
+      if (Array.isArray(l) && l.length >= 5) {
+        linksById.set(l[0], { originId: String(l[1]), originSlot: l[2] });
+      } else if (l && typeof l === 'object' && l.id !== undefined) {
+        linksById.set(l.id, { originId: String(l.origin_id), originSlot: l.origin_slot });
+      }
+    }
+    return { graph, prefix, boundary, nodesById, linksById };
+  }
+
+  const isSkipped = (node) => node.mode === 2 || node.mode === 4;
+
+  // 인스턴스의 k번째 서브그래프 입력값 해석 — 외부 링크 우선, 아니면 승격 위젯 값
+  function resolveInstanceInput(instCtx, instNode, sgDef, inputIndex, depth) {
+    const instInput = (instNode.inputs || [])[inputIndex];
+    if (instInput && instInput.link !== null && instInput.link !== undefined) {
+      return resolveOrigin(instCtx, instInput.link, depth + 1);
+    }
+    // 승격 위젯: sg.inputs 중 위젯형만 순서대로 instNode.widgets_values 를 소비
+    const widgetOrder = (sgDef.inputs || []).filter(isWidgetPromotedInput);
+    const pos = widgetOrder.indexOf((sgDef.inputs || [])[inputIndex]);
+    if (pos !== -1 && Array.isArray(instNode.widgets_values) && pos < instNode.widgets_values.length) {
+      return { kind: 'literal', value: instNode.widgets_values[pos] };
+    }
+    return { kind: 'broken' };
+  }
+
+  // 컨텍스트 내 링크의 최종 출처 해석 (Reroute/Primitive/서브그래프 경계 통과)
+  function resolveOrigin(ctx, linkId, depth = 0) {
+    if (depth > 64) return { kind: 'broken' };
+    const link = ctx.linksById.get(linkId);
+    if (!link) return { kind: 'broken' };
+
+    // 서브그래프 입력 노드(-10)에서 온 링크 → 인스턴스 입력으로 상향 탈출
+    if (link.originId === SUBGRAPH_INPUT_NODE_ID) {
+      const b = ctx.boundary;
+      if (!b) return { kind: 'broken' };
+      return resolveInstanceInput(b.parentCtx, b.instNode, b.sgDef, link.originSlot, depth);
+    }
+
+    const origin = ctx.nodesById.get(link.originId);
+    if (!origin) return { kind: 'broken' };
+
+    if (origin.mode === 4) {
+      // bypass — 첫 연결 입력을 그대로 통과
+      const passthrough = (origin.inputs || []).find((inp) => inp.link !== null && inp.link !== undefined);
+      if (passthrough) return resolveOrigin(ctx, passthrough.link, depth + 1);
+      return { kind: 'muted' };
+    }
+    if (origin.mode === 2) return { kind: 'muted' };
+
+    if (origin.type === 'Reroute') {
+      const upstream = (origin.inputs || []).find((inp) => inp.link !== null && inp.link !== undefined);
+      if (!upstream) return { kind: 'broken' };
+      return resolveOrigin(ctx, upstream.link, depth + 1);
+    }
+    if (origin.type === 'PrimitiveNode') {
+      const wv = Array.isArray(origin.widgets_values) ? origin.widgets_values[0] : undefined;
+      return { kind: 'literal', value: wv };
+    }
+
+    // 서브그래프 인스턴스의 출력 → 내부 그래프로 하강
+    const sgDef = subgraphById.get(origin.type);
+    if (sgDef) {
+      const outDef = (sgDef.outputs || [])[link.originSlot];
+      const innerCtx = makeCtx(sgDef, `${ctx.prefix}${origin.id}:`, { parentCtx: ctx, instNode: origin, sgDef });
+      const innerLinkId = (outDef?.linkIds || [])[0];
+      if (innerLinkId === undefined) return { kind: 'broken' };
+      return resolveOrigin(innerCtx, innerLinkId, depth + 1);
+    }
+
+    return { kind: 'link', nodeId: `${ctx.prefix}${origin.id}`, slot: link.originSlot };
+  }
+
+  function processGraph(ctx) {
+    for (const node of ctx.graph.nodes || []) {
+      const rawId = String(node.id);
+      const type = node.type;
+      if (VIRTUAL_NODE_TYPES.has(type)) continue;
+      if (isSkipped(node)) {
+        warnings.push(`비활성(mute/bypass) 노드 제외: ${node.title || type} (#${ctx.prefix}${rawId})`);
+        continue;
+      }
+
+      // 서브그래프 인스턴스 → 내부 그래프 재귀 확장 (API export 의 "인스턴스:내부" id 규칙)
+      const sgDef = subgraphById.get(type);
+      if (sgDef) {
+        const innerCtx = makeCtx(sgDef, `${ctx.prefix}${rawId}:`, { parentCtx: ctx, instNode: node, sgDef });
+        processGraph(innerCtx);
+        continue;
+      }
+
+      const apiId = `${ctx.prefix}${rawId}`;
+      const spec = objectInfo[type];
+      if (!spec) {
+        warnings.push(`서버에 없는 노드 타입: ${type} (#${apiId}) — 입력 매핑이 부정확할 수 있습니다.`);
+      }
+
+      const linkByInputName = new Map();
+      for (const inp of node.inputs || []) {
+        if (inp.link !== null && inp.link !== undefined) linkByInputName.set(inp.name, inp.link);
+      }
+
+      const inputs = {};
+      const wv = node.widgets_values;
+      const widgetQueue = Array.isArray(wv) ? [...wv] : null;
+      const widgetDict = wv && !Array.isArray(wv) && typeof wv === 'object' ? wv : null;
+      const inputSpecs = spec
+        ? { ...(spec.input?.required || {}), ...(spec.input?.optional || {}) }
+        : null;
+
+      const applyOrigin = (name, origin, fallbackWidget, widgetValue) => {
+        if (origin.kind === 'link') { inputs[name] = [origin.nodeId, origin.slot]; return; }
+        if (origin.kind === 'literal') { inputs[name] = origin.value; return; }
+        warnings.push(`${type} (#${apiId}) 의 입력 "${name}" 연결이 끊겨 있어 제외했습니다.`);
+        if (fallbackWidget) inputs[name] = widgetValue;
+      };
+
+      if (inputSpecs) {
+        for (const [name, inputSpec] of Object.entries(inputSpecs)) {
+          const widget = isWidgetSpec(inputSpec);
+          let widgetValue;
+          let hasWidgetValue = false;
+          if (widget) {
+            if (widgetDict) {
+              if (name in widgetDict) { widgetValue = widgetDict[name]; hasWidgetValue = true; }
+            } else if (widgetQueue && widgetQueue.length > 0) {
+              widgetValue = widgetQueue.shift();
+              hasWidgetValue = true;
+              // seed 류는 UI 전용 control_after_generate 값이 뒤따름 — 큐에서 소거
+              const controlFlagged = inputSpec[1] && inputSpec[1].control_after_generate;
+              const looksLikeSeed = (name === 'seed' || name === 'noise_seed');
+              if ((controlFlagged || looksLikeSeed) && widgetQueue.length > 0 && CONTROL_AFTER_GENERATE_VALUES.has(widgetQueue[0])) {
+                widgetQueue.shift();
+              }
+            }
+          }
+          const linkId = linkByInputName.get(name);
+          if (linkId !== undefined) {
+            applyOrigin(name, resolveOrigin(ctx, linkId), hasWidgetValue, widgetValue);
+            continue;
+          }
+          if (widget && hasWidgetValue) inputs[name] = widgetValue;
+          // 링크도 위젯 값도 없는 optional 입력은 생략 (API 포맷 관례)
+        }
+      } else {
+        for (const [name, linkId] of linkByInputName.entries()) {
+          applyOrigin(name, resolveOrigin(ctx, linkId), false);
+        }
+        if (Array.isArray(wv) && wv.length > 0) {
+          warnings.push(`${type} (#${apiId}) 의 위젯 값 ${wv.length}개를 매핑하지 못했습니다 (노드 스키마 없음).`);
+        }
+      }
+
+      apiWorkflow[apiId] = {
+        inputs,
+        class_type: type,
+        _meta: { title: node.title || type },
+      };
+    }
+  }
+
+  processGraph(makeCtx(uiObj, '', null));
+
+  if (Object.keys(apiWorkflow).length === 0) {
+    throw new Error('변환 결과가 비어 있습니다 — 워크플로에 실행 가능한 노드가 없습니다.');
+  }
+  return { apiWorkflow, warnings };
+}
+
 module.exports = {
+  convertUiToApi,
   isLinkInput,
   detectFormat,
   parseWorkflow,

--- a/src/tests/uiWorkflowConvert.test.js
+++ b/src/tests/uiWorkflowConvert.test.js
@@ -1,0 +1,164 @@
+/**
+ * UI 포맷 → API 포맷 변환 테스트 (#609 P3)
+ *
+ * 합성 fixture 로 핵심 규칙 검증: widgets_values 순서 매핑, seed 의
+ * control_after_generate 소거, Reroute/PrimitiveNode 해석, mute 노드 제외,
+ * 서브그래프 재귀 확장("인스턴스ID:내부ID")과 경계 링크/승격 위젯.
+ * (실 서버 검증: 3중 중첩 서브그래프 워크플로 변환 → ComfyUI /prompt 실행 성공 — PR 참고)
+ */
+const { convertUiToApi, detectFormat } = require('../services/workflowConverterService');
+
+const OBJECT_INFO = {
+  CheckpointLoaderSimple: { input: { required: { ckpt_name: [['a.safetensors', 'b.safetensors']] } } },
+  CLIPTextEncode: { input: { required: { text: ['STRING', { multiline: true }], clip: ['CLIP'] } } },
+  KSampler: {
+    input: {
+      required: {
+        model: ['MODEL'],
+        seed: ['INT', { default: 0, control_after_generate: true }],
+        steps: ['INT', { default: 20 }],
+        cfg: ['FLOAT', { default: 8 }],
+        positive: ['CONDITIONING'],
+        negative: ['CONDITIONING'],
+        latent_image: ['LATENT'],
+      },
+    },
+  },
+  EmptyLatentImage: { input: { required: { width: ['INT', {}], height: ['INT', {}], batch_size: ['INT', {}] } } },
+  VAEDecode: { input: { required: { samples: ['LATENT'], vae: ['VAE'] } } },
+  SaveImage: { input: { required: { images: ['IMAGE'], filename_prefix: ['STRING', {}] } } },
+};
+
+const link = (id, o, os, t, ts) => [id, o, os, t, ts, '*'];
+
+describe('convertUiToApi (#609 P3)', () => {
+  test('objectInfo 없으면 throw', () => {
+    expect(() => convertUiToApi({ nodes: [], links: [] }, null)).toThrow(/object_info/);
+  });
+
+  test('위젯 매핑 + seed control_after_generate 소거 + 링크 배선', () => {
+    const ui = {
+      nodes: [
+        { id: 1, type: 'CheckpointLoaderSimple', mode: 0, inputs: [], outputs: [], widgets_values: ['a.safetensors'] },
+        { id: 2, type: 'CLIPTextEncode', mode: 0, inputs: [{ name: 'clip', link: 10 }], widgets_values: ['hello prompt'] },
+        {
+          id: 3, type: 'KSampler', mode: 0,
+          inputs: [
+            { name: 'model', link: 11 },
+            { name: 'positive', link: 12 },
+            { name: 'negative', link: 13 },
+            { name: 'latent_image', link: 14 },
+          ],
+          // seed 뒤에 UI 전용 'randomize' 가 낀 형태
+          widgets_values: [12345, 'randomize', 28, 5.5],
+        },
+        { id: 4, type: 'EmptyLatentImage', mode: 0, inputs: [], widgets_values: [1024, 768, 1] },
+      ],
+      links: [
+        link(10, 1, 1, 2, 0),
+        link(11, 1, 0, 3, 0),
+        link(12, 2, 0, 3, 1),
+        link(13, 2, 0, 3, 2),
+        link(14, 4, 0, 3, 3),
+      ],
+    };
+    const { apiWorkflow, warnings } = convertUiToApi(ui, OBJECT_INFO);
+
+    expect(warnings).toEqual([]);
+    expect(apiWorkflow['3'].inputs).toEqual({
+      model: ['1', 0],
+      seed: 12345,
+      steps: 28,
+      cfg: 5.5,
+      positive: ['2', 0],
+      negative: ['2', 0],
+      latent_image: ['4', 0],
+    });
+    expect(apiWorkflow['2'].inputs).toEqual({ text: 'hello prompt', clip: ['1', 1] });
+    expect(apiWorkflow['4'].inputs).toEqual({ width: 1024, height: 768, batch_size: 1 });
+  });
+
+  test('Reroute 체인 통과 + PrimitiveNode 는 리터럴 + mute 노드 제외', () => {
+    const ui = {
+      nodes: [
+        { id: 1, type: 'CheckpointLoaderSimple', mode: 0, inputs: [], widgets_values: ['a.safetensors'] },
+        { id: 5, type: 'Reroute', mode: 0, inputs: [{ name: '', link: 20 }], outputs: [] },
+        { id: 6, type: 'PrimitiveNode', mode: 0, inputs: [], widgets_values: ['primitive text'] },
+        { id: 2, type: 'CLIPTextEncode', mode: 0, inputs: [{ name: 'clip', link: 21 }, { name: 'text', link: 22, widget: { name: 'text' } }], widgets_values: ['unused'] },
+        { id: 9, type: 'SaveImage', mode: 2, inputs: [], widgets_values: ['muted'] },
+      ],
+      links: [
+        link(20, 1, 1, 5, 0),   // ckpt.clip → reroute
+        link(21, 5, 0, 2, 0),   // reroute → encode.clip
+        link(22, 6, 0, 2, 1),   // primitive → encode.text (converted widget)
+      ],
+    };
+    const { apiWorkflow, warnings } = convertUiToApi(ui, OBJECT_INFO);
+
+    expect(apiWorkflow['2'].inputs.clip).toEqual(['1', 1]); // Reroute 를 관통해 원 출처로
+    expect(apiWorkflow['2'].inputs.text).toBe('primitive text'); // Primitive → 리터럴
+    expect(apiWorkflow['5']).toBeUndefined(); // 가상 노드 미포함
+    expect(apiWorkflow['9']).toBeUndefined(); // mute 제외
+    expect(warnings.some((w) => w.includes('비활성'))).toBe(true);
+  });
+
+  test('서브그래프 재귀 확장 — 인스턴스ID:내부ID, 경계 링크, 승격 위젯', () => {
+    const SG_ID = 'aaaa-bbbb';
+    const ui = {
+      nodes: [
+        { id: 1, type: 'CheckpointLoaderSimple', mode: 0, inputs: [], widgets_values: ['a.safetensors'] },
+        {
+          id: 7, type: SG_ID, mode: 0,
+          // sg.inputs 순서: latent(LATENT — 링크), width(INT — 승격 위젯)
+          inputs: [{ name: 'vae', link: 30 }],
+          outputs: [{ name: 'IMAGE', links: [31] }],
+          widgets_values: [512],
+        },
+        { id: 8, type: 'SaveImage', mode: 0, inputs: [{ name: 'images', link: 31 }], widgets_values: ['out'] },
+      ],
+      links: [
+        link(30, 1, 2, 7, 0),  // ckpt.vae → 인스턴스 입력 0
+        link(31, 7, 0, 8, 0),  // 인스턴스 출력 0 → SaveImage
+      ],
+      definitions: {
+        subgraphs: [{
+          id: SG_ID,
+          name: 'sg',
+          inputNode: { id: -10 },
+          outputNode: { id: -20 },
+          inputs: [
+            { id: 'i1', name: 'vae', type: 'VAE', linkIds: [100] },
+            { id: 'i2', name: 'width', type: 'INT', linkIds: [101] },
+          ],
+          outputs: [{ id: 'o1', name: 'IMAGE', type: 'IMAGE', linkIds: [103] }],
+          nodes: [
+            { id: 40, type: 'EmptyLatentImage', mode: 0, inputs: [{ name: 'width', link: 101, widget: { name: 'width' } }], widgets_values: [0, 768, 1] },
+            { id: 41, type: 'VAEDecode', mode: 0, inputs: [{ name: 'samples', link: 102 }, { name: 'vae', link: 100 }] },
+          ],
+          links: [
+            { id: 100, origin_id: -10, origin_slot: 0, target_id: 41, target_slot: 1 },
+            { id: 101, origin_id: -10, origin_slot: 1, target_id: 40, target_slot: 0 },
+            { id: 102, origin_id: 40, origin_slot: 0, target_id: 41, target_slot: 0 },
+            { id: 103, origin_id: 41, origin_slot: 0, target_id: -20, target_slot: 0 },
+          ],
+        }],
+      },
+    };
+    const { apiWorkflow, warnings } = convertUiToApi(ui, OBJECT_INFO);
+
+    expect(warnings).toEqual([]);
+    // 인스턴스 자체는 없고 내부 노드가 "7:40", "7:41" 로 확장
+    expect(apiWorkflow['7']).toBeUndefined();
+    expect(Object.keys(apiWorkflow).sort()).toEqual(['1', '7:40', '7:41', '8']);
+    // 경계: 내부 vae ← 외부 ckpt 출력 / 내부 width ← 인스턴스 승격 위젯(512)
+    expect(apiWorkflow['7:41'].inputs.vae).toEqual(['1', 2]);
+    expect(apiWorkflow['7:40'].inputs.width).toBe(512);
+    // 외부: SaveImage.images ← 서브그래프 출력의 내부 원 출처
+    expect(apiWorkflow['8'].inputs.images).toEqual(['7:41', 0]);
+  });
+
+  test('detectFormat — ui/api 구분', () => {
+    expect(detectFormat({ nodes: [], links: [] })).toBe('ui');
+    expect(detectFormat({ 1: { class_type: 'KSampler', inputs: {} } })).toBe('api');
+  });
+});


### PR DESCRIPTION
#609 Epic 의 P3. Epic 원문은 "(b) ComfyUI 확장으로 변환 위임 추천"이었으나, 실 서버에 ComfyUI-Manager 조차 없는 환경(확장 배포 경로 부재)이라 **서버측 직접 변환**으로 구현 — /object_info 를 이미 확보하고 있어 정확한 매핑이 가능함을 실증.

## 구현
- `convertUiToApi(uiObj, objectInfo)` — UI 포맷(nodes/links 그래프)을 API 포맷으로:
  - widgets_values → 입력명: /object_info 입력 스키마 **순서** 기반, `control_after_generate`(seed 류 UI 전용 값) 소거
  - Reroute 관통 · PrimitiveNode 리터럴화 · mute(2)/bypass(4) 처리
  - **서브그래프 재귀 확장**: `definitions.subgraphs` 를 API export 와 동일한 `인스턴스ID:내부ID` 규칙으로 평탄화 — 경계 IO 노드(-10/-20), `inputs[].linkIds`, 승격 위젯(위젯형 입력 순서 소비), 중첩 지원
- analyze/draft 라우트에 UI 감지·자동 변환 통합 (UI 포맷 + 서버 미선택 → 명확한 400 안내), 초안 `workflowData` 는 변환본 저장, 변환 노트/경고 동봉
- 다이얼로그: "일반 저장(UI 포맷)도 지원" 안내 + 클라이언트측 서버 필수 가드

## 검증
- **실물 최강 검증**: 실 ComfyUI 의 저장 워크플로 `sdxl-img-1b.json` (UI 19노드, 서브그래프 6종·3중 중첩) → **56 API 노드**로 변환 → 실 ComfyUI `/prompt` 제출 → **execution_success 완주** (출력 노드 2종 생성)
- 저장된 SDXL 작업판 API 본과 구조 대조 (리비전 차이 감안한 diff 로 배선 일치 확인)
- 실 라우트 E2E: draft 생성 + 변수 추출 + 빠진 노드('Logic Comparison AND' — 실제 미설치) 정확 보고
- jest 45/341 (신규 5), e2e smoke 5/5

## P4 관련 (별도 처리 예정)
실 서버에 ComfyUI-Manager 미설치 확인 (전 엔드포인트 404) — one-click 설치는 Manager 도입 전까지 실행 불가. 폴백(출처 안내)은 #614/#616 에서 기구현.

🤖 Generated with [Claude Code](https://claude.com/claude-code)