### PR TITLE
fix: UI 일관성 2차 — 단계 dot·카운트·편집기 안내 (#730)

### DIFF
--- a/frontend/src/components/admin/workboardEditor/PermissionsCard.js
+++ b/frontend/src/components/admin/workboardEditor/PermissionsCard.js
@@ -13,6 +13,7 @@ import {
   Chip,
   Autocomplete,
   Divider,
+  Alert,
 } from '@mui/material';
 import { Controller } from 'react-hook-form';
 import { WhitelistField } from './shared';
@@ -70,6 +71,22 @@ function PermissionsCard({ control, isComfyUI, serverId, outputFormat, groups, m
             )}
           />
         )}
+      />
+
+      {/* 삭제된 그룹이 참조로 남아 있으면 칩만 보이고 어떻게 치우는지 알 수 없었다 (#730 D-12) */}
+      <Controller
+        name="allowedGroupIds"
+        control={control}
+        render={({ field }) => {
+          const stale = (field.value || []).filter((id) => !groups.some((g) => g._id === id));
+          if (!stale.length) return null;
+          return (
+            <Alert severity="warning" sx={{ mt: 1.5 }}>
+              삭제된 그룹 {stale.length}개가 접근 목록에 남아 있습니다. 이 그룹으로는 아무도 접근할 수 없으니
+              칩의 &times; 를 눌러 지운 뒤 저장하세요.
+            </Alert>
+          );
+        }}
       />
 
       <Divider sx={{ my: 3 }} />

--- a/frontend/src/pages/JobHistory.js
+++ b/frontend/src/pages/JobHistory.js
@@ -19,6 +19,7 @@ import {
   DialogActions,
   ToggleButtonGroup,
   ToggleButton,
+  Tooltip,
 } from '@mui/material';
 import {
   Search,
@@ -228,6 +229,11 @@ function RowVisual({ item }) {
   );
 }
 
+const STEP_LABEL = { completed: '완료', skipped: '건너뜀', failed: '실패', running: '실행 중' };
+
+// 단계 진행 dot. 예전에는 완료만 체크 아이콘이고 나머지는 전부 단계번호였는데,
+// 실패 단계가 빨간 원 안의 숫자로 보여 "2건 실패" 인지 "2단계에서 실패" 인지 구분되지 않았다 (#730).
+// 종료 상태(완료/실패)는 아이콘, 진행 전/중은 단계번호로 나누고 툴팁에 "N단계 · 상태" 를 붙인다.
 function StepDots({ statuses }) {
   return (
     <Box sx={{ display: 'flex', gap: 0.5 }}>
@@ -235,12 +241,21 @@ function StepDots({ statuses }) {
         const done = s === 'completed' || s === 'skipped';
         const failed = s === 'failed';
         const running = s === 'running';
-        const bg = done ? 'success.main' : failed ? 'error.main' : running ? 'info.main' : 'grey.200';
-        const fg = done || failed || running ? 'common.white' : 'text.secondary';
+        const tone = done ? 'success' : failed ? 'error' : running ? 'info' : null;
         return (
-          <Box key={j} sx={{ width: 20, height: 20, borderRadius: '50%', bgcolor: bg, color: fg, display: 'grid', placeItems: 'center', fontSize: 9, fontWeight: 700, fontFamily: MONO }}>
-            {done ? <CheckCircle sx={{ fontSize: 12 }} /> : j + 1}
-          </Box>
+          <Tooltip key={j} title={`${j + 1}단계 · ${STEP_LABEL[s] || '대기'}`}>
+            <Box sx={{
+              width: 20, height: 20, borderRadius: '50%', display: 'grid', placeItems: 'center',
+              fontSize: 9, fontWeight: 700, fontFamily: MONO,
+              bgcolor: tone ? `${tone}.main` : 'grey.200',
+              // contrastText 를 써야 다크에서도 대비가 맞는다 (common.white 고정은 다크 error 에서 2.9:1)
+              color: tone ? `${tone}.contrastText` : 'text.secondary',
+            }}>
+              {done ? <CheckCircle sx={{ fontSize: 12 }} />
+                : failed ? <Close sx={{ fontSize: 12 }} />
+                : j + 1}
+            </Box>
+          </Tooltip>
         );
       })}
     </Box>

--- a/frontend/src/pages/MyImages.js
+++ b/frontend/src/pages/MyImages.js
@@ -531,10 +531,16 @@ function MyImages() {
   const { data: videosCountData }    = useQuery({ queryKey: ['contentCount', 'video'], queryFn: () => imageAPI.getVideos({ limit: 1, page: 1 }), staleTime: 60_000 });
   const { data: upTextsCountData }   = useQuery({ queryKey: ['contentCount', 'textUp'], queryFn: () => textAPI.getUploaded({ limit: 1, page: 1 }), staleTime: 60_000 });
   const { data: genTextsCountData }  = useQuery({ queryKey: ['contentCount', 'textGen'], queryFn: () => textAPI.getGenerated({ limit: 1, page: 1 }), staleTime: 60_000 });
+  // 응답 래핑이 라우트마다 다르다 (#730 D-8):
+  //   /images/*  → { images, pagination }              → res.data.pagination
+  //   /texts/*   → { success, data: { items, pagination } } → res.data.data.pagination
+  // 이미지·동영상 쪽이 .data 를 한 번 더 타고 있어서 카운트가 항상 undefined 였고,
+  // ContentTabLabel 이 count == null 이면 라벨만 그리므로 세 탭에만 숫자가 안 보였다.
+  // (images 라우트가 프로젝트 공통 응답 규약을 안 따르는 건 별도 정리 대상)
   const counts = [
-    genImagesCountData?.data?.data?.pagination?.total,
-    upImagesCountData?.data?.data?.pagination?.total,
-    videosCountData?.data?.data?.pagination?.total,
+    genImagesCountData?.data?.pagination?.total,
+    upImagesCountData?.data?.pagination?.total,
+    videosCountData?.data?.pagination?.total,
     upTextsCountData?.data?.data?.pagination?.total,
     genTextsCountData?.data?.data?.pagination?.total,
   ];


### PR DESCRIPTION
#730 의 작은 3건. 항목별로 커밋을 나눴습니다.

## D-7. 파이프라인 단계 dot 표기 (`08c2c84`)

완료 단계만 체크 아이콘이고 나머지는 전부 단계번호여서, **실패 단계가 빨간 원 안의 숫자**로 보였습니다 — "2건 실패" 인지 "2단계에서 실패" 인지 구분되지 않았습니다.

- 종료 상태(완료/실패)는 아이콘, 진행 전/중은 단계번호로 분리
- 툴팁에 `N단계 · 상태` 를 붙여 어느 쪽이든 확인 가능
- 글자색을 `common.white` 고정 → `{tone}.contrastText`. 다크 error(`#ED7178`) 위 흰 글씨는 2.9:1 이라 대비가 깨져 있었습니다 (#727 후속)

## D-8. 내 콘텐츠 탭 카운트 — **실제 버그였음** (`d8c8101`)

"부분 적용" 으로 봤던 게 응답 구조 오독 버그였습니다.

```
/images/*  → { images, pagination }                    → res.data.pagination
/texts/*   → { success, data: { items, pagination } }  → res.data.data.pagination
```

이미지·업로드·동영상 카운트가 `.data` 를 한 번 더 타고 있어 **항상 undefined** 였고, `ContentTabLabel` 은 `count == null` 이면 라벨만 그리므로 세 탭에서 숫자가 사라져 있었습니다.

→ **29 / 4 / 2 / 6 / 0** 다섯 탭 모두 표시 (브라우저 확인).

남은 문제: `images` 라우트가 프로젝트 공통 응답 규약(`{ success, data, message }`)을 따르지 않습니다. 프론트 호출부가 많아 이 PR 에서는 건드리지 않고 별도 정리 대상으로 둡니다.

좌측 필터 레일(프로젝트/태그) 카운트는 **추가하지 않았습니다** — 탭별×태그별 집계가 백엔드에 없어 `tag.usageCount`(전역)를 쓰면 실제와 다른 숫자를 보여주게 됩니다. 틀린 숫자보다 없는 편이 낫다고 판단했습니다.

## D-12. 작업판 편집기 — 삭제된 그룹 안내 (`34f090c`)

접근 그룹에 삭제된 그룹이 남아 있으면 경고색 칩만 뜨고 **왜 문제인지·어떻게 치우는지** 알 수 없었습니다. 칩 아래에 안내를 붙였습니다.

같이 지적했던 **"워크플로 JSON 미리보기 가로 잘림" 은 재확인 결과 오진**이었습니다. `whiteSpace: pre-wrap` + `wordBreak: break-all` 로 이미 줄바꿈되며, 160자에서 의도적으로 자르고 `…` 를 붙이는 티저 프리뷰입니다. 수정하지 않았습니다.

## 남은 항목

D-3 `fontSize` 161곳 · D-4 공용 컴포넌트 채택 · D-6 `aria-label` 64곳 · D-11 `size="small"` 104곳

🤖 Generated with [Claude Code](https://claude.com/claude-code)