### PR TITLE
fix: 사이드바 작업 히스토리 계속하기의 base_model 복원 (#792)

### DIFF
--- a/frontend/src/components/common/JobHistoryPanel.js
+++ b/frontend/src/components/common/JobHistoryPanel.js
@@ -61,6 +61,12 @@ import WorkboardSelectDialog from './WorkboardSelectDialog';
 import { DEFAULT_TAG_COLOR } from '../../theme';
 import { useJobActions } from '../../hooks/useJobActions';
 import { relativeTime } from '../../utils/relativeTime';
+import {
+  buildSameWorkboardContinue,
+  buildCrossWorkboardContinue,
+  buildWorkboardPickerContinue,
+  storeContinueJobData,
+} from '../../utils/continueJob';
 
 export function SavePromptDialog({ open, onClose, job, onSave }) {
   const [imageSelectOpen, setImageSelectOpen] = useState(false);
@@ -983,14 +989,14 @@ function JobHistoryPanel({
 
       if (!workboardId || workboardId === 'undefined' || workboardId === 'null') {
         toast.error('작업판 정보를 찾을 수 없습니다. 작업판 선택 페이지로 이동합니다.');
-        localStorage.setItem('continueJobData', JSON.stringify({ inputData: job.inputData, fromJobHistory: true }));
+        storeContinueJobData(buildWorkboardPickerContinue(job));
         navigate('/workboards');
         return;
       }
 
       if (!/^[0-9a-fA-F]{24}$/.test(workboardId)) {
         toast.error('잘못된 작업판 ID입니다. 작업판 선택 페이지로 이동합니다.');
-        localStorage.setItem('continueJobData', JSON.stringify({ inputData: job.inputData, fromJobHistory: true }));
+        storeContinueJobData(buildWorkboardPickerContinue(job));
         navigate('/workboards');
         return;
       }
@@ -1000,25 +1006,19 @@ function JobHistoryPanel({
 
       if (!workboard) {
         toast.error('작업판을 찾을 수 없습니다. 작업판 선택 페이지로 이동합니다.');
-        localStorage.setItem('continueJobData', JSON.stringify({ inputData: job.inputData, fromJobHistory: true }));
+        storeContinueJobData(buildWorkboardPickerContinue(job));
         navigate('/workboards');
         return;
       }
 
       if (!workboard.isActive) {
         toast.error('작업판이 비활성화되었습니다. 작업판 선택 페이지로 이동합니다.');
-        localStorage.setItem('continueJobData', JSON.stringify({ inputData: job.inputData, fromJobHistory: true }));
+        storeContinueJobData(buildWorkboardPickerContinue(job));
         navigate('/workboards');
         return;
       }
 
-      localStorage.setItem('continueJobData', JSON.stringify({
-        workboardId,
-        inputData: job.inputData,
-        workboard,
-        prevOutputFormat: job.resultVideos?.length ? 'video' : 'image', // #673
-        sameWorkboard: true, // #762 — 같은 작업판 계속하기: 히스토리 값을 기본값보다 우선 복원
-      }));
+      storeContinueJobData(buildSameWorkboardContinue({ workboardId, workboard, job }));
       navigate(`/generate/${workboardId}`);
       toast.success('작업 설정을 불러왔습니다');
     } catch (error) {
@@ -1027,7 +1027,7 @@ function JobHistoryPanel({
       else if (error.response?.status === 403) toast.error('작업판 접근 권한이 없습니다. 작업판 선택 페이지로 이동합니다.');
       else toast.error('작업을 계속할 수 없습니다. 작업판 선택 페이지로 이동합니다.');
 
-      localStorage.setItem('continueJobData', JSON.stringify({ inputData: job.inputData, fromJobHistory: true }));
+      storeContinueJobData(buildWorkboardPickerContinue(job));
       navigate('/workboards');
     }
   };
@@ -1053,16 +1053,9 @@ function JobHistoryPanel({
       ? job.resultVideos[job.resultVideos.length - 1]
       : null;
 
-    localStorage.setItem('continueJobData', JSON.stringify({
-      workboardId: workboard._id,
-      inputData: job.inputData,
-      workboard: workboard,
-      lastGeneratedMedia: {
-        image: lastGeneratedImage,
-        video: lastGeneratedVideo
-      },
-      prevOutputFormat: lastGeneratedVideo ? 'video' : 'image', // #673
-      sameWorkboard: false, // #762 — 다른 작업판 이어가기: #673 안전 조건 유지
+    storeContinueJobData(buildCrossWorkboardContinue({
+      workboard, job,
+      lastGeneratedMedia: { image: lastGeneratedImage, video: lastGeneratedVideo },
     }));
 
     setCrossWorkboardOpen(false);

--- a/frontend/src/pages/JobHistory.js
+++ b/frontend/src/pages/JobHistory.js
@@ -62,6 +62,12 @@ import SegmentTabs from '../components/common/SegmentTabs';
 import EmptyState from '../components/common/EmptyState';
 import { MONO } from '../theme';
 import { relativeTime } from '../utils/relativeTime';
+import {
+  buildSameWorkboardContinue,
+  buildCrossWorkboardContinue,
+  buildWorkboardPickerContinue,
+  storeContinueJobData,
+} from '../utils/continueJob';
 import { useJobActions } from '../hooks/useJobActions';
 
 const TYPE_LABEL = { pipeline: '파이프라인', image: '이미지', video: '영상', text: '텍스트' };
@@ -563,19 +569,20 @@ function JobHistory() {
     try {
       let workboardId = typeof job.workboardId === 'string' ? job.workboardId : (job.workboardId?._id || job.workboardId?.id);
       const fallback = () => {
-        localStorage.setItem('continueJobData', JSON.stringify({ inputData: job.inputData, fromJobHistory: true }));
+        storeContinueJobData(buildWorkboardPickerContinue(job));
         navigate('/workboards');
       };
       if (!workboardId || !/^[0-9a-fA-F]{24}$/.test(workboardId)) { toast.error('작업판 정보를 찾을 수 없습니다. 작업판 선택 페이지로 이동합니다.'); return fallback(); }
       const wbRes = await workboardAPI.getById(workboardId);
       const workboard = wbRes.data?.workboard;
       if (!workboard || !workboard.isActive) { toast.error('작업판을 사용할 수 없습니다. 작업판 선택 페이지로 이동합니다.'); return fallback(); }
-      localStorage.setItem('continueJobData', JSON.stringify({ workboardId, inputData: job.inputData, workboard, prevOutputFormat: job.resultVideos?.length ? 'video' : 'image' }));
+      // #792 — sameWorkboard 플래그 포함. 직접 조립하다 #762 수정이 이 경로에 누락됐었다.
+      storeContinueJobData(buildSameWorkboardContinue({ workboardId, workboard, job }));
       navigate(`/generate/${workboardId}`);
       toast.success('작업 설정을 불러왔습니다');
     } catch (error) {
       toast.error('작업을 계속할 수 없습니다. 작업판 선택 페이지로 이동합니다.');
-      localStorage.setItem('continueJobData', JSON.stringify({ inputData: job.inputData, fromJobHistory: true }));
+      storeContinueJobData(buildWorkboardPickerContinue(job));
       navigate('/workboards');
     }
   };
@@ -585,10 +592,8 @@ function JobHistory() {
     const job = crossJob;
     const lastImage = job.resultImages?.length ? job.resultImages[job.resultImages.length - 1] : null;
     const lastVideo = job.resultVideos?.length ? job.resultVideos[job.resultVideos.length - 1] : null;
-    localStorage.setItem('continueJobData', JSON.stringify({
-      workboardId: workboard._id, inputData: job.inputData, workboard,
-      lastGeneratedMedia: { image: lastImage, video: lastVideo },
-      prevOutputFormat: lastVideo ? 'video' : 'image', // #673
+    storeContinueJobData(buildCrossWorkboardContinue({
+      workboard, job, lastGeneratedMedia: { image: lastImage, video: lastVideo },
     }));
     setCrossJob(null);
     navigate(`/generate/${workboard._id}`);

--- a/frontend/src/pages/ProjectDetail.js
+++ b/frontend/src/pages/ProjectDetail.js
@@ -447,6 +447,7 @@ function PromptDataTab({ projectId }) {
 
   const handleWorkboardSelect = (workboard) => {
     if (selectedPromptData) {
+      // 프롬프트 데이터로 새로 생성 — 히스토리 계속하기가 아니라 base_model 복원 대상이 없다 (#792)
       localStorage.setItem('continueJobData', JSON.stringify({
         workboardId: workboard._id,
         inputData: {

--- a/frontend/src/pages/PromptDataList.js
+++ b/frontend/src/pages/PromptDataList.js
@@ -81,6 +81,7 @@ function PromptDataList() {
 
   const handleWorkboardSelect = (workboard) => {
     if (selectedPromptData) {
+      // 프롬프트 데이터로 새로 생성 — 히스토리 계속하기가 아니라 base_model 복원 대상이 없다 (#792)
       localStorage.setItem('continueJobData', JSON.stringify({
         workboardId: workboard._id,
         inputData: {

--- a/frontend/src/pages/WorkboardCatalogPage.js
+++ b/frontend/src/pages/WorkboardCatalogPage.js
@@ -60,6 +60,8 @@ function selectWorkboard(workboard, projectId, navigate) {
     try {
       const parsed = JSON.parse(continueJobData);
       if (parsed.fromJobHistory) {
+        // 작업판을 특정하지 못해 선택 페이지를 경유한 경우 — 원래 작업판과 같다는 보장이 없으므로
+        // sameWorkboard 를 붙이지 않는다 (크로스로 취급, #673 안전 조건 유지). utils/continueJob 미사용 (#792)
         localStorage.setItem('continueJobData', JSON.stringify({
           workboardId: workboard._id, inputData: parsed.inputData, workboard,
         }));

--- a/frontend/src/utils/continueJob.js
+++ b/frontend/src/utils/continueJob.js
@@ -1,0 +1,59 @@
+// '계속하기' / '다른 작업판으로 이어가기' 페이로드 생성 (#792).
+//
+// 이 페이로드는 localStorage('continueJobData') 를 거쳐 ImageGeneration 이 소비한다.
+// 진입점이 두 곳(JobHistoryPanel · pages/JobHistory)이고 각자 객체를 직접 조립하다가,
+// #762 수정이 한쪽에만 적용되어 같은 버그가 다른 경로에 남았다. 계약을 여기 한 곳에 모은다.
+//
+// 소비 측 계약 (ImageGeneration.js):
+//   sameWorkboard    같은 작업판 계속하기 여부. true 면 히스토리의 base_model 을 작업판
+//                    기본값보다 우선 복원한다 (#762)
+//   prevOutputFormat 이전 작업의 출력 타입. 크로스에서 출력 타입이 다르면 base_model
+//                    prefill 을 건너뛴다 (#673)
+
+const KEY = 'continueJobData';
+
+// 결과물이 비디오면 'video', 아니면 'image' (#673)
+function outputFormatOf(job) {
+  return job?.resultVideos?.length ? 'video' : 'image';
+}
+
+/**
+ * 같은 작업판에서 계속하기.
+ * 히스토리에 남은 모델은 이 작업판에서 실제로 선택됐던 유효값이므로 기본값보다 우선한다.
+ */
+export function buildSameWorkboardContinue({ workboardId, workboard, job }) {
+  return {
+    workboardId,
+    workboard,
+    inputData: job.inputData,
+    prevOutputFormat: outputFormatOf(job),
+    sameWorkboard: true,
+  };
+}
+
+/**
+ * 다른 작업판으로 이어가기 (크로스).
+ * 이전 모델이 새 작업판에서 유효하다는 보장이 없으므로 #673 안전 조건을 그대로 둔다.
+ */
+export function buildCrossWorkboardContinue({ workboard, job, lastGeneratedMedia }) {
+  return {
+    workboardId: workboard._id,
+    workboard,
+    inputData: job.inputData,
+    lastGeneratedMedia,
+    prevOutputFormat: outputFormatOf(job),
+    sameWorkboard: false,
+  };
+}
+
+/**
+ * 작업판을 특정하지 못해 선택 페이지로 보낼 때의 최소 페이로드.
+ * base_model 복원 판단에 쓰이는 필드가 없으므로 sameWorkboard 도 없다.
+ */
+export function buildWorkboardPickerContinue(job) {
+  return { inputData: job.inputData, fromJobHistory: true };
+}
+
+export function storeContinueJobData(payload) {
+  localStorage.setItem(KEY, JSON.stringify(payload));
+}


### PR DESCRIPTION
## 원인

#762 는 `components/common/JobHistoryPanel.js` **만** 고쳤다. 계속하기 진입점은 두 곳이다.

```
ProjectDetail  → JobHistoryPanel.handleContinue    sameWorkboard: true  ✅ #762
사이드바 /jobs → pages/JobHistory.handleContinue   플래그 없음          ❌ 누락
```

`ImageGeneration.js` 의 판정이 이 플래그 하나에 걸려 있다.

```js
const allowBaseModelPrefill = sameWorkboardContinue
  || (!(prevOutputFormat && prevOutputFormat !== workboardData.outputFormat) && !bmHasDefault);
```

플래그가 없으면 #673 의 **크로스 안전조건이 같은 작업판에도 적용**되어, base_model 기본값이 있는 작업판에서 히스토리 모델 복원이 skip 된다. H3 계열은 전부 기본값을 갖고 있어 100% 재현된다.

## 수정

플래그 한 줄로 끝나지만, 같은 계약을 두 파일이 각자 조립하는 것이 근본 원인이다. 페이로드 생성을 `utils/continueJob.js` 로 모으고 양쪽 모두 그것을 쓰게 했다.

- `buildSameWorkboardContinue` / `buildCrossWorkboardContinue` / `buildWorkboardPickerContinue`
- 헬퍼를 쓰지 않는 3곳(`WorkboardCatalogPage` · `ProjectDetail` · `PromptDataList`)에는 이유를 주석으로 남겼다 — 크로스로 취급해야 하거나, base_model 복원 대상 자체가 없는 경로다

## 검증

| 상황 | prefill | |
|---|---|---|
| 같은 작업판 · 기본값 있음 | ✅ 복원 | 이번 버그 |
| 같은 작업판 · 기본값 없음 | ✅ 복원 | |
| 크로스 · 기본값 있음 | ⛔ skip | #673 보존 |
| 크로스 · 기본값 없음 · 출력 일치 | ✅ 복원 | |
| 크로스 · 출력 타입 불일치 | ⛔ skip | #673 보존 |
| 작업판 선택 경유 | ⛔ skip | 같은 작업판 보장 없음 |

빌드 산출물에 `sameWorkboard:!0` / `!1` 이 각 1회 — 헬퍼 공유로 호출부가 합쳐졌다. jest 421 통과.

**한계**: 프론트엔드에 테스트 러너가 연결돼 있지 않아(`frontend/package.json` 에 test 스크립트 없음, `sanitizeHtml.test.js` 는 실행되지 않는 고아 파일) 위 검증은 헬퍼 직접 실행 + 빌드 산출물 확인으로 했다. **UI 클릭 검증은 하지 못했다** — 브라우저 세션이 사용자 계정이라 테스트 데이터를 남기지 않기 위해. 프로덕션 확인 시 이 경로를 한 번 봐주시면 좋겠다.

## 후속

두 히스토리 구현의 통합은 #794 로 분리.

closes #792