### PR TITLE
fix: 작업판 편집기 필드 전환/추가 시 기본값 오염 (#760)

### DIFF
--- a/frontend/src/components/admin/workboardEditor/WorkboardEditor.js
+++ b/frontend/src/components/admin/workboardEditor/WorkboardEditor.js
@@ -351,6 +351,9 @@ export function WorkboardEditor({ workboard, onSave, onCancel }) {
             />
 
             <FieldInspector
+              // 선택 전환마다 강제 remount (#760) — RHF Controller 는 name 변경 시 remount 가
+              // 필요하며, 재사용하면 이전 필드 값이 새 필드 경로로 승계된다 (기본값 오염 버그)
+              key={selectedFieldIdx}
               control={control}
               watch={watch}
               selectedIdx={selectedFieldIdx}

--- a/frontend/src/components/admin/workboardEditor/shared.js
+++ b/frontend/src/components/admin/workboardEditor/shared.js
@@ -157,6 +157,11 @@ export const emptyCustomField = (type) => ({
   required: false,
   formatString: '',
   options: [],
+  // defaultValue 등을 명시적으로 비워 둔다 (#760) — 키가 없으면(undefined) RHF 가
+  // 직전 선택 필드의 값을 새 필드 경로로 이어받아 기본값이 오염된다.
+  defaultValue: '',
+  placeholder: '',
+  description: '',
   imageConfig: { maxImages: 1 },
   videoConfig: { maxVideos: 1 },
 });


### PR DESCRIPTION
## 변경사항 요약

**증상**: 기본값이 있는 필드(이미지 크기 등)를 편집한 뒤 기본값이 없는 필드로 전환/추가하면, 이전 필드의 기본값이 새 필드의 기본값 입력기에 섞여 나옴 (2026-08-06 사용자 보고).

**재현·원인 (실브라우저)**: "이미지 크기 선택 → 필드 추가 → 베이스 모델" 플로우에서 새 필드 기본값에 `1024x1024` 오염 재현. 원인 두 겹:
1. FieldInspector 의 모든 RHF Controller 가 `additionalCustomFields.${selectedIdx}.*` 로 **name 만 바꿔 재사용** — RHF 는 name 변경 시 remount 를 요구하며, 재사용 시 이전 필드 값이 새 경로로 승계됨
2. `emptyCustomField` 에 `defaultValue` 키가 없어(undefined) 새 필드가 이전 값을 **빈값으로 덮지 못함** (보고자 진단 그대로)

**수정**:
- `FieldInspector` 에 `key={selectedFieldIdx}` — 선택 전환마다 강제 remount
- `emptyCustomField` 에 `defaultValue`/`placeholder`/`description` 명시적 빈값

## 검증

- 실브라우저: 수정 전 오염 재현 스크린샷 확보 → 수정 후 동일 플로우에서 기본값 공백 확인
- jest 48 suites / 377 tests, frontend build, docker frontend 재배포

closes #760

🤖 Generated with [Claude Code](https://claude.com/claude-code)