### PR TITLE
fix: 작업 재시도 경로 복구 + 공용 확인 다이얼로그 (#728)

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -14,6 +14,7 @@ import AdminRoute from './components/AdminRoute';
 import Header from './components/Header';
 import Sidebar from './components/Sidebar';
 import CommandPalette from './components/common/CommandPalette';
+import { ConfirmProvider } from './components/common/ConfirmDialog';
 import Login from './pages/Login';
 import Signup from './pages/Signup';
 import ForgotPassword from './pages/ForgotPassword';
@@ -72,6 +73,7 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <ColorSchemeProvider>
         <ThemedApp>
+          <ConfirmProvider>
           <AuthProvider>
             <Router>
               <div className="App">
@@ -94,6 +96,7 @@ function App() {
             </div>
           </Router>
           </AuthProvider>
+          </ConfirmProvider>
         </ThemedApp>
       </ColorSchemeProvider>
     </QueryClientProvider>

--- a/frontend/src/components/common/ConfirmDialog.js
+++ b/frontend/src/components/common/ConfirmDialog.js
@@ -1,0 +1,98 @@
+import React, { createContext, useCallback, useContext, useState } from 'react';
+import { Dialog, DialogTitle, DialogContent, DialogActions, DialogContentText, Button, Box } from '@mui/material';
+import { WarningAmberRounded } from '@mui/icons-material';
+
+// 공용 확인 다이얼로그 (#728) — 네이티브 window.confirm 대체.
+//
+// window.confirm 은 테마·다크모드·모바일 어디에도 맞지 않고, 경고를 '\n\n' 줄바꿈으로
+// 표현할 수밖에 없어 "되돌릴 수 없음" 이 본문과 같은 무게로 보였다.
+// 여기서는 결과(description)를 본문으로, 되돌릴 수 없는 동작은 danger 로 분리해 표기한다.
+//
+// 사용:
+//   const confirm = useConfirm();
+//   if (await confirm({ title: '삭제하시겠습니까?', description: '...', danger: true })) { ... }
+//
+// 문자열 하나만 넘기면 title 로 취급한다 — confirm('삭제하시겠습니까?')
+
+const ConfirmContext = createContext(null);
+
+export function useConfirm() {
+  const ctx = useContext(ConfirmContext);
+  if (!ctx) throw new Error('useConfirm 은 ConfirmProvider 안에서만 쓸 수 있습니다');
+  return ctx;
+}
+
+export function ConfirmProvider({ children }) {
+  const [pending, setPending] = useState(null);
+
+  const confirm = useCallback(
+    (options) =>
+      new Promise((resolve) => {
+        setPending({ opts: typeof options === 'string' ? { title: options } : options || {}, resolve });
+      }),
+    []
+  );
+
+  const settle = (result) => {
+    setPending((cur) => {
+      cur?.resolve(result);
+      return null;
+    });
+  };
+
+  const o = pending?.opts || {};
+  const danger = !!o.danger;
+
+  return (
+    <ConfirmContext.Provider value={confirm}>
+      {children}
+      <Dialog
+        open={!!pending}
+        onClose={() => settle(false)}
+        maxWidth="xs"
+        fullWidth
+        aria-labelledby="confirm-dialog-title"
+      >
+        <DialogTitle id="confirm-dialog-title" sx={{ display: 'flex', alignItems: 'center', gap: 1.5, pb: 1 }}>
+          {danger && <WarningAmberRounded fontSize="small" sx={{ color: 'error.main' }} />}
+          {o.title}
+        </DialogTitle>
+        <DialogContent>
+          {o.description && <DialogContentText sx={{ textWrap: 'pretty' }}>{o.description}</DialogContentText>}
+          {danger && (
+            <Box
+              sx={{
+                mt: o.description ? 2.5 : 0,
+                px: 2.5,
+                py: 2,
+                borderRadius: 2,
+                bgcolor: 'error.light',
+                color: (theme) => (theme.palette.mode === 'light' ? 'error.dark' : 'error.main'),
+                fontSize: 12.5,
+                fontWeight: 600,
+              }}
+            >
+              {o.dangerNote || '이 작업은 되돌릴 수 없습니다.'}
+            </Box>
+          )}
+        </DialogContent>
+        <DialogActions>
+          {/* 파괴적 동작에서는 취소가 기본 포커스 — Enter 오폭 방지 */}
+          <Button onClick={() => settle(false)} autoFocus={danger}>
+            {o.cancelLabel || '취소'}
+          </Button>
+          <Button
+            variant="contained"
+            color={danger ? 'error' : 'primary'}
+            onClick={() => settle(true)}
+            autoFocus={!danger}
+          >
+            {o.confirmLabel || '확인'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </ConfirmContext.Provider>
+  );
+}
+
+export default ConfirmProvider;

--- a/frontend/src/components/common/ConversationHistoryPanel.js
+++ b/frontend/src/components/common/ConversationHistoryPanel.js
@@ -37,10 +37,12 @@ import { Chat as ChatIcon, BookmarkAdd as BookmarkAddIcon } from '@mui/icons-mat
 import { Collapse, Paper } from '@mui/material';
 import { conversationAPI, textAPI } from '../../services/api';
 import Pagination from './Pagination';
+import { useConfirm } from './ConfirmDialog';
 
 // LLM 대화 히스토리 패널 (#373).
 // JobHistory 페이지의 \"텍스트\" 탭에서 사용. 카드 리스트 + 상세 다이얼로그.
 function ConversationHistoryPanel({ fetchFn, queryKey = 'conversations' }) {
+  const confirm = useConfirm();
   const [page, setPage] = useState(1);
   const [detailItem, setDetailItem] = useState(null);
   const queryClient = useQueryClient();
@@ -181,8 +183,12 @@ function ConversationHistoryPanel({ fetchFn, queryKey = 'conversations' }) {
                   <IconButton
                     size="small"
                     color="error"
-                    onClick={() => {
-                      if (window.confirm('이 대화를 삭제하시겠어요?')) {
+                    onClick={async () => {
+                      if (await confirm({
+                        title: '이 대화를 삭제하시겠습니까?',
+                        description: '주고받은 메시지가 모두 사라집니다.',
+                        danger: true, confirmLabel: '삭제',
+                      })) {
                         deleteMutation.mutate(conv._id);
                       }
                     }}

--- a/frontend/src/components/common/JobHistoryPanel.js
+++ b/frontend/src/components/common/JobHistoryPanel.js
@@ -59,6 +59,7 @@ import VideoViewerDialog from './VideoViewerDialog';
 import ProjectTagChip from './ProjectTagChip';
 import WorkboardSelectDialog from './WorkboardSelectDialog';
 import { DEFAULT_TAG_COLOR } from '../../theme';
+import { useJobActions } from '../../hooks/useJobActions';
 
 export function SavePromptDialog({ open, onClose, job, onSave }) {
   const [imageSelectOpen, setImageSelectOpen] = useState(false);
@@ -934,31 +935,10 @@ function JobHistoryPanel({
   const extractor = responseExtractor || defaultExtractor;
   const { jobs, pagination } = extractor(data);
 
-  // 사용자 설정 가져오기
-  const { data: profileData } = useQuery({ queryKey: ['userProfile'], queryFn: () => userAPI.getProfile() });
-  const userPreferences = profileData?.data?.user?.preferences || {};
-
-  const retryMutation = useMutation({ mutationFn: jobAPI.retry,
-    onSuccess: () => { toast.success('작업을 재시도합니다'); queryClient.invalidateQueries({ queryKey: Array.isArray(queryKey) ? queryKey : [queryKey] }); },
-    onError: (error) => { toast.error('재시도 실패: ' + error.message); } });
-
-  const cancelMutation = useMutation({ mutationFn: jobAPI.cancel,
-    onSuccess: () => { toast.success('작업이 취소되었습니다'); queryClient.invalidateQueries({ queryKey: Array.isArray(queryKey) ? queryKey : [queryKey] }); },
-    onError: (error) => { toast.error('취소 실패: ' + error.message); } });
-
-  const deleteMutation = useMutation({ mutationFn: ({ id, deleteContent }) => jobAPI.delete(id, deleteContent),
-      onSuccess: (response) => {
-        const { deletedImagesCount, deletedVideosCount } = response.data;
-        if (deletedImagesCount > 0 || deletedVideosCount > 0) {
-          toast.success(`작업과 ${deletedImagesCount}개 이미지, ${deletedVideosCount}개 동영상이 삭제되었습니다`);
-          queryClient.invalidateQueries({ queryKey: ['generatedImages'] });
-          queryClient.invalidateQueries({ queryKey: ['generatedVideos'] });
-        } else {
-          toast.success('작업이 삭제되었습니다');
-        }
-        queryClient.invalidateQueries({ queryKey: Array.isArray(queryKey) ? queryKey : [queryKey] });
-      },
-      onError: (error) => { toast.error('삭제 실패: ' + error.message); } });
+  // 재시도/취소/삭제는 전역 피드(pages/JobHistory.js)와 동작을 공유한다 (#728).
+  // 사용자 설정(deleteContentWithHistory 등)도 훅이 함께 제공 — 중복 조회 제거.
+  const jobActions = useJobActions({ invalidateKeys: [queryKey] });
+  const userPreferences = jobActions.preferences;
 
   const savePromptMutation = useMutation({ mutationFn: promptDataAPI.create,
     onSuccess: () => { toast.success('프롬프트 데이터가 저장되었습니다'); setSavePromptOpen(false); setSavingJob(null); },
@@ -977,24 +957,9 @@ function JobHistoryPanel({
       console.error('Failed to fetch job detail:', error);
     }
   };
-  const handleRetry = (job) => { if (window.confirm('작업을 재시도하시겠습니까?')) retryMutation.mutate(job._id); };
-  const handleCancel = (job) => { if (window.confirm('작업을 취소하시겠습니까?')) cancelMutation.mutate(job._id); };
-
-  const handleDelete = (job) => {
-    const hasContent = (job.resultImages?.length > 0) || (job.resultVideos?.length > 0);
-    const deleteContentSetting = userPreferences.deleteContentWithHistory;
-
-    if (deleteContentSetting && hasContent) {
-      const contentCount = (job.resultImages?.length || 0) + (job.resultVideos?.length || 0);
-      if (window.confirm(`작업과 연관된 ${contentCount}개의 컨텐츠(이미지/동영상)도 함께 삭제하시겠습니까?\n\n이 작업은 되돌릴 수 없습니다.`)) {
-        deleteMutation.mutate({ id: job._id, deleteContent: true });
-      }
-    } else {
-      if (window.confirm('작업 히스토리를 삭제하시겠습니까?\n\n생성된 이미지/동영상은 보존됩니다.')) {
-        deleteMutation.mutate({ id: job._id, deleteContent: false });
-      }
-    }
-  };
+  const handleRetry = jobActions.retry;
+  const handleCancel = jobActions.cancel;
+  const handleDelete = jobActions.remove;
 
   const handleImageView = (items, index = 0, isVideo = false) => {
     if (isVideo) {

--- a/frontend/src/components/common/PipelinePanel.js
+++ b/frontend/src/components/common/PipelinePanel.js
@@ -52,6 +52,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { pipelineAPI, pipelineRunAPI, projectAPI, jobAPI, tagAPI, textAPI, workboardAPI, promptDataAPI } from '../../services/api';
 import { MONO } from '../../theme';
+import { useConfirm } from './ConfirmDialog';
 
 // 파이프라인 step 의 이미지 결과 — 썸네일 그리드 + 클릭 시 큰 보기 (#409).
 // runStep.imageGenerationJobId 가 populate 되어 있어야 함 (백엔드 단일 GET 만 populate).
@@ -104,6 +105,7 @@ function StepImageThumbnails({ runStep }) {
 // 프로젝트 종속 작업판 파이프라인 (#397).
 // 단계: 목록 → 빌더 → 실행. 모두 한 패널에서.
 function PipelinePanel({ projectId }) {
+  const confirm = useConfirm();
   const [view, setView] = useState('list'); // list | builder | runner
   const [editingPipelineId, setEditingPipelineId] = useState(null);
   const [runningPipelineId, setRunningPipelineId] = useState(null);
@@ -182,8 +184,12 @@ function PipelinePanel({ projectId }) {
               pipeline={p}
               onRun={() => { setRunningPipelineId(p._id); setView('runner'); }}
               onEdit={() => { setEditingPipelineId(p._id); setView('builder'); }}
-              onDelete={() => {
-                if (window.confirm(`"${p.name}" 파이프라인을 삭제하시겠습니까?`)) {
+              onDelete={async () => {
+                if (await confirm({
+                  title: `"${p.name}" 파이프라인을 삭제하시겠습니까?`,
+                  description: '단계 구성이 사라집니다. 실행 기록은 남습니다.',
+                  danger: true, confirmLabel: '삭제',
+                })) {
                   deleteMutation.mutate(p._id);
                 }
               }}
@@ -1974,6 +1980,7 @@ function formatRunTime(iso) {
 
 // 파이프라인 히스토리 패널 (#407). 프로젝트 상세 탭에서 사용.
 export function PipelineHistoryPanel({ projectId }) {
+  const confirm = useConfirm();
   const queryClient = useQueryClient();
   const [selectedRunId, setSelectedRunId] = useState(null);
 
@@ -2113,8 +2120,12 @@ export function PipelineHistoryPanel({ projectId }) {
               key={r._id}
               run={r}
               onSelect={() => setSelectedRunId(r._id)}
-              onDelete={() => {
-                if (window.confirm('이 실행 기록을 삭제하시겠어요?')) deleteMutation.mutate(r._id);
+              onDelete={async () => {
+                if (await confirm({
+                  title: '이 실행 기록을 삭제하시겠습니까?',
+                  description: '실행 중 생성된 콘텐츠는 보존됩니다.',
+                  confirmLabel: '삭제',
+                })) deleteMutation.mutate(r._id);
               }}
             />
           ))}

--- a/frontend/src/components/common/TextContentPanel.js
+++ b/frontend/src/components/common/TextContentPanel.js
@@ -34,6 +34,7 @@ import toast from 'react-hot-toast';
 import { textAPI } from '../../services/api';
 import Pagination from './Pagination';
 import TagInput from './TagInput';
+import { useConfirm } from './ConfirmDialog';
 
 const MAX_CONTENT_LENGTH = 1_000_000;
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
@@ -49,6 +50,7 @@ function stripExtension(filename) {
 // kind: 'uploaded' (직접 작성, 편집/생성 가능) | 'generated' (대화에서 저장, 태그/삭제만 가능).
 // defaultTags: 새 항목 생성 시 기본 태그 (프로젝트 맥락에서 프로젝트 태그 자동 추가용).
 function TextContentPanel({ kind = 'uploaded', defaultTags = [], filterTags = [], title }) {
+  const confirm = useConfirm();
   const isUploaded = kind === 'uploaded';
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState('');
@@ -227,8 +229,11 @@ function TextContentPanel({ kind = 'uploaded', defaultTags = [], filterTags = []
                   <IconButton
                     size="small"
                     color="error"
-                    onClick={() => {
-                      if (window.confirm('삭제하시겠습니까?')) deleteMutation.mutate(item._id);
+                    onClick={async () => {
+                      if (await confirm({
+                        title: '이 텍스트를 삭제하시겠습니까?',
+                        danger: true, confirmLabel: '삭제',
+                      })) deleteMutation.mutate(item._id);
                     }}
                   >
                     <DeleteIcon fontSize="small" />

--- a/frontend/src/hooks/useJobActions.js
+++ b/frontend/src/hooks/useJobActions.js
@@ -1,0 +1,110 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
+import { jobAPI, userAPI } from '../services/api';
+import { useConfirm } from '../components/common/ConfirmDialog';
+
+// 작업(job) 공통 액션 — 재시도 / 취소 / 삭제 (#728).
+//
+// 히스토리는 두 화면에 서로 다른 레이아웃으로 존재한다:
+//   - pages/JobHistory.js            전역 통합 피드 (사이드바 → 작업 히스토리)
+//   - components/common/JobHistoryPanel.js  프로젝트 상세용 패널
+// 레이아웃은 다르지만 **동작은 같아야 한다**. 예전에는 각자 구현해서 전역 피드에만
+// 재시도가 빠져 있었다 (실패를 가장 먼저 만나는 화면에 복구 경로가 없었음).
+// 액션을 여기로 모아 한쪽에만 기능이 붙는 사고를 구조적으로 막는다.
+//
+// invalidateKeys: 액션 성공 후 무효화할 쿼리 키 배열 (화면마다 다름)
+
+const asKeyArray = (keys) =>
+  (Array.isArray(keys) ? keys : [keys]).filter(Boolean).map((k) => (Array.isArray(k) ? k : [k]));
+
+export function useJobActions({ invalidateKeys }) {
+  const queryClient = useQueryClient();
+  const confirm = useConfirm();
+
+  const { data: profileData } = useQuery({ queryKey: ['userProfile'], queryFn: () => userAPI.getProfile() });
+  const preferences = profileData?.data?.user?.preferences || {};
+
+  const invalidate = () => {
+    asKeyArray(invalidateKeys).forEach((queryKey) => queryClient.invalidateQueries({ queryKey }));
+  };
+
+  const retryMutation = useMutation({
+    mutationFn: jobAPI.retry,
+    onSuccess: () => { toast.success('작업을 재시도합니다'); invalidate(); },
+    onError: (error) => toast.error('재시도 실패: ' + (error.response?.data?.message || error.message)),
+  });
+
+  const cancelMutation = useMutation({
+    mutationFn: jobAPI.cancel,
+    onSuccess: () => { toast.success('작업이 취소되었습니다'); invalidate(); },
+    onError: (error) => toast.error('취소 실패: ' + (error.response?.data?.message || error.message)),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: ({ id, deleteContent }) => jobAPI.delete(id, deleteContent),
+    onSuccess: (response) => {
+      const { deletedImagesCount = 0, deletedVideosCount = 0 } = response.data || {};
+      if (deletedImagesCount > 0 || deletedVideosCount > 0) {
+        toast.success(`작업과 ${deletedImagesCount}개 이미지, ${deletedVideosCount}개 동영상이 삭제되었습니다`);
+        queryClient.invalidateQueries({ queryKey: ['generatedImages'] });
+        queryClient.invalidateQueries({ queryKey: ['generatedVideos'] });
+      } else {
+        toast.success('작업이 삭제되었습니다');
+      }
+      invalidate();
+    },
+    onError: (error) => toast.error('삭제 실패: ' + (error.response?.data?.message || error.message)),
+  });
+
+  const retry = async (job) => {
+    const ok = await confirm({
+      title: '작업을 재시도하시겠습니까?',
+      description: '같은 입력값으로 작업을 큐에 다시 넣습니다.',
+      confirmLabel: '재시도',
+    });
+    if (ok) retryMutation.mutate(job._id);
+  };
+
+  const cancel = async (job) => {
+    const ok = await confirm({
+      title: '작업을 취소하시겠습니까?',
+      description: '진행 중이던 외부 API 호출까지 즉시 중단됩니다.',
+      confirmLabel: '작업 취소',
+      cancelLabel: '계속 진행',
+    });
+    if (ok) cancelMutation.mutate(job._id);
+  };
+
+  // 콘텐츠 동반 삭제는 사용자 설정(deleteContentWithHistory)에 따라 분기.
+  // 동반 삭제일 때만 되돌릴 수 없으므로 danger 는 그 경우에만 붙인다.
+  const remove = async (job) => {
+    const contentCount = (job.resultImages?.length || 0) + (job.resultVideos?.length || 0);
+    const withContent = !!preferences.deleteContentWithHistory && contentCount > 0;
+
+    const ok = await confirm(
+      withContent
+        ? {
+            title: '작업과 콘텐츠를 함께 삭제하시겠습니까?',
+            description: `연관된 ${contentCount}개의 콘텐츠(이미지/동영상)도 같이 삭제됩니다.`,
+            danger: true,
+            confirmLabel: '모두 삭제',
+          }
+        : {
+            title: '작업 히스토리를 삭제하시겠습니까?',
+            description: '생성된 이미지/동영상은 보존됩니다.',
+            confirmLabel: '삭제',
+          }
+    );
+    if (ok) deleteMutation.mutate({ id: job._id, deleteContent: withContent });
+  };
+
+  return {
+    retry,
+    cancel,
+    remove,
+    preferences,
+    isPending: retryMutation.isPending || cancelMutation.isPending || deleteMutation.isPending,
+  };
+}
+
+export default useJobActions;

--- a/frontend/src/pages/JobHistory.js
+++ b/frontend/src/pages/JobHistory.js
@@ -36,6 +36,8 @@ import {
   Close,
   ViewList,
   GridView,
+  RestartAlt,
+  StopCircle,
 } from '@mui/icons-material';
 import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import { useNavigate, useSearchParams } from 'react-router-dom';
@@ -59,6 +61,7 @@ import SegmentTabs from '../components/common/SegmentTabs';
 import EmptyState from '../components/common/EmptyState';
 import { MONO } from '../theme';
 import { relativeTime } from '../utils/relativeTime';
+import { useJobActions } from '../hooks/useJobActions';
 
 const TYPE_LABEL = { pipeline: '파이프라인', image: '이미지', video: '영상', text: '텍스트' };
 
@@ -467,9 +470,6 @@ function JobHistory() {
   const { data: convsRes, isLoading: convsLoading } = useQuery({ queryKey: ['historyConvs', limit], queryFn: () => conversationAPI.getMy({ limit }), placeholderData: keepPreviousData });
   const { data: runsRes, isLoading: runsLoading } = useQuery({ queryKey: ['historyRuns', limit], queryFn: () => dashboardAPI.getAllPipelineRuns({ limit }), refetchInterval: config.monitoring.recentJobsInterval, placeholderData: keepPreviousData });
 
-  const { data: profileData } = useQuery({ queryKey: ['userProfile'], queryFn: () => userAPI.getProfile() });
-  const userPreferences = profileData?.data?.user?.preferences || {};
-
   const loading = jobsLoading || convsLoading || runsLoading;
 
   const items = useMemo(() => {
@@ -512,19 +512,9 @@ function JobHistory() {
   const changeViewMode = (mode) => { if (mode) { setViewMode(mode); localStorage.setItem('jobHistoryViewMode', mode); } };
 
   // ---- mutations ----
-  const deleteMutation = useMutation({ mutationFn: ({ id, deleteContent }) => jobAPI.delete(id, deleteContent),
-      onSuccess: (response) => {
-        const { deletedImagesCount = 0, deletedVideosCount = 0 } = response.data || {};
-        if (deletedImagesCount > 0 || deletedVideosCount > 0) {
-          toast.success(`작업과 ${deletedImagesCount}개 이미지, ${deletedVideosCount}개 동영상이 삭제되었습니다`);
-          queryClient.invalidateQueries({ queryKey: ['generatedImages'] });
-          queryClient.invalidateQueries({ queryKey: ['generatedVideos'] });
-        } else {
-          toast.success('작업이 삭제되었습니다');
-        }
-        queryClient.invalidateQueries({ queryKey: ['historyJobs'] });
-      },
-      onError: (error) => toast.error('삭제 실패: ' + error.message), });
+  // 재시도/취소/삭제는 프로젝트 상세 패널(JobHistoryPanel)과 동작을 공유한다 (#728).
+  // 예전에는 각자 구현이라 이 화면에만 재시도가 빠져 있었다.
+  const jobActions = useJobActions({ invalidateKeys: ['historyJobs'] });
   const savePromptMutation = useMutation({ mutationFn: promptDataAPI.create,
     onSuccess: () => { toast.success('프롬프트 데이터가 저장되었습니다'); setSaveJob(null); },
     onError: (error) => toast.error('프롬프트 저장 실패: ' + (error.response?.data?.message || error.message)), });
@@ -550,18 +540,9 @@ function JobHistory() {
     }
   };
 
-  const handleDelete = (job) => {
-    closeMenu();
-    const hasContent = (job.resultImages?.length > 0) || (job.resultVideos?.length > 0);
-    if (userPreferences.deleteContentWithHistory && hasContent) {
-      const n = (job.resultImages?.length || 0) + (job.resultVideos?.length || 0);
-      if (window.confirm(`작업과 연관된 ${n}개의 컨텐츠(이미지/동영상)도 함께 삭제하시겠습니까?\n\n이 작업은 되돌릴 수 없습니다.`)) {
-        deleteMutation.mutate({ id: job._id, deleteContent: true });
-      }
-    } else if (window.confirm('작업 히스토리를 삭제하시겠습니까?\n\n생성된 이미지/동영상은 보존됩니다.')) {
-      deleteMutation.mutate({ id: job._id, deleteContent: false });
-    }
-  };
+  const handleDelete = (job) => { closeMenu(); jobActions.remove(job); };
+  const handleRetry = (job) => { closeMenu(); jobActions.retry(job); };
+  const handleCancel = (job) => { closeMenu(); jobActions.cancel(job); };
 
   const handleContinue = async (job) => {
     try {
@@ -692,6 +673,17 @@ function JobHistory() {
         {menuJob && ['completed', 'failed'].includes(menuJob.status) && (
           <MenuItem onClick={() => { const j = menuJob; closeMenu(); setSaveJob(j); }}>
             <Save fontSize="small" sx={{ mr: 1 }} /> 프롬프트 저장
+          </MenuItem>
+        )}
+        {/* 실패 복구 경로 — 이 화면에 없어서 실패한 작업을 되살릴 방법이 없었다 (#728) */}
+        {menuJob?.status === 'failed' && (
+          <MenuItem onClick={() => handleRetry(menuJob)}>
+            <RestartAlt fontSize="small" sx={{ mr: 1 }} /> 재시도
+          </MenuItem>
+        )}
+        {menuJob && ['pending', 'processing'].includes(menuJob.status) && (
+          <MenuItem onClick={() => handleCancel(menuJob)}>
+            <StopCircle fontSize="small" sx={{ mr: 1 }} /> 작업 취소
           </MenuItem>
         )}
         <MenuItem onClick={() => menuJob && handleDelete(menuJob)} sx={{ color: 'error.main' }}>

--- a/frontend/src/pages/MyImages.js
+++ b/frontend/src/pages/MyImages.js
@@ -36,6 +36,7 @@ import TagInput from '../components/common/TagInput';
 import MediaGrid from '../components/common/MediaGrid';
 import TextContentPanel from '../components/common/TextContentPanel';
 import PageHeader from '../components/common/PageHeader';
+import { useConfirm } from '../components/common/ConfirmDialog';
 
 // 필터 레일 (5c 후속) — 좌측 sticky. 프로젝트 / 일반 태그 그룹.
 // 클릭으로 selectedTagIds 토글. backend 변경 없이 기존 ?tags=... CSV 로 필터.
@@ -340,6 +341,7 @@ function UploadDialog({ open, onClose, onSuccess }) {
 }
 
 function MyImages() {
+  const confirm = useConfirm();
   const [tab, setTab] = useState(0);
   const [uploadOpen, setUploadOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
@@ -411,34 +413,26 @@ function MyImages() {
     setEditOpen(true);
   };
 
-  const handleDelete = (item) => {
+  const handleDelete = async (item) => {
     const deleteHistorySetting = userPreferences.deleteHistoryWithContent;
 
     if (tab === 1) {
-      if (window.confirm('이미지를 삭제하시겠습니까?')) {
+      if (await confirm({ title: '업로드한 이미지를 삭제하시겠습니까?', danger: true, confirmLabel: '삭제' })) {
         deleteUploadedMutation.mutate(item._id);
       }
-    } else if (tab === 2) {
-      if (deleteHistorySetting && item.jobId) {
-        if (window.confirm('동영상과 연관된 작업 히스토리도 함께 삭제하시겠습니까?\n\n이 작업은 되돌릴 수 없습니다.')) {
-          deleteVideoMutation.mutate({ id: item._id, deleteJob: true });
-        }
-      } else {
-        if (window.confirm('동영상을 삭제하시겠습니까?\n\n작업 히스토리는 보존됩니다.')) {
-          deleteVideoMutation.mutate({ id: item._id, deleteJob: false });
-        }
-      }
-    } else {
-      if (deleteHistorySetting && item.jobId) {
-        if (window.confirm('이미지와 연관된 작업 히스토리도 함께 삭제하시겠습니까?\n\n이 작업은 되돌릴 수 없습니다.')) {
-          deleteGeneratedMutation.mutate({ id: item._id, deleteJob: true });
-        }
-      } else {
-        if (window.confirm('이미지를 삭제하시겠습니까?\n\n작업 히스토리는 보존됩니다.')) {
-          deleteGeneratedMutation.mutate({ id: item._id, deleteJob: false });
-        }
-      }
+      return;
     }
+
+    const isVideo = tab === 2;
+    const label = isVideo ? '동영상' : '이미지';
+    const withHistory = !!deleteHistorySetting && !!item.jobId;
+    const ok = await confirm(withHistory
+      ? { title: `${label}과 작업 히스토리를 함께 삭제하시겠습니까?`, description: `${label}을 만든 작업 기록도 같이 사라집니다.`, danger: true, confirmLabel: '모두 삭제' }
+      : { title: `${label}을 삭제하시겠습니까?`, description: '작업 히스토리는 보존됩니다.', confirmLabel: '삭제' });
+    if (!ok) return;
+
+    const mutation = isVideo ? deleteVideoMutation : deleteGeneratedMutation;
+    mutation.mutate({ id: item._id, deleteJob: withHistory });
   };
 
   const handleUploadSuccess = () => {

--- a/frontend/src/pages/ProjectDetail.js
+++ b/frontend/src/pages/ProjectDetail.js
@@ -60,6 +60,7 @@ import ProjectEditDialog from '../components/common/ProjectEditDialog';
 import { BRAND_GRADIENTS } from '../utils/brandGradients';
 import { downloadBlob } from '../utils/download';
 import { useAuth } from '../contexts/AuthContext';
+import { useConfirm } from '../components/common/ConfirmDialog';
 
 // 이미지/비디오 편집 다이얼로그
 function ImageEditDialog({ image, open, onClose, isVideo = false, projectId }) {
@@ -139,6 +140,7 @@ function ImageEditDialog({ image, open, onClose, isVideo = false, projectId }) {
 
 // 이미지 탭 - MediaGrid 사용
 function ImagesTab({ projectId }) {
+  const confirm = useConfirm();
   const [editOpen, setEditOpen] = useState(false);
   const [editImage, setEditImage] = useState(null);
   const [editIsVideo, setEditIsVideo] = useState(false);
@@ -202,30 +204,20 @@ function ImagesTab({ projectId }) {
     setEditOpen(true);
   };
 
-  const handleDeleteImage = (item) => {
-    const deleteHistorySetting = userPreferences.deleteHistoryWithContent;
-    if (deleteHistorySetting && item.jobId) {
-      if (window.confirm('이미지와 연관된 작업 히스토리도 함께 삭제하시겠습니까?\n\n이 작업은 되돌릴 수 없습니다.')) {
-        deleteGeneratedMutation.mutate({ id: item._id, deleteJob: true });
-      }
-    } else {
-      if (window.confirm('이미지를 삭제하시겠습니까?\n\n작업 히스토리는 보존됩니다.')) {
-        deleteGeneratedMutation.mutate({ id: item._id, deleteJob: false });
-      }
-    }
+  const handleDeleteImage = async (item) => {
+    const withHistory = !!userPreferences.deleteHistoryWithContent && !!item.jobId;
+    const ok = await confirm(withHistory
+      ? { title: '이미지와 작업 히스토리를 함께 삭제하시겠습니까?', description: '이미지를 만든 작업 기록도 같이 사라집니다.', danger: true, confirmLabel: '모두 삭제' }
+      : { title: '이미지를 삭제하시겠습니까?', description: '작업 히스토리는 보존됩니다.', confirmLabel: '삭제' });
+    if (ok) deleteGeneratedMutation.mutate({ id: item._id, deleteJob: withHistory });
   };
 
-  const handleDeleteVideo = (item) => {
-    const deleteHistorySetting = userPreferences.deleteHistoryWithContent;
-    if (deleteHistorySetting && item.jobId) {
-      if (window.confirm('동영상과 연관된 작업 히스토리도 함께 삭제하시겠습니까?\n\n이 작업은 되돌릴 수 없습니다.')) {
-        deleteVideoMutation.mutate({ id: item._id, deleteJob: true });
-      }
-    } else {
-      if (window.confirm('동영상을 삭제하시겠습니까?\n\n작업 히스토리는 보존됩니다.')) {
-        deleteVideoMutation.mutate({ id: item._id, deleteJob: false });
-      }
-    }
+  const handleDeleteVideo = async (item) => {
+    const withHistory = !!userPreferences.deleteHistoryWithContent && !!item.jobId;
+    const ok = await confirm(withHistory
+      ? { title: '동영상과 작업 히스토리를 함께 삭제하시겠습니까?', description: '동영상을 만든 작업 기록도 같이 사라집니다.', danger: true, confirmLabel: '모두 삭제' }
+      : { title: '동영상을 삭제하시겠습니까?', description: '작업 히스토리는 보존됩니다.', confirmLabel: '삭제' });
+    if (ok) deleteVideoMutation.mutate({ id: item._id, deleteJob: withHistory });
   };
 
   const handleImageBulkToggle = useCallback((id) => {
@@ -580,6 +572,7 @@ function WorldviewTab({ projectTag }) {
 
 // 작업판 멤버십 탭 (#396).
 function WorkboardsTab({ projectId }) {
+  const confirm = useConfirm();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -649,8 +642,12 @@ function WorkboardsTab({ projectId }) {
               <IconButton
                 size="small"
                 color="error"
-                onClick={() => {
-                  if (window.confirm('작업판을 프로젝트에서 제거하시겠습니까? (작업판 자체는 삭제되지 않습니다)')) {
+                onClick={async () => {
+                  if (await confirm({
+                    title: '작업판을 프로젝트에서 제거하시겠습니까?',
+                    description: '연결만 끊습니다. 작업판 자체는 삭제되지 않습니다.',
+                    confirmLabel: '제거',
+                  })) {
                     removeMutation.mutate(wb._id);
                   }
                 }}

--- a/frontend/src/pages/WorkboardCatalogPage.js
+++ b/frontend/src/pages/WorkboardCatalogPage.js
@@ -50,6 +50,7 @@ import { usePersistedState } from '../hooks/usePersistedState';
 import { MONO } from '../theme';
 import PageHeader from '../components/common/PageHeader';
 import EmptyState from '../components/common/EmptyState';
+import { useConfirm } from '../components/common/ConfirmDialog';
 
 
 // ── 사용자: 작업판 선택(실행) ────────────────────────────────
@@ -113,6 +114,7 @@ function WorkboardDetailDialog({ workboard, open, onClose, onSelect }) {
 // ── 공통 페이지: admin 권한에 따라 관리 UI 표시/미표시 ───────────
 // 사용자 "작업판"(admin=false)과 관리자 "작업판 관리"(admin=true)가 같은 레이아웃을 공유.
 function WorkboardCatalogPage({ admin = false }) {
+  const confirm = useConfirm();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [searchParams] = useSearchParams();
@@ -167,12 +169,20 @@ function WorkboardCatalogPage({ admin = false }) {
   const handleSelect = (wb) => { setDetailWb(null); selectWorkboard(wb, projectId, navigate); };
   const handleEdit = (wb) => navigate(`/admin/workboards/${wb._id}/edit`);
   const handleCreate = () => navigate('/admin/workboards/new');
-  const handleDelete = (wb) => {
-    if (window.confirm(`"${wb.name}" 작업판을 완전히 삭제하시겠습니까?\n\n이 작업은 되돌릴 수 없습니다.`)) deleteMutation.mutate(wb._id);
+  const handleDelete = async (wb) => {
+    if (await confirm({
+      title: `"${wb.name}" 작업판을 완전히 삭제하시겠습니까?`,
+      description: '작업판 정의와 입력 양식이 사라집니다. 이미 생성된 결과물은 보존됩니다.',
+      danger: true, confirmLabel: '완전 삭제',
+    })) deleteMutation.mutate(wb._id);
   };
-  const handleToggle = (wb) => {
+  const handleToggle = async (wb) => {
     const action = wb.isActive ? '비활성화' : '활성화';
-    if (window.confirm(`"${wb.name}" 작업판을 ${action}하시겠습니까?`)) toggleMutation.mutate({ id: wb._id, isActive: wb.isActive });
+    if (await confirm({
+      title: `"${wb.name}" 작업판을 ${action}하시겠습니까?`,
+      description: wb.isActive ? '비활성화하면 일반 사용자에게 보이지 않습니다.' : '활성화하면 허용된 그룹의 사용자에게 노출됩니다.',
+      confirmLabel: action,
+    })) toggleMutation.mutate({ id: wb._id, isActive: wb.isActive });
   };
   const handleDuplicate = (wb) => {
     const name = prompt('복제할 작업판의 이름을 입력하세요:', `${wb.name} (복제)`);

--- a/frontend/src/pages/admin/GroupManagementPage.js
+++ b/frontend/src/pages/admin/GroupManagementPage.js
@@ -37,6 +37,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { groupAPI, adminAPI } from '../../services/api';
 import PageHeader from '../../components/common/PageHeader';
+import { useConfirm } from '../../components/common/ConfirmDialog';
 
 // 그룹 생성/편집 다이얼로그
 function GroupFormDialog({ open, onClose, group, onSave }) {
@@ -203,6 +204,7 @@ function GroupMembersDialog({ open, onClose, group }) {
 }
 
 function GroupManagementPage() {
+  const confirm = useConfirm();
   const [formOpen, setFormOpen] = useState(false);
   const [membersOpen, setMembersOpen] = useState(false);
   const [editingGroup, setEditingGroup] = useState(null);
@@ -254,12 +256,16 @@ function GroupManagementPage() {
     setFormOpen(true);
   };
 
-  const handleDelete = (group) => {
+  const handleDelete = async (group) => {
     if (group.isDefault) {
       toast.error('기본 그룹은 삭제할 수 없습니다.');
       return;
     }
-    if (window.confirm(`"${group.name}" 그룹을 삭제하시겠습니까? 멤버는 해제됩니다.`)) {
+    if (await confirm({
+      title: `"${group.name}" 그룹을 삭제하시겠습니까?`,
+      description: '이 그룹의 멤버는 그룹에서 해제되고, 그룹에만 허용됐던 작업판에 접근할 수 없게 됩니다.',
+      danger: true, confirmLabel: '삭제',
+    })) {
       deleteMutation.mutate(group._id);
     }
   };


### PR DESCRIPTION
## 1. 전역 작업 히스토리에 재시도가 없던 문제

같은 기능이 두 곳에 각자 구현돼 있어 **한쪽에만 재시도가 빠져** 있었습니다.

| 구현 | 사용처 | 재시도 |
|---|---|---|
| `pages/JobHistory.js` | 사이드바 → 작업 히스토리 | **없음** |
| `components/common/JobHistoryPanel.js` | 프로젝트 상세 | 있음 |

사용자가 실패를 가장 먼저 만나는 화면에 복구 경로가 없는 상태였습니다.

**`hooks/useJobActions.js`** 를 신설해 재시도·취소·삭제와 확인 플로우를 양쪽이 공유합니다. 레이아웃은 서로 다른 채로 두고(전면 통합은 약 2000줄 재작성이라 별도 과제로 남김), **동작만 한 곳에 모아** "한쪽에만 액션이 붙는" 사고를 구조적으로 막았습니다.

- `/jobs` 메뉴에 **재시도**(failed) · **작업 취소**(pending/processing) 노출
- 재시도 아이콘은 '계속하기'(`Refresh`)와 헷갈리지 않게 `RestartAlt` 사용
- `JobHistoryPanel` 의 중복 `userProfile` 조회 제거 (훅이 제공)

## 2. 네이티브 `window.confirm` 23곳 제거

**`components/common/ConfirmDialog.js`** — `ConfirmProvider` + `useConfirm()`. Promise 기반이라 `if (window.confirm(x))` → `if (await confirm({...}))` 로 구조 변경 없이 옮겨집니다.

기존에는 경고를 `\n\n` 줄바꿈으로 붙일 수밖에 없어 **"되돌릴 수 없습니다" 가 본문과 같은 무게**로 보였습니다. 이제:

- 결과는 `description`
- 되돌릴 수 없는 동작은 `danger` → 경고 아이콘 + 경고 박스 + error 색 버튼
- **파괴적 동작은 '취소'에 기본 포커스** (Enter 오폭 방지)
- 확인 버튼 라벨을 동작명으로 (`확인` → `삭제` / `재시도` / `완전 삭제`)

전환 내역: PipelinePanel(2) · JobHistoryPanel(4) · ConversationHistoryPanel(1) · TextContentPanel(1) · ProjectDetail(5) · MyImages(5) · JobHistory(2) · WorkboardCatalogPage(2) · GroupManagementPage(1)

문구도 함께 정리해 **삭제 범위(콘텐츠 동반 여부)를 제목에서 바로** 알 수 있게 했습니다.

## 검증

- 실패한 작업 → ⋮ 메뉴에 재시도 노출 → 확인 다이얼로그 → 취소까지 브라우저 확인
- danger 변형(작업판 완전 삭제)은 경고 박스·버튼색 확인 후 **취소 → 작업판 10개 유지(데이터 불변)** 확인
- 콘솔 에러 없음, `window.confirm`/`alert` 잔여 **0건**
- 프론트 테스트 33개 통과

## 남은 과제

두 히스토리의 **레이아웃 중복**은 남아 있습니다. 전면 통합(`JobHistoryPanel` 폐기 + ProjectDetail 을 v2 피드로 이식)은 회귀 범위가 커서 별도 라운드로 미뤘습니다.

closes #728

🤖 Generated with [Claude Code](https://claude.com/claude-code)