### PR TITLE
fix: 생성 작업 큐 자동 재시도 제거 (#750)

### DIFF
--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -71,11 +71,10 @@ const initializeQueues = async () => {
       defaultJobOptions: {
         removeOnComplete: 50,
         removeOnFail: 20,
-        attempts: 3,
-        backoff: {
-          type: 'exponential',
-          delay: 2000
-        }
+        // 자동 재시도 없음 (#750): 생성 실패는 대부분 외부의 의도적 중단(ComfyUI interrupt 등)
+        // 또는 provider 의 결정적 오류라, 자동 재시도가 무거운 워크플로우를 되살리거나
+        // 종량 API 를 이중 과금시킬 수 있다. 복구는 수동 재시도(최대 3회)로 충분.
+        attempts: 1
       }
     });
 
@@ -358,7 +357,8 @@ const processImageGeneration = async (job) => {
   try {
     job.progress(5);
 
-    // 취소 체크포인트 1 — 생성 시작 전. throw 하지 않음 (throw 시 Bull attempts 재시도가 발동) (#521)
+    // 취소 체크포인트 1 — 생성 시작 전. throw 하지 않음 — 실패로 기록되면 안 되는 정상 종료 (#521)
+    // (#750 이후 attempts=1 이라 재시도 오발 문제는 없지만, cancelled 를 failed 로 만들지 않는 것은 여전히 중요)
     if (await isJobCancelled(jobId)) {
       console.log(`🚫 Job ${jobId} cancelled — skipping generation`);
       return { cancelled: true };


### PR DESCRIPTION
## 변경사항 요약

image generation 큐 \`defaultJobOptions.attempts: 3 → 1\` — 자동 재시도 제거 (백오프 설정 삭제).

**배경**: ComfyUI 쪽에서 과부하 워크플로우를 직접 interrupt 하면 vcc-manager 는 실패로 인식 → Bull 자동 재시도가 같은 워크플로우를 최대 3회 재제출 → "취소했는데 계속 도는" 현상 (2026-08-03 실사용 보고). 생성 실패는 대부분 외부의 의도적 중단이거나 provider 의 결정적 오류라 자동 재시도는 GPU 과부하 재유발·종량 API 이중 과금 위험만 남김.

- 수동 재시도(작업 히스토리, \`POST /jobs/:id/retry\`, 최대 3회)는 그대로 유지
- pipeline 큐는 기존부터 attempts 1 — 정합
- #521 취소 체크포인트 주석을 현행에 맞게 갱신

## 검증

- jest 48 suites / 375 tests 통과
- docker compose 재빌드·기동 — health OK, 큐 초기화 정상

closes #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)