### PR TITLE
fix: UI 일관성 1차 — 표기·날짜·라벨 (#730)

### DIFF
--- a/docs/design-v2/TOKENS.md
+++ b/docs/design-v2/TOKENS.md
@@ -57,6 +57,13 @@ v2 는 `palette.*.light` 를 **저알파 틴트 배경**으로 재정의했다. 
 | navbar (콘솔 레일) | `#0B0D10`, 활성 `#181B21` |
 | grey 스케일 | 다크 반전 정책 유지 (#442) — `grey.50~300` 은 어두운 surface |
 
+## 표기 규칙
+
+- **시각**: 목록·카드의 "언제"는 `utils/relativeTime` (7일 지나면 `yy. M. d.` 폴백). 상세 다이얼로그·관리 테이블처럼 **정확한 시점이 필요한 곳만** 절대 표기 (#730)
+- **명칭**: 한 화면은 한 이름으로만 부른다 — `/content` 는 **"내 콘텐츠"** (사이드바·명령 팔레트·페이지 제목·대시보드 링크 일치). 표준어는 "콘텐츠" (컨텐츠 아님)
+- **빈 값**: 카드에서 설명이 비면 placeholder 문구 대신 자리를 비운다. 높이 정렬이 필요하면 `minHeight` 로 확보
+- **주 액션 색**: primary 고정. success/warning 등 의미색은 상태 표시에만 쓰고 버튼에 쓰지 않는다
+
 ## 컴포넌트 라이브러리 (직접 호출 — 사본 생성 금지)
 
 `frontend/src/components/common/`: PageHeader · SegmentTabs · EmptyState · ToneChip (+화면 라운드에서 추가 예정)

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -109,7 +109,7 @@ function MainLayout() {
   const location = useLocation();
   const queryClient = useQueryClient();
 
-  // 특정 메뉴 선택 시 쿼리 무효화 (작업 히스토리, 내 컨텐츠)
+  // 특정 메뉴 선택 시 쿼리 무효화 (작업 히스토리, 내 콘텐츠)
   useEffect(() => {
     const refreshPaths = ['/jobs', '/content'];
     if (refreshPaths.includes(location.pathname)) {

--- a/frontend/src/components/Sidebar.js
+++ b/frontend/src/components/Sidebar.js
@@ -41,7 +41,7 @@ const workItems = [
   { text: '대시보드', path: '/dashboard', icon: <Dashboard /> },
   { text: '작업판', path: '/workboards', icon: <ViewModule /> },
   { text: '프로젝트', path: '/projects', icon: <FolderSpecial /> },
-  { text: '내 컨텐츠', path: '/content', icon: <Image /> },
+  { text: '내 콘텐츠', path: '/content', icon: <Image /> },
   { text: '작업 히스토리', path: '/jobs', icon: <History /> },
 ];
 
@@ -181,7 +181,7 @@ function Sidebar({ mobileOpen, onMobileToggle }) {
       sx={{
         width: { md: DRAWER_WIDTH },
         flexShrink: { md: 0 },
-        // 사이드바 영역 자체의 배경색을 drawer paper 와 동일하게 — 컨텐츠 짧을 때 / 스크롤 시 흰 영역 노출 방지 (PC 도)
+        // 사이드바 영역 자체의 배경색을 drawer paper 와 동일하게 — 콘텐츠 짧을 때 / 스크롤 시 흰 영역 노출 방지 (PC 도)
         bgcolor: { md: 'navbar.main' },
       }}
     >
@@ -195,7 +195,7 @@ function Sidebar({ mobileOpen, onMobileToggle }) {
         }}
         sx={{
           display: { xs: 'block', md: 'none' },
-          '& .MuiDrawer-paper': paperSx, // 컨텐츠가 Paper 높이를 초과할 때 하단 흰색 노출 방지 (#327)
+          '& .MuiDrawer-paper': paperSx, // 콘텐츠가 Paper 높이를 초과할 때 하단 흰색 노출 방지 (#327)
         }}
       >
         {drawer}

--- a/frontend/src/components/common/CommandPalette.js
+++ b/frontend/src/components/common/CommandPalette.js
@@ -101,7 +101,7 @@ export default function CommandPalette({ open, onClose }) {
       {
         group: '명령',
         icon: <ImageIcon fontSize="small" />,
-        name: '내 컨텐츠',
+        name: '내 콘텐츠',
         action: () => navigate('/content'),
       },
       {

--- a/frontend/src/components/common/ConversationChatPanel.js
+++ b/frontend/src/components/common/ConversationChatPanel.js
@@ -170,7 +170,7 @@ function ConversationChatPanel({ workboard, conversationId }) {
               content={msg.content}
               attachments={msg.attachments}
               actions={msg.role === 'assistant' && (
-                <Tooltip title="이 응답을 텍스트 컨텐츠로 저장">
+                <Tooltip title="이 응답을 텍스트 콘텐츠로 저장">
                   <IconButton
                     size="small"
                     onClick={() => saveMessageMutation.mutate({ conversationJobId: conversationId, messageIndex: idx })}

--- a/frontend/src/components/common/ConversationHistoryPanel.js
+++ b/frontend/src/components/common/ConversationHistoryPanel.js
@@ -38,6 +38,7 @@ import { Collapse, Paper } from '@mui/material';
 import { conversationAPI, textAPI } from '../../services/api';
 import Pagination from './Pagination';
 import { useConfirm } from './ConfirmDialog';
+import { relativeTime } from '../../utils/relativeTime';
 
 // LLM 대화 히스토리 패널 (#373).
 // JobHistory 페이지의 \"텍스트\" 탭에서 사용. 카드 리스트 + 상세 다이얼로그.
@@ -115,7 +116,7 @@ function ConversationHistoryPanel({ fetchFn, queryKey = 'conversations' }) {
                   )}
                   <Box sx={{ flexGrow: 1 }} />
                   <Typography variant="caption" color="text.secondary">
-                    {new Date(conv.createdAt).toLocaleString('ko-KR')}
+                    {relativeTime(conv.createdAt)}
                   </Typography>
                 </Stack>
                 {lastUserMsg && (
@@ -277,7 +278,7 @@ function ConversationHistoryPanel({ fetchFn, queryKey = 'conversations' }) {
                     </Typography>
                   </Box>
                   {msg.role === 'assistant' && (
-                    <Tooltip title="이 응답을 텍스트 컨텐츠로 저장">
+                    <Tooltip title="이 응답을 텍스트 콘텐츠로 저장">
                       <IconButton
                         size="small"
                         onClick={() => saveMessageMutation.mutate({ conversationJobId: detailItem._id, messageIndex: idx })}

--- a/frontend/src/components/common/JobHistoryPanel.js
+++ b/frontend/src/components/common/JobHistoryPanel.js
@@ -60,6 +60,7 @@ import ProjectTagChip from './ProjectTagChip';
 import WorkboardSelectDialog from './WorkboardSelectDialog';
 import { DEFAULT_TAG_COLOR } from '../../theme';
 import { useJobActions } from '../../hooks/useJobActions';
+import { relativeTime } from '../../utils/relativeTime';
 
 export function SavePromptDialog({ open, onClose, job, onSave }) {
   const [imageSelectOpen, setImageSelectOpen] = useState(false);
@@ -518,7 +519,7 @@ function JobCard({ job, onView, onRetry, onCancel, onDelete, onImageView, onCont
             <Box>
               <Typography variant="caption" color="text.secondary" display="block">생성 시간</Typography>
               <Typography variant="body2" sx={{ fontSize: '0.75rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                {new Date(job.createdAt).toLocaleDateString()}
+                {relativeTime(job.createdAt)}
               </Typography>
             </Box>
             <Box>

--- a/frontend/src/components/common/MediaGrid.js
+++ b/frontend/src/components/common/MediaGrid.js
@@ -39,6 +39,7 @@ import { downloadBlob, downloadFromUrl } from '../../utils/download';
 import Pagination from './Pagination';
 import VideoViewerDialog from './VideoViewerDialog';
 import ProjectTagChip from './ProjectTagChip';
+import { relativeTime } from '../../utils/relativeTime';
 
 function ImageDetailDialog({ image, open, onClose, type }) {
   if (!image) return null;
@@ -152,7 +153,7 @@ function ImageCard({ image, type, onEdit, onDelete, onView, readOnly = false, sh
         </Typography>
         <Typography variant="caption" color="text.secondary" display="block">{formatFileSize(image.size)}</Typography>
         <Typography variant="caption" color="text.secondary" display="block">
-          {new Date(image.createdAt).toLocaleDateString()}
+          {relativeTime(image.createdAt)}
         </Typography>
 
         {showTags && image.tags?.length > 0 && (
@@ -261,7 +262,7 @@ function VideoCard({ video, onEdit, onDelete, onView, readOnly = false, showTags
         </Typography>
         <Typography variant="caption" color="text.secondary" display="block">{formatFileSize(video.size)}</Typography>
         <Typography variant="caption" color="text.secondary" display="block">
-          {new Date(video.createdAt).toLocaleDateString()}
+          {relativeTime(video.createdAt)}
         </Typography>
 
         {showTags && video.tags?.length > 0 && (

--- a/frontend/src/components/common/MetadataItemGrid.js
+++ b/frontend/src/components/common/MetadataItemGrid.js
@@ -15,7 +15,7 @@ import { Box, Typography } from '@mui/material';
  * @param {Array} props.items — 렌더할 아이템 배열
  * @param {(item, index) => React.Node} props.renderItem — 카드 렌더 콜백
  * @param {(item, index) => string|number} [props.getKey] — key 추출 (default: item.id || index)
- * @param {React.Node} [props.empty] — items.length === 0 일 때 렌더할 컨텐츠
+ * @param {React.Node} [props.empty] — items.length === 0 일 때 렌더할 콘텐츠
  * @param {Object} [props.sx] — 추가 스타일
  */
 function MetadataItemGrid({ items, renderItem, getKey, empty, sx }) {

--- a/frontend/src/components/common/PipelinePanel.js
+++ b/frontend/src/components/common/PipelinePanel.js
@@ -259,7 +259,6 @@ function PipelineCard({ pipeline, onRun, onEdit, onDelete }) {
           <Box sx={{ display: 'flex', gap: 1, flexShrink: 0 }}>
             <Button
               variant="contained"
-              color="success"
               startIcon={<PlayArrowIcon />}
               onClick={onRun}
               disabled={steps.length === 0}
@@ -333,7 +332,6 @@ function PipelineCard({ pipeline, onRun, onEdit, onDelete }) {
       {isMobile && (
         <CardActions sx={{ pt: 0, justifyContent: 'flex-end', borderTop: 1, borderColor: 'divider' }}>
           <Button
-            color="success"
             variant="contained"
             startIcon={<PlayArrowIcon />}
             onClick={onRun}
@@ -1735,7 +1733,6 @@ function PipelineRunner({ projectId, pipelineId, onClose }) {
           {!runId && (
             <Button
               variant="contained"
-              color="success"
               startIcon={startMutation.isPending ? <CircularProgress size={18} color="inherit" /> : <PlayArrowIcon />}
               onClick={handleStart}
               disabled={startMutation.isPending || !initialPrompt.trim()}

--- a/frontend/src/components/common/TextContentPanel.js
+++ b/frontend/src/components/common/TextContentPanel.js
@@ -35,6 +35,7 @@ import { textAPI } from '../../services/api';
 import Pagination from './Pagination';
 import TagInput from './TagInput';
 import { useConfirm } from './ConfirmDialog';
+import { relativeTime } from '../../utils/relativeTime';
 
 const MAX_CONTENT_LENGTH = 1_000_000;
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
@@ -46,7 +47,7 @@ function stripExtension(filename) {
   return idx > 0 ? filename.slice(0, idx) : filename;
 }
 
-// 텍스트 컨텐츠 패널 (#387).
+// 텍스트 콘텐츠 패널 (#387).
 // kind: 'uploaded' (직접 작성, 편집/생성 가능) | 'generated' (대화에서 저장, 태그/삭제만 가능).
 // defaultTags: 새 항목 생성 시 기본 태그 (프로젝트 맥락에서 프로젝트 태그 자동 추가용).
 function TextContentPanel({ kind = 'uploaded', defaultTags = [], filterTags = [], title }) {
@@ -183,7 +184,7 @@ function TextContentPanel({ kind = 'uploaded', defaultTags = [], filterTags = []
                   )}
                   <Box sx={{ flexGrow: 1 }} />
                   <Typography variant="caption" color="text.secondary">
-                    {new Date(item.createdAt).toLocaleString('ko-KR')}
+                    {relativeTime(item.createdAt)}
                   </Typography>
                 </Stack>
                 <Typography

--- a/frontend/src/components/common/WorkboardCatalog.js
+++ b/frontend/src/components/common/WorkboardCatalog.js
@@ -3,6 +3,7 @@ import { usePersistedState } from '../../hooks/usePersistedState';
 import { Box, Paper, Typography, Chip, IconButton, Button, InputBase } from '@mui/material';
 import { MONO } from '../../theme';
 import { ToneChip } from './ToneChip';
+import { relativeTime } from '../../utils/relativeTime';
 import {
   Search,
   Close,
@@ -222,10 +223,11 @@ export function WorkboardCard({ wb, admin, onClick, onEdit, onMenu, onInfo, grou
         <ToneChip tone={OUT_TONE[out]} label={out} mono sx={{ flex: '0 0 auto' }} />
       </Box>
 
-      {/* description */}
+      {/* description — 없으면 자리만 비운다. 카드 높이 정렬을 위해 minHeight 는 유지하되
+          "설명이 없습니다." 를 반복 노출하지 않는다 (#730) */}
       <Typography sx={{ fontSize: 11.5, color: 'text.secondary', lineHeight: 1.5, textWrap: 'pretty', minHeight: 32,
         display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>
-        {wb.description || '설명이 없습니다.'}
+        {wb.description}
       </Typography>
 
       {/* admin: allowed groups */}
@@ -257,7 +259,7 @@ export function WorkboardCard({ wb, admin, onClick, onEdit, onMenu, onInfo, grou
       {admin ? (
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           <Typography sx={{ fontSize: 11, color: 'text.tertiary' }} noWrap>
-            {wb.updatedAt ? new Date(wb.updatedAt).toLocaleDateString() : ''}{wb.createdBy?.nickname ? ` · ${wb.createdBy.nickname}` : ''}
+            {relativeTime(wb.updatedAt)}{wb.createdBy?.nickname ? ` · ${wb.createdBy.nickname}` : ''}
           </Typography>
           <Box sx={{ flex: 1 }} />
           <Button variant="outlined" startIcon={<Edit />} onClick={(e) => { e.stopPropagation(); onEdit && onEdit(wb); }}>편집</Button>
@@ -273,7 +275,7 @@ export function WorkboardCard({ wb, admin, onClick, onEdit, onMenu, onInfo, grou
           <Box sx={{ flex: 1 }} />
           <AccessTime sx={{ fontSize: 12, color: 'text.tertiary' }} />
           <Typography sx={{ fontSize: 11, color: 'text.tertiary', fontFamily: MONO }}>
-            {wb.updatedAt ? new Date(wb.updatedAt).toLocaleDateString() : ''}
+            {relativeTime(wb.updatedAt)}
           </Typography>
         </Box>
       )}

--- a/frontend/src/components/common/WorkboardChatPanel.js
+++ b/frontend/src/components/common/WorkboardChatPanel.js
@@ -331,7 +331,7 @@ function WorkboardChatPanel({ workboard, projectId, useWorldview, onUseMessage }
                         이 응답을 프롬프트로 사용
                       </Button>
                     )}
-                    <Tooltip title="이 응답을 텍스트 컨텐츠로 저장">
+                    <Tooltip title="이 응답을 텍스트 콘텐츠로 저장">
                       <IconButton
                         size="small"
                         onClick={() => saveMessageMutation.mutate({ conversationJobId: conversationId, messageIndex: idx })}

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -263,7 +263,7 @@ function Dashboard() {
           <SectionCard
             icon={<ImageIcon fontSize="small" sx={{ color: 'text.secondary' }} />}
             title="최근 생성 이미지"
-            action="컨텐츠 라이브러리 →"
+            action="내 콘텐츠 →"
             onAction={() => navigate('/content')}
           >
             {imagesLoading ? (

--- a/frontend/src/pages/ImageGeneration.js
+++ b/frontend/src/pages/ImageGeneration.js
@@ -884,6 +884,7 @@ function ImageGeneration() {
                     multiline
                     rows={4}
                     label="프롬프트"
+                    required // 고급 설정의 '베이스 모델*' 등과 필수 표시를 맞춤 (#730)
                     placeholder="생성하고 싶은 이미지에 대한 설명을 입력하세요..."
                     error={!!errors.prompt}
                     helperText={errors.prompt?.message || '명사 위주, 콤마로 구분. 가중치는 (word:1.2) 문법.'}

--- a/frontend/src/pages/MyImages.js
+++ b/frontend/src/pages/MyImages.js
@@ -542,7 +542,7 @@ function MyImages() {
   return (
     <Container maxWidth="xl" sx={{ mt: 4, mb: 4 }}>
       <PageHeader
-        title="내 컨텐츠"
+        title="내 콘텐츠"
         description="프로젝트에서 생성·업로드된 모든 자산. 탭으로 종류별 전환."
         actions={!bulkMode && !isTextTab && (
           <Box sx={{ display: 'flex', gap: 1.5, flexShrink: 0 }}>

--- a/frontend/src/pages/ProjectList.js
+++ b/frontend/src/pages/ProjectList.js
@@ -147,9 +147,10 @@ function ProjectGridCard({ project, isFav, onOpen, onToggleFav, onMenu }) {
           <Typography sx={{ fontWeight: 600, fontSize: 14 }} noWrap>{project.name}</Typography>
           <TagPill tag={project.tagId} />
         </Box>
+        {/* 설명 없으면 자리만 비움 — 카드 높이 정렬용 minHeight 는 유지 (#730) */}
         <Typography sx={{ fontSize: 12, color: 'text.secondary', lineHeight: 1.5, textWrap: 'pretty', minHeight: 36,
           display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>
-          {project.description || '설명이 없습니다.'}
+          {project.description}
         </Typography>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25, mt: 1.5, pt: 1.5, borderTop: '1px solid', borderColor: 'divider' }}>
           <StatRow project={project} mono />
@@ -178,7 +179,9 @@ function ProjectListRow({ project, isFav, onOpen, onToggleFav, onMenu, first }) 
           <TagPill tag={project.tagId} />
           {isFav && <Star sx={{ fontSize: 13, color: 'warning.main' }} />}
         </Box>
-        <Typography sx={{ fontSize: 12, color: 'text.tertiary', mt: 0.25 }} noWrap>{project.description || '설명이 없습니다.'}</Typography>
+        {project.description && (
+          <Typography sx={{ fontSize: 12, color: 'text.tertiary', mt: 0.25 }} noWrap>{project.description}</Typography>
+        )}
       </Box>
       <Box sx={{ display: { xs: 'none', sm: 'flex' }, flex: '0 0 auto' }}><StatRow project={project} mono /></Box>
       <Typography sx={{ fontSize: 11, color: 'text.tertiary', fontFamily: MONO, flex: '0 0 auto' }}>{relativeTime(project.updatedAt)}</Typography>

--- a/frontend/src/pages/Settings.js
+++ b/frontend/src/pages/Settings.js
@@ -95,16 +95,16 @@ function Settings() {
     <Container maxWidth="md" sx={{ mb: 8 }}>
       <PageHeader title="설정" description="삭제 동작, 계속하기, NSFW 필터, 작업판 검색 조건의 기본 동작을 설정합니다." />
 
-      <SettingCard title="삭제 동작" description="작업 히스토리와 컨텐츠(이미지/동영상) 삭제 시의 연동 동작">
+      <SettingCard title="삭제 동작" description="작업 히스토리와 콘텐츠(이미지/동영상) 삭제 시의 연동 동작">
         <SettingRow
-          label="작업 히스토리 삭제 시 연관 컨텐츠도 같이 삭제"
+          label="작업 히스토리 삭제 시 연관 콘텐츠도 같이 삭제"
           caption="이 옵션이 켜져 있으면 히스토리 삭제 시 생성된 이미지나 동영상도 같이 삭제됩니다. 삭제 전에 확인 창이 표시됩니다."
           checked={preferences.deleteContentWithHistory || false}
           onChange={handleToggle('deleteContentWithHistory')}
           disabled={busy}
         />
         <SettingRow
-          label="컨텐츠 삭제 시 작업 히스토리도 같이 삭제"
+          label="콘텐츠 삭제 시 작업 히스토리도 같이 삭제"
           caption="이 옵션이 켜져 있으면 이미지/동영상 삭제 시 해당 작업 히스토리도 같이 삭제됩니다. 삭제 전에 확인 창이 표시됩니다."
           checked={preferences.deleteHistoryWithContent || false}
           onChange={handleToggle('deleteHistoryWithContent')}

--- a/frontend/src/pages/TagSearch.js
+++ b/frontend/src/pages/TagSearch.js
@@ -44,6 +44,7 @@ import toast from 'react-hot-toast';
 import { tagAPI } from '../services/api';
 import TagInput from '../components/common/TagInput';
 import { DEFAULT_TAG_COLOR } from '../theme';
+import { relativeTime } from '../utils/relativeTime';
 
 function SearchTabPanel({ children, value, index }) {
   return (
@@ -487,7 +488,7 @@ function TagSearch() {
                           </TableCell>
                           <TableCell align="center">{tag.usageCount}</TableCell>
                           <TableCell align="center">
-                            {new Date(tag.createdAt).toLocaleDateString()}
+                            {relativeTime(tag.createdAt)}
                           </TableCell>
                           <TableCell align="center">
                             {tag.isProjectTag ? (

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -128,7 +128,7 @@ export const conversationAPI = {
   getAll: (params) => api.get('/conversations/all', { params }),
 };
 
-// 텍스트 컨텐츠 — UploadedText (직접 작성) / GeneratedText (대화에서 저장) (#387)
+// 텍스트 콘텐츠 — UploadedText (직접 작성) / GeneratedText (대화에서 저장) (#387)
 export const textAPI = {
   // 직접 작성
   getUploaded: (params) => api.get('/texts/uploaded', { params }),

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -60,7 +60,7 @@ const DARK = {
   // 밝아진 만큼 흰 글씨는 대비가 깨져 contrastText 를 딥 레드블랙으로 (다크 primary 의 #06231D 와 같은 패턴).
   error:     { main: '#ED7178', light: 'rgba(237,113,120,0.14)', dark: '#C73E44', contrastText: '#2A0E10' },
   info:      { main: '#5C9CE8', light: 'rgba(92,156,232,0.14)', dark: '#3D7CC8', contrastText: '#FFFFFF' },
-  // 다크 사이드바 — 컨텐츠보다 더 어두운 콘솔 레일
+  // 다크 사이드바 — 콘텐츠보다 더 어두운 콘솔 레일
   navbar:    { main: '#0B0D10', light: '#181B21', dark: '#05070A', contrastText: '#E9EBEF' },
   background:{ default: '#101216', paper: '#181B21' },
   // tertiary: #5F6671 은 surface 대비 2.98:1 로 AA 미달이었음 → 4.5:1 로 상향 (#727)


### PR DESCRIPTION
#730 의 12건 중 **성격이 같은 5건**. 나머지(`fontSize` 161곳, `aria-label` 64곳 등)는 이슈에 적은 대로 별도 PR 로 나눕니다.

## D-1. 화면 명칭 통일

`/content` 를 **세 가지 이름**으로 부르고 있었습니다.

| 위치 | 전 | 후 |
|---|---|---|
| 사이드바 | 내 **컨텐츠** | **내 콘텐츠** |
| 대시보드 위젯 링크 | **컨텐츠 라이브러리** → | **내 콘텐츠** → |
| 명령 팔레트 / 페이지 제목 | 내 컨텐츠 | **내 콘텐츠** |

코드 전체의 "컨텐츠"(19곳)도 표준어 **"콘텐츠"** 로 교체했습니다. 잔여 0건.

## D-2. 날짜 표기

작업판 카탈로그만 `toLocaleDateString` 이라 `2026. 7. 12.`(4자리 연도), 히스토리·프로젝트는 `relativeTime` 폴백이라 `26. 7. 11.` — 화면마다 달랐습니다.

규칙을 세우고 `TOKENS.md` 에 명시했습니다:
- **목록·카드의 "언제"** → `utils/relativeTime`
- **상세 다이얼로그·관리 테이블**처럼 정확한 시점이 필요한 곳 → 절대 표기 유지 (사용자 가입일, 최종 로그인, 실행 시작/종료 등)

전환: WorkboardCatalog(2) · MediaGrid(2) · JobHistoryPanel(1) · ConversationHistoryPanel(1) · TextContentPanel(1) · TagSearch(1)

## D-5. 필수 입력 표시

작업판 실행에서 **프롬프트는 필수인데 라벨에 `*` 가 없었습니다.** "베이스 모델\*", "이미지 크기\*" 와 어긋나 무엇이 필수인지 알 수 없었습니다.

## D-9. 빈 설명

카드에서 **"설명이 없습니다."** 를 반복 노출하던 것을 제거했습니다 — 작업판 8장 중 6장, 프로젝트 2장 중 2장이 이 문구로 본문 자리를 채우고 있었습니다. 카드 높이 정렬용 `minHeight` 는 유지했고, 빈 섹션이 더 어색한 상세 다이얼로그는 문구를 남겼습니다.

부수 효과로 카드 제목 잘림도 줄었습니다 (`Uncensored Chat - Qwen3...` → 전체 표시).

## D-10. 주 액션 색

파이프라인 **"실행"/"시작" 버튼만 success(초록)** 여서 다른 화면의 주 액션(테라코타)과 어긋났습니다. primary 로 통일했고, 단계 상태 아이콘의 success 색은 그대로 뒀습니다.

## 검증

브라우저에서 확인 — "컨텐츠" 잔존 0, "설명이 없습니다" 잔존 0, 날짜 `26. 7. 12.` 형식 통일, 실행 버튼 테라코타. 콘솔 에러 없음. 프론트 테스트 33개 통과.

## 남은 항목 (#730 은 계속 열어둠)

D-3 `fontSize` 161곳 · D-4 공용 컴포넌트 채택 · D-6 `aria-label` 64곳 · D-7 파이프라인 단계 dot · D-8 카운트 부분 적용 · D-11 `size="small"` 104곳 · D-12 편집기 잔여

🤖 Generated with [Claude Code](https://claude.com/claude-code)