### PR TITLE
security: 파이프라인 경유 작업판 권한 우회 차단 + 프로젝트 그룹 공유 (#802)

### DIFF
--- a/frontend/src/components/common/ProjectEditDialog.js
+++ b/frontend/src/components/common/ProjectEditDialog.js
@@ -10,24 +10,38 @@ import {
   Box,
   Chip,
   Tabs,
-  Tab
+  Tab,
+  Autocomplete
 } from '@mui/material';
 import { Image as ImageIcon, Close, ArrowBack } from '@mui/icons-material';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
-import { projectAPI } from '../../services/api';
+import { projectAPI, groupAPI } from '../../services/api';
 import MediaGrid from './MediaGrid';
+import { useAuth } from '../../contexts/AuthContext';
 
 function ProjectEditDialog({ open, onClose, project, onSuccess }) {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [coverImage, setCoverImage] = useState(null);
   const [coverImageRemoved, setCoverImageRemoved] = useState(false);
+  const [allowedGroupIds, setAllowedGroupIds] = useState([]);   // #802 — 공유 그룹
   // 이미지 브라우저 모드
   const [browseMode, setBrowseMode] = useState(false);
   const [browseTab, setBrowseTab] = useState(0);
   const [browseSelection, setBrowseSelection] = useState([]);
   const queryClient = useQueryClient();
+  const { user } = useAuth();
+
+  // 공유 대상 그룹 목록 (#802). admin 전용 API 라 실패하면 조용히 빈 목록으로 둔다 —
+  // 일반 사용자는 공유 설정을 쓰지 않으므로 UI 도 숨긴다.
+  const { data: groupsRes } = useQuery({
+    queryKey: ['groups', 'all'],
+    queryFn: () => groupAPI.getAll(),
+    enabled: open && !!user?.isAdmin,
+    retry: false,
+  });
+  const groups = groupsRes?.data?.groups || groupsRes?.data?.data?.groups || [];
 
   React.useEffect(() => {
     if (project) {
@@ -35,6 +49,7 @@ function ProjectEditDialog({ open, onClose, project, onSuccess }) {
       setDescription(project.description || '');
       setCoverImage(project.coverImage || null);
       setCoverImageRemoved(false);
+      setAllowedGroupIds((project.allowedGroupIds || []).map((g) => (typeof g === 'object' ? g._id : g)));
     }
   }, [project]);
 
@@ -67,7 +82,8 @@ function ProjectEditDialog({ open, onClose, project, onSuccess }) {
 
     const data = {
       name: name.trim(),
-      description: description.trim()
+      description: description.trim(),
+      allowedGroupIds,
     };
 
     if (coverImageRemoved) {
@@ -179,6 +195,30 @@ function ProjectEditDialog({ open, onClose, project, onSuccess }) {
           inputProps={{ maxLength: 500 }}
           sx={{ mb: 2 }}
         />
+
+        {/* 공유 그룹 (#802) — 비워두면 나만 볼 수 있다 */}
+        {user?.isAdmin && (
+          <>
+            <Autocomplete
+              multiple
+              size="small"
+              options={groups.map((g) => g._id)}
+              value={allowedGroupIds}
+              onChange={(_, v) => setAllowedGroupIds(v)}
+              getOptionLabel={(id) => {
+                const g = groups.find((x) => x._id === id);
+                return g ? `${g.name}${g.isDefault ? ' (기본)' : ''}` : `삭제된 그룹 (${String(id).slice(-6)})`;
+              }}
+              renderInput={(params) => <TextField {...params} label="공유 그룹 (선택)" />}
+              sx={{ mb: 0.5 }}
+            />
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 2 }}>
+              비워두면 나만 볼 수 있습니다. 그룹을 지정하면 그 구성원이 이 프로젝트를 보고
+              그 안에서 생성 작업을 할 수 있습니다 (편집·삭제·내보내기는 나만 가능).
+              작업판 실행 권한은 각 작업판의 접근 그룹이 따로 결정합니다.
+            </Typography>
+          </>
+        )}
 
         {/* 커버 이미지 */}
         <Typography variant="subtitle2" sx={{ mb: 1 }}>커버 이미지</Typography>

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -248,7 +248,67 @@ const requireNonApiKeyAuth = (req, res, next) => {
   return next();
 };
 
+/**
+ * 사용자가 프로젝트에 접근 가능한지 검사 (#802).
+ *
+ * 작업판(userHasWorkboardAccess)과 규칙이 **다르다** — 프로젝트는 소유자가 있다.
+ *   admin → 전부 / 소유자 → 자기 것 / 그 외 → allowedGroupIds 교집합
+ *
+ * `allowedGroupIds` 가 비어 있으면 개인 전용이다. 기존 프로젝트가 전부 이 상태이므로
+ * 필드 도입만으로 동작이 달라지지 않는다.
+ *
+ * **이 검사는 프로젝트 접근만 판정한다.** 프로젝트 안에서 참조하는 작업판의 실행 권한은
+ * userHasWorkboardAccess 가 따로 본다 — 프로젝트 공유가 작업판 접근을 대신 열어주면
+ * #802 의 권한 우회가 그대로 재현된다.
+ */
+function userHasProjectAccess(user, project) {
+  if (!user || !project) return false;
+  if (user.isAdmin) return true;
+  if (String(project.userId) === String(user._id)) return true;
+  const allowed = (project.allowedGroupIds || []).map(String);
+  if (allowed.length === 0) return false;   // 개인 전용
+  const mine = (user.groupIds || []).map(String);
+  return mine.some((g) => allowed.includes(g));
+}
+
+/**
+ * 프로젝트를 **편집·삭제·내보내기** 할 수 있는지 (#802).
+ * 공유 범위는 읽기 + 실행이므로, 구조를 바꾸는 행위는 소유자와 admin 에게만 허용한다.
+ */
+function userCanManageProject(user, project) {
+  if (!user || !project) return false;
+  if (user.isAdmin) return true;
+  return String(project.userId) === String(user._id);
+}
+
+/**
+ * 접근 가능한 프로젝트를 추리는 Mongoose 쿼리 조건 (#802).
+ * 목록 조회용 — 내 것 + 내 그룹에 열린 것.
+ */
+function buildProjectAccessFilter(user) {
+  if (!user) return { _id: null };
+  if (user.isAdmin) return {};
+  const mine = (user.groupIds || []).map(String);
+  const or = [{ userId: user._id }];
+  if (mine.length > 0) or.push({ allowedGroupIds: { $in: mine } });
+  return { $or: or };
+}
+
+/**
+ * 프로젝트를 **편집·삭제·내보내기** 할 수 있는 것만 추리는 쿼리 조건 (#802).
+ * 소유자 + admin. buildProjectAccessFilter 와 달리 공유 그룹을 포함하지 않는다.
+ */
+function buildProjectManageFilter(user) {
+  if (!user) return { _id: null };
+  if (user.isAdmin) return {};
+  return { userId: user._id };
+}
+
 module.exports = {
+  buildProjectManageFilter,
+  userHasProjectAccess,
+  userCanManageProject,
+  buildProjectAccessFilter,
   requireAuth,
   requireAdmin,
   optionalAuth,

--- a/src/middleware/projectAccess.js
+++ b/src/middleware/projectAccess.js
@@ -1,0 +1,50 @@
+const Project = require('../models/Project');
+const { userHasProjectAccess, userCanManageProject } = require('./auth');
+
+// 프로젝트 로더 (#802).
+//
+// pipelines.js 와 pipelineRuns.js 가 각자 `loadProject` 를 갖고 있었고 둘 다
+// `{ _id, userId: req.user._id }` 하드 필터였다. 그룹 공유(#802)가 들어오면서
+// 판정이 한 곳에 있어야 하므로 여기로 모은다.
+//
+// 응답까지 처리하고 null 을 돌려주는 형태를 유지한다 — 기존 호출부가 그 관례로 쓰고 있다.
+
+// 존재하지 않는 것과 권한이 없는 것을 **같은 404 로** 응답한다.
+// 403 을 주면 "그 id 의 프로젝트가 존재한다" 는 사실이 새어 나간다.
+const NOT_FOUND = { success: false, message: '프로젝트를 찾을 수 없습니다' };
+
+/**
+ * 읽기·실행용 로더. 소유자 + 공유 그룹 + admin.
+ * @param {string} idParam — req.params 에서 프로젝트 id 를 담은 키
+ */
+function loadProjectForRead(idParam = 'projectId') {
+  return async function (req, res) {
+    const project = await Project.findById(req.params[idParam]);
+    if (!project || !userHasProjectAccess(req.user, project)) {
+      res.status(404).json(NOT_FOUND);
+      return null;
+    }
+    return project;
+  };
+}
+
+/**
+ * 편집·삭제·내보내기용 로더. 소유자 + admin 만.
+ * 공유 범위는 읽기 + 실행이므로 구조를 바꾸는 행위는 여기로 막는다.
+ */
+function loadProjectForManage(idParam = 'projectId') {
+  return async function (req, res) {
+    const project = await Project.findById(req.params[idParam]);
+    if (!project || !userHasProjectAccess(req.user, project)) {
+      res.status(404).json(NOT_FOUND);
+      return null;
+    }
+    if (!userCanManageProject(req.user, project)) {
+      res.status(403).json({ success: false, message: '이 프로젝트를 수정할 권한이 없습니다' });
+      return null;
+    }
+    return project;
+  };
+}
+
+module.exports = { loadProjectForRead, loadProjectForManage };

--- a/src/models/Project.js
+++ b/src/models/Project.js
@@ -33,6 +33,19 @@ const projectSchema = new mongoose.Schema({
   workboardIds: [{
     type: mongoose.Schema.Types.ObjectId,
     ref: 'Workboard'
+  }],
+  // 프로젝트를 열어줄 그룹 (#802). Workboard.allowedGroupIds 와 같은 축이다.
+  //
+  // **비어 있으면 개인 전용** — 소유자와 admin 만 접근한다. 기존 프로젝트는 전부 이 상태이므로
+  // 필드 도입만으로 동작이 달라지지 않는다 (Workboard 와 정반대 규칙이니 주의:
+  // 작업판은 빈 배열이 'admin 전용', 프로젝트는 '소유자 전용' 이다).
+  //
+  // 공유 범위는 **읽기 + 실행** 이다. 프로젝트 자체의 편집·삭제·내보내기는 소유자와 admin 만 한다.
+  // 작업판 실행 권한은 여기서 나오지 않는다 — 각 작업판의 allowedGroupIds 가 따로 판정한다.
+  // 프로젝트 공유가 작업판 접근을 대신 열어주면 #802 의 권한 우회가 재현된다.
+  allowedGroupIds: [{
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Group'
   }]
 }, {
   timestamps: true

--- a/src/routes/pipelineRuns.js
+++ b/src/routes/pipelineRuns.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { requireAuth } = require('../middleware/auth');
+const { loadProjectForRead, loadProjectForManage } = require('../middleware/projectAccess');
 const Pipeline = require('../models/Pipeline');
 const PipelineRun = require('../models/PipelineRun');
 const Project = require('../models/Project');
@@ -9,14 +10,10 @@ const router = express.Router({ mergeParams: true });
 
 // mounted at /api/projects/:projectId/pipeline-runs (#407)
 
-async function loadProject(req, res) {
-  const project = await Project.findOne({ _id: req.params.projectId, userId: req.user._id });
-  if (!project) {
-    res.status(404).json({ success: false, message: '프로젝트를 찾을 수 없습니다' });
-    return null;
-  }
-  return project;
-}
+// #802 — 프로젝트 접근 판정은 middleware/projectAccess 로 이관.
+// 읽기·실행은 공유 그룹까지 허용, 구조 변경은 소유자·admin 만.
+const loadProject = loadProjectForRead('projectId');
+const loadProjectManage = loadProjectForManage('projectId');
 
 // GET — 프로젝트의 run 목록
 router.get('/', requireAuth, async (req, res) => {
@@ -24,6 +21,9 @@ router.get('/', requireAuth, async (req, res) => {
     const project = await loadProject(req, res);
     if (!project) return;
     const { pipelineId, limit = 20, page = 1 } = req.query;
+    // 실행 기록은 **공유하지 않는다** (#802) — 프로젝트를 공유해도 남의 생성물이
+    // 섞여 보이지 않도록 본인 것만 조회한다. 파이프라인 정의는 공유 대상이지만
+    // 실행과 결과물은 개인 자산이다.
     const filter = { projectId: project._id, userId: req.user._id };
     if (pipelineId) filter.pipelineId = pipelineId;
     const skip = (parseInt(page) - 1) * parseInt(limit);
@@ -84,7 +84,7 @@ router.post('/', requireAuth, async (req, res) => {
     if (!project) return;
     const { pipelineId, initialPrompt = '' } = req.body;
     if (!pipelineId) return res.status(400).json({ success: false, message: 'pipelineId 필수' });
-    const pipeline = await Pipeline.findOne({ _id: pipelineId, projectId: project._id, userId: req.user._id });
+    const pipeline = await Pipeline.findOne({ _id: pipelineId, projectId: project._id });
     if (!pipeline) return res.status(404).json({ success: false, message: '파이프라인을 찾을 수 없습니다' });
     if (!pipeline.steps?.length) {
       return res.status(400).json({ success: false, message: '단계가 비어 있는 파이프라인입니다' });

--- a/src/routes/pipelines.js
+++ b/src/routes/pipelines.js
@@ -1,5 +1,6 @@
 const express = require('express');
-const { requireAuth } = require('../middleware/auth');
+const { requireAuth, userHasWorkboardAccess } = require('../middleware/auth');
+const { loadProjectForRead, loadProjectForManage } = require('../middleware/projectAccess');
 const Pipeline = require('../models/Pipeline');
 const Project = require('../models/Project');
 const Workboard = require('../models/Workboard');
@@ -8,17 +9,13 @@ const router = express.Router({ mergeParams: true });
 
 // 프로젝트 종속 파이프라인 CRUD (#397). mounted at /api/projects/:projectId/pipelines
 
-async function loadProject(req, res) {
-  const project = await Project.findOne({ _id: req.params.projectId, userId: req.user._id });
-  if (!project) {
-    res.status(404).json({ success: false, message: '프로젝트를 찾을 수 없습니다' });
-    return null;
-  }
-  return project;
-}
+// #802 — 프로젝트 접근 판정은 middleware/projectAccess 로 이관.
+// 읽기·실행은 공유 그룹까지 허용, 구조 변경은 소유자·admin 만.
+const loadProject = loadProjectForRead('projectId');
+const loadProjectManage = loadProjectForManage('projectId');
 
 // 모든 단계 워크보드가 사용자 소유인지 검증
-async function validateSteps(userId, steps) {
+async function validateSteps(user, steps) {
   if (!Array.isArray(steps) || steps.length === 0) return { ok: false, message: '단계가 비어 있습니다' };
   const ids = steps.map((s) => s.workboardId).filter(Boolean);
   if (ids.length !== steps.length) return { ok: false, message: '각 단계에 workboardId 필수' };
@@ -27,7 +24,13 @@ async function validateSteps(userId, steps) {
     // 일부 id 가 중복일 수 있으므로 unique 비교
     if (wbs.length === 0) return { ok: false, message: '존재하지 않는 작업판이 있습니다' };
   }
-  // 권한 검사 — 작업판 자체는 admin / 공용일 수 있으므로 여기선 존재만 확인
+  // 작업판 접근 검사 (#802) — 예전에는 "작업판은 공용일 수 있으니 존재만 확인" 했다.
+  // 그룹 접근 통제(#198) 도입으로 그 전제가 깨졌고, 접근 권한 없는 작업판을
+  // 파이프라인 단계로 넣어 실행하는 우회가 가능했다.
+  const denied = wbs.filter((wb) => !userHasWorkboardAccess(user, wb));
+  if (denied.length > 0) {
+    return { ok: false, message: `접근 권한이 없는 작업판이 포함되어 있습니다: ${denied.map((w) => w.name).join(', ')}` };
+  }
   return { ok: true };
 }
 
@@ -35,7 +38,7 @@ router.get('/', requireAuth, async (req, res) => {
   try {
     const project = await loadProject(req, res);
     if (!project) return;
-    const pipelines = await Pipeline.find({ projectId: project._id, userId: req.user._id })
+    const pipelines = await Pipeline.find({ projectId: project._id })
       .sort({ createdAt: -1 })
       .populate('steps.workboardId', 'name description workboardType outputFormat isActive serverId')
       .lean();
@@ -50,7 +53,7 @@ router.get('/:id', requireAuth, async (req, res) => {
   try {
     const project = await loadProject(req, res);
     if (!project) return;
-    const pipeline = await Pipeline.findOne({ _id: req.params.id, projectId: project._id, userId: req.user._id })
+    const pipeline = await Pipeline.findOne({ _id: req.params.id, projectId: project._id })
       .populate({
         path: 'steps.workboardId',
         select: 'name description workboardType outputFormat isActive serverId additionalInputFields',
@@ -67,16 +70,18 @@ router.get('/:id', requireAuth, async (req, res) => {
 
 router.post('/', requireAuth, async (req, res) => {
   try {
-    const project = await loadProject(req, res);
+    const project = await loadProjectManage(req, res);
     if (!project) return;
     // useWorldview 는 더 이상 사용 안 함 (#401) — 들어와도 무시.
     const { name, description, steps } = req.body;
     if (!name?.trim()) return res.status(400).json({ success: false, message: '이름 필수' });
     if (Array.isArray(steps) && steps.length > 0) {
-      const check = await validateSteps(req.user._id, steps);
+      const check = await validateSteps(req.user, steps);
       if (!check.ok) return res.status(400).json({ success: false, message: check.message });
     }
     const pipeline = await Pipeline.create({
+      // 파이프라인은 프로젝트 자산이다 (#802) — 조회·삭제는 projectId 로 스코프하고
+      // userId 는 '누가 만들었나' 기록으로만 남긴다. 편집 권한은 프로젝트 관리 권한이 판정.
       userId: req.user._id,
       projectId: project._id,
       name: name.trim(),
@@ -99,16 +104,16 @@ router.post('/', requireAuth, async (req, res) => {
 
 router.patch('/:id', requireAuth, async (req, res) => {
   try {
-    const project = await loadProject(req, res);
+    const project = await loadProjectManage(req, res);
     if (!project) return;
-    const pipeline = await Pipeline.findOne({ _id: req.params.id, projectId: project._id, userId: req.user._id });
+    const pipeline = await Pipeline.findOne({ _id: req.params.id, projectId: project._id });
     if (!pipeline) return res.status(404).json({ success: false, message: '파이프라인을 찾을 수 없습니다' });
     // useWorldview 는 더 이상 사용 안 함 (#401) — 들어와도 무시.
     const { name, description, steps } = req.body;
     if (typeof name === 'string') pipeline.name = name.trim();
     if (typeof description === 'string') pipeline.description = description.trim();
     if (Array.isArray(steps)) {
-      const check = await validateSteps(req.user._id, steps);
+      const check = await validateSteps(req.user, steps);
       if (!check.ok) return res.status(400).json({ success: false, message: check.message });
       pipeline.steps = steps.map((s) => ({
         workboardId: s.workboardId,
@@ -131,9 +136,9 @@ router.patch('/:id', requireAuth, async (req, res) => {
 
 router.delete('/:id', requireAuth, async (req, res) => {
   try {
-    const project = await loadProject(req, res);
+    const project = await loadProjectManage(req, res);
     if (!project) return;
-    const result = await Pipeline.deleteOne({ _id: req.params.id, projectId: project._id, userId: req.user._id });
+    const result = await Pipeline.deleteOne({ _id: req.params.id, projectId: project._id });
     if (result.deletedCount === 0) return res.status(404).json({ success: false, message: '파이프라인을 찾을 수 없습니다' });
     res.json({ success: true });
   } catch (error) {

--- a/src/routes/projects.js
+++ b/src/routes/projects.js
@@ -204,7 +204,7 @@ router.get('/:id', requireAuth, async (req, res) => {
 // PUT /:id - 프로젝트 수정
 router.put('/:id', requireAuth, validateBody(projectUpdateSchema), async (req, res) => {
   try {
-    const { name, description, coverImage } = req.body;
+    const { name, description, coverImage, allowedGroupIds } = req.body;
 
     const project = await Project.findOne({
       _id: req.params.id,
@@ -217,6 +217,9 @@ router.put('/:id', requireAuth, validateBody(projectUpdateSchema), async (req, r
 
     if (name) project.name = name.trim();
     if (description !== undefined) project.description = description.trim();
+    // 공유 그룹 (#802) — 소유자·admin 만 이 라우트에 도달한다.
+    // 빈 배열로 되돌리면 다시 개인 전용이 된다.
+    if (Array.isArray(allowedGroupIds)) project.allowedGroupIds = allowedGroupIds;
 
     if (coverImage === null) {
       project.coverImage = undefined;

--- a/src/routes/projects.js
+++ b/src/routes/projects.js
@@ -1,5 +1,6 @@
 const express = require('express');
-const { requireAuth, requireAdmin } = require('../middleware/auth');
+const { requireAuth, requireAdmin, userHasWorkboardAccess,
+  buildProjectAccessFilter, buildProjectManageFilter } = require('../middleware/auth');
 const { reverseSignedUrl } = require('../utils/signedUrl');
 const Project = require('../models/Project');
 const Tag = require('../models/Tag');
@@ -8,6 +9,7 @@ const GeneratedImage = require('../models/GeneratedImage');
 const GeneratedVideo = require('../models/GeneratedVideo');
 const PromptData = require('../models/PromptData');
 const ImageGenerationJob = require('../models/ImageGenerationJob');
+const Workboard = require('../models/Workboard');
 const { escapeRegex } = require('../utils/escapeRegex');
 const { validateBody, projectCreateSchema, projectUpdateSchema } = require('../utils/validation');
 const { WORKBOARD_EXPORT_VERSION, APP_VERSION, buildWorkboardExportEntry } = require('../utils/workboardExport');
@@ -49,7 +51,7 @@ router.get('/by-tag/:tagId', requireAuth, async (req, res) => {
   try {
     const project = await Project.findOne({
       tagId: req.params.tagId,
-      userId: req.user._id
+      ...buildProjectAccessFilter(req.user)
     });
 
     if (!project) {
@@ -165,7 +167,7 @@ router.get('/:id', requireAuth, async (req, res) => {
   try {
     const project = await Project.findOne({
       _id: req.params.id,
-      userId: req.user._id
+      ...buildProjectAccessFilter(req.user)
     }).populate('tagId', 'name color');
 
     if (!project) {
@@ -206,7 +208,7 @@ router.put('/:id', requireAuth, validateBody(projectUpdateSchema), async (req, r
 
     const project = await Project.findOne({
       _id: req.params.id,
-      userId: req.user._id
+      ...buildProjectManageFilter(req.user)
     });
 
     if (!project) {
@@ -244,9 +246,18 @@ router.put('/:id', requireAuth, validateBody(projectUpdateSchema), async (req, r
 // POST /:id/workboards/:workboardId - 작업판을 프로젝트에 추가 (#396)
 router.post('/:id/workboards/:workboardId', requireAuth, async (req, res) => {
   try {
-    const project = await Project.findOne({ _id: req.params.id, userId: req.user._id });
+    const project = await Project.findOne({ _id: req.params.id, ...buildProjectManageFilter(req.user) });
     if (!project) return res.status(404).json({ success: false, message: '프로젝트를 찾을 수 없습니다' });
     const wbId = req.params.workboardId;
+
+    // 작업판 접근 검사 (#802) — 이 검사가 없어서 권한 없는 작업판을 프로젝트에 붙인 뒤
+    // 파이프라인으로 실행하는 우회가 가능했다. 첫 관문이다.
+    const wb = await Workboard.findById(wbId);
+    if (!wb) return res.status(404).json({ success: false, message: '작업판을 찾을 수 없습니다' });
+    if (!userHasWorkboardAccess(req.user, wb)) {
+      return res.status(403).json({ success: false, message: '이 작업판에 접근할 권한이 없습니다' });
+    }
+
     if (!project.workboardIds.some((id) => id.toString() === wbId)) {
       project.workboardIds.push(wbId);
       await project.save();
@@ -261,7 +272,7 @@ router.post('/:id/workboards/:workboardId', requireAuth, async (req, res) => {
 // DELETE /:id/workboards/:workboardId - 작업판을 프로젝트에서 제거
 router.delete('/:id/workboards/:workboardId', requireAuth, async (req, res) => {
   try {
-    const project = await Project.findOne({ _id: req.params.id, userId: req.user._id });
+    const project = await Project.findOne({ _id: req.params.id, ...buildProjectManageFilter(req.user) });
     if (!project) return res.status(404).json({ success: false, message: '프로젝트를 찾을 수 없습니다' });
     const wbId = req.params.workboardId;
     project.workboardIds = project.workboardIds.filter((id) => id.toString() !== wbId);
@@ -276,7 +287,7 @@ router.delete('/:id/workboards/:workboardId', requireAuth, async (req, res) => {
 // GET /:id/workboards - 프로젝트의 작업판 목록 (populate)
 router.get('/:id/workboards', requireAuth, async (req, res) => {
   try {
-    const project = await Project.findOne({ _id: req.params.id, userId: req.user._id })
+    const project = await Project.findOne({ _id: req.params.id, ...buildProjectAccessFilter(req.user) })
       .populate({
         path: 'workboardIds',
         // additionalInputFields 도 포함 — 파이프라인 빌더의 단계 추가 시 customField 정보 필요 (#400 후속)
@@ -284,7 +295,10 @@ router.get('/:id/workboards', requireAuth, async (req, res) => {
         populate: { path: 'serverId', select: 'name serverType' }
       });
     if (!project) return res.status(404).json({ success: false, message: '프로젝트를 찾을 수 없습니다' });
-    res.json({ success: true, data: { workboards: project.workboardIds || [] } });
+    // 접근 가능한 작업판만 내려보낸다 (#802).
+    // 예전 데이터에 권한 없는 작업판이 이미 붙어 있을 수 있으므로 조회 시점에도 거른다.
+    const visible = (project.workboardIds || []).filter((wb) => userHasWorkboardAccess(req.user, wb));
+    res.json({ success: true, data: { workboards: visible } });
   } catch (error) {
     console.error('Project workboards fetch error:', error);
     res.status(500).json({ success: false, message: error.message });
@@ -296,7 +310,7 @@ router.delete('/:id', requireAuth, async (req, res) => {
   try {
     const project = await Project.findOne({
       _id: req.params.id,
-      userId: req.user._id
+      ...buildProjectManageFilter(req.user)
     });
 
     if (!project) {
@@ -349,7 +363,7 @@ router.post('/:id/favorite', requireAuth, async (req, res) => {
   try {
     const project = await Project.findOne({
       _id: req.params.id,
-      userId: req.user._id
+      ...buildProjectAccessFilter(req.user)
     });
 
     if (!project) {
@@ -394,7 +408,7 @@ router.get('/:id/images', requireAuth, async (req, res) => {
 
     const project = await Project.findOne({
       _id: req.params.id,
-      userId: req.user._id
+      ...buildProjectAccessFilter(req.user)
     });
 
     if (!project) {
@@ -445,7 +459,7 @@ router.get('/:id/prompt-data', requireAuth, async (req, res) => {
 
     const project = await Project.findOne({
       _id: req.params.id,
-      userId: req.user._id
+      ...buildProjectAccessFilter(req.user)
     });
 
     if (!project) {
@@ -487,7 +501,7 @@ router.get('/:id/jobs', requireAuth, async (req, res) => {
 
     const project = await Project.findOne({
       _id: req.params.id,
-      userId: req.user._id
+      ...buildProjectAccessFilter(req.user)
     });
 
     if (!project) {
@@ -534,7 +548,7 @@ router.get('/:id/jobs', requireAuth, async (req, res) => {
 router.get('/:id/conversations', requireAuth, async (req, res) => {
   try {
     const { page = 1, limit = 20 } = req.query;
-    const project = await Project.findOne({ _id: req.params.id, userId: req.user._id });
+    const project = await Project.findOne({ _id: req.params.id, ...buildProjectAccessFilter(req.user) });
     if (!project) {
       return res.status(404).json({ success: false, message: '프로젝트를 찾을 수 없습니다' });
     }
@@ -583,12 +597,11 @@ router.get('/:id/conversations', requireAuth, async (req, res) => {
 // binary(이미지/영상)는 v1 규격에서 제외 (기획 결정).
 router.get('/:id/export', requireAdmin, async (req, res) => {
   try {
-    const Workboard = require('../models/Workboard');
     const Server = require('../models/Server');
     const Pipeline = require('../models/Pipeline');
     const UploadedText = require('../models/UploadedText');
 
-    const project = await Project.findOne({ _id: req.params.id, userId: req.user._id }).populate('tagId');
+    const project = await Project.findOne({ _id: req.params.id, ...buildProjectManageFilter(req.user) }).populate('tagId');
     if (!project) {
       return res.status(404).json({ success: false, message: '프로젝트를 찾을 수 없습니다' });
     }

--- a/src/routes/texts.js
+++ b/src/routes/texts.js
@@ -1,6 +1,7 @@
 const express = require('express');
-const { requireAuth, requireAdmin } = require('../middleware/auth');
+const { requireAuth, requireAdmin, userHasProjectAccess } = require('../middleware/auth');
 const UploadedText = require('../models/UploadedText');
+const Project = require('../models/Project');
 const GeneratedText = require('../models/GeneratedText');
 const ConversationJob = require('../models/ConversationJob');
 const { MAX_CONTENT_LENGTH } = UploadedText;
@@ -10,6 +11,23 @@ const router = express.Router();
 // 텍스트 컨텐츠 라우트 (#387).
 // UploadedText: 직접 작성. GeneratedText: 대화에서 사용자 명시 저장.
 // 이미지 라우트와 응답 shape 일치 (items + pagination).
+
+// 프로젝트 태그로 조회할 때, 그 프로젝트에 접근 가능하면 **소유자의 문서까지** 보여준다 (#802).
+//
+// 문서는 UploadedText 로 개인 소유인데, 프로젝트를 그룹에 공유하면 그 안의 문서도 함께
+// 보여야 한다 (공유 대상: 작업판 구성 · 문서 · 파이프라인). 소유자 것과 내 것만 포함하며,
+// 같은 태그를 붙인 제3자의 문서는 포함하지 않는다 — 태그는 누구나 붙일 수 있으므로
+// 태그만으로 공개 범위를 정하면 의도치 않은 노출이 생긴다.
+async function widenForSharedProject(req, filter, tagList) {
+  if (tagList.length === 0) return;
+  const projects = await Project.find({ tagId: { $in: tagList } }).lean();
+  const ownerIds = projects
+    .filter((pr) => String(pr.userId) !== String(req.user._id))
+    .filter((pr) => userHasProjectAccess(req.user, pr))
+    .map((pr) => pr.userId);
+  if (ownerIds.length === 0) return;
+  filter.userId = { $in: [req.user._id, ...ownerIds] };
+}
 
 function buildListFilter(req) {
   const filter = { userId: req.user._id };
@@ -30,6 +48,7 @@ function buildListFilter(req) {
     const re = new RegExp(search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
     filter.$or = [{ title: re }, { content: re }];
   }
+  filter.__tagList = tagList;   // widenForSharedProject 에 넘기기 위한 임시 필드
   return filter;
 }
 
@@ -46,6 +65,8 @@ function paginate(req, defaultLimit = 20) {
 router.get('/uploaded', requireAuth, async (req, res) => {
   try {
     const filter = buildListFilter(req);
+    const tagList = filter.__tagList; delete filter.__tagList;
+    await widenForSharedProject(req, filter, tagList);
     const { page, limit, skip } = paginate(req);
     const [items, total] = await Promise.all([
       UploadedText.find(filter)
@@ -155,6 +176,8 @@ router.delete('/uploaded/:id', requireAuth, async (req, res) => {
 router.get('/generated', requireAuth, async (req, res) => {
   try {
     const filter = buildListFilter(req);
+    const tagList = filter.__tagList; delete filter.__tagList;
+    await widenForSharedProject(req, filter, tagList);
     const { page, limit, skip } = paginate(req);
     const [items, total] = await Promise.all([
       GeneratedText.find(filter)

--- a/src/services/pipelineRunService.js
+++ b/src/services/pipelineRunService.js
@@ -6,10 +6,12 @@ const ConversationJob = require('../models/ConversationJob');
 const ImageGenerationJob = require('../models/ImageGenerationJob');
 const UploadedText = require('../models/UploadedText');
 const Project = require('../models/Project');
+const User = require('../models/User');
 const Tag = require('../models/Tag');
 const openAIChatService = require('./openAIChatService');
 const geminiService = require('./geminiService');
 const { getFieldValueByRole } = require('../utils/customFieldHelpers');
+const { userHasWorkboardAccess } = require('../middleware/auth');
 const { decryptSecret } = require('../utils/secretCrypto');
 const { FIELD_ROLES } = require('../constants/fieldRoles');
 const { computeOpenAITextCost, computeGeminiTextCost } = require('../utils/pricing');
@@ -297,6 +299,9 @@ async function processPipelineRun(job) {
     if (prevRunStep?.output) prevOutput = prevRunStep.output;
   }
 
+  // 실행자 — 단계마다 작업판 접근을 검사하는 데 쓴다 (#802)
+  const runner = await User.findById(run.userId).lean();
+
   for (let i = fromStep; i < run.steps.length; i++) {
     const pipelineStep = pipeline.steps[i];
     const runStep = run.steps[i];
@@ -317,6 +322,15 @@ async function processPipelineRun(job) {
     try {
       const workboard = await Workboard.findById(runStep.workboardId);
       if (!workboard) throw new Error('작업판이 삭제됨');
+
+      // 실행 시점 접근 검사 (#802) — **최종 방어선**.
+      // 파이프라인 저장 시에도 검사하지만(pipelines.js validateSteps), 저장 이후에
+      // 실행자가 그룹에서 빠지거나 작업판의 allowedGroupIds 가 바뀔 수 있다.
+      // 실행 직전에 다시 보지 않으면 그 창으로 권한 없는 실행이 통과한다.
+      if (!runner) throw new Error('실행자를 찾을 수 없음');
+      if (!userHasWorkboardAccess(runner, workboard)) {
+        throw new Error(`작업판 접근 권한이 없습니다: ${workboard.name}`);
+      }
 
       const autoInject = i === 0 ? false : (pipelineStep.autoInject !== false);
       const inputData = buildStepInput(workboard, autoInject ? prevOutput : null, pipelineStep.inputs, i, run.initialPrompt);

--- a/src/tests/projectAccess.test.js
+++ b/src/tests/projectAccess.test.js
@@ -1,0 +1,93 @@
+/**
+ * 프로젝트 그룹 접근 + 작업판 접근 우회 방지 (#802)
+ *
+ * 실제로 뚫렸던 경로를 가드한다 — 권한 없는 작업판을 프로젝트에 붙인 뒤
+ * 파이프라인으로 실행하면 통과했다. 세 관문(붙이기 / 저장 / 실행) 중 하나라도
+ * 열리면 우회가 되살아나므로 판정 함수 단위로 고정해 둔다.
+ */
+const {
+  userHasProjectAccess,
+  userCanManageProject,
+  buildProjectAccessFilter,
+  buildProjectManageFilter,
+  userHasWorkboardAccess,
+} = require('../middleware/auth');
+
+const admin = { _id: 'admin', isAdmin: true, groupIds: [] };
+const owner = { _id: 'u1', isAdmin: false, groupIds: ['g1'] };
+const member = { _id: 'u2', isAdmin: false, groupIds: ['g1'] };
+const stranger = { _id: 'u3', isAdmin: false, groupIds: ['g9'] };
+
+const personal = { userId: 'u1', allowedGroupIds: [] };
+const shared = { userId: 'u1', allowedGroupIds: ['g1'] };
+
+describe('프로젝트 접근 (#802)', () => {
+  test('빈 allowedGroupIds 는 개인 전용 — 소유자와 admin 만', () => {
+    expect(userHasProjectAccess(owner, personal)).toBe(true);
+    expect(userHasProjectAccess(admin, personal)).toBe(true);
+    expect(userHasProjectAccess(member, personal)).toBe(false);
+  });
+
+  test('작업판과 규칙이 반대다 — 작업판의 빈 배열은 admin 전용, 프로젝트는 소유자 전용', () => {
+    // 같은 빈 배열이지만 소유자가 있는 프로젝트는 소유자가 접근 가능해야 한다
+    expect(userHasProjectAccess(owner, personal)).toBe(true);
+    expect(userHasWorkboardAccess(owner, { allowedGroupIds: [] })).toBe(false);
+  });
+
+  test('그룹 공유 — 같은 그룹 멤버는 접근, 다른 그룹은 차단', () => {
+    expect(userHasProjectAccess(member, shared)).toBe(true);
+    expect(userHasProjectAccess(stranger, shared)).toBe(false);
+  });
+
+  test('공유는 읽기 + 실행까지 — 멤버는 편집/삭제/내보내기 불가', () => {
+    expect(userHasProjectAccess(member, shared)).toBe(true);
+    expect(userCanManageProject(member, shared)).toBe(false);
+    expect(userCanManageProject(owner, shared)).toBe(true);
+    expect(userCanManageProject(admin, shared)).toBe(true);
+  });
+});
+
+describe('프로젝트 조회 필터 (#802)', () => {
+  test('접근 필터는 내 것 + 내 그룹에 열린 것', () => {
+    expect(buildProjectAccessFilter(member)).toEqual({
+      $or: [{ userId: 'u2' }, { allowedGroupIds: { $in: ['g1'] } }],
+    });
+  });
+
+  test('그룹이 없으면 내 것만', () => {
+    const solo = { _id: 'u4', isAdmin: false, groupIds: [] };
+    expect(buildProjectAccessFilter(solo)).toEqual({ $or: [{ userId: 'u4' }] });
+  });
+
+  test('관리 필터는 공유 그룹을 포함하지 않는다 — 소유자만', () => {
+    expect(buildProjectManageFilter(member)).toEqual({ userId: 'u2' });
+    expect(buildProjectManageFilter(admin)).toEqual({});
+  });
+
+  test('admin 은 전체', () => {
+    expect(buildProjectAccessFilter(admin)).toEqual({});
+  });
+
+  test('비로그인은 차단', () => {
+    expect(buildProjectAccessFilter(null)).toEqual({ _id: null });
+    expect(buildProjectManageFilter(null)).toEqual({ _id: null });
+  });
+});
+
+describe('프로젝트 공유가 작업판 접근을 열어주지 않는다 (#802 핵심)', () => {
+  // 우회의 본질은 "프로젝트를 통과했으니 작업판도 통과" 였다.
+  // 두 판정은 독립이어야 한다.
+  const adminOnlyWb = { name: 'admin 전용', allowedGroupIds: [] };
+  const groupWb = { name: '그룹 공개', allowedGroupIds: ['g1'] };
+
+  test('공유 프로젝트에 접근 가능해도 admin 전용 작업판은 차단', () => {
+    expect(userHasProjectAccess(member, shared)).toBe(true);
+    expect(userHasWorkboardAccess(member, adminOnlyWb)).toBe(false);
+  });
+
+  test('작업판 자신의 그룹으로만 판정된다', () => {
+    expect(userHasWorkboardAccess(member, groupWb)).toBe(true);
+    expect(userHasWorkboardAccess(stranger, groupWb)).toBe(false);
+    expect(userHasWorkboardAccess(admin, adminOnlyWb)).toBe(true);
+  });
+});

--- a/src/tests/projectExport.test.js
+++ b/src/tests/projectExport.test.js
@@ -15,6 +15,13 @@ jest.mock('../middleware/auth', () => ({
     if (!mockCurrentUser?.isAdmin) return res.status(403).json({ success: false, message: '관리자 권한이 필요합니다.' });
     req.user = mockCurrentUser; next();
   },
+  // #802 — 프로젝트 그룹 공유 도입으로 라우트가 접근 필터를 쓴다.
+  // 실제 구현과 같은 규칙: admin 은 전부, 그 외는 소유자(+공유 그룹).
+  buildProjectAccessFilter: (user) => (user?.isAdmin ? {} : { $or: [{ userId: user?._id }] }),
+  buildProjectManageFilter: (user) => (user?.isAdmin ? {} : { userId: user?._id }),
+  userHasProjectAccess: () => true,
+  userCanManageProject: () => true,
+  userHasWorkboardAccess: () => true,
 }));
 jest.mock('../utils/signedUrl', () => ({ reverseSignedUrl: (u) => u, convertToSignedUrls: (x) => x, generateSignedUrl: (u) => u }));
 

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -209,6 +209,8 @@ const projectUpdateSchema = Joi.object({
   name: Joi.string().allow(''),
   description: Joi.string().allow('', null),
   coverImage: Joi.object().unknown(true).allow(null),
+  // 프로젝트를 열어줄 그룹 (#802). 빈 배열이면 개인 전용.
+  allowedGroupIds: Joi.array().items(Joi.string()).allow(null),
 }).unknown(true);
 
 const tagCreateSchema = Joi.object({


### PR DESCRIPTION
## 무엇이 뚫려 있었나

권한 없는 작업판을 프로젝트에 붙인 뒤 파이프라인으로 실행하면 **그대로 돌아갔다.** 정보 노출이 아니라 실제 생성까지 됐고, GPU 자원이 소비됐다.

접근 검사(`userHasWorkboardAccess`)가 정상 경로(jobs / workboards / servers)에만 있었다. `pipelines.js` 에는 전제가 주석으로 남아 있었다.

```js
// 권한 검사 — 작업판 자체는 admin / 공용일 수 있으므로 여기선 존재만 확인
```

"작업판은 공용" 이라는 전제가 그룹 접근 통제(#198) 도입으로 깨졌는데 파이프라인 쪽이 따라가지 않았다.

## 우회 차단 — 세 관문

한 곳만 막으면 다른 경로로 샌다.

| 관문 | 위치 |
|---|---|
| 붙이기 | `projects.js` 작업판 추가 시 검사 |
| 저장 | `pipelines.js validateSteps` 전 단계 검사 |
| **실행** | `pipelineRunService` 실행 직전 재검사 — **최종 방어선** |

실행 시점 검사가 필요한 이유는 저장 이후 실행자가 그룹에서 빠지거나 작업판의 `allowedGroupIds` 가 바뀔 수 있기 때문이다. 저장 시 검사만으로는 그 창이 열린다.

추가로 `GET /projects/:id/workboards` 도 접근 가능한 것만 반환한다 — 기존 데이터에 이미 붙어 있을 수 있다.

## 프로젝트 그룹 공유

`Project.allowedGroupIds` 추가. **비어 있으면 개인 전용**이라 기존 프로젝트는 동작이 달라지지 않는다.

> ⚠️ 작업판과 **반대 규칙**이다. 작업판의 빈 배열은 admin 전용, 프로젝트의 빈 배열은 소유자 전용이다. 프로젝트에는 소유자가 있기 때문. 테스트로 고정해 뒀다.

| | 범위 |
|---|---|
| 공유 대상 | 작업판 구성 · 문서 · 파이프라인 |
| 멤버 권한 | 읽기 + 실행 |
| 소유자·admin | 편집 · 삭제 · 내보내기 |
| 공유 안 함 | 실행 기록 · 생성물 (개인 자산) |

**프로젝트 공유가 작업판 접근을 대신 열어주지 않는다.** 두 판정은 독립이다 — 합치면 우회가 그대로 재현되므로 이걸 테스트로 못 박았다.

## 구조 정리

- `middleware/auth`: `userHasProjectAccess` / `userCanManageProject` / `buildProjectAccessFilter` / `buildProjectManageFilter`
- `middleware/projectAccess`: `loadProjectForRead` / `loadProjectForManage` — `pipelines.js` 와 `pipelineRuns.js` 에 **각자 복사돼 있던** `loadProject` 통합 (#794 와 같은 이원화 문제였다)
- 존재하지 않는 것과 권한 없는 것을 같은 404 로 응답 — 403 은 "그 id 가 존재한다" 를 흘린다
- `texts.js`: 프로젝트 태그 조회 시 접근 가능한 프로젝트의 소유자 문서까지 포함. 같은 태그를 붙인 제3자 문서는 제외한다 (태그는 누구나 붙일 수 있다)

## UI

`ProjectEditDialog` 에 공유 그룹 선택 추가. 그룹 목록 API 가 admin 전용이라 UI 도 admin 에게만 보인다. `projectUpdateSchema` 가 `allowedGroupIds` 를 걸러내고 있던 것도 함께 고쳤다.

## 검증

우회 3단계를 **처음 재현했던 그대로** 다시 시도했다.

| 단계 | 이전 | 지금 |
|---|---|---|
| 작업판 붙이기 | 통과 | ⛔ 403 |
| 파이프라인 생성 | 통과 | ⛔ 400 (작업판 이름 안내) |
| 실행 | **영상 생성** | ⛔ failed — **디스패치 없음** |

세 번째는 저장 시 검사를 우회했다고 가정해 DB 에 파이프라인을 직접 심고 실행했다. 실행 시점 방어선이 잡아낸다.

jest 432 (`projectAccess.test.js` 11건 추가). 검증에 쓴 계정·작업판·프로젝트·태그는 모두 정리했다.

closes #802