### PR TITLE
feat: LTX-2.5 T2V 작업판 배포본 (#791)

### DIFF
--- a/workboards/README.md
+++ b/workboards/README.md
@@ -27,6 +27,7 @@
 |---|---|---|---|
 | `comfyui/minimax-h3-fl2v.json` | MiniMax H3 - FL2V | 영상 + 스테레오 오디오 | H3 모델 4종 |
 | `comfyui/minimax-h3-r2v.json` | MiniMax H3 - R2V | 〃 | H3 모델 4종 + VHS_LoadVideo |
+| `comfyui/ltx-2.5-t2v.json` | LTX-2.5 - T2V | 영상 + 동기화 오디오 | LTX-2.5 모델 6종 · ComfyUI 0.32+ |
 
 ---
 
@@ -141,6 +142,53 @@ VCC 에는 이 작성법을 작업판에 붙여두는 기능이 있다 — 관�
 
 동봉하지 않는 이유는 해당 문서가 MiniMax H3 Community License Agreement 아래 배포되고, 그 재배포 조항의
 적용 지역에서 한국이 제외돼 있기 때문이다 (모델 사용과는 무관하며, 재배포에만 걸린다).
+
+---
+
+## LTX-2.5
+
+텍스트에서 **영상과 동기화된 오디오를 한 번에** 만든다. 2단계 샘플링(저해상도 생성 → 잠재 업스케일 →
+재샘플링)으로 디테일을 올린다. ComfyUI 0.32 이상이 필요하다 (공식 템플릿이 그때 들어왔다).
+
+### 필요한 모델
+
+```
+models/
+├── diffusion_models/LTX-2/ltx-2.5-22b-distilled-transformer-comfy-int8-convrot.safetensors
+├── text_encoders/gemma4-12b-with-proj-ltx-2.5-comfy-int8-convrot.safetensors
+├── text_encoders/gemma4_e2b_it_bf16.safetensors
+├── vae/LTX-2/ltx-2.5-video-vae-bf16.safetensors
+├── vae/LTX-2/ltx-2.5-audio-vae-bf16.safetensors
+└── latent_upscale_models/ltx-2.5-latent-spatial-upscaler-x2-bf16-1.0.safetensors
+```
+
+받는 곳: [🤗 Lightricks/LTX-2.5](https://huggingface.co/Lightricks) — **접근 권한 승인이 선행**되어야 한다.
+텍스트 인코더와 업스케일러는 루트에, 나머지는 `LTX-2/` 아래에 둔 기준이다. 다른 위치에 뒀다면
+작업판의 워크플로에서 해당 경로 문자열을 고쳐야 한다.
+
+### 해상도는 64의 배수
+
+2단계 구조상 해상도를 반으로 줄여 1단계를 돌리므로, **절반이 32의 배수** 여야 한다. 즉 원본은 64의 배수다.
+64의 배수가 아니면 조용히 깎여서 나온다 (832×480 을 넣으면 832×448 이 나온다).
+
+| 프리셋 | 실제 출력 |
+|---|---|
+| 832×448 | 그대로 |
+| 1024×576 | 그대로 (정확한 16:9) |
+| 1280×704 | 그대로 |
+| 1920×1088 | 그대로 |
+
+### 프롬프트 자동 확장
+
+워크플로 안에 프롬프트 전용 언어모델(`gemma4_e2b_it`)이 들어 있다. **기본으로 켜져 있다.**
+"a lighthouse at dusk" 처럼 짧게 적어도 샷 구성·카메라 무빙·조명·질감·사운드스케이프를 갖춘
+LTX 형식 프롬프트로 늘려준다.
+
+비용은 **처음 쓰는 프롬프트당 10초 남짓**이고, 같은 프롬프트를 다시 쓰면 결과가 캐시되어 추가 시간이 없다.
+시드만 바꿔 여러 장 뽑는 경우 첫 장에만 붙는다.
+
+이 작업판에는 프롬프트 가이드(관리자 → 프롬프트 가이드)를 연결할 필요가 없다 — LTX 문법 지식이
+이미 워크플로 안에 있다.
 
 ---
 

--- a/workboards/comfyui/ltx-2.5-t2v.json
+++ b/workboards/comfyui/ltx-2.5-t2v.json
@@ -1,0 +1,131 @@
+{
+  "_exportVersion": 1,
+  "appVersion": {
+    "major": 3,
+    "minor": 17
+  },
+  "exportedAt": "2026-08-12T12:13:44.722Z",
+  "workboard": {
+    "name": "LTX-2.5 - T2V",
+    "description": "LTX-2.5 — 텍스트에서 영상 + 동기화 오디오를 생성합니다. 2단계 샘플링(저해상도 생성 → 잠재 업스케일 → 재샘플링)으로 디테일을 올립니다.",
+    "workboardType": "image",
+    "outputFormat": "video",
+    "additionalInputFields": [
+      {
+        "name": "base_model",
+        "label": "베이스 모델",
+        "type": "baseModel",
+        "required": true,
+        "defaultValue": "LTX-2\\ltx-2.5-22b-distilled-transformer-comfy-int8-convrot.safetensors",
+        "formatString": "{{##base_model##}}",
+        "imageConfig": {
+          "maxImages": 1
+        },
+        "videoConfig": {
+          "maxVideos": 1
+        },
+        "audioConfig": {
+          "maxAudios": 1
+        },
+        "options": []
+      },
+      {
+        "name": "image_size",
+        "label": "영상 크기",
+        "type": "select",
+        "required": true,
+        "options": [
+          {
+            "key": "832x448 (빠른 확인)",
+            "value": "832x448"
+          },
+          {
+            "key": "1024x576 (16:9 정확)",
+            "value": "1024x576"
+          },
+          {
+            "key": "1280x704 (HD 근사)",
+            "value": "1280x704"
+          },
+          {
+            "key": "1920x1088 (FHD 근사)",
+            "value": "1920x1088"
+          }
+        ],
+        "defaultValue": "1024x576",
+        "description": "가로·세로 모두 64의 배수여야 실제 출력이 일치합니다",
+        "formatString": "{{##image_size##}}",
+        "imageConfig": {
+          "maxImages": 1
+        },
+        "videoConfig": {
+          "maxVideos": 1
+        },
+        "audioConfig": {
+          "maxAudios": 1
+        }
+      },
+      {
+        "name": "duration",
+        "label": "길이 (초)",
+        "type": "select",
+        "required": true,
+        "options": [
+          {
+            "key": "3초",
+            "value": "3"
+          },
+          {
+            "key": "5초",
+            "value": "5"
+          },
+          {
+            "key": "10초",
+            "value": "10"
+          }
+        ],
+        "defaultValue": "5",
+        "formatString": "{{##duration##}}",
+        "imageConfig": {
+          "maxImages": 1
+        },
+        "videoConfig": {
+          "maxVideos": 1
+        },
+        "audioConfig": {
+          "maxAudios": 1
+        }
+      },
+      {
+        "name": "prompt_enhance",
+        "label": "프롬프트 자동 확장",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": true,
+        "description": "짧게 적어도 샷 구성·카메라·조명·사운드까지 갖춘 프롬프트로 알아서 늘려줍니다. 처음 쓰는 프롬프트에만 10초 남짓 걸리고, 같은 프롬프트를 다시 쓰면 추가 시간이 없습니다.",
+        "formatString": "{{##prompt_enhance##}}",
+        "imageConfig": {
+          "maxImages": 1
+        },
+        "videoConfig": {
+          "maxVideos": 1
+        },
+        "audioConfig": {
+          "maxAudios": 1
+        },
+        "options": []
+      }
+    ],
+    "workflowData": "{\n  \"75\": {\n    \"inputs\": {\n      \"video\": [\n        \"370\",\n        0\n      ],\n      \"filename_prefix\": \"{{##user_id##}}/video/LTX_2.5_t2v\",\n      \"format\": \"auto\",\n      \"codec\": \"auto\"\n    },\n    \"class_type\": \"SaveVideo\",\n    \"_meta\": {\n      \"title\": \"Save Video\"\n    }\n  },\n  \"338\": {\n    \"inputs\": {\n      \"noise_seed\": \"{{##seed##}}\"\n    },\n    \"class_type\": \"RandomNoise\",\n    \"_meta\": {\n      \"title\": \"RandomNoise\"\n    }\n  },\n  \"339\": {\n    \"inputs\": {\n      \"noise_seed\": \"{{##seed##}}\"\n    },\n    \"class_type\": \"RandomNoise\",\n    \"_meta\": {\n      \"title\": \"RandomNoise\"\n    }\n  },\n  \"340\": {\n    \"inputs\": {\n      \"video_latent\": [\n        \"348\",\n        0\n      ],\n      \"audio_latent\": [\n        \"367\",\n        1\n      ]\n    },\n    \"class_type\": \"LTXVConcatAVLatent\",\n    \"_meta\": {\n      \"title\": \"LTXVConcatAVLatent\"\n    }\n  },\n  \"341\": {\n    \"inputs\": {\n      \"sampler_name\": \"euler_ancestral\"\n    },\n    \"class_type\": \"KSamplerSelect\",\n    \"_meta\": {\n      \"title\": \"KSamplerSelect\"\n    }\n  },\n  \"344\": {\n    \"inputs\": {\n      \"noise\": [\n        \"339\",\n        0\n      ],\n      \"guider\": [\n        \"388\",\n        0\n      ],\n      \"sampler\": [\n        \"352\",\n        0\n      ],\n      \"sigmas\": [\n        \"404\",\n        0\n      ],\n      \"latent_image\": [\n        \"377\",\n        0\n      ]\n    },\n    \"class_type\": \"SamplerCustomAdvanced\",\n    \"_meta\": {\n      \"title\": \"SamplerCustomAdvanced\"\n    }\n  },\n  \"348\": {\n    \"inputs\": {\n      \"samples\": [\n        \"367\",\n        0\n      ],\n      \"upscale_model\": [\n        \"371\",\n        0\n      ],\n      \"vae\": [\n        \"385\",\n        0\n      ]\n    },\n    \"class_type\": \"LTXVLatentUpsampler\",\n    \"_meta\": {\n      \"title\": \"LTXVLatentUpsampler\"\n    }\n  },\n  \"352\": {\n    \"inputs\": {\n      \"sampler_name\": \"euler_ancestral\"\n    },\n    \"class_type\": \"KSamplerSelect\",\n    \"_meta\": {\n      \"title\": \"KSamplerSelect\"\n    }\n  },\n  \"353\": {\n    \"inputs\": {\n      \"values.a\": [\n        \"372\",\n        0\n      ],\n      \"expression\": \"a/2\"\n    },\n    \"class_type\": \"ComfyMathExpression\",\n    \"_meta\": {\n      \"title\": \"ComfyMathExpression\"\n    }\n  },\n  \"355\": {\n    \"inputs\": {\n      \"values.a\": [\n        \"360\",\n        0\n      ],\n      \"expression\": \"a/2\"\n    },\n    \"class_type\": \"ComfyMathExpression\",\n    \"_meta\": {\n      \"title\": \"ComfyMathExpression\"\n    }\n  },\n  \"356\": {\n    \"inputs\": {\n      \"width\": [\n        \"353\",\n        1\n      ],\n      \"height\": [\n        \"355\",\n        1\n      ],\n      \"length\": [\n        \"378\",\n        1\n      ],\n      \"batch_size\": 1\n    },\n    \"class_type\": \"EmptyLTXVLatentVideo\",\n    \"_meta\": {\n      \"title\": \"EmptyLTXVLatentVideo\"\n    }\n  },\n  \"358\": {\n    \"inputs\": {\n      \"samples\": [\n        \"369\",\n        1\n      ],\n      \"audio_vae\": [\n        \"386\",\n        0\n      ]\n    },\n    \"class_type\": \"LTXVAudioVAEDecode\",\n    \"_meta\": {\n      \"title\": \"LTXVAudioVAEDecode\"\n    }\n  },\n  \"359\": {\n    \"inputs\": {\n      \"values.a\": [\n        \"361\",\n        0\n      ],\n      \"expression\": \"a\"\n    },\n    \"class_type\": \"ComfyMathExpression\",\n    \"_meta\": {\n      \"title\": \"Math Expression (fps)\"\n    }\n  },\n  \"360\": {\n    \"inputs\": {\n      \"value\": \"{{##height##}}\"\n    },\n    \"class_type\": \"PrimitiveInt\",\n    \"_meta\": {\n      \"title\": \"Height\"\n    }\n  },\n  \"361\": {\n    \"inputs\": {\n      \"value\": 24\n    },\n    \"class_type\": \"PrimitiveInt\",\n    \"_meta\": {\n      \"title\": \"Frame Rate\"\n    }\n  },\n  \"362\": {\n    \"inputs\": {\n      \"value\": \"{{##duration##}}\"\n    },\n    \"class_type\": \"PrimitiveInt\",\n    \"_meta\": {\n      \"title\": \"Duration\"\n    }\n  },\n  \"364\": {\n    \"inputs\": {\n      \"clip\": [\n        \"387\",\n        0\n      ],\n      \"text\": [\n        \"382\",\n        0\n      ]\n    },\n    \"class_type\": \"CLIPTextEncode\",\n    \"_meta\": {\n      \"title\": \"CLIPTextEncode\"\n    }\n  },\n  \"365\": {\n    \"inputs\": {\n      \"positive\": [\n        \"364\",\n        0\n      ],\n      \"negative\": [\n        \"373\",\n        0\n      ],\n      \"frame_rate\": [\n        \"359\",\n        0\n      ]\n    },\n    \"class_type\": \"LTXVConditioning\",\n    \"_meta\": {\n      \"title\": \"LTXVConditioning\"\n    }\n  },\n  \"366\": {\n    \"inputs\": {\n      \"audio_vae\": [\n        \"386\",\n        0\n      ],\n      \"frames_number\": [\n        \"378\",\n        1\n      ],\n      \"frame_rate\": [\n        \"359\",\n        1\n      ],\n      \"batch_size\": 1\n    },\n    \"class_type\": \"LTXVEmptyLatentAudio\",\n    \"_meta\": {\n      \"title\": \"LTXVEmptyLatentAudio\"\n    }\n  },\n  \"367\": {\n    \"inputs\": {\n      \"av_latent\": [\n        \"344\",\n        0\n      ]\n    },\n    \"class_type\": \"LTXVSeparateAVLatent\",\n    \"_meta\": {\n      \"title\": \"LTXVSeparateAVLatent\"\n    }\n  },\n  \"368\": {\n    \"inputs\": {\n      \"noise\": [\n        \"338\",\n        0\n      ],\n      \"guider\": [\n        \"391\",\n        0\n      ],\n      \"sampler\": [\n        \"341\",\n        0\n      ],\n      \"sigmas\": [\n        \"395\",\n        0\n      ],\n      \"latent_image\": [\n        \"340\",\n        0\n      ]\n    },\n    \"class_type\": \"SamplerCustomAdvanced\",\n    \"_meta\": {\n      \"title\": \"SamplerCustomAdvanced\"\n    }\n  },\n  \"369\": {\n    \"inputs\": {\n      \"av_latent\": [\n        \"368\",\n        0\n      ]\n    },\n    \"class_type\": \"LTXVSeparateAVLatent\",\n    \"_meta\": {\n      \"title\": \"LTXVSeparateAVLatent\"\n    }\n  },\n  \"370\": {\n    \"inputs\": {\n      \"images\": [\n        \"374\",\n        0\n      ],\n      \"audio\": [\n        \"358\",\n        0\n      ],\n      \"fps\": [\n        \"359\",\n        0\n      ],\n      \"bit_depth\": 8\n    },\n    \"class_type\": \"CreateVideo\",\n    \"_meta\": {\n      \"title\": \"CreateVideo\"\n    }\n  },\n  \"371\": {\n    \"inputs\": {\n      \"model_name\": \"ltx-2.5-latent-spatial-upscaler-x2-bf16-1.0.safetensors\"\n    },\n    \"class_type\": \"LatentUpscaleModelLoader\",\n    \"_meta\": {\n      \"title\": \"LatentUpscaleModelLoader\"\n    }\n  },\n  \"372\": {\n    \"inputs\": {\n      \"value\": \"{{##width##}}\"\n    },\n    \"class_type\": \"PrimitiveInt\",\n    \"_meta\": {\n      \"title\": \"Width\"\n    }\n  },\n  \"373\": {\n    \"inputs\": {\n      \"clip\": [\n        \"387\",\n        0\n      ],\n      \"text\": \"{{##negative_prompt##}}\"\n    },\n    \"class_type\": \"CLIPTextEncode\",\n    \"_meta\": {\n      \"title\": \"CLIPTextEncode\"\n    }\n  },\n  \"374\": {\n    \"inputs\": {\n      \"samples\": [\n        \"369\",\n        0\n      ],\n      \"vae\": [\n        \"385\",\n        0\n      ],\n      \"tile_size\": 768,\n      \"overlap\": 64,\n      \"temporal_size\": 4096,\n      \"temporal_overlap\": 32\n    },\n    \"class_type\": \"VAEDecodeTiled\",\n    \"_meta\": {\n      \"title\": \"VAEDecodeTiled\"\n    }\n  },\n  \"376\": {\n    \"inputs\": {\n      \"value\": \"{{##prompt##}}\"\n    },\n    \"class_type\": \"PrimitiveStringMultiline\",\n    \"_meta\": {\n      \"title\": \"Prompt\"\n    }\n  },\n  \"377\": {\n    \"inputs\": {\n      \"video_latent\": [\n        \"356\",\n        0\n      ],\n      \"audio_latent\": [\n        \"366\",\n        0\n      ]\n    },\n    \"class_type\": \"LTXVConcatAVLatent\",\n    \"_meta\": {\n      \"title\": \"LTXVConcatAVLatent\"\n    }\n  },\n  \"378\": {\n    \"inputs\": {\n      \"values.a\": [\n        \"362\",\n        0\n      ],\n      \"values.b\": [\n        \"361\",\n        0\n      ],\n      \"expression\": \"a * b + 1\"\n    },\n    \"class_type\": \"ComfyMathExpression\",\n    \"_meta\": {\n      \"title\": \"Math Expression (length)\"\n    }\n  },\n  \"380\": {\n    \"inputs\": {\n      \"clip\": [\n        \"393\",\n        0\n      ],\n      \"prompt\": [\n        \"376\",\n        0\n      ],\n      \"max_length\": 600,\n      \"sampling_mode\": \"on\",\n      \"sampling_mode.temperature\": 0.7,\n      \"sampling_mode.top_k\": 64,\n      \"sampling_mode.top_p\": 0.95,\n      \"sampling_mode.min_p\": 0.05,\n      \"sampling_mode.repetition_penalty\": 1.15,\n      \"sampling_mode.seed\": 0,\n      \"sampling_mode.presence_penalty\": 0,\n      \"thinking\": false,\n      \"use_default_template\": true\n    },\n    \"class_type\": \"TextGenerateLTX2Prompt\",\n    \"_meta\": {\n      \"title\": \"TextGenerateLTX2Prompt\"\n    }\n  },\n  \"382\": {\n    \"inputs\": {\n      \"on_false\": [\n        \"376\",\n        0\n      ],\n      \"on_true\": [\n        \"380\",\n        0\n      ],\n      \"switch\": [\n        \"383\",\n        0\n      ]\n    },\n    \"class_type\": \"ComfySwitchNode\",\n    \"_meta\": {\n      \"title\": \"ComfySwitchNode\"\n    }\n  },\n  \"383\": {\n    \"inputs\": {\n      \"value\": \"{{##prompt_enhance##}}\"\n    },\n    \"class_type\": \"PrimitiveBoolean\",\n    \"_meta\": {\n      \"title\": \"Boolean (Enable Prompt Enhance)\"\n    }\n  },\n  \"384\": {\n    \"inputs\": {\n      \"unet_name\": \"{{##base_model##}}\",\n      \"weight_dtype\": \"default\"\n    },\n    \"class_type\": \"UNETLoader\",\n    \"_meta\": {\n      \"title\": \"UNETLoader\"\n    }\n  },\n  \"385\": {\n    \"inputs\": {\n      \"vae_name\": \"LTX-2\\\\ltx-2.5-video-vae-bf16.safetensors\"\n    },\n    \"class_type\": \"VAELoader\",\n    \"_meta\": {\n      \"title\": \"VAELoader\"\n    }\n  },\n  \"386\": {\n    \"inputs\": {\n      \"vae_name\": \"LTX-2\\\\ltx-2.5-audio-vae-bf16.safetensors\"\n    },\n    \"class_type\": \"VAELoader\",\n    \"_meta\": {\n      \"title\": \"VAELoader\"\n    }\n  },\n  \"387\": {\n    \"inputs\": {\n      \"clip_name\": \"gemma4-12b-with-proj-ltx-2.5-comfy-int8-convrot.safetensors\",\n      \"type\": \"ltxv\",\n      \"device\": \"default\"\n    },\n    \"class_type\": \"CLIPLoader\",\n    \"_meta\": {\n      \"title\": \"CLIPLoader\"\n    }\n  },\n  \"388\": {\n    \"inputs\": {\n      \"model\": [\n        \"384\",\n        0\n      ],\n      \"positive\": [\n        \"365\",\n        0\n      ],\n      \"negative\": [\n        \"365\",\n        1\n      ],\n      \"video_cfg\": 1,\n      \"audio_cfg\": 1\n    },\n    \"class_type\": \"LTXVDualCFGGuider\",\n    \"_meta\": {\n      \"title\": \"LTXVDualCFGGuider\"\n    }\n  },\n  \"391\": {\n    \"inputs\": {\n      \"model\": [\n        \"384\",\n        0\n      ],\n      \"positive\": [\n        \"365\",\n        0\n      ],\n      \"negative\": [\n        \"365\",\n        1\n      ],\n      \"video_cfg\": 1,\n      \"audio_cfg\": 1\n    },\n    \"class_type\": \"LTXVDualCFGGuider\",\n    \"_meta\": {\n      \"title\": \"LTXVDualCFGGuider\"\n    }\n  },\n  \"393\": {\n    \"inputs\": {\n      \"clip_name\": \"gemma4_e2b_it_bf16.safetensors\",\n      \"type\": \"ltxv\",\n      \"device\": \"default\"\n    },\n    \"class_type\": \"CLIPLoader\",\n    \"_meta\": {\n      \"title\": \"CLIPLoader\"\n    }\n  },\n  \"395\": {\n    \"inputs\": {\n      \"sigmas\": \"0.85, 0.7250, 0.4219, 0.0\"\n    },\n    \"class_type\": \"ManualSigmas\",\n    \"_meta\": {\n      \"title\": \"ManualSigmas\"\n    }\n  },\n  \"404\": {\n    \"inputs\": {\n      \"sigmas\": \"1.0, 0.99375, 0.9875, 0.98125, 0.975, 0.909375, 0.725, 0.421875, 0.0\"\n    },\n    \"class_type\": \"ManualSigmas\",\n    \"_meta\": {\n      \"title\": \"ManualSigmas\"\n    }\n  }\n}",
+    "allowedModelTypes": [],
+    "modelExposurePolicy": "full",
+    "modelWhitelist": [],
+    "loraExposurePolicy": "full",
+    "loraWhitelist": [],
+    "version": 2
+  },
+  "server": {
+    "name": "ComfyUI-Video",
+    "serverType": "ComfyUI"
+  }
+}


### PR DESCRIPTION
ComfyUI 0.32 에 들어온 공식 템플릿 `video_ltx2_5_t2v` 를 API 포맷으로 변환해 작업판으로 만들었다. 영상 + 동기화 오디오를 한 번에 생성하며, 2단계 샘플링(저해상도 → 잠재 업스케일 → 재샘플링)을 그대로 유지한다.

## 해상도 — 64의 배수

2단계 구조가 해상도를 반으로 줄여 1단계를 돌리므로 **절반이 32의 배수**여야 한다. 즉 원본은 64의 배수다.

`832×480` 을 요청하면 조용히 `832×448` 이 나온다 (480/2=240 → 32배수로 내림 224 → ×2 = 448). 프리셋 4종을 모두 64배수로 교체해 라벨과 실제를 일치시켰다. `1024×576` 요청 → `1024×576` 출력으로 확인.

## 프롬프트 자동 확장 — 기본 켜짐

**확장기가 쓰는 모델은 12B 가 아니다.** `gemma4-12b-with-proj` 는 LTX 본 텍스트 인코더로 확장 여부와 무관하게 항상 로딩되고, 확장기는 별도의 `gemma4_e2b_it` 를 쓴다.

비용은 새 프롬프트당 12~14초, 같은 프롬프트 재사용 시 0초(ComfyUI 가 노드 출력을 캐시)로 실측됐다. 시드만 바꿔 여러 장 뽑으면 첫 장에만 붙는다.

출력 품질은 확인할 만하다 — `"a lighthouse at dusk"` 5단어가 샷 구성·카메라 무빙·조명·질감·**사운드스케이프**를 갖춘 872자 LTX 형식 프롬프트가 된다.

## 검증

- `1024×576` · 3초 → h264 + aac 스테레오, 46초
- 확장 on/off 가 같은 시드에서 다른 결과 (297KB vs 381KB, md5 상이) — 프롬프트가 실제로 바뀜을 확인
- 확장기 단독 실행으로 출력 텍스트 직접 확인

## 부수 산출물

`~/dev/services/vcc-manager-workflows/ltx-2.5/` 에 공식 템플릿 원본 3종, API 변환본, 변환기(`flatten.js`)를 정리했다. 변환기는 서브그래프 전개 · 위젯 순서 · `COMFY_DYNAMICCOMBO_V3` 점 표기 · `control_after_generate` 여분 값을 처리한다.

변환 과정에서 확인한 것 두 가지:
- dynamic combo 의 하위 입력은 **`부모.자식` 점 표기**다 (`sampling_mode.temperature`). 평탄한 형제 키는 검증기가 무시한다
- 위젯 타입 판정은 **허용목록**이어야 한다. 차단목록으로 하면 `COMFY_MATCHTYPE_V3` 같은 신규 링크 타입을 위젯으로 오인해 값이 한 칸씩 밀린다

## 후속 — I2V/FL2V 는 별도

FLF2V 템플릿 기반 통합 작업판(#785 의 H3 FL2V 방식)을 시도했으나 **첨부 조합과 무관하게** `Sizes of tensors must match... Expected size 1 but got size 25` 로 실패했다. `_vcc.bypassUnless` 문제가 아니라(둘 다 첨부해 우회가 하나도 없는 경우에도 동일) FLF2V 템플릿 변환 자체의 결함이다. 원인 규명 후 별도로 올린다 — 이 PR 에는 포함하지 않았다.

closes #791