### PR TITLE
refactor: UI 일관성 3차 — size prop 중복 제거·PageHeader 채택 (#730)

### DIFF
--- a/frontend/src/components/admin/WorkflowImportDialog.js
+++ b/frontend/src/components/admin/WorkflowImportDialog.js
@@ -203,7 +203,6 @@ export default function WorkflowImportDialog({ open, onClose }) {
                         {/* informed one-click 설치 (#609 P4) — 출처 확인 모달을 거친다 */}
                         {r.repos[0].installId && installState[r.node] !== 'success' && (
                           <Button
-                            size="small"
                             variant="outlined"
                             disabled={installState[r.node] === 'installing'}
                             startIcon={installState[r.node] === 'installing' ? <CircularProgress size={12} /> : null}
@@ -217,10 +216,10 @@ export default function WorkflowImportDialog({ open, onClose }) {
                     ))}
                     {Object.values(installState).includes('success') && (
                       <Box sx={{ mt: 1, display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
-                        <Button size="small" variant="contained" color="warning" disabled={rebootState === 'rebooting'} onClick={() => setRebootState('confirm')}>
+                        <Button variant="contained" color="warning" disabled={rebootState === 'rebooting'} onClick={() => setRebootState('confirm')}>
                           {rebootState === 'rebooting' ? '재시작 요청됨' : 'ComfyUI 재시작'}
                         </Button>
-                        <Button size="small" onClick={handleAnalyze}>다시 분석</Button>
+                        <Button onClick={handleAnalyze}>다시 분석</Button>
                         <Typography variant="caption" color="text.secondary">
                           설치된 노드는 재시작 후 반영됩니다 (재시작 ~1분).
                         </Typography>

--- a/frontend/src/components/admin/workboardEditor/FieldBuilder.js
+++ b/frontend/src/components/admin/workboardEditor/FieldBuilder.js
@@ -32,7 +32,7 @@ function FieldBuilder({ fields, selectedIdx, onSelect, onAdd, onMove }) {
           {fields.length}개 필드 · 드래그로 순서 변경 · 클릭하면 우측에서 편집
         </Typography>
         <Box sx={{ flex: 1 }} />
-        <Button variant="contained" size="small" startIcon={<Add />} onClick={(e) => setAddMenuAnchor(e.currentTarget)}>
+        <Button variant="contained" startIcon={<Add />} onClick={(e) => setAddMenuAnchor(e.currentTarget)}>
           필드 추가
         </Button>
         <Menu anchorEl={addMenuAnchor} open={Boolean(addMenuAnchor)} onClose={() => setAddMenuAnchor(null)}>

--- a/frontend/src/components/admin/workboardEditor/FieldInspector.js
+++ b/frontend/src/components/admin/workboardEditor/FieldInspector.js
@@ -57,7 +57,7 @@ function SelectOptionsEditor({ control, fieldIndex }) {
       <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
         <Typography variant="overline" color="text.secondary">선택 옵션</Typography>
         <Box sx={{ flex: 1 }} />
-        <Button size="small" startIcon={<Add />} onClick={() => append({ key: '', value: '' })}>
+        <Button startIcon={<Add />} onClick={() => append({ key: '', value: '' })}>
           옵션 추가
         </Button>
       </Box>
@@ -85,14 +85,14 @@ function SelectOptionsEditor({ control, fieldIndex }) {
                         name={`additionalCustomFields.${fieldIndex}.options.${optIndex}.key`}
                         control={control}
                         render={({ field }) => (
-                          <TextField {...field} size="small" label="표시명" sx={{ flex: 1 }} />
+                          <TextField {...field} label="표시명" sx={{ flex: 1 }} />
                         )}
                       />
                       <Controller
                         name={`additionalCustomFields.${fieldIndex}.options.${optIndex}.value`}
                         control={control}
                         render={({ field }) => (
-                          <TextField {...field} size="small" label="실제 값" sx={{ flex: 1, '& input': { fontFamily: MONO, fontSize: 12 } }} />
+                          <TextField {...field} label="실제 값" sx={{ flex: 1, '& input': { fontFamily: MONO, fontSize: 12 } }} />
                         )}
                       />
                       <IconButton size="small" color="error" onClick={() => remove(optIndex)}>
@@ -133,7 +133,7 @@ function InspectorForm({ control, watch, selectedIdx, serverId, onRemove }) {
           name={`additionalCustomFields.${selectedIdx}.name`}
           control={control}
           render={({ field: f }) => (
-            <TextField {...f} fullWidth size="small" label="필드명 (영문)" placeholder="예: customField1"
+            <TextField {...f} fullWidth label="필드명 (영문)" placeholder="예: customField1"
               helperText="워크플로우 변수명으로 사용됩니다"
               sx={{ '& input': { fontFamily: MONO } }} />
           )}
@@ -142,14 +142,14 @@ function InspectorForm({ control, watch, selectedIdx, serverId, onRemove }) {
           name={`additionalCustomFields.${selectedIdx}.label`}
           control={control}
           render={({ field: f }) => (
-            <TextField {...f} fullWidth size="small" label="표시명" placeholder="예: 커스텀 옵션" />
+            <TextField {...f} fullWidth label="표시명" placeholder="예: 커스텀 옵션" />
           )}
         />
         <Controller
           name={`additionalCustomFields.${selectedIdx}.type`}
           control={control}
           render={({ field: f }) => (
-            <TextField {...f} fullWidth size="small" select label="입력 타입">
+            <TextField {...f} fullWidth select label="입력 타입">
               {FIELD_TYPES.map((t) => (
                 <MenuItem key={t.type} value={t.type}>{t.label}</MenuItem>
               ))}
@@ -160,7 +160,7 @@ function InspectorForm({ control, watch, selectedIdx, serverId, onRemove }) {
           name={`additionalCustomFields.${selectedIdx}.formatString`}
           control={control}
           render={({ field: f }) => (
-            <TextField {...f} fullWidth size="small" label="Workflow 형식 문자열"
+            <TextField {...f} fullWidth label="Workflow 형식 문자열"
               placeholder={`예: {{##${field.name || 'field_name'}##}}`}
               helperText="비워두면 필드명으로 자동 생성"
               sx={{ '& input': { fontFamily: MONO } }} />
@@ -196,7 +196,6 @@ function InspectorForm({ control, watch, selectedIdx, serverId, onRemove }) {
                   {...f}
                   value={f.value || ''}
                   fullWidth
-                  size="small"
                   select
                   label="기본값 (선택)"
                   // displayEmpty 는 값이 ''여도 "선택 없음"을 렌더하므로 label 을 항상 띄운다
@@ -224,7 +223,7 @@ function InspectorForm({ control, watch, selectedIdx, serverId, onRemove }) {
             }
             if (fieldType === 'image') return <Box />;
             return (
-              <TextField {...f} value={f.value ?? ''} fullWidth size="small"
+              <TextField {...f} value={f.value ?? ''} fullWidth
                 label="기본값" type={fieldType === 'number' ? 'number' : 'text'} />
             );
           }}
@@ -235,7 +234,7 @@ function InspectorForm({ control, watch, selectedIdx, serverId, onRemove }) {
             name={`additionalCustomFields.${selectedIdx}.placeholder`}
             control={control}
             render={({ field: f }) => (
-              <TextField {...f} value={f.value ?? ''} fullWidth size="small" label="플레이스홀더" />
+              <TextField {...f} value={f.value ?? ''} fullWidth label="플레이스홀더" />
             )}
           />
         )}
@@ -243,7 +242,7 @@ function InspectorForm({ control, watch, selectedIdx, serverId, onRemove }) {
           name={`additionalCustomFields.${selectedIdx}.description`}
           control={control}
           render={({ field: f }) => (
-            <TextField {...f} value={f.value ?? ''} fullWidth size="small" label="설명" helperText="입력 아래 도움말로 표시" />
+            <TextField {...f} value={f.value ?? ''} fullWidth label="설명" helperText="입력 아래 도움말로 표시" />
           )}
         />
 
@@ -258,7 +257,7 @@ function InspectorForm({ control, watch, selectedIdx, serverId, onRemove }) {
             name={`additionalCustomFields.${selectedIdx}.imageConfig.maxImages`}
             control={control}
             render={({ field: f }) => (
-              <TextField {...f} value={f.value || 1} fullWidth size="small" select label="최대 이미지 수">
+              <TextField {...f} value={f.value || 1} fullWidth select label="최대 이미지 수">
                 {[1, 2, 3].map((n) => <MenuItem key={n} value={n}>{n}개</MenuItem>)}
               </TextField>
             )}

--- a/frontend/src/components/admin/workboardEditor/SettingsRail.js
+++ b/frontend/src/components/admin/workboardEditor/SettingsRail.js
@@ -87,7 +87,6 @@ function LlmParamsCard({ control }) {
             fullWidth
             multiline
             minRows={5}
-            size="small"
             label="추가 LLM 파라미터 (JSON)"
             placeholder={'{\n  "temperature": 1.0,\n  "chat_template_kwargs": { "enable_thinking": false }\n}'}
             helperText="OpenAI 계열은 요청 본문 최상위, Gemini 는 generationConfig 에 병합"

--- a/frontend/src/pages/JobHistory.js
+++ b/frontend/src/pages/JobHistory.js
@@ -438,21 +438,21 @@ function HistoryCard({ item, onOpenMedia, onMenu, onContinue, onCross, onTextCon
         <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', mt: 'auto', pt: 0.5 }} onClick={(e) => e.stopPropagation()}>
           {(item.type === 'image' || item.type === 'video') && item.status !== 'error' && (
             <>
-              <Button size="small" variant="outlined" startIcon={<Refresh />} onClick={() => onContinue(item.raw)}>계속</Button>
-              <Button size="small" variant="outlined" startIcon={<ArrowForward />} onClick={() => onCross(item.raw)}>다른작업</Button>
+              <Button variant="outlined" startIcon={<Refresh />} onClick={() => onContinue(item.raw)}>계속</Button>
+              <Button variant="outlined" startIcon={<ArrowForward />} onClick={() => onCross(item.raw)}>다른작업</Button>
               <IconButton size="small" onClick={(e) => onMenu(e, item)}><MoreVert fontSize="small" /></IconButton>
             </>
           )}
           {item.type === 'text' && (
             <>
               {item.workboardId && item.status !== 'error' && (
-                <Button size="small" variant="outlined" startIcon={<PlayArrow />} onClick={() => onTextContinue(item)}>이어가기</Button>
+                <Button variant="outlined" startIcon={<PlayArrow />} onClick={() => onTextContinue(item)}>이어가기</Button>
               )}
-              <Button size="small" variant="text" onClick={() => onTextDetail(item)}>전문 보기</Button>
+              <Button variant="text" onClick={() => onTextDetail(item)}>전문 보기</Button>
             </>
           )}
           {item.type === 'pipeline' && item.projectId && (
-            <Button size="small" variant="text" onClick={() => onPipelineDetail(item)}>상세 →</Button>
+            <Button variant="text" onClick={() => onPipelineDetail(item)}>상세 →</Button>
           )}
         </Box>
       </Box>

--- a/frontend/src/pages/ProjectList.js
+++ b/frontend/src/pages/ProjectList.js
@@ -102,7 +102,7 @@ function ProjectCreateDialog({ open, onClose, onOpenImport }) {
       </DialogContent>
       <DialogActions>
         {onOpenImport && (
-          <Button size="small" startIcon={<FileUpload />} onClick={() => { onClose(); onOpenImport(); }} sx={{ mr: 'auto' }}>
+          <Button startIcon={<FileUpload />} onClick={() => { onClose(); onOpenImport(); }} sx={{ mr: 'auto' }}>
             내보내기 파일에서 시작
           </Button>
         )}

--- a/frontend/src/pages/PromptDataList.js
+++ b/frontend/src/pages/PromptDataList.js
@@ -18,6 +18,7 @@ import { promptDataAPI } from '../services/api';
 import PromptDataPanel from '../components/common/PromptDataPanel';
 import PromptDataFormDialog from '../components/common/PromptDataFormDialog';
 import WorkboardSelectDialog from '../components/common/WorkboardSelectDialog';
+import PageHeader from '../components/common/PageHeader';
 
 function PromptDataList() {
   const navigate = useNavigate();
@@ -101,19 +102,22 @@ function PromptDataList() {
 
   return (
     <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
-      <Box display="flex" justifyContent="space-between" alignItems="center" mb={3}>
-        <Typography variant="h4">프롬프트 데이터</Typography>
-        <Button
-          variant="contained"
-          startIcon={<Add />}
-          onClick={() => {
-            setEditingPromptData(null);
-            setFormOpen(true);
-          }}
-        >
-          새 프롬프트
-        </Button>
-      </Box>
+      <PageHeader
+        title="프롬프트 데이터"
+        description="자주 쓰는 프롬프트를 저장해 두고 작업판 실행에서 불러옵니다."
+        actions={
+          <Button
+            variant="contained"
+            startIcon={<Add />}
+            onClick={() => {
+              setEditingPromptData(null);
+              setFormOpen(true);
+            }}
+          >
+            새 프롬프트
+          </Button>
+        }
+      />
 
       <PromptDataPanel
         fetchFn={promptDataAPI.getAll}

--- a/frontend/src/pages/TagSearch.js
+++ b/frontend/src/pages/TagSearch.js
@@ -45,6 +45,7 @@ import { tagAPI } from '../services/api';
 import TagInput from '../components/common/TagInput';
 import { DEFAULT_TAG_COLOR } from '../theme';
 import { relativeTime } from '../utils/relativeTime';
+import PageHeader from '../components/common/PageHeader';
 
 function SearchTabPanel({ children, value, index }) {
   return (
@@ -236,10 +237,10 @@ function TagSearch() {
 
   return (
     <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
-      <Box display="flex" alignItems="center" gap={2} mb={3}>
-        <LocalOffer color="primary" sx={{ fontSize: 32 }} />
-        <Typography variant="h4">태그</Typography>
-      </Box>
+      <PageHeader
+        title="태그"
+        description="태그로 콘텐츠를 찾고, 내 태그를 만들고 정리합니다."
+      />
 
       <Tabs
         value={mainTab}

--- a/frontend/src/pages/admin/BackupRestorePage.js
+++ b/frontend/src/pages/admin/BackupRestorePage.js
@@ -602,7 +602,7 @@ function BackupRestorePage() {
                   <Alert severity="info">서버에 백업 파일이 없습니다. <code>./scripts/upload-backup-file.sh &lt;파일.zip&gt;</code> 로 올린 뒤 새로고침하세요.</Alert>
                 ) : (
                   <TextField
-                    select fullWidth size="small" label="서버 백업 파일"
+                    select fullWidth label="서버 백업 파일"
                     value={selectedServerFile}
                     onChange={(e) => { setSelectedServerFile(e.target.value); setValidationResult(null); }}
                     SelectProps={{ native: true }} InputLabelProps={{ shrink: true }}
@@ -616,9 +616,9 @@ function BackupRestorePage() {
                   </TextField>
                 )}
                 <Box sx={{ mt: 1, display: 'flex', gap: 1 }}>
-                  <Button size="small" onClick={() => refetchServerFiles()}>목록 새로고침</Button>
+                  <Button onClick={() => refetchServerFiles()}>목록 새로고침</Button>
                   <Button
-                    size="small" variant="outlined"
+ variant="outlined"
                     disabled={!selectedServerFile || validateServerMutation.isPending}
                     onClick={() => { setValidationResult(null); validateServerMutation.mutate(selectedServerFile); }}
                   >


### PR DESCRIPTION
#730 의 D-11 · D-4. 항목별 커밋으로 나눴습니다.

## D-11. `theme` defaultProps 와 중복된 `size="small"` 제거 (`c5c9a86`)

`theme.js` 가 `MuiButton` / `MuiTextField` / `MuiChip` 에 `defaultProps { size: 'small' }` 을 주므로 해당 컴포넌트의 명시 지정은 중복입니다. **26곳 제거.**

이슈에 적었던 **"104곳 잔존" 은 과대평가**였습니다. 실제 분포를 세어 보니:

| | 개수 | 비고 |
|---|---|---|
| **제거 대상** | **26** | Button · TextField · Chip |
| 유지 | 78 | IconButton 57 · FormControl 7 · Switch 4 · ToggleButtonGroup 4 · Autocomplete 3 · Table/ProjectTagChip/Alert 각 1 |

유지분은 `theme` 에 `defaultProps` 가 없어 명시가 **필요한** 것들입니다. 일괄 제거했다면 컨트롤 크기가 커지는 회귀가 났을 겁니다.

검증: 버튼 높이 30px + `sizeSmall` 클래스 유지, 칩 24px — 렌더 결과 동일.

## D-4. `PageHeader` 채택 (`abf05ca`)

프롬프트 데이터·태그 두 페이지만 `h4` + 커스텀 `Box` 로 헤더를 직접 만들고 있어, 다른 화면(`h1` 24/800)과 **제목 크기·좌측 정렬·설명 유무**가 어긋났습니다. 태그는 아이콘만 있고 설명이 없어 페이지 목적도 알 수 없었습니다.

두 페이지 모두 설명 문구를 새로 붙였습니다:
- 프롬프트 데이터 — "자주 쓰는 프롬프트를 저장해 두고 작업판 실행에서 불러옵니다."
- 태그 — "태그로 콘텐츠를 찾고, 내 태그를 만들고 정리합니다."

`SegmentTabs` 채택(현재 `/jobs` 1곳)은 **남겨뒀습니다** — 탭 UI 가 화면마다 다른 건 단순 교체가 아니라 각 화면의 탭 의미(전환 vs 필터)를 다시 정해야 해서 별도 라운드가 맞다고 판단했습니다.

## 검증

빌드 통과, 프론트 테스트 33개 통과, 브라우저에서 두 페이지 헤더 정렬 확인.

## 남은 항목

D-3 `fontSize` 하드코딩 161곳 · D-6 `aria-label` 누락 64곳

🤖 Generated with [Claude Code](https://claude.com/claude-code)