### PR TITLE
feat: 워크플로 조건부 입력 생략 — _vcc.omitInputsUnless (#771)

### DIFF
--- a/docs/COMFYUI_WORKFLOW.md
+++ b/docs/COMFYUI_WORKFLOW.md
@@ -149,6 +149,43 @@ image / video 타입 커스텀 필드는 파일명 플레이스홀더 외에 **�
 단일 작업판에서 첨부/미첨부를 모두 처리할 수 있다 (분기는 스위치 노드에 `select` 출력 연결).
 설치·사용법은 [comfyui-nodes/vcc-nodes/README.md](../comfyui-nodes/vcc-nodes/README.md) 참고.
 
+#### D-2. 조건부 입력 생략 — `_vcc.omitInputsUnless` (#771)
+
+ComfyUI 의 optional 입력은 **키를 넣지 않는 것**이 곧 미사용이다. 노드에 `_vcc` 블록을
+두면 치환 결과가 falsy 인 입력 키를 요청 단위로 제거할 수 있다.
+
+```json
+"136": {
+  "class_type": "MiniMaxH3ReferenceToVideo",
+  "inputs": {
+    "ref_images.ref_image_0": ["137", 0],
+    "ref_images.ref_image_1": ["139", 0]
+  },
+  "_vcc": {
+    "omitInputsUnless": {
+      "ref_images.ref_image_1": "{{##ref_image_2_attached##}}"
+    }
+  }
+}
+```
+
+| 항목 | 동작 |
+|---|---|
+| falsy 판정 | `0` `"0"` `""` `false` `null` `"false"` `NaN` |
+| 적용 시점 | 플레이스홀더 치환 **직후** (조건식이 값으로 평가된 뒤) |
+| `_vcc` | 조건 유무와 무관하게 **항상 제거** — ComfyUI 로 넘기지 않는다 |
+| 입력 키 | 점이 있어도 (`ref_images.ref_image_1`) **경로가 아닌 리터럴 키** |
+| 미지원 | JSON 파싱 실패 시 fallback 문자열 치환 경로 (따옴표 없는 플레이스홀더 사용 시) |
+
+**왜 필요한가** — autogrow 입력(예: H3 참조 이미지 최대 9슬롯)은 요청마다 개수가 달라진다.
+미첨부 슬롯에 흰 PNG(#230)를 넣으면 모델이 그걸 참조로 인식하고, 전 슬롯 필수화는 참조
+1장만 필요한 요청에 3장을 강요하게 된다. 키를 빼는 것만이 "그 슬롯은 없다" 를 표현한다.
+
+**노드는 지우지 않아도 된다** — 입력 키가 사라지면 상류 `LoadImage` 는 고아가 되고,
+ComfyUI 는 출력 노드에서 도달 불가능한 노드를 검증도 실행도 하지 않는다 (실측 확인).
+
+**주의** — 필수(required) 입력을 지우면 ComfyUI 제출이 실패한다. optional 입력에만 쓸 것.
+
 ### 2.3 워크플로우 JSON 치환 로직
 
 #### A. 재귀적 객체 순회 (이중 Seed 지원)

--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -9,6 +9,7 @@ const geminiService = require('./geminiService');
 const gptImageService = require('./gptImageService');
 const dIceAllService = require('./dIceAllService');
 const { computeOpenAIImageCost, computeGeminiImageCost } = require('../utils/pricing');
+const { applyOmitDirectives } = require('../utils/workflowOmit');
 const ImageGenerationJob = require('../models/ImageGenerationJob');
 const GeneratedImage = require('../models/GeneratedImage');
 const GeneratedVideo = require('../models/GeneratedVideo');
@@ -858,8 +859,17 @@ const injectInputsIntoWorkflow = async (workflowTemplate, inputData, workboard =
   try {
     const workflowObj = JSON.parse(workflowTemplate);
     const replacedObj = replaceInObject(workflowObj, replacements, seedValue);
+
+    // 조건부 입력 생략 (#771) — 치환이 끝난 뒤에 적용해야 조건식이 값으로 평가된다.
+    // fallback(문자열 치환) 경로에서는 JSON 구조가 없어 지원하지 않는다.
+    const { workflow: prunedObj, omitted } = applyOmitDirectives(replacedObj);
+    if (omitted.length > 0) {
+      console.log(`✂️ 조건부 입력 생략 (${omitted.length}개):`,
+        omitted.map((o) => `#${o.node}.${o.input}`).join(', '));
+    }
+
     return {
-      workflowJson: replacedObj,
+      workflowJson: prunedObj,
       actualSeed: seedValue
     };
   } catch (error) {

--- a/src/tests/workflowOmit.test.js
+++ b/src/tests/workflowOmit.test.js
@@ -1,0 +1,126 @@
+const { applyOmitDirectives, isFalsy } = require('../utils/workflowOmit');
+
+// #771 — 조건부 입력 생략.
+// autogrow 슬롯(ref_images.ref_image_N)을 요청 단위로 없애기 위한 기능이라,
+// "점이 들어간 키를 경로가 아닌 리터럴로 다루는가" 가 핵심 계약이다.
+
+const node = (inputs, omitRules) => ({
+  class_type: 'MiniMaxH3ReferenceToVideo',
+  inputs: { ...inputs },
+  ...(omitRules ? { _vcc: { omitInputsUnless: omitRules } } : {}),
+});
+
+describe('isFalsy (#771)', () => {
+  test('미첨부를 뜻하는 값들', () => {
+    for (const v of [0, '0', '', '  ', false, null, undefined, 'false', 'FALSE', 'null']) {
+      expect(isFalsy(v)).toBe(true);
+    }
+  });
+
+  test('첨부를 뜻하는 값들', () => {
+    for (const v of [1, '1', true, 'true', 'yes', 'image.png', 2]) {
+      expect(isFalsy(v)).toBe(false);
+    }
+  });
+
+  test('NaN 은 falsy — 숫자 치환 실패를 미첨부로 본다', () => {
+    expect(isFalsy(NaN)).toBe(true);
+  });
+});
+
+describe('applyOmitDirectives (#771)', () => {
+  describe('입력 제거', () => {
+    test('조건이 falsy 면 해당 입력만 제거', () => {
+      const wf = {
+        136: node(
+          { 'ref_images.ref_image_0': ['137', 0], 'ref_images.ref_image_1': ['139', 0], prompt: 'x' },
+          { 'ref_images.ref_image_1': 0 }
+        ),
+      };
+      const { workflow, omitted } = applyOmitDirectives(wf);
+      expect(workflow['136'].inputs).toEqual({ 'ref_images.ref_image_0': ['137', 0], prompt: 'x' });
+      expect(omitted).toEqual([{ node: '136', input: 'ref_images.ref_image_1' }]);
+    });
+
+    test('조건이 truthy 면 유지', () => {
+      const wf = {
+        136: node({ 'ref_images.ref_image_1': ['139', 0] }, { 'ref_images.ref_image_1': 1 }),
+      };
+      const { workflow, omitted } = applyOmitDirectives(wf);
+      expect(workflow['136'].inputs['ref_images.ref_image_1']).toEqual(['139', 0]);
+      expect(omitted).toHaveLength(0);
+    });
+
+    test('여러 슬롯을 개별 판정 — 가변 개수의 핵심', () => {
+      const wf = {
+        136: node(
+          {
+            'ref_images.ref_image_0': ['1', 0],
+            'ref_images.ref_image_1': ['2', 0],
+            'ref_images.ref_image_2': ['3', 0],
+          },
+          {
+            'ref_images.ref_image_0': 1,
+            'ref_images.ref_image_1': 0,
+            'ref_images.ref_image_2': 0,
+          }
+        ),
+      };
+      const { workflow, omitted } = applyOmitDirectives(wf);
+      expect(Object.keys(workflow['136'].inputs)).toEqual(['ref_images.ref_image_0']);
+      expect(omitted).toHaveLength(2);
+    });
+
+    test('점이 들어간 키를 경로가 아닌 리터럴로 취급', () => {
+      const wf = {
+        136: node({ 'ref_images.ref_image_1': ['139', 0] }, { 'ref_images.ref_image_1': 0 }),
+      };
+      const { workflow } = applyOmitDirectives(wf);
+      // ref_images 라는 중첩 객체가 생기거나 남으면 안 된다
+      expect(workflow['136'].inputs).toEqual({});
+      expect(workflow['136'].inputs.ref_images).toBeUndefined();
+    });
+
+    test('존재하지 않는 입력 키를 가리켜도 안전', () => {
+      const wf = { 136: node({ prompt: 'x' }, { 'ref_images.ref_image_9': 0 }) };
+      const { workflow, omitted } = applyOmitDirectives(wf);
+      expect(workflow['136'].inputs).toEqual({ prompt: 'x' });
+      expect(omitted).toHaveLength(0);
+    });
+  });
+
+  describe('_vcc 스트립', () => {
+    test('조건이 truthy 여도 _vcc 는 제거된다', () => {
+      const wf = { 136: node({ a: 1 }, { a: 1 }) };
+      const { workflow } = applyOmitDirectives(wf);
+      expect(workflow['136']._vcc).toBeUndefined();
+    });
+
+    test('omitInputsUnless 가 없는 _vcc 도 제거', () => {
+      const wf = { 1: { class_type: 'X', inputs: {}, _vcc: { somethingElse: true } } };
+      const { workflow } = applyOmitDirectives(wf);
+      expect(workflow['1']._vcc).toBeUndefined();
+    });
+  });
+
+  describe('무해한 입력', () => {
+    test('_vcc 없는 노드는 그대로', () => {
+      const wf = { 1: { class_type: 'LoadImage', inputs: { image: 'a.png' } } };
+      const { workflow, omitted } = applyOmitDirectives(wf);
+      expect(workflow['1']).toEqual({ class_type: 'LoadImage', inputs: { image: 'a.png' } });
+      expect(omitted).toHaveLength(0);
+    });
+
+    test('빈/비정상 입력', () => {
+      expect(applyOmitDirectives({}).omitted).toHaveLength(0);
+      expect(applyOmitDirectives(null).workflow).toBeNull();
+      expect(applyOmitDirectives(undefined).omitted).toHaveLength(0);
+    });
+
+    test('inputs 가 없는 노드에 지시자가 있어도 죽지 않는다', () => {
+      const wf = { 1: { class_type: 'X', _vcc: { omitInputsUnless: { a: 0 } } } };
+      expect(() => applyOmitDirectives(wf)).not.toThrow();
+      expect(wf['1']._vcc).toBeUndefined();
+    });
+  });
+});

--- a/src/utils/workflowOmit.js
+++ b/src/utils/workflowOmit.js
@@ -1,0 +1,83 @@
+// 워크플로 조건부 입력 생략 (#771).
+//
+// ComfyUI 의 optional 입력은 "키를 넣지 않는 것" 이 곧 미사용이다. 그런데 VCC 는 워크플로
+// JSON 을 고정 템플릿으로 두고 플레이스홀더만 치환하므로, 요청마다 키를 넣었다 뺐다 할
+// 수단이 없었다.
+//
+// 이 결핍이 특히 아픈 곳은 autogrow 입력이다. MiniMaxH3ReferenceToVideo 의
+// `ref_images.ref_image_0..8` 처럼 슬롯 개수가 요청마다 달라지는 경우, 미첨부 슬롯에
+// 흰 PNG(#230) 를 넣으면 모델이 그걸 참조 이미지로 인식해버린다. 전 슬롯 필수화도
+// 답이 아니다 — 참조 1장만 필요한 요청에 3장을 강요하게 된다.
+//
+// 노드에 `_vcc.omitInputsUnless` 를 두면 치환 결과가 falsy 인 입력 키를 제거한다:
+//
+//   "136": {
+//     "class_type": "MiniMaxH3ReferenceToVideo",
+//     "inputs": {
+//       "ref_images.ref_image_0": ["137", 0],
+//       "ref_images.ref_image_1": ["139", 0]
+//     },
+//     "_vcc": {
+//       "omitInputsUnless": { "ref_images.ref_image_1": "{{##ref_image_2_attached##}}" }
+//     }
+//   }
+//
+// 키가 사라지면 상류 LoadImage 는 자동으로 고아가 되고, ComfyUI 는 출력 노드에서
+// 도달 불가능한 노드를 검증도 실행도 하지 않는다 (실측 확인). 즉 노드를 지울 필요가 없다.
+//
+// `_vcc` 는 조건 유무와 무관하게 항상 제거한다 — ComfyUI 로 넘기지 않는다.
+
+// falsy 판정 — 플레이스홀더 치환 결과는 number(1/0) 또는 string 일 수 있다.
+// `_attached` 는 number 로 치환되지만, 사용자가 select 값 등을 조건으로 쓸 수도 있어
+// 문자열 "0" / "false" / "" 도 falsy 로 본다.
+function isFalsy(value) {
+  if (value === undefined || value === null) return true;
+  if (typeof value === 'boolean') return !value;
+  if (typeof value === 'number') return value === 0 || Number.isNaN(value);
+  if (typeof value === 'string') {
+    const s = value.trim().toLowerCase();
+    return s === '' || s === '0' || s === 'false' || s === 'null' || s === 'undefined';
+  }
+  return false;
+}
+
+/**
+ * 워크플로 객체에서 `_vcc.omitInputsUnless` 지시자를 적용한다.
+ *
+ * 플레이스홀더 치환이 **끝난 뒤** 호출해야 한다 (조건식이 이미 값으로 바뀐 상태여야 함).
+ * 입력 키는 점이 포함돼도 (`ref_images.ref_image_1`) 경로가 아닌 **리터럴 키**로 취급한다 —
+ * ComfyUI autogrow 입력명이 원래 점 표기다.
+ *
+ * @param {Object} workflowObj — 치환 완료된 워크플로 (API 포맷: nodeId → {inputs, class_type, ...})
+ * @returns {{ workflow: Object, omitted: Array<{node: string, input: string}> }}
+ */
+function applyOmitDirectives(workflowObj) {
+  const omitted = [];
+  if (!workflowObj || typeof workflowObj !== 'object') {
+    return { workflow: workflowObj, omitted };
+  }
+
+  for (const [nodeId, node] of Object.entries(workflowObj)) {
+    if (!node || typeof node !== 'object') continue;
+
+    const directive = node._vcc;
+    // 지시자가 없어도 _vcc 자체는 항상 제거 대상 (ComfyUI 로 넘기지 않는다)
+    if (directive === undefined) continue;
+    delete node._vcc;
+
+    const rules = directive && directive.omitInputsUnless;
+    if (!rules || typeof rules !== 'object') continue;
+    if (!node.inputs || typeof node.inputs !== 'object') continue;
+
+    for (const [inputKey, condition] of Object.entries(rules)) {
+      if (!Object.prototype.hasOwnProperty.call(node.inputs, inputKey)) continue;
+      if (!isFalsy(condition)) continue;
+      delete node.inputs[inputKey];
+      omitted.push({ node: nodeId, input: inputKey });
+    }
+  }
+
+  return { workflow: workflowObj, omitted };
+}
+
+module.exports = { applyOmitDirectives, isFalsy };


### PR DESCRIPTION
## 배경

ComfyUI 의 optional 입력은 **키를 넣지 않는 것**이 곧 미사용이다. 그런데 VCC 는 워크플로 JSON 을 고정 템플릿으로 두고 플레이스홀더만 치환하므로, 요청마다 키를 넣었다 뺐다 할 수단이 없었다.

autogrow 입력에서 특히 문제가 된다. `MiniMaxH3ReferenceToVideo` 의 참조 슬롯은 요청마다 개수가 다른데:

- 미첨부 슬롯에 흰 PNG (#230) → **모델이 그걸 참조 이미지로 인식해버린다**
- 투명 PNG → 알파 처리 이슈로 위험
- 전 슬롯 필수화 → 참조 1장만 필요한 요청에 3장을 강요
- 개수별 작업판 분리 → 성립하지 않음

## 변경

노드에 `_vcc.omitInputsUnless` 를 두면 치환 결과가 falsy 인 입력 키를 제거한다.

```json
"136": {
  "class_type": "MiniMaxH3ReferenceToVideo",
  "inputs": {
    "ref_images.ref_image_0": ["137", 0],
    "ref_images.ref_image_1": ["139", 0]
  },
  "_vcc": {
    "omitInputsUnless": { "ref_images.ref_image_1": "{{##ref_image_2_attached##}}" }
  }
}
```

- `src/utils/workflowOmit.js` — `applyOmitDirectives` + `isFalsy`
- `queueService.injectInputsIntoWorkflow` 의 치환 **직후** 적용
- `_vcc` 는 조건 유무와 무관하게 항상 스트립
- `docs/COMFYUI_WORKFLOW.md` D-2 규약 문서화

## 설계 근거

**`inputs` 밖에 둔 이유** — 지시자를 `inputs` 안에 섞으면 실제 ComfyUI 입력명과 충돌할 여지가 있고, 삭제가 누락되면 그대로 ComfyUI 로 넘어간다. `_meta` 처럼 바깥에 두면 그 위험이 없다.

**조건을 플레이스홀더로 받은 이유** — `_attached` 전용으로 굳히면 select 값 등 다른 조건에 못 쓴다.

**노드를 지우지 않는 이유** — 입력 키가 사라지면 상류 `LoadImage` 는 고아가 되는데, **ComfyUI 는 출력 노드에서 도달 불가능한 노드를 검증도 실행도 하지 않는다.** 존재하지 않는 파일을 가리키는 고아 `LoadImage` 를 포함해 제출해도 통과함을 실측 확인했다. 노드 삭제 로직이 불필요하다.

**점 표기 키** — `ref_images.ref_image_1` 은 경로가 아닌 **리터럴 키**로 취급. autogrow 입력명이 원래 점 표기다.

## 검증 (실서버 ComfyUI)

H3 R2V 워크플로(노드 19개, 조건부 참조 슬롯 7개)로 전 구간 확인:

| 첨부 | 남은 참조 슬롯 |
|---|---|
| 이미지 1장 | `ref_image_0` |
| 이미지 3장 | `ref_image_0,1,2` |
| 이미지 1 + 비디오 1 | `ref_image_0`, `ref_video_0`, `ref_video_audio_0` |
| 이미지 2 + 비디오 2 | 6슬롯 전부 |
| 참조 없음 | 없음 (T2V 동작) |

- 실제 생성 성공 (39.5초) — 생략된 슬롯의 고아 `LoadImage` 가 **존재하지 않는 파일**(`NOT_UPLOADED_2.png`)을 가리켜도 무해
- 단위 테스트 13개, 전체 **401개 통과**

## 범위

H3 전용이 아니라 **optional 입력을 가진 모든 ComfyUI 노드**에 쓰이는 범용 기능이다. #758 의 `VCC Optional Image` 커스텀 노드가 필요했던 결핍도 이걸로 해소된다.

JSON 파싱 실패 시 fallback 문자열 치환 경로는 미지원 — 문서에 명시했다.

## 후속

- #772 — audio 필드 타입 (H3 `ref_audios` 슬롯을 채우려면 필요)

closes #771