### PR TITLE
fix: 라이트·다크 텍스트 대비 WCAG AA 충족 (#727)

### DIFF
--- a/docs/design-v2/TOKENS.md
+++ b/docs/design-v2/TOKENS.md
@@ -11,6 +11,15 @@
 1. **구조 토큰은 모드 공통, 컬러만 모드별** — 두 모드는 같은 앱, 다른 분위기
 2. **이중 포인트**: 라이트 = 테라코타, 다크 = 민트 (의도된 정체성)
 3. 페이지는 색·간격·폰트를 직접 쓰지 않는다 — theme 토큰과 `components/common/` 라이브러리만 호출 (CLAUDE.md UI 규칙)
+4. **텍스트는 라이트·다크 양쪽에서 WCAG AA 를 만족한다** (본문 4.5:1 / 24px+ 또는 굵은 18.66px+ 는 3:1). 토큰을 새로 넣거나 바꿀 때는 **두 모드 모두** 측정할 것 — 한쪽만 보면 반대쪽이 깨진다 (#727)
+
+## `.light` 은 "틴트" — MUI 파생과 충돌 주의 (#727)
+
+v2 는 `palette.*.light` 를 **저알파 틴트 배경**으로 재정의했다. 그런데 MUI 는 `.light` 을 "밝은 명도 변형" 으로 가정하고 일부 컴포넌트가 여기서 **글자색을 파생**한다.
+
+- 실제 사고: 다크모드 `<Alert>` 본문이 `rgba(...,0.14)` 를 글자색으로 물려받아 대비 **1.36:1** (사실상 안 보임). `theme.js` 의 `MuiAlert` 오버라이드로 배경/글자/아이콘을 명시 지정해 해결.
+- MUI v5 소스 기준 `palette[color].light` 를 참조하는 컴포넌트는 **Alert 뿐**. 새 MUI 컴포넌트를 도입할 때 이 목록을 다시 확인할 것.
+- 틴트 위에 글자를 얹을 때: **라이트는 `.dark`, 다크는 `.main`** (`ToneChip` 이 이 규칙의 기준 구현). 라이트 틴트는 밝아서 `.main` 이 묻힌다.
 
 ## 구조 토큰 (모드 공통)
 
@@ -29,7 +38,7 @@
 |---|---|
 | bg / surface | `#F6F2EC` / `#FFFDFA` |
 | divider / strong | `#E8E0D4` / `#D6CBB9` (grey.300/400) |
-| text 1/2/3/disabled | `#2A241C` / `#6E6557` / `#A39A8A` / `#C9C0B2` |
+| text 1/2/3/disabled | `#2A241C` / `#6E6557` / `#776E5F` / `#C9C0B2` |
 | **primary (테라코타)** | main `#C96A3B` · dark `#A04E26` · tint `#F7E8DF` |
 | secondary (진행 보라) | `#7A5CC4` · tint `#EFE9F9` |
 | success / warning / error / info | `#4D8A4D` / `#B07514` / `#C73E44` / `#4A7DBF` (+각 tint) |
@@ -41,10 +50,10 @@
 |---|---|
 | bg / surface | `#101216` / `#181B21` |
 | divider / strong | `#262B34` / `#343B47` |
-| text 1/2/3/disabled | `#E9EBEF` / `#9AA1AD` / `#5F6671` / `#3E434C` |
+| text 1/2/3/disabled | `#E9EBEF` / `#9AA1AD` / `#808895` / `#3E434C` |
 | **primary (민트)** | main `#3DD6B8` · dark `#2AA890` · tint rgba(61,214,184,.12) · on-accent `#06231D` |
 | secondary | `#9B7CE0` | 
-| success / warning / error / info | `#3DD68C` / `#E0B341` / `#E85C64` / `#5C9CE8` (+rgba tint) |
+| success / warning / error / info | `#3DD68C` / `#E0B341` / `#ED7178` / `#5C9CE8` (+rgba tint) |
 | navbar (콘솔 레일) | `#0B0D10`, 활성 `#181B21` |
 | grey 스케일 | 다크 반전 정책 유지 (#442) — `grey.50~300` 은 어두운 surface |
 

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -34,7 +34,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useAuth } from '../contexts/AuthContext';
 import { useColorScheme } from '../contexts/ColorSchemeContext';
 import { serverAPI } from '../services/api';
-import { MONO } from '../theme';
+import { MONO, toneText } from '../theme';
 import { BRAND_GRADIENTS } from '../utils/brandGradients';
 import NotificationsPopover from './common/NotificationsPopover';
 
@@ -78,8 +78,9 @@ function ServerStatusPill({ isAdmin }) {
       }}
       title={isAdmin ? '서버 관리로 이동' : undefined}
     >
-      <DnsIcon sx={{ fontSize: 13, color: allOk ? 'success.main' : 'warning.main' }} />
-      <Typography sx={{ fontSize: 11.5, fontWeight: 700, color: allOk ? 'success.main' : 'warning.main' }}>
+      {/* 틴트 위 의미색 글씨 — .main 은 라이트에서 3.4~3.6:1 로 AA 미달이라 toneText 로 모드별 분기 (#727) */}
+      <DnsIcon sx={(theme) => ({ fontSize: 13, color: toneText(theme, allOk ? 'success' : 'warning') })} />
+      <Typography sx={(theme) => ({ fontSize: 11.5, fontWeight: 700, color: toneText(theme, allOk ? 'success' : 'warning') })}>
         서버 {healthy}/{servers.length} {allOk ? '정상' : '점검 필요'}
       </Typography>
     </ButtonBase>

--- a/frontend/src/components/admin/ServerManagement.js
+++ b/frontend/src/components/admin/ServerManagement.js
@@ -161,7 +161,7 @@ function ServerCard({
             <ToneChip tone={statusChip.tone} label={statusChip.label} mono />
             {!server.isActive && <ToneChip tone="neutral" label="비활성" />}
           </Box>
-          <Typography sx={{ fontSize: 12, color: 'text.disabled', fontFamily: MONO, mt: 0.25 }} noWrap>{server.serverUrl}</Typography>
+          <Typography sx={{ fontSize: 12, color: 'text.tertiary', fontFamily: MONO, mt: 0.25 }} noWrap>{server.serverUrl}</Typography>
         </Box>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25, flex: '0 0 auto' }}>
         <Tooltip title="헬스체크">
@@ -690,9 +690,9 @@ function ServerManagement() {
           { label: '실행 중 큐', value: activeQueue },
         ].map((st) => (
           <Paper key={st.label} variant="outlined" sx={{ p: 3.5 }}>
-            <Typography sx={{ fontSize: 11, color: 'text.disabled', textTransform: 'uppercase', letterSpacing: '0.06em' }}>{st.label}</Typography>
+            <Typography sx={{ fontSize: 11, color: 'text.tertiary', textTransform: 'uppercase', letterSpacing: '0.06em' }}>{st.label}</Typography>
             <Typography sx={{ fontSize: 24, fontWeight: 700, mt: 0.5, color: st.color }}>
-              {st.value}{st.suffix && <Box component="span" sx={{ fontSize: 12, color: 'text.disabled', ml: 0.5 }}>{st.suffix}</Box>}
+              {st.value}{st.suffix && <Box component="span" sx={{ fontSize: 12, color: 'text.tertiary', ml: 0.5 }}>{st.suffix}</Box>}
             </Typography>
           </Paper>
         ))}

--- a/frontend/src/components/common/EmptyState.js
+++ b/frontend/src/components/common/EmptyState.js
@@ -12,7 +12,7 @@ export default function EmptyState({ icon, title, description, action, sx }) {
   return (
     <Box sx={{ p: 5, textAlign: 'center', border: '1px dashed', borderColor: 'divider', borderRadius: 2, ...sx }}>
       {icon && (
-        <Box sx={{ color: 'text.disabled', mb: 1.5, '& svg': { fontSize: 32 } }}>{icon}</Box>
+        <Box sx={{ color: 'text.tertiary', mb: 1.5, '& svg': { fontSize: 32 } }}>{icon}</Box>
       )}
       {title && <Typography sx={{ fontWeight: 600, mb: 0.5 }}>{title}</Typography>}
       {description && (

--- a/frontend/src/components/common/JobHistoryPanel.js
+++ b/frontend/src/components/common/JobHistoryPanel.js
@@ -417,7 +417,7 @@ function JobCard({ job, onView, onRetry, onCancel, onDelete, onImageView, onCont
                   sx={{
                     width: { xs: 40, sm: 56, md: 64 },
                     height: { xs: 40, sm: 56, md: 64 },
-                    bgcolor: 'grey.200', color: 'grey.600',
+                    bgcolor: 'grey.200', color: 'text.secondary', // grey.600 은 AA 미달 (#727)
                     cursor: 'pointer',
                     fontSize: { xs: '0.65rem', sm: '0.75rem' },
                     flexShrink: 0,
@@ -470,7 +470,7 @@ function JobCard({ job, onView, onRetry, onCancel, onDelete, onImageView, onCont
                   sx={{
                     width: { xs: 40, sm: 56, md: 64 },
                     height: { xs: 40, sm: 56, md: 64 },
-                    bgcolor: 'grey.200', color: 'grey.600',
+                    bgcolor: 'grey.200', color: 'text.secondary', // grey.600 은 AA 미달 (#727)
                     cursor: 'pointer',
                     fontSize: { xs: '0.65rem', sm: '0.75rem' },
                     flexShrink: 0,

--- a/frontend/src/components/common/MetadataItemCard.js
+++ b/frontend/src/components/common/MetadataItemCard.js
@@ -124,7 +124,7 @@ const MetadataItemCard = React.memo(function MetadataItemCard({
             alignItems: 'center',
             justifyContent: 'center',
             bgcolor: 'action.hover',
-            color: 'text.disabled'
+            color: 'text.tertiary'
           }}
         >
           <noImagePlaceholder.Icon sx={{ fontSize: 44 }} />

--- a/frontend/src/components/common/NotificationsPopover.js
+++ b/frontend/src/components/common/NotificationsPopover.js
@@ -122,7 +122,7 @@ export default function NotificationsPopover() {
         <Box sx={{ overflow: 'auto', flex: 1 }}>
           {items.length === 0 ? (
             <Box sx={{ p: 4, textAlign: 'center', color: 'text.secondary' }}>
-              <BellIcon sx={{ fontSize: 28, color: 'text.disabled', mb: 1 }} />
+              <BellIcon sx={{ fontSize: 28, color: 'text.tertiary', mb: 1 }} />
               <Typography variant="body2">알림 없음</Typography>
               <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
                 파이프라인 실행 중·완료 알림이 여기 표시됩니다.

--- a/frontend/src/components/common/PipelinePanel.js
+++ b/frontend/src/components/common/PipelinePanel.js
@@ -652,7 +652,7 @@ function LaneConnector({ isMobile, prevOutput, autoInject }) {
         gap: 0.5,
         py: isMobile ? 1.5 : 0,
         minHeight: isMobile ? 0 : 120,
-        color: autoInject ? 'success.main' : 'text.disabled',
+        color: autoInject ? 'success.main' : 'text.tertiary',
       }}
     >
       <ConnectorIcon fontSize="small" />
@@ -1898,7 +1898,7 @@ function PipelineRunner({ projectId, pipelineId, onClose }) {
                   const dotColor = r.status === 'completed' ? 'success.main'
                     : r.status === 'failed' ? 'error.main'
                     : r.status === 'running' || r.status === 'pending' ? 'info.main'
-                    : 'text.disabled';
+                    : 'text.tertiary';
                   const isCurrent = String(r._id) === String(runId);
                   return (
                     <Box

--- a/frontend/src/components/common/ToneChip.js
+++ b/frontend/src/components/common/ToneChip.js
@@ -1,30 +1,39 @@
 import React from 'react';
 import { Chip } from '@mui/material';
-import { MONO } from '../../theme';
+import { MONO, toneText } from '../../theme';
 
 // 상태/출력 등 의미 색이 있는 칩 — light/dark 양쪽 테마 토큰 기반 (#548 — WorkboardCatalog 내장에서 승격).
 // 같은 의미(완료/실패 등)는 모든 화면에서 이 컴포넌트로 표기한다 (MUI Chip color 직접 사용 금지).
-const TONE_SX = {
-  success: { bgcolor: 'success.light', color: 'success.main' },
-  info: { bgcolor: 'info.light', color: 'info.main' },
-  warning: { bgcolor: 'warning.light', color: 'warning.main' },
-  error: { bgcolor: 'error.light', color: 'error.main' },
-  accent: { bgcolor: 'primary.light', color: 'primary.main' }, // v2 — .light 토큰이 모드별 틴트 (#562)
-  neutral: { bgcolor: 'grey.100', color: 'text.secondary' },
+//
+// 글자색은 모드별로 다른 토큰을 쓴다 (#727). 틴트(.light) 위에 .main 을 얹던 기존 방식은
+// 라이트에서 5개 톤 전부 3.13~4.20:1 로 AA 미달이었다 — 라이트 틴트가 밝아 .main 이 묻힌다.
+// 라이트는 한 단계 진한 .dark(4.86~6.02:1), 다크는 틴트가 어두우므로 .main 유지(4.89~7.45:1).
+const TONE_PALETTE = {
+  success: 'success',
+  info: 'info',
+  warning: 'warning',
+  error: 'error',
+  accent: 'primary', // v2 — .light 토큰이 모드별 틴트 (#562)
 };
 
 export function ToneChip({ tone, label, mono, sx }) {
-  const ts = TONE_SX[tone] || TONE_SX.neutral;
   return (
     <Chip
       variant="filled"
       label={label}
-      sx={{
-        height: 24, fontSize: '11.5px', fontWeight: 600, border: 0,
-        ...(mono && { fontFamily: MONO, fontSize: '11px' }),
-        '& .MuiChip-label': { px: '11px' },
-        ...ts, ...sx,
-      }}
+      sx={[
+        (theme) => {
+          const key = TONE_PALETTE[tone];
+          if (!key) return { bgcolor: theme.palette.grey[100], color: theme.palette.text.secondary };
+          return { bgcolor: theme.palette[key].light, color: toneText(theme, key) };
+        },
+        {
+          height: 24, fontSize: '11.5px', fontWeight: 600, border: 0,
+          '& .MuiChip-label': { px: '11px' },
+          ...(mono && { fontFamily: MONO, fontSize: '11px' }),
+        },
+        ...(Array.isArray(sx) ? sx : [sx]),
+      ]}
     />
   );
 }

--- a/frontend/src/components/common/WorkboardCatalog.js
+++ b/frontend/src/components/common/WorkboardCatalog.js
@@ -62,7 +62,8 @@ const OUT_TONE = { image: 'accent', video: 'warning', text: 'info' };
 // ToneChip 은 common/ToneChip 으로 승격 (#548) — 기존 import 호환 재export
 export { ToneChip };
 
-// 의미 색 없는 태그 칩 — 투명 배경 + 옅은 테두리 + tertiary 글씨 (종류 라벨 등).
+// 의미 색 없는 태그 칩 — 투명 배경 + 옅은 테두리 + 보조 글씨 (종류 라벨 등).
+// 글씨는 grey.600 이었으나 라이트에서 3.79:1 로 AA 미달 → text.secondary 로 교체 (#727).
 export function TagChip({ label, mono, sx }) {
   return (
     <Chip
@@ -70,7 +71,7 @@ export function TagChip({ label, mono, sx }) {
       label={label}
       sx={{
         height: 24, fontSize: mono ? '10.5px' : '11.5px', bgcolor: 'transparent',
-        borderColor: 'divider', color: 'grey.600',
+        borderColor: 'divider', color: 'text.secondary',
         ...(mono && { fontFamily: MONO }),
         '& .MuiChip-label': { px: '11px' }, ...sx,
       }}
@@ -128,7 +129,7 @@ function FilterToggle({ active, onClick, children, count }) {
     >
       {children}
       {count != null && (
-        <Box component="span" sx={{ fontSize: 10.5, fontFamily: MONO, color: active ? 'rgba(255,255,255,0.8)' : 'text.disabled' }}>
+        <Box component="span" sx={{ fontSize: 10.5, fontFamily: MONO, color: active ? 'rgba(255,255,255,0.8)' : 'text.tertiary' }}>
           {count}
         </Box>
       )}
@@ -147,10 +148,10 @@ export function WorkboardFilters({ q, setQ, outSel, toggleOut, svcSel, toggleSvc
       {/* search */}
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 2.5 }}>
         <Paper variant="outlined" sx={{ flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', px: 1, height: 34, bgcolor: 'background.paper' }}>
-          <Search fontSize="small" sx={{ color: 'text.disabled', mr: 0.5 }} />
+          <Search fontSize="small" sx={{ color: 'text.tertiary', mr: 0.5 }} />
           <InputBase value={q} onChange={(e) => setQ(e.target.value)} placeholder="작업판 이름 · 설명 검색" sx={{ flex: 1, fontSize: 13 }} />
         </Paper>
-        <Typography sx={{ fontSize: 12, color: 'text.disabled', fontFamily: MONO, flex: '0 0 auto' }}>
+        <Typography sx={{ fontSize: 12, color: 'text.tertiary', fontFamily: MONO, flex: '0 0 auto' }}>
           {shown === total ? `${total}개` : `${shown} / ${total}`}
         </Typography>
       </Box>
@@ -158,14 +159,14 @@ export function WorkboardFilters({ q, setQ, outSel, toggleOut, svcSel, toggleSvc
       {/* two axes */}
       <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: { xs: 2.5, sm: 4.5 }, alignItems: 'center' }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
-          <Typography sx={{ fontSize: 11, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'text.disabled' }}>출력</Typography>
+          <Typography sx={{ fontSize: 11, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'text.tertiary' }}>출력</Typography>
           {OUTPUT_AXIS.map((o) => (
             <FilterToggle key={o.k} active={outSel.includes(o.k)} onClick={() => toggleOut(o.k)} count={counts.out[o.k] || 0}>{o.label}</FilterToggle>
           ))}
         </Box>
         <Box sx={{ width: '1px', height: 22, bgcolor: 'divider', display: { xs: 'none', sm: 'block' } }} />
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
-          <Typography sx={{ fontSize: 11, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'text.disabled' }}>서버</Typography>
+          <Typography sx={{ fontSize: 11, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'text.tertiary' }}>서버</Typography>
           {SERVER_AXIS.map((s) => (
             <FilterToggle key={s.k} active={svcSel.includes(s.k)} onClick={() => toggleSvc(s.k)} count={counts.svc[s.k] || 0}>{s.label}</FilterToggle>
           ))}
@@ -173,7 +174,7 @@ export function WorkboardFilters({ q, setQ, outSel, toggleOut, svcSel, toggleSvc
         {anyActive && (
           <>
             <Box sx={{ flex: 1 }} />
-            <Button variant="text" startIcon={<Close />} onClick={onClear} sx={{ color: 'text.disabled' }}>초기화</Button>
+            <Button variant="text" startIcon={<Close />} onClick={onClear} sx={{ color: 'text.tertiary' }}>초기화</Button>
           </>
         )}
       </Box>
@@ -214,7 +215,7 @@ export function WorkboardCard({ wb, admin, onClick, onEdit, onMenu, onInfo, grou
             <Typography sx={{ fontSize: 13.5, fontWeight: 600 }} noWrap>{wb.name}</Typography>
             {admin && <WbStatusBadge isActive={wb.isActive} />}
           </Box>
-          <Typography sx={{ fontSize: 11, color: 'text.disabled', fontFamily: MONO, mt: 0.25 }} noWrap>
+          <Typography sx={{ fontSize: 11, color: 'text.tertiary', fontFamily: MONO, mt: 0.25 }} noWrap>
             {kind.label}{wb.version ? ` · v${wb.version}` : ''}
           </Typography>
         </Box>
@@ -230,7 +231,7 @@ export function WorkboardCard({ wb, admin, onClick, onEdit, onMenu, onInfo, grou
       {/* admin: allowed groups */}
       {admin && groupNames && groupNames.length > 0 && (
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexWrap: 'wrap' }}>
-          <Typography sx={{ fontSize: 10.5, color: 'text.disabled' }}>허용</Typography>
+          <Typography sx={{ fontSize: 10.5, color: 'text.tertiary' }}>허용</Typography>
           {groupNames.map((g) => (
             <TagChip key={g} label={g} />
           ))}
@@ -239,9 +240,9 @@ export function WorkboardCard({ wb, admin, onClick, onEdit, onMenu, onInfo, grou
 
       {/* stats row */}
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 2.5, pt: 2.5, mt: 'auto',
-        borderTop: '1px solid', borderColor: 'divider', fontSize: 11, color: 'text.disabled', fontFamily: MONO }}>
+        borderTop: '1px solid', borderColor: 'divider', fontSize: 11, color: 'text.tertiary', fontFamily: MONO }}>
         <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
-          <Box sx={{ width: 6, height: 6, borderRadius: '50%', bgcolor: archived ? 'text.disabled' : 'success.main', flex: '0 0 auto' }} />
+          <Box sx={{ width: 6, height: 6, borderRadius: '50%', bgcolor: archived ? 'text.tertiary' : 'success.main', flex: '0 0 auto' }} />
           <Box component="span" sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{serverName}</Box>
         </Box>
         <Box sx={{ flex: 1 }} />
@@ -255,7 +256,7 @@ export function WorkboardCard({ wb, admin, onClick, onEdit, onMenu, onInfo, grou
       {/* footer */}
       {admin ? (
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <Typography sx={{ fontSize: 11, color: 'text.disabled' }} noWrap>
+          <Typography sx={{ fontSize: 11, color: 'text.tertiary' }} noWrap>
             {wb.updatedAt ? new Date(wb.updatedAt).toLocaleDateString() : ''}{wb.createdBy?.nickname ? ` · ${wb.createdBy.nickname}` : ''}
           </Typography>
           <Box sx={{ flex: 1 }} />
@@ -270,8 +271,8 @@ export function WorkboardCard({ wb, admin, onClick, onEdit, onMenu, onInfo, grou
             </Button>
           )}
           <Box sx={{ flex: 1 }} />
-          <AccessTime sx={{ fontSize: 12, color: 'text.disabled' }} />
-          <Typography sx={{ fontSize: 11, color: 'text.disabled', fontFamily: MONO }}>
+          <AccessTime sx={{ fontSize: 12, color: 'text.tertiary' }} />
+          <Typography sx={{ fontSize: 11, color: 'text.tertiary', fontFamily: MONO }}>
             {wb.updatedAt ? new Date(wb.updatedAt).toLocaleDateString() : ''}
           </Typography>
         </Box>

--- a/frontend/src/pages/MyImages.js
+++ b/frontend/src/pages/MyImages.js
@@ -110,8 +110,10 @@ function FilterRow({ label, color, active, onClick }) {
         py: 0.5,
         borderRadius: 1,
         cursor: 'pointer',
+        // 선택 표시는 틴트 배경 + 굵기로 충분하다. 여기에 브랜드색 글씨까지 얹으면
+        // action.selected 가 배경을 어둡게 해 .main 3.78 / .dark 4.36 으로 둘 다 AA 미달이 된다 (#727).
         bgcolor: active ? 'action.selected' : 'transparent',
-        color: active ? 'primary.main' : 'text.primary',
+        color: 'text.primary',
         fontSize: 13,
         fontWeight: active ? 600 : 400,
         '&:hover': active ? {} : { bgcolor: 'action.hover' },

--- a/frontend/src/pages/Profile.js
+++ b/frontend/src/pages/Profile.js
@@ -47,6 +47,7 @@ import { userAPI, apiKeyAPI } from '../services/api';
 import { useAuth } from '../contexts/AuthContext';
 import { MONO } from '../theme';
 import { BRAND_GRADIENTS } from '../utils/brandGradients';
+import { ToneChip } from '../components/common/ToneChip';
 
 // v2 스탯 카드 — outlined + mono 숫자 (#564)
 function StatCard({ title, value, subtitle }) {
@@ -422,7 +423,11 @@ function SecuritySettings() {
                       px: 1.5,
                       mb: 0.5,
                       borderRadius: 1,
-                      bgcolor: apiKey.isRevoked ? 'action.disabledBackground' : 'action.hover'
+                      // 반투명 오버레이(action.*)를 쓰면 그 위에 얹히는 ToneChip 틴트와 겹쳐 쌓여
+                      // 다크에서 대비가 3.5:1 아래로 내려간다 (#727). 불투명 표면 + 보더로 구분한다.
+                      bgcolor: 'background.default',
+                      border: '1px solid',
+                      borderColor: apiKey.isRevoked ? 'divider' : 'transparent',
                     }}
                   >
                     <Box sx={{ minWidth: 0, flex: 1 }}>
@@ -430,9 +435,8 @@ function SecuritySettings() {
                         <Typography variant="body2" fontWeight="medium" noWrap>
                           {apiKey.name}
                         </Typography>
-                        {apiKey.isRevoked && (
-                          <Chip label="파기됨" color="error" variant="outlined" />
-                        )}
+                        {/* MUI Chip color 직접 사용은 금지 규칙 (ToneChip 주석) + error.main 이 라이트에서 3.74:1 (#727) */}
+                        {apiKey.isRevoked && <ToneChip tone="error" label="파기됨" />}
                       </Box>
                       <Typography variant="caption" color="text.secondary" component="div">
                         {apiKey.prefix}... | 생성: {formatDate(apiKey.createdAt)}

--- a/frontend/src/pages/ProjectList.js
+++ b/frontend/src/pages/ProjectList.js
@@ -60,7 +60,7 @@ function TagPill({ tag }) {
 function StatRow({ project, mono }) {
   const c = project.counts || {};
   return (
-    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25, fontSize: 11, color: 'text.disabled', fontFamily: mono ? MONO : undefined }}>
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25, fontSize: 11, color: 'text.tertiary', fontFamily: mono ? MONO : undefined }}>
       <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}><ImageIcon sx={{ fontSize: 13 }} /> {c.images || 0}</Box>
       <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}><TextSnippet sx={{ fontSize: 13 }} /> {c.promptData || 0}</Box>
       <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}><History sx={{ fontSize: 13 }} /> {c.jobs || 0}</Box>
@@ -154,7 +154,7 @@ function ProjectGridCard({ project, isFav, onOpen, onToggleFav, onMenu }) {
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25, mt: 1.5, pt: 1.5, borderTop: '1px solid', borderColor: 'divider' }}>
           <StatRow project={project} mono />
           <Box sx={{ flex: 1 }} />
-          <Typography sx={{ fontSize: 11, color: 'text.disabled', fontFamily: MONO }}>{relativeTime(project.updatedAt)}</Typography>
+          <Typography sx={{ fontSize: 11, color: 'text.tertiary', fontFamily: MONO }}>{relativeTime(project.updatedAt)}</Typography>
         </Box>
       </Box>
     </Paper>
@@ -178,10 +178,10 @@ function ProjectListRow({ project, isFav, onOpen, onToggleFav, onMenu, first }) 
           <TagPill tag={project.tagId} />
           {isFav && <Star sx={{ fontSize: 13, color: 'warning.main' }} />}
         </Box>
-        <Typography sx={{ fontSize: 12, color: 'text.disabled', mt: 0.25 }} noWrap>{project.description || '설명이 없습니다.'}</Typography>
+        <Typography sx={{ fontSize: 12, color: 'text.tertiary', mt: 0.25 }} noWrap>{project.description || '설명이 없습니다.'}</Typography>
       </Box>
       <Box sx={{ display: { xs: 'none', sm: 'flex' }, flex: '0 0 auto' }}><StatRow project={project} mono /></Box>
-      <Typography sx={{ fontSize: 11, color: 'text.disabled', fontFamily: MONO, flex: '0 0 auto' }}>{relativeTime(project.updatedAt)}</Typography>
+      <Typography sx={{ fontSize: 11, color: 'text.tertiary', fontFamily: MONO, flex: '0 0 auto' }}>{relativeTime(project.updatedAt)}</Typography>
       <IconButton size="small" onClick={(e) => { e.stopPropagation(); onMenu(e, project); }}><MoreVert fontSize="small" /></IconButton>
     </Box>
   );
@@ -192,7 +192,7 @@ function ViewToggle({ view, setView }) {
     <Box component="button" onClick={() => setView(v)} sx={{
       display: 'inline-flex', alignItems: 'center', gap: 0.5, px: '10px', height: 26, borderRadius: 1, border: 0, cursor: 'pointer',
       fontSize: 12, fontWeight: 500, bgcolor: view === v ? 'background.paper' : 'transparent',
-      color: view === v ? 'text.primary' : 'text.disabled', boxShadow: view === v ? 1 : 'none' }}>
+      color: view === v ? 'text.primary' : 'text.secondary', boxShadow: view === v ? 1 : 'none' }}>
       {icon} {label}
     </Box>
   );
@@ -271,19 +271,20 @@ function ProjectList() {
       {/* 검색 / 필터 */}
       <Box sx={{ display: 'flex', gap: 2, mb: 4.5, alignItems: 'center', flexWrap: 'wrap' }}>
         <Paper variant="outlined" sx={{ display: 'flex', alignItems: 'center', px: 1, height: 34, minWidth: { sm: 300 }, flex: { xs: 1, sm: '0 1 auto' } }}>
-          <Search fontSize="small" sx={{ color: 'text.disabled', mr: 0.5 }} />
+          <Search fontSize="small" sx={{ color: 'text.tertiary', mr: 0.5 }} />
           <InputBase value={search} onChange={(e) => setSearch(e.target.value)} placeholder="프로젝트 이름 · 태그 · 설명 검색" sx={{ flex: 1, fontSize: 13 }} />
         </Paper>
         <Box sx={{ display: 'flex', gap: '4px', p: '3px', bgcolor: 'grey.100', borderRadius: 1.5, border: '1px solid', borderColor: 'divider' }}>
           {[{ v: 'all', l: '전체' }, { v: 'fav', l: '즐겨찾기' }].map((f) => (
             <Box key={f.v} component="button" onClick={() => setFilter(f.v)} sx={{
               px: '10px', height: 26, borderRadius: 1, border: 0, cursor: 'pointer', fontSize: 12, fontWeight: 500,
-              bgcolor: filter === f.v ? 'background.paper' : 'transparent', color: filter === f.v ? 'text.primary' : 'text.disabled',
+              // 미선택도 클릭 가능한 옵션이라 읽혀야 함 — grey.100 위에서 tertiary 는 4.2:1 로 미달 (#727)
+              bgcolor: filter === f.v ? 'background.paper' : 'transparent', color: filter === f.v ? 'text.primary' : 'text.secondary',
               boxShadow: filter === f.v ? 1 : 'none' }}>{f.l}</Box>
           ))}
         </Box>
         <Box sx={{ flex: 1 }} />
-        <Typography sx={{ fontSize: 12, color: 'text.disabled', fontFamily: MONO }}>{visible.length}개</Typography>
+        <Typography sx={{ fontSize: 12, color: 'text.tertiary', fontFamily: MONO }}>{visible.length}개</Typography>
       </Box>
 
       {projects.length === 0 ? (
@@ -308,7 +309,7 @@ function ProjectList() {
           ))}
           {/* 새 프로젝트 만들기 affordance */}
           <Box onClick={() => setCreateOpen(true)} sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
-            gap: 1, p: 3, minHeight: 200, border: '1px dashed', borderColor: 'divider', borderRadius: 2, color: 'text.disabled', cursor: 'pointer',
+            gap: 1, p: 3, minHeight: 200, border: '1px dashed', borderColor: 'divider', borderRadius: 2, color: 'text.tertiary', cursor: 'pointer',
             transition: 'all 120ms', '&:hover': { borderColor: 'primary.main', color: 'primary.main', bgcolor: 'action.hover' } }}>
             <Add />
             <Typography sx={{ fontSize: 13, fontWeight: 500 }}>새 프로젝트 만들기</Typography>

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -13,11 +13,22 @@ export const MONO = '"JetBrains Mono","SF Mono","Menlo","Consolas",monospace';
 
 // 태그 기본색 — light primary.main 과 동일. 태그색은 DB 저장 데이터(모드 불변)라
 // palette 대신 고정 상수로 단일화 (#694). 새 태그색 fallback 은 이 상수를 쓸 것.
-export const DEFAULT_TAG_COLOR = '#C96A3B';
+// primary.main 상향에 맞춰 동반 조정 (#727) — 태그 칩은 흰 글씨를 얹으므로 대비 3.74 → 5.03.
+// 이미 DB 에 저장된 태그색은 그대로 유지된다 (이 상수는 신규 fallback 전용).
+export const DEFAULT_TAG_COLOR = '#B05526';
+
+// 틴트/표면 위에 "의미 색 글씨"를 얹을 때 쓰는 모드별 토큰 선택 (#727).
+// 라이트 표면은 밝아서 .main 이 묻힌다(3.1~4.2:1) → 한 단계 진한 .dark 를 쓴다.
+// 다크 표면은 어두우므로 .main 이 그대로 잘 읽힌다(4.9~7.5:1).
+// 사용: sx={(theme) => ({ color: toneText(theme, 'success') })}
+export const toneText = (theme, key) =>
+  theme.palette.mode === 'light' ? theme.palette[key].dark : theme.palette[key].main;
 
 const LIGHT = {
-  // 테라코타 포인트
-  primary:   { main: '#C96A3B', light: '#F7E8DF', dark: '#A04E26', contrastText: '#FFFFFF' },
+  // 테라코타 포인트.
+  // main 은 #C96A3B → #B05526 으로 상향 (#727). 기존 값은 흰 글씨 버튼 3.74:1 / 본문 텍스트 3.69:1 로
+  // WCAG AA 미달이었다. #B05526 은 전부 통과하는 가장 밝은 값 (버튼 5.03 · paper 4.96 · bg 4.51).
+  primary:   { main: '#B05526', light: '#F7E8DF', dark: '#A04E26', contrastText: '#FFFFFF' },
   // 진행/파이프라인 계열 보라
   secondary: { main: '#7A5CC4', light: '#EFE9F9', dark: '#5C42A0', contrastText: '#FFFFFF' },
   success:   { main: '#4D8A4D', light: '#E8F1E4', dark: '#3A6E3A', contrastText: '#FFFFFF' },
@@ -27,7 +38,9 @@ const LIGHT = {
   // 라이트 사이드바 — 페이지 배경과 한 몸 (보더 없는 레일), 활성/hover 는 surface 픽
   navbar:    { main: '#F6F2EC', light: '#FFFDFA', dark: '#EFE9DE', contrastText: '#2A241C' },
   background:{ default: '#F6F2EC', paper: '#FFFDFA' },
-  text:      { primary: '#2A241C', secondary: '#6E6557', tertiary: '#A39A8A', disabled: '#C9C0B2' },
+  // tertiary: #A39A8A 는 bg 대비 2.5:1 로 WCAG AA 미달이었음 → 4.5:1 로 상향 (#727).
+  // secondary(5.14:1) 와 간격이 좁아졌지만, 사이드바 섹션 라벨·ID·메타 등 정보성 텍스트에 쓰이므로 가독성 우선.
+  text:      { primary: '#2A241C', secondary: '#6E6557', tertiary: '#776E5F', disabled: '#C9C0B2' },
   divider:   '#E8E0D4',
   // warm-neutral grey 스케일
   grey: {
@@ -43,12 +56,15 @@ const DARK = {
   secondary: { main: '#9B7CE0', light: 'rgba(155,124,224,0.16)', dark: '#7A5CC4', contrastText: '#FFFFFF' },
   success:   { main: '#3DD68C', light: 'rgba(61,214,140,0.14)', dark: '#2AA868', contrastText: '#06231D' },
   warning:   { main: '#E0B341', light: 'rgba(224,179,65,0.14)', dark: '#B08A2A', contrastText: '#1C1812' },
-  error:     { main: '#E85C64', light: 'rgba(232,92,100,0.14)', dark: '#C73E44', contrastText: '#FFFFFF' },
+  // error: #E85C64 는 자체 틴트 위에서 4.27:1 로 AA 미달이었음 → 밝기 상향 (#727).
+  // 밝아진 만큼 흰 글씨는 대비가 깨져 contrastText 를 딥 레드블랙으로 (다크 primary 의 #06231D 와 같은 패턴).
+  error:     { main: '#ED7178', light: 'rgba(237,113,120,0.14)', dark: '#C73E44', contrastText: '#2A0E10' },
   info:      { main: '#5C9CE8', light: 'rgba(92,156,232,0.14)', dark: '#3D7CC8', contrastText: '#FFFFFF' },
   // 다크 사이드바 — 컨텐츠보다 더 어두운 콘솔 레일
   navbar:    { main: '#0B0D10', light: '#181B21', dark: '#05070A', contrastText: '#E9EBEF' },
   background:{ default: '#101216', paper: '#181B21' },
-  text:      { primary: '#E9EBEF', secondary: '#9AA1AD', tertiary: '#5F6671', disabled: '#3E434C' },
+  // tertiary: #5F6671 은 surface 대비 2.98:1 로 AA 미달이었음 → 4.5:1 로 상향 (#727)
+  text:      { primary: '#E9EBEF', secondary: '#9AA1AD', tertiary: '#808895', disabled: '#3E434C' },
   divider:   '#262B34',
   // 다크 grey 스케일 — bgcolor: 'grey.50/100/...' 가 다크에서 어두운 surface 로 동작 (#442 정책 유지)
   grey: {
@@ -115,6 +131,22 @@ export function buildVccTheme(mode = 'light') {
           root: { borderRadius: 999, fontWeight: 600, fontSize: 11.5 },
           sizeSmall: { height: 25 },
           label: { paddingInline: 11 }, // 텍스트 주변 여유 (#556)
+        },
+      },
+      // v2 는 palette.*.light 를 "틴트(저알파 배경)" 로 재정의했는데, MUI 는 .light 을 "밝은 명도 변형" 으로
+      // 가정해 standard Alert 의 **텍스트 색**을 여기서 파생한다. 다크에서 알파 0.14 가 글자색에 그대로 실려
+      // 대비가 1.36:1 까지 떨어졌음 (#727). 파생에 맡기지 않고 배경/글자/아이콘을 명시 지정한다.
+      MuiAlert: {
+        styleOverrides: {
+          root: ({ theme, ownerState }) => {
+            const p = theme.palette[ownerState?.severity || 'success'];
+            return {
+              borderRadius: 8,
+              backgroundColor: p.light,        // 틴트 (라이트=옅은 단색 / 다크=저알파 rgba)
+              color: theme.palette.text.primary, // 본문은 기본 텍스트색 — 양쪽 모드 모두 AA 충족
+              '& .MuiAlert-icon': { color: theme.palette.mode === 'light' ? p.dark : p.main },
+            };
+          },
         },
       },
       MuiPaper: {


### PR DESCRIPTION
UI 전면 검토에서 발견한 대비 결함을 브라우저 실측(알파 합성 반영) 기준으로 수정했습니다.

## 근본 원인

**1. `.light` 토큰이 "틴트"인데 MUI 는 "밝은 명도 변형"으로 가정**

standard Alert 가 다크모드에서 `palette[severity].light` 를 **글자색**으로 파생하는데, v2 는 이 토큰을 저알파 rgba 틴트로 재정의해 두었습니다. 알파 0.14 가 글자색에 그대로 실려 **1.36:1** 까지 떨어졌습니다 (`<Alert>` 93회 / 38개 파일 전부 해당).

MUI v5 소스를 확인해 `.light` 을 파생에 쓰는 컴포넌트가 **Alert 뿐**임을 확인했고, `MuiAlert` styleOverrides 로 배경/글자/아이콘을 명시 지정했습니다.

**2. 밝은 라이트 표면 위에서 의미색·브랜드색이 묻힘**

- ToneChip 5개 톤 **전부** 3.13~4.20:1 (완료/실패 등 전 화면 상태 칩)
- primary 텍스트·버튼 3.69~3.74:1 (주 액션 버튼 전체)

## 토큰 변경

| 토큰 | 전 | 후 | 대비 |
|---|---|---|---|
| LIGHT `primary.main` | `#C96A3B` | `#B05526` | 버튼 흰글씨 3.74 → **5.03** |
| LIGHT `text.tertiary` | `#A39A8A` | `#776E5F` | 2.50 → **4.50** |
| DARK `text.tertiary` | `#5F6671` | `#808895` | 2.98 → **4.82** |
| DARK `error.main` | `#E85C64` | `#ED7178` | 틴트 위 4.27 → **5.03** |

`primary.main` 은 전부 AA 를 통과하는 **가장 밝은 값**을 골랐습니다 (사용자 확인). `primary.dark` 는 그대로 두어 위계를 유지합니다. `DEFAULT_TAG_COLOR` 도 동반 조정했고, 이미 DB 에 저장된 태그색은 바뀌지 않습니다.

## 컴포넌트

- **`toneText(theme, key)` 헬퍼 추가** — 틴트 위 의미색 글씨는 라이트 `.dark` / 다크 `.main`. ToneChip 과 Header 서버상태 칩에 적용
- `TagChip` 글씨 `grey.600` → `text.secondary` (3.79 → 5.65)
- **`text.disabled`(1.5:1) 오용 30곳 정리** → `text.tertiary`. 메타·카운트·날짜·미선택 탭 등 비활성이 아닌 곳에 4번째 텍스트 단계처럼 쓰이고 있었습니다. 실제 비활성 컨트롤은 MUI 가 `.Mui-disabled` 로 처리하므로 대상이 아닙니다
- 클릭 가능한 미선택 토글은 `text.secondary` (읽혀야 하는 옵션)
- Profile 파기된 API 키 — MUI `Chip color` 직접 사용(ToneChip 주석의 금지 규칙 위반) → ToneChip 으로 교체 + 행 배경을 불투명색으로. 반투명 오버레이 위에 틴트가 겹쳐 쌓이면서 다크에서 3.5:1 아래로 내려갔습니다

## 검증

`/dashboard` `/workboards` `/jobs` `/content` `/projects` `/tags` `/prompt-data` `/settings` `/profile` `/admin/users` `/admin/servers` × 라이트·다크 = **위반 0건**.

남은 2건은 예외입니다:
- 비활성 입력(프로필 이메일) — WCAG 면제 대상
- `templates/capabilities.js` 서버 브랜드 컬러 위 흰 글씨 3.2:1 — CLAUDE.md 가 명시적으로 허용한 토큰 외 예외라 **이 PR 에서 건드리지 않았습니다**. 별도 판단이 필요합니다

`docs/design-v2/TOKENS.md` 에 바뀐 값과 함께 `.light` 틴트 ↔ MUI 파생 충돌 주의사항, 양쪽 모드 AA 원칙을 추가했습니다.

프론트 테스트 33개 통과.

closes #727

🤖 Generated with [Claude Code](https://claude.com/claude-code)