### PR TITLE
fix: 조건부 생략 필드의 미첨부 안내 문구 정정 (#774)

### DIFF
--- a/frontend/src/pages/ImageGeneration.js
+++ b/frontend/src/pages/ImageGeneration.js
@@ -176,7 +176,7 @@ function PromptDataSelectDialog({ open, onClose, onSelect }) {
 }
 
 // 사용자 정의 이미지 입력 필드 컴포넌트
-function CustomImageField({ field, value, onChange, maxImages = 1, isComfyUI = false }) {
+function CustomImageField({ field, value, onChange, maxImages = 1, isComfyUI = false, omitConditioned = false }) {
   const [selectedImages, setSelectedImages] = useState(value || []);
   const [dialogOpen, setDialogOpen] = useState(false);
 
@@ -290,9 +290,13 @@ function CustomImageField({ field, value, onChange, maxImages = 1, isComfyUI = f
           <Typography variant="caption" color="text.secondary">
             최대 {maxImages}장
           </Typography>
+          {/* 조건부 생략(_vcc.omitInputsUnless, #771) 대상이면 흰 이미지가 모델에 도달하지 않는다.
+              입력 키가 제거되어 상류 LoadImage 가 고아가 되기 때문 — 안내를 사실에 맞춘다 (#774) */}
           {isComfyUI && (
             <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
-              미첨부 시 1024×1024 흰색 이미지가 자동으로 사용됩니다
+              {omitConditioned
+                ? '첨부하지 않으면 이 항목은 사용되지 않습니다'
+                : '미첨부 시 1024×1024 흰색 이미지가 자동으로 사용됩니다'}
             </Typography>
           )}
         </Box>
@@ -1171,6 +1175,7 @@ function ImageGeneration() {
                                 onChange={formField.onChange}
                                 maxImages={field.imageConfig?.maxImages || 3}
                                 isComfyUI={workboardData?.serverId?.serverType === 'ComfyUI'}
+                                omitConditioned={(workboardData?.omitConditionedFields || []).includes(field.name)}
                               />
                               {fieldState.error && (
                                 <Typography variant="caption" color="error" sx={{ display: 'block', mt: 0.5 }}>

--- a/src/routes/workboards.js
+++ b/src/routes/workboards.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const mongoose = require('mongoose');
 const { requireAuth, requireAdmin, buildWorkboardAccessFilter, userHasWorkboardAccess } = require('../middleware/auth');
+const { getOmitConditionedFieldNames } = require('../utils/workflowOmit');
 const Workboard = require('../models/Workboard');
 const Server = require('../models/Server');
 const Group = require('../models/Group');
@@ -513,7 +514,12 @@ router.get('/:id', requireAuth, async (req, res) => {
       return res.status(403).json({ message: '이 작업판에 접근할 권한이 없습니다.' });
     }
 
-    res.json({ workboard });
+    // 조건부 생략 대상 필드 (#774) — 생성 화면의 미첨부 안내 문구 분기용.
+    // 프론트가 workflowData 를 파싱하지 않도록 백엔드가 계산해 내려준다.
+    const payload = workboard.toObject();
+    payload.omitConditionedFields = getOmitConditionedFieldNames(workboard.workflowData);
+
+    res.json({ workboard: payload });
   } catch (error) {
     res.status(500).json({ message: error.message });
   }

--- a/src/tests/workflowOmit.test.js
+++ b/src/tests/workflowOmit.test.js
@@ -124,3 +124,64 @@ describe('applyOmitDirectives (#771)', () => {
     });
   });
 });
+
+const { getOmitConditionedFieldNames } = require('../utils/workflowOmit');
+
+// #774 — 생성 화면의 "미첨부 시 흰 이미지" 안내를 분기하기 위한 판정.
+// 조건부 생략 대상 필드는 흰 이미지가 모델에 도달하지 않으므로 문구가 달라야 한다.
+
+describe('getOmitConditionedFieldNames (#774)', () => {
+  const wf = (nodes) => JSON.stringify(nodes);
+
+  test('_attached 조건이 걸린 필드명을 추출', () => {
+    const s = wf({
+      136: {
+        class_type: 'X',
+        inputs: { 'ref_images.ref_image_0': ['1', 0] },
+        _vcc: { omitInputsUnless: { 'ref_images.ref_image_0': '{{##ref_image_1_attached##}}' } },
+      },
+    });
+    expect(getOmitConditionedFieldNames(s)).toEqual(['ref_image_1']);
+  });
+
+  test('여러 노드·여러 슬롯에서 중복 없이 모은다', () => {
+    const s = wf({
+      1: { _vcc: { omitInputsUnless: { a: '{{##img1_attached##}}', b: '{{##img2_attached##}}' } } },
+      2: { _vcc: { omitInputsUnless: { c: '{{##img1_attached##}}' } } },
+    });
+    expect(getOmitConditionedFieldNames(s).sort()).toEqual(['img1', 'img2']);
+  });
+
+  test('비디오 필드도 동일하게 인식 — 슬롯 2개가 한 필드를 공유해도 1건', () => {
+    const s = wf({
+      1: {
+        _vcc: {
+          omitInputsUnless: {
+            'ref_videos.ref_video_0': '{{##ref_video_1_attached##}}',
+            'ref_video_audios.ref_video_audio_0': '{{##ref_video_1_attached##}}',
+          },
+        },
+      },
+    });
+    expect(getOmitConditionedFieldNames(s)).toEqual(['ref_video_1']);
+  });
+
+  test('_attached 형태가 아닌 조건은 제외 — 특정 필드의 첨부 여부와 무관하다', () => {
+    const s = wf({ 1: { _vcc: { omitInputsUnless: { a: '{{##mode##}}', b: '1', c: 0 } } } });
+    expect(getOmitConditionedFieldNames(s)).toEqual([]);
+  });
+
+  test('_vcc 없는 워크플로는 빈 배열', () => {
+    expect(getOmitConditionedFieldNames(wf({ 1: { class_type: 'LoadImage', inputs: {} } }))).toEqual([]);
+  });
+
+  test('파싱 불가 워크플로는 빈 배열 — 따옴표 없는 플레이스홀더는 _vcc 가 애초에 동작 안 함', () => {
+    expect(getOmitConditionedFieldNames('{ "1": { "inputs": { "w": {{##width##}} } } }')).toEqual([]);
+  });
+
+  test('빈 입력', () => {
+    expect(getOmitConditionedFieldNames('')).toEqual([]);
+    expect(getOmitConditionedFieldNames(null)).toEqual([]);
+    expect(getOmitConditionedFieldNames(undefined)).toEqual([]);
+  });
+});

--- a/src/utils/workflowOmit.js
+++ b/src/utils/workflowOmit.js
@@ -80,4 +80,48 @@ function applyOmitDirectives(workflowObj) {
   return { workflow: workflowObj, omitted };
 }
 
-module.exports = { applyOmitDirectives, isFalsy };
+/**
+ * 워크플로에서 "미첨부 시 슬롯이 생략되는" 필드 이름을 추출한다 (#774).
+ *
+ * 생성 화면은 image 필드에 "미첨부 시 흰색 이미지가 자동으로 사용됩니다" 를 안내하는데,
+ * `_vcc.omitInputsUnless` 로 조건이 걸린 필드는 그게 사실이 아니다 — 입력 키가 제거되어
+ * 상류 LoadImage 가 고아가 되고 흰 이미지는 모델에 도달하지 않는다. 안내 문구를 바꾸려면
+ * 프론트가 "이 필드가 조건부인가" 를 알아야 한다.
+ *
+ * 프론트에서 workflowData 를 파싱하게 만들 이유가 없어 백엔드가 계산해 내려준다.
+ *
+ * 조건식이 `{{##필드명_attached##}}` 형태일 때만 해당 필드로 인식한다. 다른 플레이스홀더를
+ * 조건으로 쓴 경우(select 값 등)는 어떤 필드의 첨부 여부와 직결되지 않으므로 제외한다.
+ *
+ * @param {string} workflowData — 작업판의 워크플로 JSON 문자열 (치환 전)
+ * @returns {string[]} 조건부 생략 대상 필드 이름 (중복 제거)
+ */
+function getOmitConditionedFieldNames(workflowData) {
+  if (!workflowData || typeof workflowData !== 'string') return [];
+
+  let parsed;
+  try {
+    parsed = JSON.parse(workflowData);
+  } catch {
+    // 따옴표 없는 플레이스홀더를 쓴 워크플로는 파싱되지 않는다. 그런 워크플로는
+    // 애초에 _vcc 가 동작하지 않으므로 (문자열 치환 fallback 경로) 빈 배열이 맞다.
+    return [];
+  }
+  if (!parsed || typeof parsed !== 'object') return [];
+
+  const names = new Set();
+  const ATTACHED = /^\{\{##([A-Za-z0-9_]+)_attached##\}\}$/;
+
+  for (const node of Object.values(parsed)) {
+    const rules = node && node._vcc && node._vcc.omitInputsUnless;
+    if (!rules || typeof rules !== 'object') continue;
+    for (const condition of Object.values(rules)) {
+      if (typeof condition !== 'string') continue;
+      const m = condition.trim().match(ATTACHED);
+      if (m) names.add(m[1]);
+    }
+  }
+  return [...names];
+}
+
+module.exports = { applyOmitDirectives, isFalsy, getOmitConditionedFieldNames };


### PR DESCRIPTION
## 문제

이미지 필드에 항상 이 안내가 표시된다 (`ImageGeneration.js:295`, 조건은 `isComfyUI` 뿐).

> 미첨부 시 1024×1024 흰색 이미지가 자동으로 사용됩니다

`_vcc.omitInputsUnless` (#771) 로 조건이 걸린 필드에서는 **사실이 아니다.** 미첨부 슬롯은 입력 키가 제거되어 상류 `LoadImage` 가 고아가 되고, 흰 이미지는 모델에 도달하지 않는다.

MiniMax H3 R2V 가 그 경우다. 참조 이미지 3칸 모두 이 문구가 떴다. H3 에서 흰 이미지가 참조로 들어가면 결과가 망가지므로, 사용자가 "빈 칸을 두면 흰 이미지가 참조되겠구나" 라고 오해하면 **불필요하게 첨부를 강요당한다.**

## 변경

| 파일 | 내용 |
|---|---|
| `utils/workflowOmit.js` | `getOmitConditionedFieldNames` — 조건이 `{{##필드명_attached##}}` 형태인 필드명 추출 |
| `routes/workboards.js` | 단건 조회 응답에 `omitConditionedFields` 포함 |
| `pages/ImageGeneration.js` | 해당 필드는 `첨부하지 않으면 이 항목은 사용되지 않습니다` |

**백엔드가 계산해 내려주는 이유** — 프론트에서 `workflowData` 를 파싱하게 만들 이유가 없다.

**`_attached` 형태만 인식하는 이유** — select 값 등 다른 플레이스홀더를 조건으로 쓴 경우는 특정 필드의 첨부 여부와 직결되지 않는다.

## 검증

| 작업판 | 판정 결과 |
|---|---|
| MiniMax H3 - R2V | `["ref_image_1","ref_image_2","ref_image_3","ref_video_1","ref_video_2"]` |
| MiniMax H3 - I2V | `[]` |
| SDXL T2I - LoRA | `[]` |

화면 확인 — R2V 는 새 문구, I2V 는 기존 문구 유지. 조건부 생략을 쓰지 않는 작업판은 영향 없다.

단위 테스트 7개 추가, 전체 **408개 통과**.

## 범위 조정

원래 이슈의 2번(LoRA·부정 프롬프트 노출)은 조사 결과 **#199 (작업판 풀 커스텀화) 의 잔여 범위**임이 확인돼 **#777 로 이관**했다.

프롬프트·부정 프롬프트·시드·LoRA 는 `additionalInputFields` 밖에서 하드코딩 렌더된다. #711 이 "필드를 어떻게 그리는가" 는 통일했지만 "어떤 입력이 존재하는가" 는 손대지 않았다. 여기에 "안 쓰면 숨긴다" 규칙만 적용하면 증상은 가려지지만 하드코딩은 그대로 남는다.

closes #774