### PR TITLE
feat: 배포용 작업판 workboards/ + export 버전 표기 정정 (#779)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,7 +335,10 @@ updatelog 가 아니라 **GitHub 이슈의 version label 검색** 으로 확인.
 1. `dev → main` PR 직전, 이전 태그 이후 머지된 PR 들의 **사용자 가시 결과** 만 추려 정리
 2. `docs/updatelogs/v{major}.md` 파일 확인 (없으면 `# v{major} 업데이트 내역` 제목으로 생성). 최상단에 `## v{version}` 섹션 추가 (최신이 상단)
 3. release 직전 또는 직후, 포함된 이슈 / PR 에 `v{version}` label 일괄 부여
-4. `frontend/src/config.js` 의 `version.major` 값이 현재 메이저 버전과 일치하는지 확인
+4. 버전 표기 갱신 — 두 곳 모두
+   - `package.json` 의 `version` (백엔드 단일 소스. 작업판 export 의 `appVersion` 이 여기서 파생됨)
+   - `frontend/src/config.js` 의 `version.major` / `version.minor`
+5. 워크플로·필드를 고친 작업판이 `workboards/` 에 배포 중이면 **다시 내보내 파일 교체** (배포본과 실제 동작이 어긋나지 않도록)
 
 ### 파일 위치
 - 업데이트 내역: `docs/updatelogs/v{major}.md`
@@ -353,6 +356,7 @@ updatelog 가 아니라 **GitHub 이슈의 version label 검색** 으로 확인.
 - `docs/TEST_CHECKLIST.md` - 테스트 체크리스트
 - `docs/COMFYUI_WORKFLOW.md` - ComfyUI 워크플로우 가이드
 - `docs/COMFYUI_WORKFLOW_AUTHORING.md` - 작업판용 워크플로 **작성** 가이드 (신규 워크플로 만들 때)
+- `workboards/README.md` - 배포용 작업판 (import 로 바로 등록 가능한 완성품)
 - `docs/API.md` - API 문서
 - `docs/MCP_SERVER_API.md` - MCP Server 도구 호출 명세
 - `docs/DEPLOYMENT.md` - 배포 가이드

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,7 +1,7 @@
 const config = {
   version: {
     major: 3,
-    minor: 14
+    minor: 16
   },
   monitoring: {
     // 작업 목록 모니터링 주기 (기본 3초)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vcc-manager",
-  "version": "1.0.0",
+  "version": "3.16.1",
   "description": "Visual Content Creator Manager - ComfyUI integration service",
   "main": "src/server.js",
   "scripts": {

--- a/src/tests/workboardExportVersion.test.js
+++ b/src/tests/workboardExportVersion.test.js
@@ -1,0 +1,38 @@
+const pkg = require('../../package.json');
+const { APP_VERSION, parseAppVersion, WORKBOARD_EXPORT_VERSION } = require('../utils/workboardExport');
+
+// #779 — 이전에는 APP_VERSION 이 { major: 1, minor: 3 } 으로 하드코딩돼 있었다.
+// export/import 가 같은 상수를 참조해 경고는 안 떴지만, 내보낸 파일에 실제와 다른 버전이
+// 박히고 메이저 호환성 검사가 죽은 코드가 됐다. package.json 을 단일 소스로 삼는다.
+
+describe('workboardExport APP_VERSION (#779)', () => {
+  test('package.json 의 version 에서 파생된다', () => {
+    const [major, minor] = pkg.version.split('.').map(Number);
+    expect(APP_VERSION).toEqual({ major, minor });
+  });
+
+  test('하드코딩된 옛 값(1.3)이 아니다', () => {
+    expect(APP_VERSION).not.toEqual({ major: 1, minor: 3 });
+  });
+
+  test('메이저는 실제 릴리스 대와 일치 (v3.x)', () => {
+    expect(APP_VERSION.major).toBeGreaterThanOrEqual(3);
+  });
+
+  describe('parseAppVersion', () => {
+    test('semver 문자열 파싱', () => {
+      expect(parseAppVersion('3.16.1')).toEqual({ major: 3, minor: 16 });
+      expect(parseAppVersion('10.0.0')).toEqual({ major: 10, minor: 0 });
+    });
+
+    test('비정상 입력은 0으로 — export 가 죽지 않도록', () => {
+      expect(parseAppVersion('')).toEqual({ major: 0, minor: 0 });
+      expect(parseAppVersion(null)).toEqual({ major: 0, minor: 0 });
+      expect(parseAppVersion('abc')).toEqual({ major: 0, minor: 0 });
+    });
+  });
+
+  test('export 규격 버전은 앱 버전과 별개로 유지된다', () => {
+    expect(WORKBOARD_EXPORT_VERSION).toBe(1);
+  });
+});

--- a/src/utils/workboardExport.js
+++ b/src/utils/workboardExport.js
@@ -2,7 +2,24 @@
 // 작업판 단건 export(routes/workboards.js)와 프로젝트 export(routes/projects.js)가 공용.
 
 const WORKBOARD_EXPORT_VERSION = 1;
-const APP_VERSION = { major: 1, minor: 3 };
+
+// 앱 버전은 package.json 을 단일 소스로 삼는다 (#779).
+// 이전에는 `{ major: 1, minor: 3 }` 이 하드코딩돼 있었다. export 와 import 가 같은 상수를
+// 참조하므로 경고가 뜨지는 않았지만, 두 가지가 문제였다:
+//   1. 내보낸 파일에 실제와 다른 버전(v1.3)이 박힌다 — 배포용 파일에는 치명적
+//   2. routes/workboards.js 의 메이저 호환성 검사가 죽은 코드가 된다 (항상 자기 자신과 비교)
+// 릴리스 시 package.json 의 version 을 갱신하면 여기도 따라온다.
+const { version: PKG_VERSION } = require('../../package.json');
+
+function parseAppVersion(v) {
+  const [major, minor] = String(v || '').split('.').map((n) => parseInt(n, 10));
+  return {
+    major: Number.isFinite(major) ? major : 0,
+    minor: Number.isFinite(minor) ? minor : 0,
+  };
+}
+
+const APP_VERSION = parseAppVersion(PKG_VERSION);
 
 // 작업판 문서 → export entry. allowedGroupIds 는 제외 — ObjectId 가 instance 간
 // 매칭되지 않아 import 시 기본 그룹 자동 할당이 안전한 default (#기존 규격 유지).
@@ -26,4 +43,4 @@ function buildWorkboardExportEntry(workboard, server) {
   };
 }
 
-module.exports = { WORKBOARD_EXPORT_VERSION, APP_VERSION, buildWorkboardExportEntry };
+module.exports = { WORKBOARD_EXPORT_VERSION, APP_VERSION, buildWorkboardExportEntry, parseAppVersion };

--- a/workboards/README.md
+++ b/workboards/README.md
@@ -1,0 +1,114 @@
+# 배포용 작업판
+
+바로 가져다 쓸 수 있는 작업판 모음. 각 파일은 VCC Manager 의 **작업판 내보내기 형식**이라
+관리자 화면에서 가져오기만 하면 등록된다.
+
+앱 버전과 함께 관리된다 — 이 디렉토리의 작업판은 같은 커밋의 VCC Manager 에서 동작이 확인된 것이다.
+
+---
+
+## 설치
+
+1. **관리자 → 작업판 관리 → 가져오기**
+2. 아래 JSON 파일 선택
+3. 서버 선택 — 이름·타입이 같은 서버가 있으면 자동 매칭된다. 없으면 직접 고른다
+4. 저장
+
+가져오기 시 접근 그룹은 **기본 그룹**이 자동 할당된다. 다른 그룹에도 열려면 등록 후 작업판 편집기에서 조정한다.
+(내보내기 형식에 그룹이 포함되지 않는 이유는 인스턴스마다 그룹 ID 가 달라 매칭이 불가능하기 때문이다.)
+
+---
+
+## 목록
+
+### ComfyUI
+
+| 파일 | 작업판 | 출력 | 요구 사항 |
+|---|---|---|---|
+| `comfyui/minimax-h3-t2v.json` | MiniMax H3 - T2V | 영상 + 스테레오 오디오 | H3 모델 4종 |
+| `comfyui/minimax-h3-i2v.json` | MiniMax H3 - I2V | 〃 | H3 모델 4종 |
+| `comfyui/minimax-h3-r2v.json` | MiniMax H3 - R2V | 〃 | H3 모델 4종 + VHS_LoadVideo |
+
+---
+
+## MiniMax H3
+
+텍스트·이미지·영상·오디오를 함께 이해하고, **영상과 스테레오 오디오를 한 번의 패스로** 생성한다.
+음성·효과음·음악이 따로 붙는 게 아니라 함께 모델링된다. 최대 2K · 24fps · 약 15초.
+
+### 필요한 모델
+
+ComfyUI 서버에 아래가 설치돼 있어야 한다.
+
+```
+models/
+├── diffusion_models/minimax/minimax_h3_fl2va_pruned_int8_convrot.safetensors
+├── text_encoders/qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors
+└── vae/minimax/
+    ├── minimax_h3_video_vae_fp16.safetensors
+    └── minimax_h3_audio_vae_fp32.safetensors
+```
+
+받는 곳: [🤗 Comfy-Org/MiniMax-H3](https://huggingface.co/Comfy-Org/MiniMax-H3)
+
+텍스트 인코더와 VAE 는 H3 에 고정이라 워크플로에 하드코딩돼 있다. 사용자에게 노출되는 모델 선택은
+diffusion 모델 하나뿐이다.
+
+### 세 모드의 차이
+
+| | 입력 | 용도 |
+|---|---|---|
+| **T2V** | 프롬프트만 | 빠른 컨셉 확인, 짧은 클립 |
+| **I2V** | 시작 프레임 1장 | 정지 이미지에서 움직임 만들기 |
+| **R2V** | 참조 이미지 최대 3장 + 참조 영상 최대 2개 | 인물·모션·스타일·목소리 이어받기 |
+
+R2V 의 참조 영상은 **프레임과 사운드트랙이 함께** 참조된다 (`VHS_LoadVideo` 필요).
+
+### R2V — 첨부한 것만 참조된다
+
+참조 슬롯은 **첨부한 것만 모델에 전달**된다. 빈 칸은 그냥 없는 것으로 취급되므로,
+참조 1장만 필요하면 1장만 넣으면 된다. 나머지를 억지로 채울 필요가 없다.
+
+이는 워크플로의 `_vcc.omitInputsUnless` 로 구현돼 있다. 자세한 내용은
+[COMFYUI_WORKFLOW_AUTHORING.md](../docs/COMFYUI_WORKFLOW_AUTHORING.md) §3 참고.
+
+### 길이 · 해상도 제약
+
+H3 는 프레임 수가 **17k+5 격자**만 유효하다. 작업판에서 select 로 고정해 뒀다.
+
+| 길이 | 프레임 |
+|---|---|
+| 3초 | 73 |
+| 5초 | 124 |
+| 10초 | 243 |
+| 15초 | 362 |
+
+해상도는 짧은 변 768px 기준, 32의 배수.
+
+| 프리셋 | 크기 |
+|---|---|
+| 0.4MP | 864 × 480 |
+| 0.8MP | 1216 × 672 |
+| 네이티브 | 1344 × 768 |
+
+### 프롬프트 작성
+
+H3 는 프롬프트에 **샷 구성·카메라·오디오를 함께** 적는 형식을 쓴다. 공식 가이드 구조
+(`integrated_multimodal_description` / `overall_soundscape` / `non_diegetic_music`)를 따르면 결과가 크게 달라진다.
+
+가이드를 작업판에 연결하는 기능이 있다 — 관리자 → 프롬프트 가이드에서 등록한 뒤 작업판에 연결하면
+프롬프트 생성 시 자동으로 합성된다.
+
+---
+
+## 갱신 규칙
+
+- 워크플로나 필드를 고쳤으면 **작업판을 다시 내보내 이 디렉토리의 파일을 교체**한다. 그러지 않으면
+  배포본과 실제 동작이 어긋난다
+- `appVersion` 은 내보낸 시점의 앱 버전이다. `package.json` 의 version 에서 파생된다
+- 새 작업판을 추가할 때는 이 README 의 목록과 요구 사항도 함께 갱신한다
+
+## 관련 문서
+
+- [COMFYUI_WORKFLOW_AUTHORING.md](../docs/COMFYUI_WORKFLOW_AUTHORING.md) — 워크플로를 직접 만들 때
+- [COMFYUI_WORKFLOW.md](../docs/COMFYUI_WORKFLOW.md) — VCC 내부 처리 로직

--- a/workboards/comfyui/minimax-h3-i2v.json
+++ b/workboards/comfyui/minimax-h3-i2v.json
@@ -1,0 +1,142 @@
+{
+  "_exportVersion": 1,
+  "appVersion": {
+    "major": 3,
+    "minor": 16
+  },
+  "exportedAt": "2026-08-10T07:34:39.313Z",
+  "workboard": {
+    "name": "MiniMax H3 - I2V",
+    "description": "시작 프레임 한 장에서 영상을 생성합니다. 오디오도 함께 만들어집니다.",
+    "workboardType": "image",
+    "outputFormat": "video",
+    "additionalInputFields": [
+      {
+        "imageConfig": {
+          "maxImages": 1
+        },
+        "videoConfig": {
+          "maxVideos": 1
+        },
+        "name": "first_frame",
+        "label": "시작 프레임",
+        "type": "image",
+        "required": true,
+        "options": [],
+        "formatString": "{{##first_frame##}}"
+      },
+      {
+        "imageConfig": {
+          "maxImages": 1
+        },
+        "videoConfig": {
+          "maxVideos": 1
+        },
+        "name": "base_model",
+        "label": "베이스 모델",
+        "type": "baseModel",
+        "required": true,
+        "defaultValue": "minimax\\minimax_h3_fl2va_pruned_int8_convrot.safetensors",
+        "options": [],
+        "formatString": "{{##base_model##}}"
+      },
+      {
+        "imageConfig": {
+          "maxImages": 1
+        },
+        "videoConfig": {
+          "maxVideos": 1
+        },
+        "name": "image_size",
+        "label": "영상 크기",
+        "type": "select",
+        "required": true,
+        "defaultValue": "864x480",
+        "description": "H3 네이티브는 짧은 변 768px · 32의 배수",
+        "options": [
+          {
+            "key": "864x480 (0.4MP)",
+            "value": "864x480"
+          },
+          {
+            "key": "1216x672 (0.8MP)",
+            "value": "1216x672"
+          },
+          {
+            "key": "1344x768 (네이티브)",
+            "value": "1344x768"
+          }
+        ],
+        "formatString": "{{##image_size##}}"
+      },
+      {
+        "imageConfig": {
+          "maxImages": 1
+        },
+        "videoConfig": {
+          "maxVideos": 1
+        },
+        "name": "length",
+        "label": "길이",
+        "type": "select",
+        "required": true,
+        "defaultValue": "124",
+        "description": "H3 는 17k+5 프레임 격자만 지원합니다",
+        "options": [
+          {
+            "key": "3초 (73프레임)",
+            "value": "73"
+          },
+          {
+            "key": "5초 (124프레임)",
+            "value": "124"
+          },
+          {
+            "key": "10초 (243프레임)",
+            "value": "243"
+          },
+          {
+            "key": "15초 (362프레임)",
+            "value": "362"
+          }
+        ],
+        "formatString": "{{##length##}}"
+      },
+      {
+        "imageConfig": {
+          "maxImages": 1
+        },
+        "videoConfig": {
+          "maxVideos": 1
+        },
+        "name": "steps",
+        "label": "샘플링 스텝",
+        "type": "select",
+        "required": false,
+        "defaultValue": "20",
+        "options": [
+          {
+            "key": "20 (기본)",
+            "value": "20"
+          },
+          {
+            "key": "30 (정밀)",
+            "value": "30"
+          }
+        ],
+        "formatString": "{{##steps##}}"
+      }
+    ],
+    "workflowData": "{\n  \"6\": {\n    \"inputs\": {\n      \"unet_name\": \"{{##base_model##}}\",\n      \"weight_dtype\": \"default\"\n    },\n    \"class_type\": \"UNETLoader\",\n    \"_meta\": {\n      \"title\": \"H3 디퓨전 모델\"\n    }\n  },\n  \"9\": {\n    \"inputs\": {\n      \"model\": [\n        \"6\",\n        0\n      ],\n      \"scheduler\": \"simple\",\n      \"steps\": \"{{##steps##}}\",\n      \"denoise\": 1\n    },\n    \"class_type\": \"BasicScheduler\",\n    \"_meta\": {\n      \"title\": \"스케줄러\"\n    }\n  },\n  \"10\": {\n    \"inputs\": {\n      \"samples\": [\n        \"14\",\n        0\n      ],\n      \"vae\": [\n        \"11\",\n        0\n      ]\n    },\n    \"class_type\": \"VAEDecode\",\n    \"_meta\": {\n      \"title\": \"비디오 디코드\"\n    }\n  },\n  \"11\": {\n    \"inputs\": {\n      \"vae_name\": \"minimax\\\\minimax_h3_video_vae_fp16.safetensors\"\n    },\n    \"class_type\": \"VAELoader\",\n    \"_meta\": {\n      \"title\": \"비디오 VAE\"\n    }\n  },\n  \"13\": {\n    \"inputs\": {\n      \"clip_name\": \"qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors\",\n      \"type\": \"minimax\",\n      \"device\": \"default\"\n    },\n    \"class_type\": \"CLIPLoader\",\n    \"_meta\": {\n      \"title\": \"H3 텍스트 인코더\"\n    }\n  },\n  \"14\": {\n    \"inputs\": {\n      \"noise\": [\n        \"15\",\n        0\n      ],\n      \"guider\": [\n        \"16\",\n        0\n      ],\n      \"sampler\": [\n        \"17\",\n        0\n      ],\n      \"sigmas\": [\n        \"9\",\n        0\n      ],\n      \"latent_image\": [\n        \"104\",\n        1\n      ]\n    },\n    \"class_type\": \"SamplerCustomAdvanced\",\n    \"_meta\": {\n      \"title\": \"샘플링\"\n    }\n  },\n  \"15\": {\n    \"inputs\": {\n      \"noise_seed\": \"{{##seed##}}\"\n    },\n    \"class_type\": \"RandomNoise\",\n    \"_meta\": {\n      \"title\": \"노이즈 시드\"\n    }\n  },\n  \"16\": {\n    \"inputs\": {\n      \"model\": [\n        \"6\",\n        0\n      ],\n      \"conditioning\": [\n        \"104\",\n        0\n      ]\n    },\n    \"class_type\": \"BasicGuider\",\n    \"_meta\": {\n      \"title\": \"가이더\"\n    }\n  },\n  \"17\": {\n    \"inputs\": {\n      \"sampler_name\": \"res_multistep\"\n    },\n    \"class_type\": \"KSamplerSelect\",\n    \"_meta\": {\n      \"title\": \"샘플러 선택\"\n    }\n  },\n  \"23\": {\n    \"inputs\": {\n      \"samples\": [\n        \"14\",\n        0\n      ],\n      \"vae\": [\n        \"24\",\n        0\n      ]\n    },\n    \"class_type\": \"VAEDecodeAudio\",\n    \"_meta\": {\n      \"title\": \"오디오 디코드\"\n    }\n  },\n  \"24\": {\n    \"inputs\": {\n      \"vae_name\": \"minimax\\\\minimax_h3_audio_vae_fp32.safetensors\"\n    },\n    \"class_type\": \"VAELoader\",\n    \"_meta\": {\n      \"title\": \"오디오 VAE\"\n    }\n  },\n  \"91\": {\n    \"inputs\": {\n      \"images\": [\n        \"10\",\n        0\n      ],\n      \"audio\": [\n        \"23\",\n        0\n      ],\n      \"fps\": 24\n    },\n    \"class_type\": \"CreateVideo\",\n    \"_meta\": {\n      \"title\": \"비디오 합성 (24fps)\"\n    }\n  },\n  \"92\": {\n    \"inputs\": {\n      \"filename_prefix\": \"{{##user_id##}}/video/MiniMax_H3_i2v\",\n      \"format\": \"auto\",\n      \"codec\": \"auto\",\n      \"video\": [\n        \"91\",\n        0\n      ]\n    },\n    \"class_type\": \"SaveVideo\",\n    \"_meta\": {\n      \"title\": \"비디오 저장\"\n    }\n  },\n  \"104\": {\n    \"inputs\": {\n      \"clip\": [\n        \"13\",\n        0\n      ],\n      \"vae\": [\n        \"11\",\n        0\n      ],\n      \"prompt\": \"{{##prompt##}}\",\n      \"width\": \"{{##width##}}\",\n      \"height\": \"{{##height##}}\",\n      \"length\": \"{{##length##}}\",\n      \"first_frame\": [\n        \"114\",\n        0\n      ]\n    },\n    \"class_type\": \"MiniMaxH3ImageToVideo\",\n    \"_meta\": {\n      \"title\": \"H3 조건화 (I2V — 시작 프레임)\"\n    }\n  },\n  \"114\": {\n    \"inputs\": {\n      \"image\": \"{{##first_frame##}}\"\n    },\n    \"class_type\": \"LoadImage\",\n    \"_meta\": {\n      \"title\": \"시작 프레임\"\n    }\n  }\n}",
+    "allowedModelTypes": [],
+    "modelExposurePolicy": "full",
+    "modelWhitelist": [],
+    "loraExposurePolicy": "full",
+    "loraWhitelist": [],
+    "version": 1
+  },
+  "server": {
+    "name": "ComfyUI-Video",
+    "serverType": "ComfyUI"
+  }
+}

--- a/workboards/comfyui/minimax-h3-r2v.json
+++ b/workboards/comfyui/minimax-h3-r2v.json
@@ -1,0 +1,199 @@
+{
+  "_exportVersion": 1,
+  "appVersion": {
+    "major": 3,
+    "minor": 16
+  },
+  "exportedAt": "2026-08-10T07:34:39.315Z",
+  "workboard": {
+    "name": "MiniMax H3 - R2V",
+    "description": "참조 이미지·영상으로 인물·모션·스타일·목소리를 이어받아 생성합니다. 첨부한 것만 참조로 쓰입니다.",
+    "workboardType": "image",
+    "outputFormat": "video",
+    "additionalInputFields": [
+      {
+        "imageConfig": {
+          "maxImages": 1
+        },
+        "videoConfig": {
+          "maxVideos": 1
+        },
+        "name": "ref_image_1",
+        "label": "참조 이미지 1",
+        "type": "image",
+        "required": true,
+        "options": [],
+        "formatString": "{{##ref_image_1##}}"
+      },
+      {
+        "imageConfig": {
+          "maxImages": 1
+        },
+        "videoConfig": {
+          "maxVideos": 1
+        },
+        "name": "ref_image_2",
+        "label": "참조 이미지 2 (선택)",
+        "type": "image",
+        "required": false,
+        "options": [],
+        "formatString": "{{##ref_image_2##}}"
+      },
+      {
+        "imageConfig": {
+          "maxImages": 1
+        },
+        "videoConfig": {
+          "maxVideos": 1
+        },
+        "name": "ref_image_3",
+        "label": "참조 이미지 3 (선택)",
+        "type": "image",
+        "required": false,
+        "options": [],
+        "formatString": "{{##ref_image_3##}}"
+      },
+      {
+        "imageConfig": {
+          "maxImages": 1
+        },
+        "videoConfig": {
+          "maxVideos": 1
+        },
+        "name": "ref_video_1",
+        "label": "참조 영상 1 (선택)",
+        "type": "video",
+        "required": false,
+        "description": "영상의 사운드트랙도 함께 참조됩니다",
+        "options": [],
+        "formatString": "{{##ref_video_1##}}"
+      },
+      {
+        "imageConfig": {
+          "maxImages": 1
+        },
+        "videoConfig": {
+          "maxVideos": 1
+        },
+        "name": "ref_video_2",
+        "label": "참조 영상 2 (선택)",
+        "type": "video",
+        "required": false,
+        "options": [],
+        "formatString": "{{##ref_video_2##}}"
+      },
+      {
+        "imageConfig": {
+          "maxImages": 1
+        },
+        "videoConfig": {
+          "maxVideos": 1
+        },
+        "name": "base_model",
+        "label": "베이스 모델",
+        "type": "baseModel",
+        "required": true,
+        "defaultValue": "minimax\\minimax_h3_fl2va_pruned_int8_convrot.safetensors",
+        "options": [],
+        "formatString": "{{##base_model##}}"
+      },
+      {
+        "imageConfig": {
+          "maxImages": 1
+        },
+        "videoConfig": {
+          "maxVideos": 1
+        },
+        "name": "image_size",
+        "label": "영상 크기",
+        "type": "select",
+        "required": true,
+        "defaultValue": "864x480",
+        "description": "H3 네이티브는 짧은 변 768px · 32의 배수",
+        "options": [
+          {
+            "key": "864x480 (0.4MP)",
+            "value": "864x480"
+          },
+          {
+            "key": "1216x672 (0.8MP)",
+            "value": "1216x672"
+          },
+          {
+            "key": "1344x768 (네이티브)",
+            "value": "1344x768"
+          }
+        ],
+        "formatString": "{{##image_size##}}"
+      },
+      {
+        "imageConfig": {
+          "maxImages": 1
+        },
+        "videoConfig": {
+          "maxVideos": 1
+        },
+        "name": "length",
+        "label": "길이",
+        "type": "select",
+        "required": true,
+        "defaultValue": "124",
+        "description": "H3 는 17k+5 프레임 격자만 지원합니다",
+        "options": [
+          {
+            "key": "3초 (73프레임)",
+            "value": "73"
+          },
+          {
+            "key": "5초 (124프레임)",
+            "value": "124"
+          },
+          {
+            "key": "10초 (243프레임)",
+            "value": "243"
+          },
+          {
+            "key": "15초 (362프레임)",
+            "value": "362"
+          }
+        ],
+        "formatString": "{{##length##}}"
+      },
+      {
+        "imageConfig": {
+          "maxImages": 1
+        },
+        "videoConfig": {
+          "maxVideos": 1
+        },
+        "name": "steps",
+        "label": "샘플링 스텝",
+        "type": "select",
+        "required": false,
+        "defaultValue": "20",
+        "options": [
+          {
+            "key": "20 (기본)",
+            "value": "20"
+          },
+          {
+            "key": "30 (정밀)",
+            "value": "30"
+          }
+        ],
+        "formatString": "{{##steps##}}"
+      }
+    ],
+    "workflowData": "{\n  \"127\": {\n    \"inputs\": {\n      \"unet_name\": \"{{##base_model##}}\",\n      \"weight_dtype\": \"default\"\n    },\n    \"class_type\": \"UNETLoader\",\n    \"_meta\": {\n      \"title\": \"H3 디퓨전 모델\"\n    }\n  },\n  \"128\": {\n    \"inputs\": {\n      \"clip_name\": \"qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors\",\n      \"type\": \"minimax\",\n      \"device\": \"default\"\n    },\n    \"class_type\": \"CLIPLoader\",\n    \"_meta\": {\n      \"title\": \"H3 텍스트 인코더\"\n    }\n  },\n  \"119\": {\n    \"inputs\": {\n      \"vae_name\": \"minimax\\\\minimax_h3_video_vae_fp16.safetensors\"\n    },\n    \"class_type\": \"VAELoader\",\n    \"_meta\": {\n      \"title\": \"비디오 VAE\"\n    }\n  },\n  \"120\": {\n    \"inputs\": {\n      \"vae_name\": \"minimax\\\\minimax_h3_audio_vae_fp32.safetensors\"\n    },\n    \"class_type\": \"VAELoader\",\n    \"_meta\": {\n      \"title\": \"오디오 VAE\"\n    }\n  },\n  \"151\": {\n    \"inputs\": {\n      \"image\": \"{{##ref_image_1##}}\"\n    },\n    \"class_type\": \"LoadImage\",\n    \"_meta\": {\n      \"title\": \"참조 이미지 1\"\n    }\n  },\n  \"152\": {\n    \"inputs\": {\n      \"image\": \"{{##ref_image_2##}}\"\n    },\n    \"class_type\": \"LoadImage\",\n    \"_meta\": {\n      \"title\": \"참조 이미지 2\"\n    }\n  },\n  \"153\": {\n    \"inputs\": {\n      \"image\": \"{{##ref_image_3##}}\"\n    },\n    \"class_type\": \"LoadImage\",\n    \"_meta\": {\n      \"title\": \"참조 이미지 3\"\n    }\n  },\n  \"161\": {\n    \"inputs\": {\n      \"video\": \"{{##ref_video_1##}}\",\n      \"force_rate\": 0,\n      \"custom_width\": 0,\n      \"custom_height\": 0,\n      \"frame_load_cap\": 0,\n      \"skip_first_frames\": 0,\n      \"select_every_nth\": 1\n    },\n    \"class_type\": \"VHS_LoadVideo\",\n    \"_meta\": {\n      \"title\": \"참조 비디오 1\"\n    }\n  },\n  \"162\": {\n    \"inputs\": {\n      \"video\": \"{{##ref_video_2##}}\",\n      \"force_rate\": 0,\n      \"custom_width\": 0,\n      \"custom_height\": 0,\n      \"frame_load_cap\": 0,\n      \"skip_first_frames\": 0,\n      \"select_every_nth\": 1\n    },\n    \"class_type\": \"VHS_LoadVideo\",\n    \"_meta\": {\n      \"title\": \"참조 비디오 2\"\n    }\n  },\n  \"136\": {\n    \"inputs\": {\n      \"clip\": [\n        \"128\",\n        0\n      ],\n      \"vae\": [\n        \"119\",\n        0\n      ],\n      \"audio_vae\": [\n        \"120\",\n        0\n      ],\n      \"prompt\": \"{{##prompt##}}\",\n      \"width\": \"{{##width##}}\",\n      \"height\": \"{{##height##}}\",\n      \"length\": \"{{##length##}}\",\n      \"ref_image_size\": \"match\",\n      \"ref_images.ref_image_0\": [\n        \"151\",\n        0\n      ],\n      \"ref_images.ref_image_1\": [\n        \"152\",\n        0\n      ],\n      \"ref_images.ref_image_2\": [\n        \"153\",\n        0\n      ],\n      \"ref_videos.ref_video_0\": [\n        \"161\",\n        0\n      ],\n      \"ref_video_audios.ref_video_audio_0\": [\n        \"161\",\n        2\n      ],\n      \"ref_videos.ref_video_1\": [\n        \"162\",\n        0\n      ],\n      \"ref_video_audios.ref_video_audio_1\": [\n        \"162\",\n        2\n      ]\n    },\n    \"class_type\": \"MiniMaxH3ReferenceToVideo\",\n    \"_meta\": {\n      \"title\": \"H3 조건화 (R2V — 참조 가변)\"\n    },\n    \"_vcc\": {\n      \"omitInputsUnless\": {\n        \"ref_images.ref_image_0\": \"{{##ref_image_1_attached##}}\",\n        \"ref_images.ref_image_1\": \"{{##ref_image_2_attached##}}\",\n        \"ref_images.ref_image_2\": \"{{##ref_image_3_attached##}}\",\n        \"ref_videos.ref_video_0\": \"{{##ref_video_1_attached##}}\",\n        \"ref_video_audios.ref_video_audio_0\": \"{{##ref_video_1_attached##}}\",\n        \"ref_videos.ref_video_1\": \"{{##ref_video_2_attached##}}\",\n        \"ref_video_audios.ref_video_audio_1\": \"{{##ref_video_2_attached##}}\"\n      }\n    }\n  },\n  \"126\": {\n    \"inputs\": {\n      \"model\": [\n        \"127\",\n        0\n      ],\n      \"conditioning\": [\n        \"136\",\n        0\n      ]\n    },\n    \"class_type\": \"BasicGuider\",\n    \"_meta\": {\n      \"title\": \"가이더\"\n    }\n  },\n  \"124\": {\n    \"inputs\": {\n      \"model\": [\n        \"127\",\n        0\n      ],\n      \"scheduler\": \"simple\",\n      \"steps\": \"{{##steps##}}\",\n      \"denoise\": 1\n    },\n    \"class_type\": \"BasicScheduler\",\n    \"_meta\": {\n      \"title\": \"스케줄러\"\n    }\n  },\n  \"123\": {\n    \"inputs\": {\n      \"sampler_name\": \"res_multistep\"\n    },\n    \"class_type\": \"KSamplerSelect\",\n    \"_meta\": {\n      \"title\": \"샘플러 선택\"\n    }\n  },\n  \"129\": {\n    \"inputs\": {\n      \"noise_seed\": \"{{##seed##}}\"\n    },\n    \"class_type\": \"RandomNoise\",\n    \"_meta\": {\n      \"title\": \"노이즈 시드\"\n    }\n  },\n  \"125\": {\n    \"inputs\": {\n      \"noise\": [\n        \"129\",\n        0\n      ],\n      \"guider\": [\n        \"126\",\n        0\n      ],\n      \"sampler\": [\n        \"123\",\n        0\n      ],\n      \"sigmas\": [\n        \"124\",\n        0\n      ],\n      \"latent_image\": [\n        \"136\",\n        1\n      ]\n    },\n    \"class_type\": \"SamplerCustomAdvanced\",\n    \"_meta\": {\n      \"title\": \"샘플링\"\n    }\n  },\n  \"122\": {\n    \"inputs\": {\n      \"samples\": [\n        \"125\",\n        0\n      ],\n      \"vae\": [\n        \"119\",\n        0\n      ]\n    },\n    \"class_type\": \"VAEDecode\",\n    \"_meta\": {\n      \"title\": \"비디오 디코드\"\n    }\n  },\n  \"121\": {\n    \"inputs\": {\n      \"samples\": [\n        \"125\",\n        0\n      ],\n      \"vae\": [\n        \"120\",\n        0\n      ]\n    },\n    \"class_type\": \"VAEDecodeAudio\",\n    \"_meta\": {\n      \"title\": \"오디오 디코드\"\n    }\n  },\n  \"130\": {\n    \"inputs\": {\n      \"images\": [\n        \"122\",\n        0\n      ],\n      \"audio\": [\n        \"121\",\n        0\n      ],\n      \"fps\": 24\n    },\n    \"class_type\": \"CreateVideo\",\n    \"_meta\": {\n      \"title\": \"비디오 합성 (24fps)\"\n    }\n  },\n  \"92\": {\n    \"inputs\": {\n      \"filename_prefix\": \"{{##user_id##}}/video/MiniMax_H3_r2v\",\n      \"format\": \"auto\",\n      \"codec\": \"auto\",\n      \"video\": [\n        \"130\",\n        0\n      ]\n    },\n    \"class_type\": \"SaveVideo\",\n    \"_meta\": {\n      \"title\": \"비디오 저장\"\n    }\n  }\n}\n",
+    "allowedModelTypes": [],
+    "modelExposurePolicy": "full",
+    "modelWhitelist": [],
+    "loraExposurePolicy": "full",
+    "loraWhitelist": [],
+    "version": 1
+  },
+  "server": {
+    "name": "ComfyUI-Video",
+    "serverType": "ComfyUI"
+  }
+}

--- a/workboards/comfyui/minimax-h3-t2v.json
+++ b/workboards/comfyui/minimax-h3-t2v.json
@@ -1,0 +1,128 @@
+{
+  "_exportVersion": 1,
+  "appVersion": {
+    "major": 3,
+    "minor": 16
+  },
+  "exportedAt": "2026-08-10T07:34:39.306Z",
+  "workboard": {
+    "name": "MiniMax H3 - T2V",
+    "description": "텍스트만으로 영상과 스테레오 오디오를 함께 생성합니다. 음성·효과음·음악이 한 번의 패스로 만들어집니다.",
+    "workboardType": "image",
+    "outputFormat": "video",
+    "additionalInputFields": [
+      {
+        "imageConfig": {
+          "maxImages": 1
+        },
+        "videoConfig": {
+          "maxVideos": 1
+        },
+        "name": "base_model",
+        "label": "베이스 모델",
+        "type": "baseModel",
+        "required": true,
+        "defaultValue": "minimax\\minimax_h3_fl2va_pruned_int8_convrot.safetensors",
+        "options": [],
+        "formatString": "{{##base_model##}}"
+      },
+      {
+        "imageConfig": {
+          "maxImages": 1
+        },
+        "videoConfig": {
+          "maxVideos": 1
+        },
+        "name": "image_size",
+        "label": "영상 크기",
+        "type": "select",
+        "required": true,
+        "defaultValue": "864x480",
+        "description": "H3 네이티브는 짧은 변 768px · 32의 배수",
+        "options": [
+          {
+            "key": "864x480 (0.4MP)",
+            "value": "864x480"
+          },
+          {
+            "key": "1216x672 (0.8MP)",
+            "value": "1216x672"
+          },
+          {
+            "key": "1344x768 (네이티브)",
+            "value": "1344x768"
+          }
+        ],
+        "formatString": "{{##image_size##}}"
+      },
+      {
+        "imageConfig": {
+          "maxImages": 1
+        },
+        "videoConfig": {
+          "maxVideos": 1
+        },
+        "name": "length",
+        "label": "길이",
+        "type": "select",
+        "required": true,
+        "defaultValue": "124",
+        "description": "H3 는 17k+5 프레임 격자만 지원합니다",
+        "options": [
+          {
+            "key": "3초 (73프레임)",
+            "value": "73"
+          },
+          {
+            "key": "5초 (124프레임)",
+            "value": "124"
+          },
+          {
+            "key": "10초 (243프레임)",
+            "value": "243"
+          },
+          {
+            "key": "15초 (362프레임)",
+            "value": "362"
+          }
+        ],
+        "formatString": "{{##length##}}"
+      },
+      {
+        "imageConfig": {
+          "maxImages": 1
+        },
+        "videoConfig": {
+          "maxVideos": 1
+        },
+        "name": "steps",
+        "label": "샘플링 스텝",
+        "type": "select",
+        "required": false,
+        "defaultValue": "20",
+        "options": [
+          {
+            "key": "20 (기본)",
+            "value": "20"
+          },
+          {
+            "key": "30 (정밀)",
+            "value": "30"
+          }
+        ],
+        "formatString": "{{##steps##}}"
+      }
+    ],
+    "workflowData": "{\n  \"6\": {\n    \"inputs\": {\n      \"unet_name\": \"{{##base_model##}}\",\n      \"weight_dtype\": \"default\"\n    },\n    \"class_type\": \"UNETLoader\",\n    \"_meta\": {\n      \"title\": \"H3 디퓨전 모델\"\n    }\n  },\n  \"9\": {\n    \"inputs\": {\n      \"model\": [\n        \"6\",\n        0\n      ],\n      \"scheduler\": \"simple\",\n      \"steps\": \"{{##steps##}}\",\n      \"denoise\": 1\n    },\n    \"class_type\": \"BasicScheduler\",\n    \"_meta\": {\n      \"title\": \"스케줄러\"\n    }\n  },\n  \"10\": {\n    \"inputs\": {\n      \"samples\": [\n        \"14\",\n        0\n      ],\n      \"vae\": [\n        \"11\",\n        0\n      ]\n    },\n    \"class_type\": \"VAEDecode\",\n    \"_meta\": {\n      \"title\": \"비디오 디코드\"\n    }\n  },\n  \"11\": {\n    \"inputs\": {\n      \"vae_name\": \"minimax\\\\minimax_h3_video_vae_fp16.safetensors\"\n    },\n    \"class_type\": \"VAELoader\",\n    \"_meta\": {\n      \"title\": \"비디오 VAE\"\n    }\n  },\n  \"13\": {\n    \"inputs\": {\n      \"clip_name\": \"qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors\",\n      \"type\": \"minimax\",\n      \"device\": \"default\"\n    },\n    \"class_type\": \"CLIPLoader\",\n    \"_meta\": {\n      \"title\": \"H3 텍스트 인코더\"\n    }\n  },\n  \"14\": {\n    \"inputs\": {\n      \"noise\": [\n        \"15\",\n        0\n      ],\n      \"guider\": [\n        \"16\",\n        0\n      ],\n      \"sampler\": [\n        \"17\",\n        0\n      ],\n      \"sigmas\": [\n        \"9\",\n        0\n      ],\n      \"latent_image\": [\n        \"104\",\n        1\n      ]\n    },\n    \"class_type\": \"SamplerCustomAdvanced\",\n    \"_meta\": {\n      \"title\": \"샘플링\"\n    }\n  },\n  \"15\": {\n    \"inputs\": {\n      \"noise_seed\": \"{{##seed##}}\"\n    },\n    \"class_type\": \"RandomNoise\",\n    \"_meta\": {\n      \"title\": \"노이즈 시드\"\n    }\n  },\n  \"16\": {\n    \"inputs\": {\n      \"model\": [\n        \"6\",\n        0\n      ],\n      \"conditioning\": [\n        \"104\",\n        0\n      ]\n    },\n    \"class_type\": \"BasicGuider\",\n    \"_meta\": {\n      \"title\": \"가이더\"\n    }\n  },\n  \"17\": {\n    \"inputs\": {\n      \"sampler_name\": \"res_multistep\"\n    },\n    \"class_type\": \"KSamplerSelect\",\n    \"_meta\": {\n      \"title\": \"샘플러 선택\"\n    }\n  },\n  \"23\": {\n    \"inputs\": {\n      \"samples\": [\n        \"14\",\n        0\n      ],\n      \"vae\": [\n        \"24\",\n        0\n      ]\n    },\n    \"class_type\": \"VAEDecodeAudio\",\n    \"_meta\": {\n      \"title\": \"오디오 디코드\"\n    }\n  },\n  \"24\": {\n    \"inputs\": {\n      \"vae_name\": \"minimax\\\\minimax_h3_audio_vae_fp32.safetensors\"\n    },\n    \"class_type\": \"VAELoader\",\n    \"_meta\": {\n      \"title\": \"오디오 VAE\"\n    }\n  },\n  \"91\": {\n    \"inputs\": {\n      \"images\": [\n        \"10\",\n        0\n      ],\n      \"audio\": [\n        \"23\",\n        0\n      ],\n      \"fps\": 24\n    },\n    \"class_type\": \"CreateVideo\",\n    \"_meta\": {\n      \"title\": \"비디오 합성 (24fps)\"\n    }\n  },\n  \"92\": {\n    \"inputs\": {\n      \"filename_prefix\": \"{{##user_id##}}/video/MiniMax_H3_t2v\",\n      \"format\": \"auto\",\n      \"codec\": \"auto\",\n      \"video\": [\n        \"91\",\n        0\n      ]\n    },\n    \"class_type\": \"SaveVideo\",\n    \"_meta\": {\n      \"title\": \"비디오 저장\"\n    }\n  },\n  \"104\": {\n    \"inputs\": {\n      \"clip\": [\n        \"13\",\n        0\n      ],\n      \"vae\": [\n        \"11\",\n        0\n      ],\n      \"prompt\": \"{{##prompt##}}\",\n      \"width\": \"{{##width##}}\",\n      \"height\": \"{{##height##}}\",\n      \"length\": \"{{##length##}}\"\n    },\n    \"class_type\": \"MiniMaxH3ImageToVideo\",\n    \"_meta\": {\n      \"title\": \"H3 조건화 (T2V — 프레임 미입력)\"\n    }\n  }\n}",
+    "allowedModelTypes": [],
+    "modelExposurePolicy": "full",
+    "modelWhitelist": [],
+    "loraExposurePolicy": "full",
+    "loraWhitelist": [],
+    "version": 1
+  },
+  "server": {
+    "name": "ComfyUI-Video",
+    "serverType": "ComfyUI"
+  }
+}


### PR DESCRIPTION
## 목적

자주 쓰이는 작업판을 리포에 함께 배포해 사용자가 받아서 바로 등록할 수 있게 한다. **앱 버전과 작업판이 함께 움직이므로** 같은 저장소에 묶는다 — 앱을 올리면 그 버전에서 동작이 확인된 작업판이 따라온다.

## 새 기능은 없다

작업판 export/import 가 이미 있어 (#404), 내보낸 JSON 을 디렉토리에 두기만 하면 **관리자 → 작업판 관리 → 가져오기** 로 등록된다.

```
workboards/
├── README.md              설치법 · 요구 모델 · 모드별 차이 · 갱신 규칙
└── comfyui/
    ├── minimax-h3-t2v.json  (필드 4)
    ├── minimax-h3-i2v.json  (필드 5)
    └── minimax-h3-r2v.json  (필드 9, 가변 참조 슬롯 7)
```

### `frontend/src/templates/` 와 구분

| | `frontend/src/templates/` | `workboards/` |
|---|---|---|
| 역할 | "새 작업판 만들기" 시작점 | 완성된 배포물 |
| 개수 | (serverType, outputFormat) 조합당 1개 | 제한 없음 |
| 결합 | 로더 · capability matrix 와 묶임 | 코드와 무관 |

## APP_VERSION 정정

```js
const APP_VERSION = { major: 1, minor: 3 };   // 실제 앱은 v3.16
```

**경고가 뜨지는 않았다** — export 와 import 가 같은 상수를 참조하므로 항상 일치한다. 실제 문제는 두 가지다.

1. 내보낸 파일에 **실제와 다른 버전**이 박힌다. 배포용 파일에는 치명적
2. `routes/workboards.js:388` 의 메이저 호환성 검사가 **죽은 코드** — 상수가 고정이라 어떤 파일이든 통과

버전 표기가 세 곳으로 갈라져 있어 릴리스마다 수동으로 맞추는 건 지속 가능하지 않았다.

| 위치 | 전 | 후 |
|---|---|---|
| `package.json` | `1.0.0` | **`3.16.1`** (단일 소스) |
| `workboardExport.js` | `{1, 3}` 하드코딩 | package.json 파생 |
| `frontend/src/config.js` | minor **14** | minor **16** |

`CLAUDE.md` 릴리스 절차에 갱신 위치 2곳과 **배포 작업판 재내보내기 규칙**을 명시했다 — 워크플로를 고쳤는데 배포본을 안 바꾸면 실제 동작과 어긋난다.

## 검증

import 검증 로직을 그대로 재현해 확인했다.

```
검증 오류: 없음
경고: 없음
서버 자동 매칭: ComfyUI-Video (ComfyUI)
_vcc 지시자 보존: 노드 136 (7슬롯)
```

`_vcc.omitInputsUnless` 가 export/import 를 거쳐도 보존되는 것까지 확인 — 이게 깨지면 R2V 의 가변 참조가 동작하지 않는다.

세 작업판 모두 이 브랜치 이전에 **실제 생성으로 검증**됐다 (T2V·I2V·R2V, VCC 경로).

단위 테스트 6개 추가, 전체 **414개 통과**.

closes #779