### PR TITLE
fix: 같은 작업판 계속하기에서 base_model 기본값이 실사용 모델을 덮던 회귀 (#762)

### DIFF
--- a/frontend/src/components/common/JobHistoryPanel.js
+++ b/frontend/src/components/common/JobHistoryPanel.js
@@ -1017,6 +1017,7 @@ function JobHistoryPanel({
         inputData: job.inputData,
         workboard,
         prevOutputFormat: job.resultVideos?.length ? 'video' : 'image', // #673
+        sameWorkboard: true, // #762 — 같은 작업판 계속하기: 히스토리 값을 기본값보다 우선 복원
       }));
       navigate(`/generate/${workboardId}`);
       toast.success('작업 설정을 불러왔습니다');
@@ -1061,6 +1062,7 @@ function JobHistoryPanel({
         video: lastGeneratedVideo
       },
       prevOutputFormat: lastGeneratedVideo ? 'video' : 'image', // #673
+      sameWorkboard: false, // #762 — 다른 작업판 이어가기: #673 안전 조건 유지
     }));
 
     setCrossWorkboardOpen(false);

--- a/frontend/src/pages/ImageGeneration.js
+++ b/frontend/src/pages/ImageGeneration.js
@@ -723,6 +723,7 @@ function ImageGeneration() {
 
       let lastGeneratedMedia = null;
       let prevOutputFormat = null; // 이전 작업의 출력 타입 (#673 — base_model prefill 조건 판단용)
+      let sameWorkboardContinue = false; // #762 — 같은 작업판 계속하기 여부
 
       if (continueJobData) {
         try {
@@ -732,6 +733,7 @@ function ImageGeneration() {
             jobInputData = parsedData.inputData;
             lastGeneratedMedia = parsedData.lastGeneratedMedia || null;
             prevOutputFormat = parsedData.prevOutputFormat || null; // #673
+            sameWorkboardContinue = parsedData.sameWorkboard === true; // #762
             localStorage.removeItem('continueJobData'); // 사용 후 제거
           } else {
           }
@@ -755,11 +757,14 @@ function ImageGeneration() {
           }
         };
 
-        // #673: 이전 작업의 base_model 을 새 작업판에 prefill 할지 결정.
-        //  ① 출력 타입이 다르면 비호환이라 skip  ② 출력 타입 같아도 작업판에 base_model 기본값이 있으면 skip  ③ 그 외 prefill
+        // #673: 이전 작업의 base_model 을 prefill 할지 결정 — 단, #673 의 조건은 **다른 작업판으로
+        // 이어가기(크로스)** 안전장치다. 같은 작업판 계속하기는 히스토리의 모델이 이 작업판에서
+        // 선택됐던 유효값이므로 기본값보다 항상 우선 복원한다 (#762 — 기본값이 실사용 모델을 덮던 회귀).
+        //  크로스: ① 출력 타입이 다르면 skip  ② 작업판에 base_model 기본값이 있으면 skip  ③ 그 외 prefill
         const bmField = (workboardData.additionalInputFields || []).find((f) => f.type === 'baseModel');
         const bmHasDefault = bmField && bmField.defaultValue !== undefined && bmField.defaultValue !== null && bmField.defaultValue !== '';
-        const allowBaseModelPrefill = !(prevOutputFormat && prevOutputFormat !== workboardData.outputFormat) && !bmHasDefault;
+        const allowBaseModelPrefill = sameWorkboardContinue
+          || (!(prevOutputFormat && prevOutputFormat !== workboardData.outputFormat) && !bmHasDefault);
 
         // F2: 기본 필드 (prompt, negativePrompt) 만 직접 매핑 — aiModel/imageSize 등은 customField 가 처리.
         // legacy job 의 {key,value} 객체 값도 그대로 set 됨 (Controller 가 value 만 추출). 이전 매칭 로직은


### PR DESCRIPTION
## 변경사항 요약

작업 히스토리 **계속하기** 시 작업판 base_model 에 기본값이 있으면 히스토리의 실사용 모델을 기본값이 덮던 회귀 수정 (2026-08-06 사용자 보고 — #673 작업의 부수 영향이라는 추정 그대로).

**원인**: #673 의 prefill skip 조건(②: 작업판에 base_model 기본값 있으면 skip)이 크로스 작업판 안전장치 의도였는데 **같은 작업판 계속하기에도 적용**됨. 같은 작업판에서는 히스토리 모델이 그 작업판에서 선택됐던 유효값이므로 항상 우선해야 함.

**수정**: continueJobData 에 `sameWorkboard` 구분자 추가 → 같은 작업판이면 무조건 히스토리 복원, 크로스일 때만 #673 조건 유지. (select 등 다른 필드는 원래 히스토리 우선 + 미매칭 시 폴백이라 영향 없음 확인)

## 검증 (실브라우저)

- same-workboard: 기본값(anima_baseV10) 있는 작업판에서 히스토리 모델 `HISTORY_MODEL_X` 정상 복원 ✅
- cross-workboard: 외부 모델 미주입, 작업판 기본값 유지 — #673 동작 보존 ✅
- jest 48 suites / 377 tests, frontend build

closes #762

🤖 Generated with [Claude Code](https://claude.com/claude-code)