### PR TITLE
fix: 작업판 접근 그룹 — 삭제된 그룹 참조 정리 + 삭제 시 참조 누락 (#740)

### DIFF
--- a/frontend/src/components/admin/workboardEditor/PermissionsCard.js
+++ b/frontend/src/components/admin/workboardEditor/PermissionsCard.js
@@ -73,17 +73,29 @@ function PermissionsCard({ control, isComfyUI, serverId, outputFormat, groups, m
         )}
       />
 
-      {/* 삭제된 그룹이 참조로 남아 있으면 칩만 보이고 어떻게 치우는지 알 수 없었다 (#730 D-12) */}
+      {/* 삭제된 그룹이 참조로 남아 있으면 칩만 보이고 어떻게 치우는지 알 수 없었다 (#730 D-12).
+          #740: 구 문구는 "아무도 접근할 수 없으니 지우세요" 였으나 사실과 달랐다 —
+          접근 판정은 ID 교집합이라 삭제된 ID 를 아직 가진 사용자에게는 보인다.
+          그냥 지우면 유효 그룹이 0개가 되어 admin 전용이 되고 그 사용자들의 접근이 끊긴다. */}
       <Controller
         name="allowedGroupIds"
         control={control}
         render={({ field }) => {
-          const stale = (field.value || []).filter((id) => !groups.some((g) => g._id === id));
+          const value = field.value || [];
+          const stale = value.filter((id) => !groups.some((g) => g._id === id));
           if (!stale.length) return null;
+          const hasValid = value.length > stale.length;
           return (
             <Alert severity="warning" sx={{ mt: 1.5 }}>
-              삭제된 그룹 {stale.length}개가 접근 목록에 남아 있습니다. 이 그룹으로는 아무도 접근할 수 없으니
-              칩의 &times; 를 눌러 지운 뒤 저장하세요.
+              삭제된 그룹 {stale.length}개가 접근 목록에 남아 있습니다.{' '}
+              {hasValid ? (
+                <>칩의 &times; 를 눌러 지운 뒤 저장하세요 — 남은 유효 그룹으로 접근은 그대로 유지됩니다.</>
+              ) : (
+                <>
+                  유효한 그룹이 하나도 없어, 이대로 지우고 저장하면 <strong>admin 만</strong> 볼 수 있게 됩니다.
+                  지우기 전에 접근을 허용할 그룹을 먼저 선택하세요.
+                </>
+              )}
             </Alert>
           );
         }}

--- a/frontend/src/pages/admin/GroupManagementPage.js
+++ b/frontend/src/pages/admin/GroupManagementPage.js
@@ -238,9 +238,16 @@ function GroupManagementPage() {
       } });
 
   const deleteMutation = useMutation({ mutationFn: (id) => groupAPI.delete(id),
-      onSuccess: () => {
-        toast.success('그룹이 삭제되었습니다.');
+      onSuccess: (res) => {
+        // 접근 목록이 비어 admin 전용이 된 작업판은 조용히 숨겨지므로 알려준다 (#740)
+        const adminOnly = res?.data?.data?.workboardsAdminOnly || 0;
+        toast.success(
+          adminOnly > 0
+            ? `그룹이 삭제되었습니다. 접근 그룹이 남지 않은 작업판 ${adminOnly}개는 admin 만 볼 수 있습니다.`
+            : '그룹이 삭제되었습니다.'
+        );
         queryClient.invalidateQueries({ queryKey: ['groups'] });
+        queryClient.invalidateQueries({ queryKey: ['workboards'] });
       },
       onError: (err) => {
         toast.error(err.response?.data?.message || '그룹 삭제 실패');

--- a/src/migrations/assignDefaultGroupToWorkboards.js
+++ b/src/migrations/assignDefaultGroupToWorkboards.js
@@ -1,9 +1,14 @@
 const Group = require('../models/Group');
 const Workboard = require('../models/Workboard');
 
-// #198 Phase B: allowedGroupIds 가 비어있는 기존 작업판 전부에 기본 그룹 자동 할당.
+// #198 Phase B: allowedGroupIds 필드 자체가 없는 기존 작업판에 기본 그룹 자동 할당.
 // 마이그레이션 후 v2.0 의 권한 미들웨어 (Phase C) 가 활성화돼도 기존 사용자의
 // 작업판 접근이 깨지지 않도록 보장.
+//
+// #740: 대상에서 `$size: 0` 을 제외했다. 빈 배열은 "admin 전용" 이라는 의도된
+// 상태이며 (그룹 삭제 후 남은 그룹이 없는 경우 등), 이걸 매 기동마다 기본 그룹으로
+// 채우면 admin 이 좁혀둔 노출 범위가 재시작 한 번에 되돌아간다.
+// 필드 미존재 (`$exists: false`) 만이 진짜 미마이그레이션 상태다.
 async function assignDefaultGroupToWorkboards() {
   try {
     const defaultGroup = await Group.findDefault();
@@ -13,12 +18,7 @@ async function assignDefaultGroupToWorkboards() {
     }
 
     const result = await Workboard.updateMany(
-      {
-        $or: [
-          { allowedGroupIds: { $exists: false } },
-          { allowedGroupIds: { $size: 0 } }
-        ]
-      },
+      { allowedGroupIds: { $exists: false } },
       { $set: { allowedGroupIds: [defaultGroup._id] } }
     );
 

--- a/src/migrations/repairDanglingWorkboardGroups.js
+++ b/src/migrations/repairDanglingWorkboardGroups.js
@@ -1,0 +1,56 @@
+const Group = require('../models/Group');
+const Workboard = require('../models/Workboard');
+
+// #740: 작업판의 dangling 접근 그룹 참조 (이미 삭제된 Group 의 ObjectId) 를
+// 현재 기본 그룹으로 치환한다.
+//
+// 배경 — 구 기본 그룹이 groups 컬렉션에서 사라진 뒤, initializeDefaultGroup 이
+// 새 기본 그룹을 만들고 사용자에게 $addToSet 했지만, assignDefaultGroupToWorkboards
+// 는 "비어있는" 작업판만 채우므로 구 ID 를 가진 작업판은 방치됐다. 접근 판정이
+// ID 교집합이라 구 ID 를 아직 가진 사용자에게만 보이는 유령 권한이 됐다.
+//
+// 멱등 — dangling 참조가 없으면 아무것도 하지 않는다.
+async function repairDanglingWorkboardGroups() {
+  try {
+    const defaultGroup = await Group.findDefault();
+    if (!defaultGroup) {
+      console.log('[Migration] 기본 그룹 없음 — initializeDefaultGroup 이 먼저 실행돼야 함. skip.');
+      return 0;
+    }
+
+    const validIds = new Set(
+      (await Group.find({}, { _id: 1 }).lean()).map((g) => String(g._id))
+    );
+
+    const workboards = await Workboard.find(
+      { allowedGroupIds: { $exists: true, $ne: [] } },
+      { name: 1, allowedGroupIds: 1 }
+    ).lean();
+
+    let repaired = 0;
+    for (const wb of workboards) {
+      const ids = (wb.allowedGroupIds || []).map(String);
+      const dangling = ids.filter((id) => !validIds.has(id));
+      if (dangling.length === 0) continue;
+
+      // 유효 참조는 보존하고, dangling 자리에 기본 그룹을 넣는다 (중복 제거).
+      const next = [...new Set([...ids.filter((id) => validIds.has(id)), String(defaultGroup._id)])];
+
+      await Workboard.updateOne({ _id: wb._id }, { $set: { allowedGroupIds: next } });
+      repaired += 1;
+      console.log(
+        `[Migration] "${wb.name}" 접근 그룹 복구 — 삭제된 참조 ${dangling.length}개 → 기본 그룹`
+      );
+    }
+
+    if (repaired > 0) {
+      console.log(`[Migration] 작업판 dangling 접근 그룹 복구 (${repaired}건)`);
+    }
+    return repaired;
+  } catch (error) {
+    console.error('[Migration] 작업판 dangling 접근 그룹 복구 오류:', error);
+    return 0;
+  }
+}
+
+module.exports = repairDanglingWorkboardGroups;

--- a/src/migrations/repairDanglingWorkboardGroups.js
+++ b/src/migrations/repairDanglingWorkboardGroups.js
@@ -9,6 +9,21 @@ const Workboard = require('../models/Workboard');
 // 는 "비어있는" 작업판만 채우므로 구 ID 를 가진 작업판은 방치됐다. 접근 판정이
 // ID 교집합이라 구 ID 를 아직 가진 사용자에게만 보이는 유령 권한이 됐다.
 //
+/**
+ * 한 작업판의 allowedGroupIds 복구 결과를 계산한다 (순수 함수 — 테스트 대상).
+ * @param {string[]} ids — 현재 allowedGroupIds (문자열)
+ * @param {Set<string>} validIds — 실존하는 Group id 집합
+ * @param {string} defaultId — 현재 기본 그룹 id
+ * @returns {{ dangling: string[], next: string[] } | null} 복구 불필요 시 null
+ */
+function computeRepairedGroupIds(ids, validIds, defaultId) {
+  const dangling = ids.filter((id) => !validIds.has(id));
+  if (dangling.length === 0) return null;
+  // 유효 참조는 보존하고, dangling 자리에 기본 그룹을 넣는다 (중복 제거).
+  const next = [...new Set([...ids.filter((id) => validIds.has(id)), defaultId])];
+  return { dangling, next };
+}
+
 // 멱등 — dangling 참조가 없으면 아무것도 하지 않는다.
 async function repairDanglingWorkboardGroups() {
   try {
@@ -30,11 +45,9 @@ async function repairDanglingWorkboardGroups() {
     let repaired = 0;
     for (const wb of workboards) {
       const ids = (wb.allowedGroupIds || []).map(String);
-      const dangling = ids.filter((id) => !validIds.has(id));
-      if (dangling.length === 0) continue;
-
-      // 유효 참조는 보존하고, dangling 자리에 기본 그룹을 넣는다 (중복 제거).
-      const next = [...new Set([...ids.filter((id) => validIds.has(id)), String(defaultGroup._id)])];
+      const repair = computeRepairedGroupIds(ids, validIds, String(defaultGroup._id));
+      if (!repair) continue;
+      const { dangling, next } = repair;
 
       await Workboard.updateOne({ _id: wb._id }, { $set: { allowedGroupIds: next } });
       repaired += 1;
@@ -54,3 +67,4 @@ async function repairDanglingWorkboardGroups() {
 }
 
 module.exports = repairDanglingWorkboardGroups;
+module.exports.computeRepairedGroupIds = computeRepairedGroupIds;

--- a/src/routes/groups.js
+++ b/src/routes/groups.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 const Group = require('../models/Group');
 const User = require('../models/User');
+const Workboard = require('../models/Workboard');
 const { requireAdmin, verifyJWT } = require('../middleware/auth');
 
 // 사용자 본인의 소속 그룹 조회 (일반 사용자도 호출 가능 — 자기 그룹만)
@@ -138,9 +139,28 @@ router.delete('/:id', requireAdmin, async (req, res) => {
       { $pull: { groupIds: group._id } }
     );
 
+    // 작업판 접근 목록에서도 제거 (#740) — 누락 시 dangling 참조가 남아
+    // 편집기에 "삭제된 그룹" 으로 표시되고, 그 ID 를 아직 가진 사용자에게만
+    // 작업판이 보이는 유령 권한이 생긴다.
+    // 결과가 빈 배열이 되는 작업판은 그대로 둔다 = admin 전용 (의도된 정책).
+    const wbResult = await Workboard.updateMany(
+      { allowedGroupIds: group._id },
+      { $pull: { allowedGroupIds: group._id } }
+    );
+
     await Group.findByIdAndDelete(group._id);
 
-    res.json({ success: true, message: '그룹이 삭제되었습니다.' });
+    // 빈 접근 목록이 된 작업판 = admin 외 접근 불가. admin 이 인지할 수 있도록 개수 안내.
+    const adminOnlyCount = await Workboard.countDocuments({ allowedGroupIds: { $size: 0 } });
+
+    res.json({
+      success: true,
+      message: '그룹이 삭제되었습니다.',
+      data: {
+        workboardsUpdated: wbResult.modifiedCount || 0,
+        workboardsAdminOnly: adminOnlyCount
+      }
+    });
   } catch (error) {
     console.error('그룹 삭제 오류:', error);
     res.status(500).json({ success: false, message: '그룹 삭제 실패' });

--- a/src/server.js
+++ b/src/server.js
@@ -43,6 +43,7 @@ const cleanupStuckBackupRestoreJobs = require('./migrations/cleanupStuckBackupRe
 const cleanupOrphanBackupFiles = require('./migrations/cleanupOrphanBackupFiles');
 const initializeDefaultGroup = require('./migrations/initializeDefaultGroup');
 const assignDefaultGroupToWorkboards = require('./migrations/assignDefaultGroupToWorkboards');
+const repairDanglingWorkboardGroups = require('./migrations/repairDanglingWorkboardGroups');
 const backfillCustomFieldRoles = require('./migrations/backfillCustomFieldRoles');
 const dropBaseInputFieldsSchema = require('./migrations/dropBaseInputFieldsSchema');
 const relocateCivitaiApiKey = require('./migrations/relocateCivitaiApiKey');
@@ -252,6 +253,7 @@ const startServer = async () => {
     await cleanupOrphanBackupFiles();
     await initializeDefaultGroup();
     await assignDefaultGroupToWorkboards();
+    await repairDanglingWorkboardGroups();
     await backfillCustomFieldRoles();
     await dropBaseInputFieldsSchema();
     await relocateCivitaiApiKey();

--- a/src/tests/repairDanglingWorkboardGroups.test.js
+++ b/src/tests/repairDanglingWorkboardGroups.test.js
@@ -1,0 +1,67 @@
+const migration = require('../migrations/repairDanglingWorkboardGroups');
+const { computeRepairedGroupIds } = migration;
+
+const DEFAULT = 'default000000000000000d';
+const VALID_A = 'aaaa00000000000000000a';
+const VALID_B = 'bbbb00000000000000000b';
+const GONE_1 = 'dead00000000000000001d';
+const GONE_2 = 'dead00000000000000002d';
+
+const validIds = new Set([DEFAULT, VALID_A, VALID_B]);
+
+describe('repairDanglingWorkboardGroups — computeRepairedGroupIds (#740)', () => {
+  test('마이그레이션 함수 export', () => {
+    expect(typeof migration).toBe('function');
+  });
+
+  describe('복구 불필요 (멱등)', () => {
+    test('모든 참조가 유효하면 null', () => {
+      expect(computeRepairedGroupIds([VALID_A, VALID_B], validIds, DEFAULT)).toBeNull();
+    });
+
+    test('기본 그룹만 있어도 null', () => {
+      expect(computeRepairedGroupIds([DEFAULT], validIds, DEFAULT)).toBeNull();
+    });
+
+    test('빈 배열 (admin 전용) 은 건드리지 않는다', () => {
+      expect(computeRepairedGroupIds([], validIds, DEFAULT)).toBeNull();
+    });
+  });
+
+  describe('dangling 참조 복구', () => {
+    test('dangling 단독 → 기본 그룹으로 치환', () => {
+      const r = computeRepairedGroupIds([GONE_1], validIds, DEFAULT);
+      expect(r.dangling).toEqual([GONE_1]);
+      expect(r.next).toEqual([DEFAULT]);
+    });
+
+    test('유효 참조는 보존하고 기본 그룹을 추가', () => {
+      const r = computeRepairedGroupIds([VALID_A, GONE_1], validIds, DEFAULT);
+      expect(r.dangling).toEqual([GONE_1]);
+      expect(r.next).toEqual([VALID_A, DEFAULT]);
+    });
+
+    test('dangling 여러 개여도 기본 그룹 하나로 합쳐진다', () => {
+      const r = computeRepairedGroupIds([GONE_1, GONE_2], validIds, DEFAULT);
+      expect(r.dangling).toEqual([GONE_1, GONE_2]);
+      expect(r.next).toEqual([DEFAULT]);
+    });
+
+    test('이미 기본 그룹을 가진 경우 중복 추가하지 않는다', () => {
+      const r = computeRepairedGroupIds([DEFAULT, GONE_1], validIds, DEFAULT);
+      expect(r.next).toEqual([DEFAULT]);
+    });
+
+    test('복구 결과는 항상 비어있지 않다 — 접근이 admin 전용으로 좁혀지지 않음', () => {
+      for (const input of [[GONE_1], [GONE_1, GONE_2], [VALID_B, GONE_1]]) {
+        const r = computeRepairedGroupIds(input, validIds, DEFAULT);
+        expect(r.next.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  test('복구 후 재실행하면 null (멱등)', () => {
+    const first = computeRepairedGroupIds([VALID_A, GONE_1], validIds, DEFAULT);
+    expect(computeRepairedGroupIds(first.next, validIds, DEFAULT)).toBeNull();
+  });
+});


### PR DESCRIPTION
## 배경

작업판 편집 > 권한 / 노출 에 "삭제된 그룹" 칩과 경고가 표시된다는 제보에서 출발.

조사 결과 존재하지 않는 그룹 ID `6a00beed757fdcb480f3c6de` 를 작업판 7개가 참조 중이었다. 표시 자체는 #713 (ObjectId 원문 → 주황 칩) 과 v3.14.0 #730 D-12 (경고 Alert) 로 가시성이 올라간 것이고, **데이터 문제는 그 이전부터 존재**했다.

발생 경로 — 구 기본 그룹이 `groups` 에서 사라짐 → `initializeDefaultGroup` 이 새 기본 그룹 생성 + 사용자에게 `$addToSet` → 그러나 `assignDefaultGroupToWorkboards` 는 `allowedGroupIds` 가 **비어 있는** 작업판만 채우므로 구 ID 를 가진 7개는 방치.

접근 판정이 ID 교집합 (`middleware/auth.js`) 이라, 구 ID 를 아직 가진 사용자 10명에게만 보이고 신 기본 그룹만 가진 12명에게는 안 보이는 상태였다.

## 변경

| 항목 | 내용 |
|---|---|
| **A** | 편집기 안내문 정정. v3.14.0 문구 "이 그룹으로는 아무도 접근할 수 없으니 칩의 × 를 눌러 지우세요" 는 사실과 달랐다 — 실제로는 10명이 그 ID 로 접근 중이었고, 안내대로 지우면 유효 그룹 0개가 되어 admin 전용이 되고 접근이 끊긴다. 유효 그룹 잔존 여부로 문구 분기 |
| **B** | `DELETE /api/groups/:id` 가 `User.groupIds` 만 `$pull` 하고 `Workboard.allowedGroupIds` 는 방치하던 근본 원인 수정. 빈 배열이 된 작업판은 그대로 허용 (= admin 전용, 결정된 정책) + 개수를 응답에 담아 그룹 관리 화면 토스트로 안내 |
| **C** | `assignDefaultGroupToWorkboards` 가 매 기동마다 `$size: 0` 을 기본 그룹으로 채워, B 의 "빈 배열 = admin 전용" 이 재시작 한 번에 뒤집히던 문제. 대상을 `$exists: false` 로 좁혀 의도적 빈 배열 보존 |
| **D** | `repairDanglingWorkboardGroups` 마이그레이션 신설 — dangling 참조를 현재 기본 그룹으로 치환. 유효 참조 보존 · 중복 제거 · 멱등 |
| — | 복구 계산을 순수 함수 `computeRepairedGroupIds` 로 분리 + 단위 테스트 10개 |

## 검증 (docker-compose 실환경)

- 마이그레이션이 작업판 7개 복구, 재기동 시 재실행 없음 (멱등)
- 작업판 1개를 빈 배열로 두고 재기동 → 빈 배열 유지 확인 (C 정책), 이후 원복
- Alert 두 갈래 (유효 그룹 있음 / 없음) 렌더 확인
- `npx jest` 356개 전부 통과
- 최종 상태: 작업판 10개 모두 유효 그룹 보유, dangling · 빈 배열 0건

## 영향

작업판 7개 (SDXL T2I - LoRA, GPT Image, Gemini Image, GPT Chat, Anima - Simple, Local Chat, Uncensored Chat) 가 비admin 22명 전원에게 보이게 된다. 기존에는 10명에게만 보였다.

closes #740