### PR TITLE
refactor: serverType 목록 단일 source 화 (#745)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,9 +275,10 @@ npm run test:e2e:headed
 
 ### 5. Server / Workboard capability 모델 (v1.8.0+)
 - Server 는 provider 단위 (`OpenAI` / `OpenAI Compatible` / `Gemini` / `ComfyUI`)
+- **serverType 목록·capability·헬스체크 spec 의 단일 source 는 `src/constants/serverTypes.js`** (#745). `frontend/src/templates/capabilities.js` 와 `mcp-server/src/constants/serverTypes.js` 는 **생성된 mirror — 직접 수정 금지**, backend 상수 수정 후 `node scripts/sync-server-type-mirrors.js` 재실행 (어긋나면 `serverTypesMirror.test.js` 실패). 신규 provider 추가 절차는 `docs/DEVELOPMENT.md` "신규 serverType 추가 절차" 참고
 - Workboard 는 (server, outputFormat) 조합으로 capability 결정. legacy `apiFormat` 필드는 v2.0 (Phase 6) 에서 완전 제거
-- 신규 작업판 템플릿은 `frontend/src/templates/<serverType>-<outputFormat>.json` 5종 + `index.js` 로더 + `capabilities.js` (capability matrix · 라벨 헬퍼) 로 정의
-- 백엔드 라우팅은 `services/queueService.js` 의 `SERVICE_MAP[(serverType, outputFormat)]` dispatcher 가 단일 진입점. 신규 provider 추가 시 한 곳만 수정
+- 신규 작업판 템플릿은 `frontend/src/templates/<serverType>-<outputFormat>.json` + `index.js` 로더 + `capabilities.js` (generated capability matrix · 라벨 헬퍼) 로 정의
+- 백엔드 라우팅은 `services/queueService.js` 의 `SERVICE_MAP[(serverType, outputFormat)]` dispatcher 가 단일 진입점
 - `routes/jobs.js` prompt-generate 는 `server.serverType` 기반으로 `geminiService.complete` / `openAIChatService.complete` 분기
 
 ### 6. 인증 정책 (JWT + API Key)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -6,7 +6,7 @@ VCC Manager 의 백엔드 / 프론트엔드 / MCP 서버 구조와 핵심 모듈
 
 여러 AI 이미지/비디오/텍스트 생성 provider 를 단일 작업판(Workboard) 모델로 추상화하여 관리하는 웹 애플리케이션.
 
-- **지원 provider** (`serverType`): `OpenAI`, `OpenAI Compatible` (Ollama / LiteLLM 등), `Gemini`, `ComfyUI`
+- **지원 provider** (`serverType`): `OpenAI`, `OpenAI Compatible` (Ollama / LiteLLM 등), `Gemini`, `ComfyUI` — 목록·capability 의 단일 source 는 `src/constants/serverTypes.js` (#745, 아래 "신규 serverType 추가 절차" 참고)
 - **출력 형식** (`outputFormat`): `image`, `video`, `text` — provider 별 capability matrix 에서 결정
 - **인증**: JWT (웹) + API Key (MCP / 외부) — 세부 정책은 root `CLAUDE.md` "알려진 패턴 및 주의사항" 참고
 
@@ -57,6 +57,28 @@ VCC Manager 의 백엔드 / 프론트엔드 / MCP 서버 구조와 핵심 모듈
 | 작업판 템플릿 | `frontend/src/templates/` | `<serverType>-<outputFormat>.json` + `index.js` 로더 + `capabilities.js` (capability matrix) (v1.8.0) |
 | 관리자 작업판 편집 | `frontend/src/components/admin/WorkboardManagement.js` | 작업판 생성·편집, 템플릿 기반 폼 |
 | 공통 컴포넌트 | `frontend/src/components/common/` | 13개 공통 다이얼로그/패널 (root `CLAUDE.md` "공통 컴포넌트 활용" 참고) |
+
+## 신규 serverType(provider) 추가 절차 (#745)
+
+serverType 목록·capability·헬스체크 spec 의 **단일 source 는 `src/constants/serverTypes.js`** 다.
+frontend(`frontend/src/templates/capabilities.js`)와 mcp-server(`mcp-server/src/constants/serverTypes.js`)는
+모듈 시스템이 달라(ESM vs CJS) 직접 공유가 불가능한 **생성된 mirror** 이며, 손으로 고치지 않는다.
+
+1. `src/constants/serverTypes.js` 의 `SERVER_TYPE_SPECS` 에 새 타입 spec 추가
+   (label / color / outputFormats / modelSource / healthCheck / defaultUrl / icon)
+2. `node scripts/sync-server-type-mirrors.js` 실행 → frontend/mcp mirror 재생성
+3. `src/services/queueService.js` 에 provider service 핸들러 작성 + `SERVICE_MAP` 에
+   `'<타입>:<format>'` 키 연결 (image/video capability 는 핸들러가 없으면 테스트 실패)
+4. `frontend/src/templates/<타입>-<format>.json` 템플릿 작성 + `index.js` `TEMPLATES` 에 등록
+   (capability 조합마다 템플릿 필요 — 테스트로 검증)
+5. `npx jest` — `serverTypesSingleSource.test.js` (capability↔SERVICE_MAP 정합)
+   + `serverTypesMirror.test.js` (mirror 동기화·템플릿 커버리지) 통과 확인
+6. 선택: `frontend/src/components/common/WorkboardCatalog.js` 의 `deriveSvc`/`SERVER_AXIS`
+   (카탈로그 필터 축 — 미등록 시 'other' 로 안전 폴백), `src/utils/pricing.js` (비용 추정),
+   모델 목록 fetcher (`modelMetadataService.js` — 새 `modelSource` 값이 필요한 경우)
+
+타입 deprecate 시에는 `DEPRECATED_SERVER_TYPE_SPECS` 로 옮기고 `migrateTo` 를 지정한다
+(Mongoose enum 잔존 + 작업판 import 폴백 + 신규 생성 차단이 자동 적용).
 
 ## MCP 서버
 

--- a/frontend/src/components/admin/ServerManagement.js
+++ b/frontend/src/components/admin/ServerManagement.js
@@ -44,16 +44,31 @@ import {
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { serverAPI, jobAPI } from '../../services/api';
-import { getServerTypeColor } from '../../templates/capabilities';
+import {
+  SERVER_TYPES,
+  KNOWN_SERVER_URLS,
+  MODEL_SYNC_SERVER_TYPES,
+  DEPRECATED_SERVER_TYPES,
+  getServerTypeColor,
+  getServerTypeLabel,
+  getServerTypeIconKey,
+} from '../../templates/capabilities';
 import { ToneChip, TagChip } from '../common/WorkboardCatalog';
 import { MONO } from '../../theme';
 import PageHeader from '../common/PageHeader';
 import EmptyState from '../common/EmptyState';
 
-// 공식 base URL 이 알려진 provider — 서버 추가 시 자동 입력 (사용자 입력 우선)
-const KNOWN_SERVER_URLS = {
-  OpenAI: 'https://api.openai.com',
-  Gemini: 'https://generativelanguage.googleapis.com',
+// 서버 타입 목록·라벨·아이콘 키·URL 프리셋은 templates/capabilities.js (generated mirror) 가 단일 source (#745)
+
+const TYPE_ICONS = { computer: <Computer />, text: <TextFields />, storage: <Storage /> };
+const getTypeIcon = (serverType) => TYPE_ICONS[getServerTypeIconKey(serverType)] || <Storage />;
+
+// 관리 화면 표기: "<라벨> API" (deprecated 는 표시만 하고 신규 생성 불가)
+const getServerTypeApiLabel = (serverType) => {
+  if (DEPRECATED_SERVER_TYPES[serverType]) {
+    return `${DEPRECATED_SERVER_TYPES[serverType].label} API (deprecated)`;
+  }
+  return SERVER_TYPES.includes(serverType) ? `${getServerTypeLabel(serverType)} API` : serverType;
 };
 
 function ServerCard({
@@ -74,7 +89,7 @@ function ServerCard({
   const isModelSyncing = modelSyncStatus?.status === 'fetching';
   const loraFailed = loraSyncStatus?.status === 'failed';
   const modelFailed = modelSyncStatus?.status === 'failed';
-  const supportsModelSync = ['ComfyUI', 'OpenAI', 'OpenAI Compatible', 'Gemini'].includes(server.serverType);
+  const supportsModelSync = MODEL_SYNC_SERVER_TYPES.includes(server.serverType);
 
   const getStatusIcon = (status) => {
     switch (status) {
@@ -98,37 +113,6 @@ function ServerCard({
     }
   };
 
-  const getTypeIcon = (serverType) => {
-    switch (serverType) {
-      case 'ComfyUI':
-        return <Computer />;
-      case 'OpenAI':
-      case 'OpenAI Compatible':
-      case 'GPT Image':
-        return <TextFields />;
-      case 'Gemini':
-        return <Storage />;
-      default:
-        return <Storage />;
-    }
-  };
-
-  const getServerTypeLabel = (serverType) => {
-    switch (serverType) {
-      case 'ComfyUI':
-        return 'ComfyUI API';
-      case 'OpenAI':
-        return 'OpenAI API';
-      case 'OpenAI Compatible':
-        return 'OpenAI Compatible API';
-      case 'Gemini':
-        return 'Gemini API';
-      case 'GPT Image':
-        return 'GPT Image API (deprecated)';
-      default:
-        return serverType;
-    }
-  };
 
   const handleHealthCheck = async () => {
     setHealthChecking(true);
@@ -157,7 +141,7 @@ function ServerCard({
         <Box sx={{ flex: 1, minWidth: 180 }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flexWrap: 'wrap' }}>
             <Typography sx={{ fontWeight: 600, fontSize: 14 }}>{server.name}</Typography>
-            <TagChip label={getServerTypeLabel(server.serverType)} />
+            <TagChip label={getServerTypeApiLabel(server.serverType)} />
             <ToneChip tone={statusChip.tone} label={statusChip.label} mono />
             {!server.isActive && <ToneChip tone="neutral" label="비활성" />}
           </Box>
@@ -373,10 +357,9 @@ function ServerDialog({ open, onClose, server, onSubmit }) {
                   }}
                   label="AI API 형식"
                 >
-                  <MenuItem value="ComfyUI">ComfyUI API</MenuItem>
-                  <MenuItem value="OpenAI">OpenAI API</MenuItem>
-                  <MenuItem value="OpenAI Compatible">OpenAI Compatible API</MenuItem>
-                  <MenuItem value="Gemini">Gemini API</MenuItem>
+                  {SERVER_TYPES.map((t) => (
+                    <MenuItem key={t} value={t}>{getServerTypeApiLabel(t)}</MenuItem>
+                  ))}
                 </Select>
               </FormControl>
             </Grid>
@@ -486,7 +469,7 @@ function ServerManagement() {
   const activeQueue = (queueStats.active || 0) + (queueStats.waiting || 0);
   const comfyUIServers = servers.filter(s => s.serverType === 'ComfyUI');
   const modelSyncSupportedServers = servers.filter(s =>
-    ['ComfyUI', 'OpenAI', 'OpenAI Compatible', 'Gemini'].includes(s.serverType)
+    MODEL_SYNC_SERVER_TYPES.includes(s.serverType)
   );
 
   const { data: loraSyncData } = useQuery({ queryKey: ['loraSyncStatuses', comfyUIServers.map(s => s._id).join(',')], queryFn: async () => {

--- a/frontend/src/pages/admin/MetadataManagementPage.js
+++ b/frontend/src/pages/admin/MetadataManagementPage.js
@@ -7,8 +7,11 @@ import CivitaiAdminHeader from '../../components/admin/CivitaiAdminHeader';
 import { serverAPI, adminAPI } from '../../services/api';
 import PageHeader from '../../components/common/PageHeader';
 
-const MODEL_SERVER_TYPES = ['ComfyUI', 'OpenAI', 'OpenAI Compatible', 'Gemini'];
-const LORA_SERVER_TYPES = ['ComfyUI'];
+// 타입 목록은 templates/capabilities.js (generated mirror) 가 단일 source (#745)
+import {
+  MODEL_SYNC_SERVER_TYPES as MODEL_SERVER_TYPES,
+  LORA_SERVER_TYPES,
+} from '../../templates/capabilities';
 
 const SELECTED_SERVER_KEY = 'vcc.metadataAdmin.selectedServerId';
 

--- a/frontend/src/templates/capabilities.js
+++ b/frontend/src/templates/capabilities.js
@@ -1,12 +1,33 @@
-// 각 server type 이 지원하는 outputFormat 목록.
-// frontend/src/templates/index.js 의 TEMPLATES 키와 일치해야 함.
-// 새 (serverType, outputFormat) 조합 지원 시 여기와 templates 양쪽을 함께 갱신.
+// generated — 수정 금지. source: src/constants/serverTypes.js (#745)
+// 재생성: node scripts/sync-server-type-mirrors.js
+// 이 파일은 backend 단일 source 의 mirror 이며, 동기화는 serverTypesMirror.test.js 가 검증한다.
 
+// 서버 등록을 허용하는 활성 serverType 목록
+export const SERVER_TYPES = [
+  "ComfyUI",
+  "OpenAI",
+  "OpenAI Compatible",
+  "Gemini"
+];
+
+// 각 server type 이 지원하는 outputFormat 목록.
+// frontend/src/templates/index.js 의 TEMPLATES 키와 일치해야 함 (테스트로 검증).
 export const CAPABILITIES = {
-  ComfyUI: ['image', 'video'],
-  OpenAI: ['image', 'text'],
-  'OpenAI Compatible': ['text'],
-  Gemini: ['image', 'text'],
+  "ComfyUI": [
+    "image",
+    "video"
+  ],
+  "OpenAI": [
+    "image",
+    "text"
+  ],
+  "OpenAI Compatible": [
+    "text"
+  ],
+  "Gemini": [
+    "image",
+    "text"
+  ]
 };
 
 const OUTPUT_FORMAT_LABELS = {
@@ -16,11 +37,54 @@ const OUTPUT_FORMAT_LABELS = {
 };
 
 const SERVER_TYPE_LABELS = {
-  ComfyUI: 'ComfyUI',
-  OpenAI: 'OpenAI',
-  'OpenAI Compatible': 'OpenAI Compatible',
-  Gemini: 'Gemini',
+  "ComfyUI": "ComfyUI",
+  "OpenAI": "OpenAI",
+  "OpenAI Compatible": "OpenAI Compatible",
+  "Gemini": "Gemini"
 };
+
+// serverType 별 distinct hex. brand-친화적 색상 사용 (시맨틱 컬러와 분리).
+// chip 은 클릭/disabled 처리 없는 표시용이라 hover state 미고려.
+// (CLAUDE.md hex 리터럴 금지 규칙의 문서화된 예외)
+const SERVER_TYPE_COLORS = {
+  "ComfyUI": "#7e57c2",
+  "OpenAI": "#10a37f",
+  "OpenAI Compatible": "#607d8b",
+  "Gemini": "#4285f4"
+};
+
+// 공식 base URL 이 알려진 provider — 서버 추가 시 자동 입력 (사용자 입력 우선)
+export const KNOWN_SERVER_URLS = {
+  "OpenAI": "https://api.openai.com",
+  "Gemini": "https://generativelanguage.googleapis.com"
+};
+
+// 서버 카드 아이콘 키 — MUI 컴포넌트 매핑은 소비처(ServerManagement)에서 수행
+const SERVER_TYPE_ICON_KEYS = {
+  "ComfyUI": "computer",
+  "OpenAI": "text",
+  "OpenAI Compatible": "text",
+  "Gemini": "storage"
+};
+
+// deprecated 타입 표시 메타 (stale 데이터 렌더용 — 신규 생성 불가)
+export const DEPRECATED_SERVER_TYPES = {
+  "GPT Image": {
+    "label": "GPT Image",
+    "icon": "text"
+  }
+};
+
+// 모델 목록 동기화 지원 타입 / LoRA(checkpoint 기반) 지원 타입
+export const MODEL_SYNC_SERVER_TYPES = [
+  "ComfyUI",
+  "OpenAI",
+  "OpenAI Compatible",
+  "Gemini"
+];
+export const LORA_SERVER_TYPES = [
+  "ComfyUI"
+];
 
 export function getCapableOutputFormats(serverType) {
   return CAPABILITIES[serverType] || [];
@@ -34,15 +98,14 @@ export function getServerTypeLabel(serverType) {
   return SERVER_TYPE_LABELS[serverType] || serverType;
 }
 
-// 4 serverType 별 distinct hex. brand-친화적 색상 사용 (시맨틱 컬러와 분리).
-// chip 은 클릭/disabled 처리 없는 표시용이라 hover state 미고려.
-const SERVER_TYPE_COLORS = {
-  ComfyUI: '#7e57c2',          // 보라 — 서드파티/오픈소스 느낌
-  OpenAI: '#10a37f',           // OpenAI brand teal
-  'OpenAI Compatible': '#607d8b', // 회색-파랑 — 호환 레이어
-  Gemini: '#4285f4',           // Google blue
-};
-
 export function getServerTypeColor(serverType) {
   return SERVER_TYPE_COLORS[serverType] || '#9e9e9e';
+}
+
+export function getServerTypeIconKey(serverType) {
+  return (
+    SERVER_TYPE_ICON_KEYS[serverType] ||
+    DEPRECATED_SERVER_TYPES[serverType]?.icon ||
+    'storage'
+  );
 }

--- a/mcp-server/src/constants/serverTypes.js
+++ b/mcp-server/src/constants/serverTypes.js
@@ -1,0 +1,15 @@
+// generated — 수정 금지. source: src/constants/serverTypes.js (#745)
+// 재생성: node scripts/sync-server-type-mirrors.js
+// 이 파일은 backend 단일 source 의 mirror 이며, 동기화는 serverTypesMirror.test.js 가 검증한다.
+
+export const SERVER_TYPES = [
+  "ComfyUI",
+  "OpenAI",
+  "OpenAI Compatible",
+  "Gemini"
+];
+export const OUTPUT_FORMATS = [
+  "image",
+  "video",
+  "text"
+];

--- a/mcp-server/src/tools/workboards.js
+++ b/mcp-server/src/tools/workboards.js
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { SERVER_TYPES, OUTPUT_FORMATS } from '../constants/serverTypes.js';
 
 /**
  * Register workboard-related tools on the MCP server.
@@ -14,8 +15,8 @@ export function registerWorkboardTools(server, apiRequest) {
     'List available workboards (image/video generation templates). Use this first to discover what generators are available.',
     {
       search: z.string().optional().describe('Search by name or description'),
-      serverType: z.enum(['ComfyUI', 'OpenAI', 'OpenAI Compatible', 'Gemini']).optional().describe('Filter by server type'),
-      outputFormat: z.enum(['image', 'video', 'text']).optional().describe('Filter by output format'),
+      serverType: z.enum(SERVER_TYPES).optional().describe('Filter by server type'),
+      outputFormat: z.enum(OUTPUT_FORMATS).optional().describe('Filter by output format'),
       page: z.coerce.number().int().positive().optional().describe('Page number (default 1)'),
       limit: z.coerce.number().int().positive().max(50).optional().describe('Items per page (default 10)'),
     },

--- a/scripts/sync-server-type-mirrors.js
+++ b/scripts/sync-server-type-mirrors.js
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+// serverType mirror 생성 스크립트 (#745).
+//
+// backend 단일 source(src/constants/serverTypes.js)에서 frontend/mcp-server 용
+// mirror 파일을 생성한다. 모듈 시스템이 달라(CJS vs ESM) 직접 공유가 불가능한
+// 의도적 mirror — 손으로 고치지 말고 backend 상수 수정 후 이 스크립트를 재실행할 것.
+//
+//   node scripts/sync-server-type-mirrors.js          # mirror 재생성
+//
+// 동기화 회귀는 src/tests/serverTypesMirror.test.js 가 잡는다 (render 결과 ↔ 디스크 비교).
+
+const fs = require('fs');
+const path = require('path');
+const {
+  SERVER_TYPE_SPECS,
+  DEPRECATED_SERVER_TYPE_SPECS,
+  SERVER_TYPES,
+  MODEL_SYNC_SERVER_TYPES,
+} = require('../src/constants/serverTypes');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const FRONTEND_TARGET = path.join(REPO_ROOT, 'frontend/src/templates/capabilities.js');
+const MCP_TARGET = path.join(REPO_ROOT, 'mcp-server/src/constants/serverTypes.js');
+
+const HEADER = `// generated — 수정 금지. source: src/constants/serverTypes.js (#745)
+// 재생성: node scripts/sync-server-type-mirrors.js
+// 이 파일은 backend 단일 source 의 mirror 이며, 동기화는 serverTypesMirror.test.js 가 검증한다.`;
+
+const json = (v) => JSON.stringify(v, null, 2);
+
+const pickMap = (field) =>
+  Object.fromEntries(SERVER_TYPES.map((t) => [t, SERVER_TYPE_SPECS[t][field]]));
+
+function renderFrontendCapabilities() {
+  const capabilities = Object.fromEntries(
+    SERVER_TYPES.map((t) => [t, [...SERVER_TYPE_SPECS[t].outputFormats]])
+  );
+  const knownUrls = Object.fromEntries(
+    SERVER_TYPES.filter((t) => SERVER_TYPE_SPECS[t].defaultUrl)
+      .map((t) => [t, SERVER_TYPE_SPECS[t].defaultUrl])
+  );
+  const deprecated = Object.fromEntries(
+    Object.entries(DEPRECATED_SERVER_TYPE_SPECS).map(([t, spec]) => [
+      t,
+      { label: spec.label, icon: spec.icon },
+    ])
+  );
+  const loraTypes = SERVER_TYPES.filter(
+    (t) => SERVER_TYPE_SPECS[t].modelSource === 'checkpoint'
+  );
+
+  return `${HEADER}
+
+// 서버 등록을 허용하는 활성 serverType 목록
+export const SERVER_TYPES = ${json(SERVER_TYPES)};
+
+// 각 server type 이 지원하는 outputFormat 목록.
+// frontend/src/templates/index.js 의 TEMPLATES 키와 일치해야 함 (테스트로 검증).
+export const CAPABILITIES = ${json(capabilities)};
+
+const OUTPUT_FORMAT_LABELS = {
+  image: '이미지',
+  video: '비디오',
+  text: '텍스트',
+};
+
+const SERVER_TYPE_LABELS = ${json(pickMap('label'))};
+
+// serverType 별 distinct hex. brand-친화적 색상 사용 (시맨틱 컬러와 분리).
+// chip 은 클릭/disabled 처리 없는 표시용이라 hover state 미고려.
+// (CLAUDE.md hex 리터럴 금지 규칙의 문서화된 예외)
+const SERVER_TYPE_COLORS = ${json(pickMap('color'))};
+
+// 공식 base URL 이 알려진 provider — 서버 추가 시 자동 입력 (사용자 입력 우선)
+export const KNOWN_SERVER_URLS = ${json(knownUrls)};
+
+// 서버 카드 아이콘 키 — MUI 컴포넌트 매핑은 소비처(ServerManagement)에서 수행
+const SERVER_TYPE_ICON_KEYS = ${json(pickMap('icon'))};
+
+// deprecated 타입 표시 메타 (stale 데이터 렌더용 — 신규 생성 불가)
+export const DEPRECATED_SERVER_TYPES = ${json(deprecated)};
+
+// 모델 목록 동기화 지원 타입 / LoRA(checkpoint 기반) 지원 타입
+export const MODEL_SYNC_SERVER_TYPES = ${json([...MODEL_SYNC_SERVER_TYPES])};
+export const LORA_SERVER_TYPES = ${json(loraTypes)};
+
+export function getCapableOutputFormats(serverType) {
+  return CAPABILITIES[serverType] || [];
+}
+
+export function getOutputFormatLabel(outputFormat) {
+  return OUTPUT_FORMAT_LABELS[outputFormat] || outputFormat;
+}
+
+export function getServerTypeLabel(serverType) {
+  return SERVER_TYPE_LABELS[serverType] || serverType;
+}
+
+export function getServerTypeColor(serverType) {
+  return SERVER_TYPE_COLORS[serverType] || '#9e9e9e';
+}
+
+export function getServerTypeIconKey(serverType) {
+  return (
+    SERVER_TYPE_ICON_KEYS[serverType] ||
+    DEPRECATED_SERVER_TYPES[serverType]?.icon ||
+    'storage'
+  );
+}
+`;
+}
+
+function renderMcpConstants() {
+  return `${HEADER}
+
+export const SERVER_TYPES = ${json(SERVER_TYPES)};
+export const OUTPUT_FORMATS = ${json(['image', 'video', 'text'])};
+`;
+}
+
+function main() {
+  fs.mkdirSync(path.dirname(MCP_TARGET), { recursive: true });
+  fs.writeFileSync(FRONTEND_TARGET, renderFrontendCapabilities());
+  fs.writeFileSync(MCP_TARGET, renderMcpConstants());
+  console.log(`✅ mirror 갱신 완료:\n- ${path.relative(REPO_ROOT, FRONTEND_TARGET)}\n- ${path.relative(REPO_ROOT, MCP_TARGET)}`);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { renderFrontendCapabilities, renderMcpConstants, FRONTEND_TARGET, MCP_TARGET };

--- a/src/constants/serverTypes.js
+++ b/src/constants/serverTypes.js
@@ -1,0 +1,100 @@
+// serverType 단일 source (#745).
+//
+// 서버(provider) 타입 목록과 타입별 capability/메타데이터의 유일한 정의처.
+// backend 는 이 모듈을 직접 import 하고, frontend/mcp-server 는 모듈 시스템이 달라
+// (ESM vs CJS) 공유가 불가능하므로 `scripts/sync-server-type-mirrors.js` 로 생성된
+// mirror 파일을 사용한다. mirror 동기화 회귀는 `src/tests/serverTypesMirror.test.js` 가 잡는다.
+//
+// 신규 serverType 추가 절차: docs/DEVELOPMENT.md 의 "신규 serverType 추가" 런북 참고.
+// 요약: 이 파일에 spec 추가 → 템플릿 JSON 추가 → sync 스크립트 실행 → SERVICE_MAP 핸들러 연결.
+
+// 타입별 spec:
+// - label/color: UI 표시용 (frontend mirror 로 전파)
+// - outputFormats: 지원하는 출력 형식 — 작업판 capability matrix 의 단일 source.
+//   'image'/'video' 는 queueService SERVICE_MAP 에 대응 핸들러가 있어야 함 (coverage 테스트로 강제).
+//   'text' 는 Bull 큐를 타지 않는 동기 SSE 경로 (routes/jobs.js).
+// - modelSource: 모델 목록 동기화 방식. 'checkpoint'(ComfyUI 파일 스캔) / 'openai'(GET /v1/models)
+//   / 'gemini'(GET /v1beta/models). 없으면 모델 동기화 미지원.
+// - healthCheck.path: serverUrl 뒤에 붙는 헬스체크 경로 (null 이면 serverUrl 자체 GET).
+// - healthCheck.auth: 'bearer'(Authorization 헤더) / 'query-key'(?key= 쿼리, Gemini 방식).
+// - defaultUrl: 서버 등록 UI 의 URL 프리셋 (frontend mirror 로 전파).
+const SERVER_TYPE_SPECS = Object.freeze({
+  'ComfyUI': Object.freeze({
+    label: 'ComfyUI',
+    color: '#7e57c2', // 보라 — 서드파티/오픈소스 느낌
+    outputFormats: Object.freeze(['image', 'video']),
+    modelSource: 'checkpoint',
+    healthCheck: Object.freeze({ path: '/system_stats', auth: 'bearer' }),
+    defaultUrl: 'http://localhost:8188',
+  }),
+  'OpenAI': Object.freeze({
+    label: 'OpenAI',
+    color: '#10a37f', // OpenAI brand teal
+    outputFormats: Object.freeze(['image', 'text']),
+    modelSource: 'openai',
+    healthCheck: Object.freeze({ path: '/v1/models', auth: 'bearer' }),
+    defaultUrl: 'https://api.openai.com',
+  }),
+  'OpenAI Compatible': Object.freeze({
+    label: 'OpenAI Compatible',
+    color: '#607d8b', // 회색-파랑 — 호환 레이어
+    outputFormats: Object.freeze(['text']),
+    modelSource: 'openai',
+    healthCheck: Object.freeze({ path: '/v1/models', auth: 'bearer' }),
+    defaultUrl: '',
+  }),
+  'Gemini': Object.freeze({
+    label: 'Gemini',
+    color: '#4285f4', // Google blue
+    outputFormats: Object.freeze(['image', 'text']),
+    modelSource: 'gemini',
+    healthCheck: Object.freeze({ path: '/v1beta/models', auth: 'query-key' }),
+    defaultUrl: 'https://generativelanguage.googleapis.com',
+  }),
+});
+
+// deprecated 타입: 신규 생성은 차단하되 stale 문서의 Mongoose 검증은 통과시킨다.
+// migrateTo 는 마이그레이션/작업판 import 폴백 매핑에 사용 (Phase 2 #181, #182 와 동일).
+const DEPRECATED_SERVER_TYPE_SPECS = Object.freeze({
+  'GPT Image': Object.freeze({
+    migrateTo: 'OpenAI',
+    healthCheck: Object.freeze({ path: '/v1/models', auth: 'bearer' }),
+  }),
+});
+
+// ─── 파생 목록 (직접 하드코딩 금지 — 반드시 여기서 import) ───────────────
+
+// 활성 타입 목록 — 신규 서버 생성 허용 대상
+const SERVER_TYPES = Object.freeze(Object.keys(SERVER_TYPE_SPECS));
+
+// Mongoose enum 용 — deprecated 포함 (stale 문서 검증 통과)
+const SERVER_TYPES_WITH_DEPRECATED = Object.freeze([
+  ...SERVER_TYPES,
+  ...Object.keys(DEPRECATED_SERVER_TYPE_SPECS),
+]);
+
+// 모델 목록 동기화 지원 타입
+const MODEL_SYNC_SERVER_TYPES = Object.freeze(
+  SERVER_TYPES.filter((t) => SERVER_TYPE_SPECS[t].modelSource)
+);
+
+// 구버전 export 문서의 serverType 폴백 매핑 (deprecated → 현행)
+const SERVER_TYPE_LEGACY_FALLBACK = Object.freeze(
+  Object.fromEntries(
+    Object.entries(DEPRECATED_SERVER_TYPE_SPECS).map(([t, spec]) => [t, spec.migrateTo])
+  )
+);
+
+// deprecated 포함 spec 조회 (healthCheck 등 기존 문서 대응용)
+const getServerTypeSpec = (serverType) =>
+  SERVER_TYPE_SPECS[serverType] || DEPRECATED_SERVER_TYPE_SPECS[serverType] || null;
+
+module.exports = {
+  SERVER_TYPE_SPECS,
+  DEPRECATED_SERVER_TYPE_SPECS,
+  SERVER_TYPES,
+  SERVER_TYPES_WITH_DEPRECATED,
+  MODEL_SYNC_SERVER_TYPES,
+  SERVER_TYPE_LEGACY_FALLBACK,
+  getServerTypeSpec,
+};

--- a/src/constants/serverTypes.js
+++ b/src/constants/serverTypes.js
@@ -17,7 +17,8 @@
 //   / 'gemini'(GET /v1beta/models). 없으면 모델 동기화 미지원.
 // - healthCheck.path: serverUrl 뒤에 붙는 헬스체크 경로 (null 이면 serverUrl 자체 GET).
 // - healthCheck.auth: 'bearer'(Authorization 헤더) / 'query-key'(?key= 쿼리, Gemini 방식).
-// - defaultUrl: 서버 등록 UI 의 URL 프리셋 (frontend mirror 로 전파).
+// - defaultUrl: 서버 등록 UI 의 URL 자동 입력 프리셋 (공식 base URL 이 알려진 provider 만, 없으면 null).
+// - icon: 서버 카드 아이콘 키 — frontend 가 MUI 컴포넌트로 매핑 ('computer'/'text'/'storage').
 const SERVER_TYPE_SPECS = Object.freeze({
   'ComfyUI': Object.freeze({
     label: 'ComfyUI',
@@ -25,7 +26,8 @@ const SERVER_TYPE_SPECS = Object.freeze({
     outputFormats: Object.freeze(['image', 'video']),
     modelSource: 'checkpoint',
     healthCheck: Object.freeze({ path: '/system_stats', auth: 'bearer' }),
-    defaultUrl: 'http://localhost:8188',
+    defaultUrl: null,
+    icon: 'computer',
   }),
   'OpenAI': Object.freeze({
     label: 'OpenAI',
@@ -34,6 +36,7 @@ const SERVER_TYPE_SPECS = Object.freeze({
     modelSource: 'openai',
     healthCheck: Object.freeze({ path: '/v1/models', auth: 'bearer' }),
     defaultUrl: 'https://api.openai.com',
+    icon: 'text',
   }),
   'OpenAI Compatible': Object.freeze({
     label: 'OpenAI Compatible',
@@ -41,7 +44,8 @@ const SERVER_TYPE_SPECS = Object.freeze({
     outputFormats: Object.freeze(['text']),
     modelSource: 'openai',
     healthCheck: Object.freeze({ path: '/v1/models', auth: 'bearer' }),
-    defaultUrl: '',
+    defaultUrl: null,
+    icon: 'text',
   }),
   'Gemini': Object.freeze({
     label: 'Gemini',
@@ -50,6 +54,7 @@ const SERVER_TYPE_SPECS = Object.freeze({
     modelSource: 'gemini',
     healthCheck: Object.freeze({ path: '/v1beta/models', auth: 'query-key' }),
     defaultUrl: 'https://generativelanguage.googleapis.com',
+    icon: 'storage',
   }),
 });
 
@@ -57,6 +62,8 @@ const SERVER_TYPE_SPECS = Object.freeze({
 // migrateTo 는 마이그레이션/작업판 import 폴백 매핑에 사용 (Phase 2 #181, #182 와 동일).
 const DEPRECATED_SERVER_TYPE_SPECS = Object.freeze({
   'GPT Image': Object.freeze({
+    label: 'GPT Image',
+    icon: 'text',
     migrateTo: 'OpenAI',
     healthCheck: Object.freeze({ path: '/v1/models', auth: 'bearer' }),
   }),

--- a/src/models/Server.js
+++ b/src/models/Server.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const { SERVER_TYPES_WITH_DEPRECATED, getServerTypeSpec } = require('../constants/serverTypes');
 
 const serverSchema = new mongoose.Schema({
   name: {
@@ -13,9 +14,9 @@ const serverSchema = new mongoose.Schema({
   },
   serverType: {
     type: String,
-    // 'GPT Image' 는 deprecated — Phase 2 마이그레이션으로 'OpenAI' 로 전환됨.
-    // enum 에는 다음 메이저까지 잔존시켜 stale 문서가 있어도 Mongoose 검증 실패가 안 나도록 함.
-    enum: ['ComfyUI', 'OpenAI', 'OpenAI Compatible', 'Gemini', 'GPT Image'],
+    // deprecated 타입('GPT Image' 등)도 포함 — stale 문서가 있어도 Mongoose 검증 실패가 안 나도록 함.
+    // 타입 목록의 단일 source 는 constants/serverTypes.js (#745).
+    enum: SERVER_TYPES_WITH_DEPRECATED,
     required: true
   },
   serverUrl: {
@@ -76,25 +77,13 @@ serverSchema.methods.checkHealth = async function() {
   const startTime = Date.now();
   
   try {
-    let healthEndpoint;
     let timeout = this.configuration?.timeout || 30000;
-    
-    // 서버 타입별 헬스체크 엔드포인트
-    switch (this.serverType) {
-      case 'ComfyUI':
-        healthEndpoint = `${this.serverUrl}/system_stats`;
-        break;
-      case 'OpenAI':
-      case 'OpenAI Compatible':
-      case 'GPT Image': // deprecated — Phase 2 후 데이터는 'OpenAI' 로 마이그레이션됨
-        healthEndpoint = `${this.serverUrl}/v1/models`;
-        break;
-      case 'Gemini':
-        healthEndpoint = `${this.serverUrl}/v1beta/models`;
-        break;
-      default:
-        healthEndpoint = this.serverUrl;
-    }
+
+    // 서버 타입별 헬스체크 엔드포인트 — spec 은 constants/serverTypes.js 단일 source (#745)
+    const spec = getServerTypeSpec(this.serverType);
+    const healthEndpoint = spec?.healthCheck?.path
+      ? `${this.serverUrl}${spec.healthCheck.path}`
+      : this.serverUrl;
 
     // at-rest 암호화된 apiKey 복호화 (#594)
     const { decryptSecret } = require('../utils/secretCrypto');
@@ -107,7 +96,7 @@ serverSchema.methods.checkHealth = async function() {
       } : {}
     };
 
-    if (this.serverType === 'Gemini' && apiKey) {
+    if (spec?.healthCheck?.auth === 'query-key' && apiKey) {
       requestConfig.params = { key: apiKey };
       requestConfig.headers = {};
     }

--- a/src/routes/servers.js
+++ b/src/routes/servers.js
@@ -8,6 +8,7 @@ const { verifyJWT, requireAdmin, userHasWorkboardAccess } = require('../middlewa
 const loraMetadataService = require('../services/loraMetadataService');
 const modelMetadataService = require('../services/modelMetadataService');
 const comfyUIService = require('../services/comfyUIService');
+const { SERVER_TYPES, MODEL_SYNC_SERVER_TYPES } = require('../constants/serverTypes');
 const { encryptSecret } = require('../utils/secretCrypto');
 const { validateBody, serverCreateSchema, serverUpdateSchema } = require('../utils/validation');
 
@@ -91,8 +92,8 @@ router.post('/', requireAdmin, validateBody(serverCreateSchema), async (req, res
       });
     }
 
-    // 서버 타입 검증 ('GPT Image' 는 deprecated — 신규 생성 차단)
-    if (!['ComfyUI', 'OpenAI', 'OpenAI Compatible', 'Gemini'].includes(serverType)) {
+    // 서버 타입 검증 — deprecated 타입은 SERVER_TYPES 에 없어 신규 생성이 차단됨 (#745)
+    if (!SERVER_TYPES.includes(serverType)) {
       return res.status(400).json({
         success: false,
         message: '지원하지 않는 서버 타입입니다.'
@@ -326,13 +327,12 @@ router.get('/:id/models', verifyJWT, async (req, res) => {
 
     const detailed = req.query.detailed === 'true';
 
-    // detailed 모드: 4종 serverType 모두 동일 응답 구조로 처리 (LoRA `/loras` 와 동일 패턴)
+    // detailed 모드: 모델 동기화 지원 serverType 모두 동일 응답 구조로 처리 (LoRA `/loras` 와 동일 패턴)
     if (detailed) {
-      const SUPPORTED = ['ComfyUI', 'OpenAI', 'OpenAI Compatible', 'Gemini'];
-      if (!SUPPORTED.includes(server.serverType)) {
+      if (!MODEL_SYNC_SERVER_TYPES.includes(server.serverType)) {
         return res.status(400).json({
           success: false,
-          message: `상세 모델 목록은 ${SUPPORTED.join(' / ')} 서버에서만 조회할 수 있습니다.`
+          message: `상세 모델 목록은 ${MODEL_SYNC_SERVER_TYPES.join(' / ')} 서버에서만 조회할 수 있습니다.`
         });
       }
 
@@ -524,11 +524,10 @@ router.post('/:id/models/sync', requireAdmin, async (req, res) => {
       });
     }
 
-    const SUPPORTED = ['ComfyUI', 'OpenAI', 'OpenAI Compatible', 'Gemini'];
-    if (!SUPPORTED.includes(server.serverType)) {
+    if (!MODEL_SYNC_SERVER_TYPES.includes(server.serverType)) {
       return res.status(400).json({
         success: false,
-        message: `모델 동기화는 ${SUPPORTED.join(' / ')} 서버에서만 사용할 수 있습니다.`
+        message: `모델 동기화는 ${MODEL_SYNC_SERVER_TYPES.join(' / ')} 서버에서만 사용할 수 있습니다.`
       });
     }
 

--- a/src/routes/workboards.js
+++ b/src/routes/workboards.js
@@ -19,9 +19,8 @@ const { WORKBOARD_EXPORT_VERSION: EXPORT_VERSION, APP_VERSION, buildWorkboardExp
 
 // 옛 환경에서 export 한 작업판 백업의 server.serverType 을 신규 enum 으로 폴백 매핑.
 // Phase 2 (#181, #182) 마이그레이션과 동일 매핑. import 자동 매칭 1차 실패 시 시도.
-const SERVER_TYPE_LEGACY_FALLBACK = {
-  'GPT Image': 'OpenAI',
-};
+// 매핑의 단일 source 는 constants/serverTypes.js 의 deprecated spec (#745).
+const { SERVER_TYPE_LEGACY_FALLBACK } = require('../constants/serverTypes');
 
 router.get('/', requireAuth, async (req, res) => {
   try {

--- a/src/services/modelMetadataService.js
+++ b/src/services/modelMetadataService.js
@@ -2,6 +2,7 @@ const axios = require('axios');
 const ServerModelCache = require('../models/ServerModelCache');
 const SystemSettings = require('../models/SystemSettings');
 const { decryptSecret } = require('../utils/secretCrypto');
+const { getServerTypeSpec } = require('../constants/serverTypes');
 
 // LoRA service 와 동일한 Civitai rate limit / 재시도 정책.
 // 단순 재구현 (Phase B 에서는 두 서비스가 독립으로 진화할 여지를 두기 위해
@@ -342,10 +343,12 @@ const syncServerProviderModels = async (server, { progressCallback = null } = {}
     if (progressCallback) progressCallback('fetching_list', 0, 0);
     await cache.updateProgress(0, 0, 'fetching_list');
 
+    // modelSource 는 constants/serverTypes.js 의 spec 이 단일 source (#745)
     let providerModels = [];
-    if (server.serverType === 'OpenAI' || server.serverType === 'OpenAI Compatible') {
+    const modelSource = getServerTypeSpec(server.serverType)?.modelSource;
+    if (modelSource === 'openai') {
       providerModels = await getOpenAIProviderModels(server.serverUrl, apiKey);
-    } else if (server.serverType === 'Gemini') {
+    } else if (modelSource === 'gemini') {
       providerModels = await getGeminiProviderModels(server.serverUrl, apiKey);
     } else {
       throw new Error(`Unsupported serverType for provider sync: ${server.serverType}`);
@@ -390,10 +393,11 @@ const syncServerProviderModels = async (server, { progressCallback = null } = {}
  * 호출자는 이 단일 진입점만 알면 됨.
  */
 const syncServerModels = async (server, opts = {}) => {
-  if (server.serverType === 'ComfyUI') {
+  const modelSource = getServerTypeSpec(server.serverType)?.modelSource;
+  if (modelSource === 'checkpoint') {
     return syncServerCheckpoints(server._id, server.serverUrl, opts);
   }
-  if (server.serverType === 'OpenAI' || server.serverType === 'OpenAI Compatible' || server.serverType === 'Gemini') {
+  if (modelSource) {
     return syncServerProviderModels(server, opts);
   }
   throw new Error(`Unsupported serverType for model sync: ${server.serverType}`);

--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -1158,6 +1158,7 @@ const clearImageGenerationQueue = async () => {
 
 module.exports = {
   initializeQueues,
+  SERVICE_MAP, // capability coverage 테스트용 (#745)
   addImageGenerationJob,
   getQueueStats,
   cancelQueueJob,

--- a/src/tests/serverTypesMirror.test.js
+++ b/src/tests/serverTypesMirror.test.js
@@ -1,0 +1,51 @@
+/**
+ * #745 — serverType mirror 동기화 회귀 테스트.
+ *
+ * frontend/mcp-server 는 모듈 시스템이 달라(ESM vs CJS) backend 단일 source 를
+ * 직접 import 할 수 없어 생성된 mirror 를 쓴다. backend 상수만 바뀌고
+ * `node scripts/sync-server-type-mirrors.js` 재실행을 잊은 회귀를 여기서 잡는다.
+ * (builtinTagsMirror.test.js 와 같은 single-source-of-truth 정책)
+ */
+const fs = require('fs');
+const path = require('path');
+const {
+  renderFrontendCapabilities,
+  renderMcpConstants,
+  FRONTEND_TARGET,
+  MCP_TARGET,
+} = require('../../scripts/sync-server-type-mirrors');
+const { SERVER_TYPE_SPECS, SERVER_TYPES } = require('../constants/serverTypes');
+
+describe('serverTypes mirror 동기화 (#745)', () => {
+  test('frontend capabilities.js 가 생성 결과와 일치 (sync 스크립트 재실행 필요 여부)', () => {
+    const onDisk = fs.readFileSync(FRONTEND_TARGET, 'utf8');
+    expect(onDisk).toBe(renderFrontendCapabilities());
+  });
+
+  test('mcp-server 상수가 생성 결과와 일치', () => {
+    const onDisk = fs.readFileSync(MCP_TARGET, 'utf8');
+    expect(onDisk).toBe(renderMcpConstants());
+  });
+
+  test('capability 조합마다 frontend 템플릿이 등록되어 있음', () => {
+    // TEMPLATES 는 JSON import 라 codegen 대상이 아님 — 키 존재만 텍스트로 검증.
+    const indexSrc = fs.readFileSync(
+      path.join(__dirname, '../../frontend/src/templates/index.js'),
+      'utf8'
+    );
+    for (const serverType of SERVER_TYPES) {
+      for (const format of SERVER_TYPE_SPECS[serverType].outputFormats) {
+        expect(indexSrc).toContain(`'${serverType}:${format}'`);
+      }
+    }
+  });
+
+  test('mcp workboards 도구가 mirror 상수를 사용 (하드코딩 enum 회귀 방지)', () => {
+    const toolSrc = fs.readFileSync(
+      path.join(__dirname, '../../mcp-server/src/tools/workboards.js'),
+      'utf8'
+    );
+    expect(toolSrc).toContain("from '../constants/serverTypes.js'");
+    expect(toolSrc).not.toMatch(/z\.enum\(\[\s*'ComfyUI'/);
+  });
+});

--- a/src/tests/serverTypesSingleSource.test.js
+++ b/src/tests/serverTypesSingleSource.test.js
@@ -1,0 +1,71 @@
+/**
+ * #745 — serverType 단일 source (constants/serverTypes.js) 정합성 테스트.
+ *
+ * 타입 목록·capability 가 소비처와 어긋나는 회귀를 잡는다:
+ * 1. capability matrix ↔ queueService SERVICE_MAP 커버리지
+ * 2. 파생 목록(deprecated 포함/제외, legacy fallback) 불변식
+ *
+ * frontend/mcp mirror 동기화 테스트는 serverTypesMirror.test.js (Phase 2) 참고.
+ */
+const {
+  SERVER_TYPE_SPECS,
+  DEPRECATED_SERVER_TYPE_SPECS,
+  SERVER_TYPES,
+  SERVER_TYPES_WITH_DEPRECATED,
+  MODEL_SYNC_SERVER_TYPES,
+  SERVER_TYPE_LEGACY_FALLBACK,
+  getServerTypeSpec,
+} = require('../constants/serverTypes');
+const { SERVICE_MAP } = require('../services/queueService');
+
+describe('serverTypes 단일 source 정합성 (#745)', () => {
+  test('image/video capability 는 SERVICE_MAP 에 핸들러가 있어야 함', () => {
+    // 'text' 는 Bull 큐를 타지 않는 동기 SSE 경로라 SERVICE_MAP 대상 아님.
+    for (const [serverType, spec] of Object.entries(SERVER_TYPE_SPECS)) {
+      for (const format of spec.outputFormats) {
+        if (format === 'text') continue;
+        const key = `${serverType}:${format}`;
+        expect(SERVICE_MAP[key]).toBeInstanceOf(Function);
+      }
+    }
+  });
+
+  test('SERVICE_MAP 의 키는 전부 유효한 serverType 을 참조', () => {
+    // capability 에 없는 잉여 키는 허용(구버전 작업판 호환)하되,
+    // 존재하지 않는 타입을 참조하는 키는 오타이므로 실패시킨다.
+    for (const key of Object.keys(SERVICE_MAP)) {
+      const [serverType, format] = key.split(':');
+      expect(SERVER_TYPES).toContain(serverType);
+      expect(['image', 'video']).toContain(format);
+    }
+  });
+
+  test('활성 타입 목록에 deprecated 타입이 섞이지 않음', () => {
+    for (const deprecatedType of Object.keys(DEPRECATED_SERVER_TYPE_SPECS)) {
+      expect(SERVER_TYPES).not.toContain(deprecatedType);
+      expect(SERVER_TYPES_WITH_DEPRECATED).toContain(deprecatedType);
+    }
+  });
+
+  test('deprecated 타입의 migrateTo 는 활성 타입이며 legacy fallback 과 일치', () => {
+    for (const [deprecatedType, spec] of Object.entries(DEPRECATED_SERVER_TYPE_SPECS)) {
+      expect(SERVER_TYPES).toContain(spec.migrateTo);
+      expect(SERVER_TYPE_LEGACY_FALLBACK[deprecatedType]).toBe(spec.migrateTo);
+    }
+  });
+
+  test('modelSource 가 있는 타입만 MODEL_SYNC_SERVER_TYPES 에 포함', () => {
+    const expected = SERVER_TYPES.filter((t) => SERVER_TYPE_SPECS[t].modelSource);
+    expect(MODEL_SYNC_SERVER_TYPES).toEqual(expected);
+  });
+
+  test('getServerTypeSpec 은 deprecated 타입도 healthCheck spec 을 반환', () => {
+    for (const serverType of SERVER_TYPES_WITH_DEPRECATED) {
+      const spec = getServerTypeSpec(serverType);
+      expect(spec).not.toBeNull();
+      expect(spec.healthCheck).toBeDefined();
+      expect(typeof spec.healthCheck.path).toBe('string');
+    }
+    expect(getServerTypeSpec('없는타입')).toBeNull();
+  });
+});

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -122,7 +122,7 @@ const validate = (schema) => {
 // 핸들러에 그대로 둔다. 클라이언트가 추가 필드를 보내는 기존 계약을 깨지 않도록
 // unknown 키는 허용. 에러 메시지는 기존 핸들러의 수동 검증 메시지와 동일하게 유지.
 
-const SERVER_TYPES = ['ComfyUI', 'OpenAI', 'OpenAI Compatible', 'Gemini'];
+const { SERVER_TYPES } = require('../constants/serverTypes');
 
 const REQUIRED_FIELD_MESSAGES = {
   'any.required': '필수 필드가 누락되었습니다.',


### PR DESCRIPTION
## 변경사항 요약

serverType 목록·capability 정보의 하드코딩 사본 25곳+ 를 backend 단일 source 로 통합.

- **Phase 1 (backend)**: `src/constants/serverTypes.js` 신설 — 타입 목록, output format capability, healthCheck spec, modelSource, 라벨/색상/아이콘/URL 프리셋의 유일한 정의처. Server 모델 enum·checkHealth, validation, servers 라우트, modelMetadataService, workboards legacy fallback 을 전부 상수 참조로 전환. `SERVICE_MAP` capability coverage 테스트 추가.
- **Phase 2 (frontend/mcp mirror)**: `scripts/sync-server-type-mirrors.js` codegen 으로 `frontend/src/templates/capabilities.js` + `mcp-server/src/constants/serverTypes.js` mirror 생성 ("generated — 수정 금지" 헤더). ServerManagement 의 라벨/아이콘 switch·드롭다운·필터, MetadataManagementPage 목록, mcp `z.enum` 을 mirror 파생으로 전환. `serverTypesMirror.test.js` 가 render↔디스크 byte 비교 + 템플릿 키 커버리지 + mcp enum 하드코딩 회귀를 가드.
- **Phase 3 (docs)**: DEVELOPMENT.md 에 "신규 serverType 추가 절차" 런북, CLAUDE.md 에 mirror 갱신 규칙.

신규 provider 추가 공수: 25개+ 파일 → **상수 spec 1곳 + 템플릿 JSON + sync 스크립트 실행 + SERVICE_MAP 핸들러**.

동작 불변 (behavior-neutral) 원칙 유지 — capability 에 없는 SERVICE_MAP 잉여 키('OpenAI Compatible:image')는 구버전 작업판 호환을 위해 존치.

## 검증

- jest 48 suites / 375 tests 통과 (신규 10 tests 포함)
- frontend vite build 통과
- docker-compose up --build — 5개 컨테이너 정상 기동, backend 큐 초기화 확인
- Playwright e2e smoke 5/5 통과

## 후속

- d-ice-all 연동 serverType 추가 (별도 이슈로 진행 예정 — 이 리팩토링의 첫 수혜 사례)

closes #745

🤖 Generated with [Claude Code](https://claude.com/claude-code)