### PR TITLE
feat: d-ice-all serverType 추가 — Codex 구독 경유 이미지 생성 (#747)

### DIFF
--- a/frontend/src/templates/capabilities.js
+++ b/frontend/src/templates/capabilities.js
@@ -7,7 +7,8 @@ export const SERVER_TYPES = [
   "ComfyUI",
   "OpenAI",
   "OpenAI Compatible",
-  "Gemini"
+  "Gemini",
+  "d-ice-all"
 ];
 
 // 각 server type 이 지원하는 outputFormat 목록.
@@ -27,6 +28,9 @@ export const CAPABILITIES = {
   "Gemini": [
     "image",
     "text"
+  ],
+  "d-ice-all": [
+    "image"
   ]
 };
 
@@ -40,7 +44,8 @@ const SERVER_TYPE_LABELS = {
   "ComfyUI": "ComfyUI",
   "OpenAI": "OpenAI",
   "OpenAI Compatible": "OpenAI Compatible",
-  "Gemini": "Gemini"
+  "Gemini": "Gemini",
+  "d-ice-all": "d-ice-all"
 };
 
 // serverType 별 distinct hex. brand-친화적 색상 사용 (시맨틱 컬러와 분리).
@@ -50,7 +55,8 @@ const SERVER_TYPE_COLORS = {
   "ComfyUI": "#7e57c2",
   "OpenAI": "#10a37f",
   "OpenAI Compatible": "#607d8b",
-  "Gemini": "#4285f4"
+  "Gemini": "#4285f4",
+  "d-ice-all": "#00acc1"
 };
 
 // 공식 base URL 이 알려진 provider — 서버 추가 시 자동 입력 (사용자 입력 우선)
@@ -64,7 +70,8 @@ const SERVER_TYPE_ICON_KEYS = {
   "ComfyUI": "computer",
   "OpenAI": "text",
   "OpenAI Compatible": "text",
-  "Gemini": "storage"
+  "Gemini": "storage",
+  "d-ice-all": "storage"
 };
 
 // deprecated 타입 표시 메타 (stale 데이터 렌더용 — 신규 생성 불가)

--- a/frontend/src/templates/d-ice-all-image.json
+++ b/frontend/src/templates/d-ice-all-image.json
@@ -1,0 +1,45 @@
+{
+  "additionalInputFields": [
+    {
+      "name": "base_model",
+      "label": "생성 프로바이더",
+      "type": "select",
+      "required": true,
+      "defaultValue": "codex",
+      "options": [
+        {
+          "key": "Codex (구독 · ImageGen)",
+          "value": "codex"
+        }
+      ],
+      "description": "d-ice-all 게이트웨이의 provider 이름입니다. 게이트웨이에 named provider 를 추가했다면 옵션을 늘려 사용하세요."
+    },
+    {
+      "name": "image_size",
+      "label": "이미지 크기",
+      "type": "select",
+      "required": true,
+      "defaultValue": "auto",
+      "options": [
+        {
+          "key": "자동 (auto)",
+          "value": "auto"
+        },
+        {
+          "key": "1024x1024",
+          "value": "1024x1024"
+        },
+        {
+          "key": "1024x1536",
+          "value": "1024x1536"
+        },
+        {
+          "key": "1536x1024",
+          "value": "1536x1024"
+        }
+      ],
+      "description": "크기 힌트입니다. 게이트웨이가 지원 범위 내에서 가장 가까운 크기로 생성합니다."
+    }
+  ],
+  "workflowData": ""
+}

--- a/frontend/src/templates/index.js
+++ b/frontend/src/templates/index.js
@@ -9,6 +9,7 @@ import openAIText from './OpenAI-text.json';
 import geminiImage from './Gemini-image.json';
 import geminiText from './Gemini-text.json';
 import openAICompatibleText from './OpenAI Compatible-text.json';
+import dIceAllImage from './d-ice-all-image.json';
 
 const TEMPLATES = {
   'ComfyUI:image': comfyImage,
@@ -18,6 +19,7 @@ const TEMPLATES = {
   'Gemini:image': geminiImage,
   'Gemini:text': geminiText,
   'OpenAI Compatible:text': openAICompatibleText,
+  'd-ice-all:image': dIceAllImage,
 };
 
 // 매핑이 없을 때 사용하는 빈 폴백 (Workboard 가 항상 baseInputFields/additionalInputFields 를 갖도록 보장).

--- a/mcp-server/src/constants/serverTypes.js
+++ b/mcp-server/src/constants/serverTypes.js
@@ -6,7 +6,8 @@ export const SERVER_TYPES = [
   "ComfyUI",
   "OpenAI",
   "OpenAI Compatible",
-  "Gemini"
+  "Gemini",
+  "d-ice-all"
 ];
 export const OUTPUT_FORMATS = [
   "image",

--- a/src/constants/serverTypes.js
+++ b/src/constants/serverTypes.js
@@ -56,6 +56,16 @@ const SERVER_TYPE_SPECS = Object.freeze({
     defaultUrl: 'https://generativelanguage.googleapis.com',
     icon: 'storage',
   }),
+  // 로컬 LLM 게이트웨이 (Codex CLI ImageGen 경유 — 구독 과금, 종량 비용 없음) (#747)
+  'd-ice-all': Object.freeze({
+    label: 'd-ice-all',
+    color: '#00acc1', // cyan — 로컬 게이트웨이 (ice 시리즈)
+    outputFormats: Object.freeze(['image']),
+    modelSource: null, // 모델 동기화 미지원 — aiModel 은 게이트웨이 provider 이름 (템플릿 select)
+    healthCheck: Object.freeze({ path: '/health', auth: 'bearer' }),
+    defaultUrl: null,
+    icon: 'storage',
+  }),
 });
 
 // deprecated 타입: 신규 생성은 차단하되 stale 문서의 Mongoose 검증은 통과시킨다.

--- a/src/services/dIceAllService.js
+++ b/src/services/dIceAllService.js
@@ -1,0 +1,85 @@
+const axios = require('axios');
+
+// d-ice-all 게이트웨이 이미지 생성 (#747).
+//
+// d-ice-all 은 OpenAI Images 호환 `/v1/images/generations` 을 제공하는 로컬 LLM
+// 게이트웨이로, 내부적으로 Codex CLI(ImageGen) 를 스폰해 구독 과금으로 이미지를
+// 생성한다 (건당 ~1분, 종량 API 비용 없음). 인증은 `x-api-key` 헤더 (미설정 게이트웨이는 생략).
+// aiModel 필드 값은 게이트웨이의 provider 이름으로 전달된다 (기본 'codex').
+
+const extractValue = (input) => {
+  if (input && typeof input === 'object' && input.value !== undefined) {
+    return input.value;
+  }
+  return input;
+};
+
+const generateImage = async (serverUrl, apiKey, prompt, options = {}) => {
+  if (!serverUrl) {
+    throw new Error('d-ice-all server URL is required');
+  }
+  const resolvedServerUrl = serverUrl.replace(/\/+$/, '');
+  const provider = extractValue(options.model) || 'codex';
+  const size = extractValue(options.size);
+  const n = Number(extractValue(options.n)) || 1;
+
+  const requestBody = {
+    provider,
+    prompt,
+    n,
+    response_format: 'b64_json',
+  };
+  if (size && size !== 'auto') requestBody.size = size;
+
+  const headers = { 'Content-Type': 'application/json' };
+  if (apiKey) headers['x-api-key'] = apiKey;
+
+  let response;
+  try {
+    response = await axios.post(
+      `${resolvedServerUrl}/v1/images/generations`,
+      requestBody,
+      {
+        headers,
+        // codex exec 에이전트 세션은 건당 수십 초~수 분 — 서버 timeout 설정을 그대로 쓰되 기본은 넉넉히
+        timeout: options.timeout || 600000,
+        signal: options.signal,
+      }
+    );
+  } catch (err) {
+    const apiMessage = err.response?.data?.error?.message;
+    if (err.response?.status === 401) {
+      throw new Error('d-ice-all: API key 인증 실패 — 서버 설정의 apiKey 를 확인하세요.');
+    }
+    if (apiMessage) throw new Error(`d-ice-all: ${apiMessage}`);
+    throw err;
+  }
+
+  const images = (response.data?.data || [])
+    .filter((entry) => entry?.b64_json)
+    .map((entry, index) => {
+      const buffer = Buffer.from(entry.b64_json, 'base64');
+      return {
+        buffer,
+        filename: `d_ice_all_${Date.now()}_${index}.png`,
+        size: buffer.length,
+        mimeType: 'image/png',
+      };
+    });
+
+  if (images.length === 0) {
+    throw new Error('No image returned from d-ice-all');
+  }
+
+  // 구독 과금 경로 — usage/비용 추정 없음 (#747)
+  return {
+    images,
+    videos: [],
+    usage: null,
+    model: provider,
+  };
+};
+
+module.exports = {
+  generateImage,
+};

--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -7,6 +7,7 @@ const sharp = require('sharp');
 const comfyUIService = require('./comfyUIService');
 const geminiService = require('./geminiService');
 const gptImageService = require('./gptImageService');
+const dIceAllService = require('./dIceAllService');
 const { computeOpenAIImageCost, computeGeminiImageCost } = require('../utils/pricing');
 const ImageGenerationJob = require('../models/ImageGenerationJob');
 const GeneratedImage = require('../models/GeneratedImage');
@@ -137,6 +138,7 @@ const SERVICE_MAP = {
   'OpenAI Compatible:image': handleOpenAIImage,
   'ComfyUI:image': handleComfyUIWorkflow,
   'ComfyUI:video': handleComfyUIWorkflow,
+  'd-ice-all:image': handleDIceAllImage,
 };
 
 const resolveServiceKey = (workboardData) => {
@@ -187,6 +189,30 @@ async function handleGeminiImage({ workboardData, inputData, job, signal }) {
     videos: result.videos,
     usage: usageNormalized,
     costEstimate,
+  };
+}
+
+// d-ice-all 게이트웨이 (Codex ImageGen 경유, 구독 과금) — usage/비용 추정 없음 (#747)
+async function handleDIceAllImage({ workboardData, inputData, job, signal }) {
+  const result = await dIceAllService.generateImage(
+    workboardData.serverUrl,
+    workboardData.apiKey,
+    buildGeminiPrompt(inputData, workboardData),
+    {
+      model: getFieldValueByRole(workboardData, inputData, FIELD_ROLES.MODEL),
+      size: extractOptionValue(getFieldValueByRole(workboardData, inputData, FIELD_ROLES.IMAGE_SIZE)),
+      n: extractOptionValue(inputData.additionalParams?.n || inputData.n) || 1,
+      timeout: workboardData.timeout,
+      signal,
+    }
+  );
+  job.progress(90);
+
+  return {
+    images: result.images,
+    videos: result.videos,
+    usage: null,
+    costEstimate: null,
   };
 }
 


### PR DESCRIPTION
## 변경사항 요약

d-ice-all v0.3.0 게이트웨이(OpenAI Images 호환, Codex CLI ImageGen 경유)를 vcc-manager 의 신규 serverType 으로 추가. **#745 단일 source 리팩토링 런북의 첫 적용 사례** — 실제 수정 파일 7개 (상수 spec + 생성 mirror 2 + 서비스 + 핸들러 + 템플릿 + 로더).

- `src/constants/serverTypes.js`: `d-ice-all` spec (outputFormats `['image']`, healthCheck `/health`, 모델 동기화 미지원) → `node scripts/sync-server-type-mirrors.js` 로 frontend/mcp mirror 재생성
- `src/services/dIceAllService.js`: 게이트웨이 `POST /v1/images/generations` 호출 — `x-api-key` 인증, `b64_json`→buffer, AbortSignal 연동, 기본 timeout 10분 (codex exec 건당 ~1분)
- `SERVICE_MAP['d-ice-all:image']` 핸들러 — 구독 과금 경로라 usage/비용 추정 없음
- `frontend/src/templates/d-ice-all-image.json`: `base_model` 은 **게이트웨이 provider 이름 select** (well-known name → MODEL role) — 모델 동기화 없이 aiModel 요건 충족

## 검증

- jest 48 suites / 375 tests (mirror·SERVICE_MAP coverage 테스트가 신규 타입 자동 검증)
- frontend vite build / docker compose 구동 / Playwright e2e smoke 5/5
- **실 E2E**: d-ice-all 서버 등록 → 헬스체크 `healthy` (spec 기반 `/health`) → 작업판 생성 → 작업 제출 → Bull 큐 → `host.docker.internal:4899` 게이트웨이 → Codex ImageGen → 1254×1254 PNG 생성·저장·signed URL 서빙 확인 (검증 리소스는 정리함)

## 후속 (별도 이슈)

- `text` capability (게이트웨이 chat completions 경유)
- 참조 이미지 전달

closes #747

🤖 Generated with [Claude Code](https://claude.com/claude-code)