### PR TITLE
feat: 오디오 출력 축 + 이원화 소스 정리 (#805 #808)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,27 @@ docker-compose down && docker-compose up --build -d
 docker-compose logs -f backend
 ```
 
+### 프론트엔드 단위 테스트 (vitest, #808)
+
+그동안 프론트엔드에 테스트 러너가 없어 UI 로직을 가드할 방법이 없었다 (`sanitizeHtml.test.js` 는
+실행되지 않는 고아 파일이었다). 작업 히스토리 이원화 정리(#794)처럼 회귀 위험이 큰 리팩터의
+전제 조건이라 연결했다.
+
+```bash
+npm run test:frontend      # 프론트만
+npm run test:all           # 백엔드(jest) + 프론트(vitest)
+pnpm --dir frontend test:watch
+```
+
+- 설정은 `frontend/vite.config.js` 의 `test` 블록 — 빌드와 같은 esbuild loader 를 쓰므로
+  `.js` 안의 JSX 도 그대로 처리된다
+- `frontend/src/setupTests.js` 에서 jest-dom matcher 등록 + 테스트 간 DOM cleanup
+- **프론트엔드는 pnpm 프로젝트다** (`pnpm-lock.yaml`). npm 으로 패키지를 추가하면 실패한다
+
+**무엇을 테스트하나** — 렌더링 스냅샷이 아니라 **계약과 판정 로직**을 고정한다.
+`utils/continueJob` 처럼 여러 화면이 공유하는 순수 모듈이 우선순위다. 실제로 그 계약이
+두 번 깨졌다 (#762 → #792).
+
 ### E2E 테스트 (Playwright, #359)
 critical user journey 자동 회귀 검증. `e2e/` 디렉토리 + `playwright.config.js` 참고.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,26 @@ docker-compose down && docker-compose up --build -d
 docker-compose logs -f backend
 ```
 
+### 패키지 매니저는 pnpm 전용
+
+**npm 을 쓰지 않는다.** 루트 · `frontend/` · `mcp-server/` 모두 `pnpm-lock.yaml` 이며
+Dockerfile 3종도 `pnpm install --frozen-lockfile` 이다.
+
+```bash
+pnpm install                 # npm install (X)
+pnpm add -D <pkg>            # npm install -D (X)
+pnpm --dir frontend test     # 하위 프로젝트
+```
+
+**이유는 공급망 공격 대비다.** npm 의 기본 hoisting 은 선언하지 않은 패키지까지 require 가능한
+상태를 만들어, 침해된 전이 의존성이 코드에 닿을 표면을 넓힌다. pnpm 의 격리된 node_modules 는
+그 표면을 줄인다. 완전한 방어는 아니지만 최소한의 방책이다.
+
+- 설치는 `--frozen-lockfile` 로 — 락파일과 다르면 조용히 해결하지 말고 실패해야 한다
+- 의존성 추가 시 락파일 변경분을 PR 에서 확인할 것 (추가된 전이 의존성이 눈에 보이도록)
+- **npm 으로 패키지를 추가하면 실패한다** — pnpm 프로젝트에서 `npm install` 은
+  `Cannot read properties of null` 로 죽는다. 에러 메시지가 원인을 안 알려주니 주의
+
 ### 프론트엔드 단위 테스트 (vitest, #808)
 
 그동안 프론트엔드에 테스트 러너가 없어 UI 로직을 가드할 방법이 없었다 (`sanitizeHtml.test.js` 는
@@ -124,8 +144,8 @@ docker-compose logs -f backend
 전제 조건이라 연결했다.
 
 ```bash
-npm run test:frontend      # 프론트만
-npm run test:all           # 백엔드(jest) + 프론트(vitest)
+pnpm run test:frontend     # 프론트만
+pnpm run test:all          # 백엔드(jest) + 프론트(vitest)
 pnpm --dir frontend test:watch
 ```
 
@@ -143,24 +163,24 @@ critical user journey 자동 회귀 검증. `e2e/` 디렉토리 + `playwright.co
 
 ```bash
 # 첫 실행 — Playwright 브라우저 다운로드
-npx playwright install chromium
+pnpm exec playwright install chromium
 
 # 전체 실행에는 .env 에 E2E_ADMIN_SECRET 설정 필요 (#381) — 미설정 시
 # 승인/admin 필요한 테스트는 skip 됨. 알파 등 외부 노출 환경에는 절대 설정 금지.
 # (playwright.config 가 .env 에서 자동 로드, 백엔드는 docker-compose 가 주입)
 
 # 헤드리스 실행 (docker-compose 가 떠 있어야 함)
-npm run test:e2e
+pnpm run test:e2e
 
 # UI 모드 / 헤드 모드
-npm run test:e2e:ui
-npm run test:e2e:headed
+pnpm run test:e2e:ui
+pnpm run test:e2e:headed
 ```
 
 **유지보수 정책** — UI 변경 시 함께 갱신:
 - 셀렉터 / 네비게이션 흐름 / 라벨 텍스트 등이 바뀌면 관련 e2e spec 도 동시 수정. 별도 후속 작업으로 미루지 말 것.
 - 핵심 user journey 추가 (예: 신규 페이지, 새 인증 흐름) 시 smoke 1개 이상 추가 권장.
-- PR 머지 전 로컬에서 `npm run test:e2e` 통과 확인.
+- PR 머지 전 로컬에서 `pnpm run test:e2e` 통과 확인.
 - 테스트가 깨졌을 때 \"테스트가 잘못됨\" 으로 무조건 spec 만 고치지 말 것 — UI 실제 동작 검증 후 spec / 실 동작 어느 쪽이 맞는지 결정.
 
 ### 환경 변수 파일

--- a/docs/MCP_SERVER_API.md
+++ b/docs/MCP_SERVER_API.md
@@ -183,21 +183,21 @@ VCC Manager MCP 서버가 제공하는 도구(Tool) 목록과 파라미터 명�
 
 - **stdio 모드**: 로컬 디스크에 파일 저장 (`responseType: "file"`)
 - **HTTP 모드 (`VCC_BASE_URL_FOR_MCP` 설정 시)**: signed URL 반환 (`responseType: "signedUrl"`)
-- **HTTP 모드 (`VCC_BASE_URL_FOR_MCP` 미설정 시)**: 이미지는 base64 인라인 (`responseType: "base64"`), 비디오는 메타데이터만 반환 (`responseType: "metadata"`)
+- **HTTP 모드 (`VCC_BASE_URL_FOR_MCP` 미설정 시)**: 이미지는 base64 인라인 (`responseType: "base64"`), 비디오·오디오는 메타데이터만 반환 (`responseType: "metadata"`)
 
 | 파라미터 | 타입 | 필수 | 설명 |
 |---------|------|------|------|
-| `mediaId` | string | **필수** | 미디어 ID (`get_job_status` 결과의 resultImages/resultVideos에서 확인) |
-| `mediaType` | `"image"` \| `"video"` | **필수** | 미디어 유형 |
+| `mediaId` | string | **필수** | 미디어 ID (`get_job_status` 결과의 resultImages/resultVideos/resultAudios에서 확인) |
+| `mediaType` | `"image"` \| `"video"` \| `"audio"` | **필수** | 미디어 유형 |
 | `downloadDir` | string | - | 다운로드 디렉토리 (stdio 모드 전용, 기본: `~/Downloads/vcc` 또는 `VCC_DOWNLOAD_DIR`) |
 
 **`responseType` 값:**
 
 | 값 | 조건 | 설명 |
 |---|------|------|
-| `signedUrl` | HTTP 모드 + `VCC_BASE_URL_FOR_MCP` 설정 | 이미지/비디오 모두 signed URL 반환 |
+| `signedUrl` | HTTP 모드 + `VCC_BASE_URL_FOR_MCP` 설정 | 이미지·비디오·오디오 모두 signed URL 반환 |
 | `base64` | HTTP 모드 + `VCC_BASE_URL_FOR_MCP` 미설정 + 이미지 | base64 인라인 이미지 |
-| `metadata` | HTTP 모드 + `VCC_BASE_URL_FOR_MCP` 미설정 + 비디오 | 메타데이터만 반환 (바이너리 없음) |
+| `metadata` | HTTP 모드 + `VCC_BASE_URL_FOR_MCP` 미설정 + 비디오·오디오 | 메타데이터만 반환 (바이너리 없음) |
 | `file` | stdio 모드 | 로컬 디스크에 파일 저장 |
 
 **응답 (stdio 모드 — `responseType: "file"`):**
@@ -212,7 +212,7 @@ VCC Manager MCP 서버가 제공하는 도구(Tool) 목록과 파라미터 명�
 
 **응답 (HTTP 모드 — `responseType: "signedUrl"`):**
 
-`VCC_BASE_URL_FOR_MCP` 설정 시 이미지/비디오 모두 동일한 형식으로 signed URL을 반환합니다.
+`VCC_BASE_URL_FOR_MCP` 설정 시 이미지·비디오·오디오 모두 동일한 형식으로 signed URL을 반환합니다.
 
 | 필드 | 설명 |
 |------|------|
@@ -235,14 +235,14 @@ VCC Manager MCP 서버가 제공하는 도구(Tool) 목록과 파라미터 명�
 
 **응답 (HTTP 모드 — `responseType: "metadata"`):**
 
-`VCC_BASE_URL_FOR_MCP` 미설정 시 비디오에 대해 메타데이터만 반환합니다.
+`VCC_BASE_URL_FOR_MCP` 미설정 시 비디오·오디오에 대해 메타데이터만 반환합니다.
 
 | 필드 | 설명 |
 |------|------|
 | `responseType` | `"metadata"` |
 | `filename` | 파일명 |
 | `size` | 파일 크기 (bytes) |
-| `mediaType` | `"video"` |
+| `mediaType` | `"video"` \| `"audio"` |
 | `note` | `VCC_BASE_URL_FOR_MCP` 설정 안내 메시지 |
 
 ---

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,13 +27,17 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/js-cookie": "^3.0.6",
     "@vitejs/plugin-react": "^5.2.0",
-    "vite": "^7.3.6"
+    "jsdom": "^30.0.1",
+    "vite": "^7.3.6",
+    "vitest": "^3.2.7"
   },
   "scripts": {
     "start": "vite",
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "proxy": "http://localhost:3000"
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -10,25 +10,25 @@ importers:
     dependencies:
       '@emotion/react':
         specifier: ^11.14.0
-        version: 11.14.0(@types/react@18.3.27)(react@18.3.1)
+        version: 11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0)
       '@emotion/styled':
         specifier: ^11.14.1
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0)
       '@hello-pangea/dnd':
         specifier: ^16.6.0
         version: 16.6.0(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/icons-material':
         specifier: ^5.18.0
-        version: 5.18.0(@mui/material@5.18.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.27)(react@18.3.1)
+        version: 5.18.0(@mui/material@5.18.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.27)(react@18.3.1)
       '@mui/material':
         specifier: ^5.18.0
-        version: 5.18.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 5.18.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-query':
         specifier: ^5.101.2
         version: 5.101.2(react@18.3.1)
       axios:
         specifier: ^1.18.1
-        version: 1.18.1
+        version: 1.18.1(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
       date-fns:
         specifier: ^3.6.0
         version: 3.6.0
@@ -55,7 +55,7 @@ importers:
         version: 2.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-markdown:
         specifier: ^10.1.0
-        version: 10.1.0(@types/react@18.3.27)(react@18.3.1)
+        version: 10.1.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0)
       react-router-dom:
         specifier: ^6.30.4
         version: 6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -74,15 +74,29 @@ importers:
         version: 3.0.6
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(vite@7.3.6(@types/node@26.1.1)(jiti@1.21.7)(terser@5.46.0))
+        version: 5.2.0(supports-color@7.2.0)(vite@7.3.6(@types/node@26.1.1)(jiti@1.21.7)(terser@5.46.0))
+      jsdom:
+        specifier: ^30.0.1
+        version: 30.0.1
       vite:
         specifier: ^7.3.6
         version: 7.3.6(@types/node@26.1.1)(jiti@1.21.7)(terser@5.46.0)
+      vitest:
+        specifier: ^3.2.7
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@26.1.1)(jiti@1.21.7)(jsdom@30.0.1)(supports-color@7.2.0)(terser@5.46.0)
 
 packages:
 
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
+
+  '@asamuzakjp/css-color@6.0.7':
+    resolution: {integrity: sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    resolution: {integrity: sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==}
+    engines: {node: ^22.13.0 || >=24.0.0}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -170,6 +184,46 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.10':
+    resolution: {integrity: sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.7':
+    resolution: {integrity: sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@emotion/babel-plugin@11.13.5':
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
@@ -380,6 +434,15 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@hello-pangea/dnd@16.6.0':
     resolution: {integrity: sha512-vfZ4GydqbtUPXSLfAvKvXQ6xwRzIjUSjVU0Sx+70VOhc2xx6CdmJXJ8YhH70RpbTUGjxctslQTHul9sIOxCfFQ==}
@@ -713,8 +776,14 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -806,6 +875,35 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  '@vitest/expect@3.2.7':
+    resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
+
+  '@vitest/mocker@3.2.7':
+    resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
+
+  '@vitest/runner@3.2.7':
+    resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
+
+  '@vitest/snapshot@3.2.7':
+    resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
+
+  '@vitest/spy@3.2.7':
+    resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
+
+  '@vitest/utils@3.2.7':
+    resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
+
   acorn@8.17.0:
     resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
@@ -838,6 +936,10 @@ packages:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
@@ -864,6 +966,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   browserslist@4.28.5:
     resolution: {integrity: sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -871,6 +976,10 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -894,6 +1003,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@3.0.0:
     resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
     engines: {node: '>=8'}
@@ -913,6 +1026,10 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
@@ -952,11 +1069,19 @@ packages:
   css-box-model@1.2.1:
     resolution: {integrity: sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   date-fns@3.6.0:
     resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
@@ -970,8 +1095,15 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deep-equal@2.2.3:
     resolution: {integrity: sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==}
@@ -1012,6 +1144,10 @@ packages:
   electron-to-chromium@1.5.389:
     resolution: {integrity: sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==}
 
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
@@ -1025,6 +1161,9 @@ packages:
 
   es-get-iterator@1.1.3:
     resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
@@ -1053,6 +1192,13 @@ packages:
 
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   expect@30.4.1:
     resolution: {integrity: sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==}
@@ -1161,6 +1307,10 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
@@ -1238,6 +1388,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -1303,6 +1456,18 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  jsdom@30.0.1:
+    resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    peerDependencies:
+      canvas: ^3.2.3
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -1329,12 +1494,22 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -1363,6 +1538,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   memoize-one@6.0.0:
     resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
@@ -1485,12 +1663,22 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1524,6 +1712,10 @@ packages:
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   raf-schd@4.0.3:
     resolution: {integrity: sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==}
@@ -1635,6 +1827,10 @@ packages:
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -1652,6 +1848,10 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -1684,6 +1884,9 @@ packages:
     resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -1710,6 +1913,12 @@ packages:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
@@ -1720,6 +1929,9 @@ packages:
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -1738,6 +1950,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   terser@5.46.0:
     resolution: {integrity: sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==}
     engines: {node: '>=10'}
@@ -1746,9 +1961,42 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.4.10:
+    resolution: {integrity: sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==}
+
+  tldts@7.4.10:
+    resolution: {integrity: sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==}
+    hasBin: true
+
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -1761,6 +2009,10 @@ packages:
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -1802,6 +2054,11 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite@7.3.6:
     resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1842,6 +2099,54 @@ packages:
       yaml:
         optional: true
 
+  vitest@3.2.7:
+    resolution: {integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.7
+      '@vitest/ui': 3.2.7
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@17.1.0:
+    resolution: {integrity: sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==}
+    engines: {node: ^22.14.0 || >=24.0.0}
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -1853,6 +2158,18 @@ packages:
   which-typed-array@1.1.22:
     resolution: {integrity: sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==}
     engines: {node: '>= 0.4'}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -1868,6 +2185,21 @@ snapshots:
 
   '@adobe/css-tools@4.5.0': {}
 
+  '@asamuzakjp/css-color@6.0.7':
+    dependencies:
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    dependencies:
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -1876,20 +2208,20 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.7':
+  '@babel/core@7.29.7(supports-color@7.2.0)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -1914,19 +2246,19 @@ snapshots:
 
   '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-module-imports@7.29.7':
+  '@babel/helper-module-imports@7.29.7(supports-color@7.2.0)':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.29.7
+      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/helper-module-imports': 7.29.7(supports-color@7.2.0)
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -1947,14 +2279,14 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/runtime@7.29.7': {}
@@ -1965,7 +2297,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.7':
+  '@babel/traverse@7.29.7(supports-color@7.2.0)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -1973,7 +2305,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -1982,9 +2314,37 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@emotion/babel-plugin@11.13.5':
+  '@bramus/specificity@2.4.2':
     dependencies:
-      '@babel/helper-module-imports': 7.29.7
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.7(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
+  '@emotion/babel-plugin@11.13.5(supports-color@7.2.0)':
+    dependencies:
+      '@babel/helper-module-imports': 7.29.7(supports-color@7.2.0)
       '@babel/runtime': 7.29.7
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
@@ -2014,10 +2374,10 @@ snapshots:
 
   '@emotion/memoize@0.9.0': {}
 
-  '@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1)':
+  '@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@emotion/babel-plugin': 11.13.5
+      '@emotion/babel-plugin': 11.13.5(supports-color@7.2.0)
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
       '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@18.3.1)
@@ -2040,12 +2400,12 @@ snapshots:
 
   '@emotion/sheet@1.4.0': {}
 
-  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1)':
+  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@emotion/babel-plugin': 11.13.5
+      '@emotion/babel-plugin': 11.13.5(supports-color@7.2.0)
       '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@18.3.27)(react@18.3.1)
+      '@emotion/react': 11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0)
       '@emotion/serialize': 1.3.3
       '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@18.3.1)
       '@emotion/utils': 1.4.2
@@ -2143,6 +2503,8 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
+  '@exodus/bytes@1.15.1': {}
+
   '@hello-pangea/dnd@16.6.0(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.7
@@ -2213,19 +2575,19 @@ snapshots:
 
   '@mui/core-downloads-tracker@5.18.0': {}
 
-  '@mui/icons-material@5.18.0(@mui/material@5.18.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.27)(react@18.3.1)':
+  '@mui/icons-material@5.18.0(@mui/material@5.18.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.27)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@mui/material': 5.18.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mui/material': 5.18.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.27
 
-  '@mui/material@5.18.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@mui/material@5.18.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@mui/core-downloads-tracker': 5.18.0
-      '@mui/system': 5.18.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1)
+      '@mui/system': 5.18.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@types/react@18.3.27)(react@18.3.1)
       '@mui/types': 7.2.24(@types/react@18.3.27)
       '@mui/utils': 5.17.1(@types/react@18.3.27)(react@18.3.1)
       '@popperjs/core': 2.11.8
@@ -2238,8 +2600,8 @@ snapshots:
       react-is: 19.2.7
       react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@18.3.27)(react@18.3.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1)
+      '@emotion/react': 11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0)
       '@types/react': 18.3.27
 
   '@mui/private-theming@5.17.1(@types/react@18.3.27)(react@18.3.1)':
@@ -2251,7 +2613,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.27
 
-  '@mui/styled-engine@5.18.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)':
+  '@mui/styled-engine@5.18.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@emotion/cache': 11.14.0
@@ -2260,14 +2622,14 @@ snapshots:
       prop-types: 15.8.1
       react: 18.3.1
     optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@18.3.27)(react@18.3.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1)
+      '@emotion/react': 11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0)
 
-  '@mui/system@5.18.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1)':
+  '@mui/system@5.18.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@types/react@18.3.27)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@mui/private-theming': 5.17.1(@types/react@18.3.27)(react@18.3.1)
-      '@mui/styled-engine': 5.18.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1))(react@18.3.1)
+      '@mui/styled-engine': 5.18.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(react@18.3.1)
       '@mui/types': 7.2.24(@types/react@18.3.27)
       '@mui/utils': 5.17.1(@types/react@18.3.27)(react@18.3.1)
       clsx: 2.1.1
@@ -2275,8 +2637,8 @@ snapshots:
       prop-types: 15.8.1
       react: 18.3.1
     optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@18.3.27)(react@18.3.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1)
+      '@emotion/react': 11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0))(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0)
       '@types/react': 18.3.27
 
   '@mui/types@7.2.24(@types/react@18.3.27)':
@@ -2445,9 +2807,16 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -2531,11 +2900,11 @@ snapshots:
 
   '@ungap/structured-clone@1.3.3': {}
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.6(@types/node@26.1.1)(jiti@1.21.7)(terser@5.46.0))':
+  '@vitejs/plugin-react@5.2.0(supports-color@7.2.0)(vite@7.3.6(@types/node@26.1.1)(jiti@1.21.7)(terser@5.46.0))':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
@@ -2543,12 +2912,54 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@3.2.7':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.7(vite@7.3.6(@types/node@26.1.1)(jiti@1.21.7)(terser@5.46.0))':
+    dependencies:
+      '@vitest/spy': 3.2.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(@types/node@26.1.1)(jiti@1.21.7)(terser@5.46.0)
+
+  '@vitest/pretty-format@3.2.7':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.7':
+    dependencies:
+      '@vitest/utils': 3.2.7
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.7':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
   acorn@8.17.0:
     optional: true
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@7.2.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -2571,6 +2982,8 @@ snapshots:
       call-bound: 1.0.4
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   asynckit@0.4.0: {}
 
   attr-accept@2.2.5: {}
@@ -2579,11 +2992,11 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.18.1:
+  axios@1.18.1(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
-      follow-redirects: 1.16.0
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@7.2.0))
       form-data: 4.0.6
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 5.0.1(supports-color@7.2.0)
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -2599,6 +3012,10 @@ snapshots:
 
   baseline-browser-mapping@2.10.42: {}
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   browserslist@4.28.5:
     dependencies:
       baseline-browser-mapping: 2.10.42
@@ -2609,6 +3026,8 @@ snapshots:
 
   buffer-from@1.1.2:
     optional: true
+
+  cac@6.7.14: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -2633,6 +3052,14 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@3.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -2650,6 +3077,8 @@ snapshots:
   character-entities@2.0.2: {}
 
   character-reference-invalid@2.0.1: {}
+
+  check-error@2.1.3: {}
 
   ci-info@4.4.0: {}
 
@@ -2686,19 +3115,37 @@ snapshots:
     dependencies:
       tiny-invariant: 1.3.3
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   css.escape@1.5.1: {}
 
   csstype@3.2.3: {}
 
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   date-fns@3.6.0: {}
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@7.2.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 7.2.0
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
       character-entities: 2.0.2
+
+  deep-eql@5.0.2: {}
 
   deep-equal@2.2.3:
     dependencies:
@@ -2760,6 +3207,8 @@ snapshots:
 
   electron-to-chromium@1.5.389: {}
 
+  entities@8.0.0: {}
+
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
@@ -2779,6 +3228,8 @@ snapshots:
       is-string: 1.1.1
       isarray: 2.0.5
       stop-iteration-iterator: 1.1.0
+
+  es-module-lexer@1.7.0: {}
 
   es-object-atoms@1.1.2:
     dependencies:
@@ -2828,6 +3279,12 @@ snapshots:
 
   estree-util-is-identifier-name@3.0.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
   expect@30.4.1:
     dependencies:
       '@jest/expect-utils': 30.4.1
@@ -2849,7 +3306,9 @@ snapshots:
 
   find-root@1.1.0: {}
 
-  follow-redirects@1.16.0: {}
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@7.2.0)):
+    optionalDependencies:
+      debug: 4.4.3(supports-color@7.2.0)
 
   for-each@0.3.5:
     dependencies:
@@ -2916,7 +3375,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hast-util-to-jsx-runtime@2.3.6:
+  hast-util-to-jsx-runtime@2.3.6(supports-color@7.2.0):
     dependencies:
       '@types/estree': 1.0.9
       '@types/hast': 3.0.5
@@ -2925,9 +3384,9 @@ snapshots:
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-mdx-expression: 2.0.1(supports-color@7.2.0)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@7.2.0)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@7.2.0)
       property-information: 7.2.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.21
@@ -2944,12 +3403,18 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-url-attributes@3.0.1: {}
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@7.2.0):
     dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
+      agent-base: 6.0.2(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3020,6 +3485,8 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-plain-obj@4.1.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -3105,6 +3572,34 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
+  jsdom@30.0.1:
+    dependencies:
+      '@asamuzakjp/css-color': 6.0.7
+      '@asamuzakjp/dom-selector': 8.3.2
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.7(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 8.10.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 17.1.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   jsesc@3.1.0: {}
 
   json-parse-even-better-errors@2.3.1: {}
@@ -3121,22 +3616,30 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
+  lru-cache@11.5.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
 
   lz-string@1.5.0: {}
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   math-intrinsics@1.1.0: {}
 
-  mdast-util-from-markdown@2.0.3:
+  mdast-util-from-markdown@2.0.3(supports-color@7.2.0):
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2
+      micromark: 4.0.2(supports-color@7.2.0)
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -3146,18 +3649,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-expression@2.0.1:
+  mdast-util-mdx-expression@2.0.1(supports-color@7.2.0):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-jsx@3.2.0:
+  mdast-util-mdx-jsx@3.2.0(supports-color@7.2.0):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.5
@@ -3165,7 +3668,7 @@ snapshots:
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -3174,13 +3677,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdxjs-esm@2.0.1:
+  mdast-util-mdxjs-esm@2.0.1(supports-color@7.2.0):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -3217,6 +3720,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdn-data@2.27.1: {}
 
   memoize-one@6.0.0: {}
 
@@ -3331,10 +3836,10 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2:
+  micromark@4.0.2(supports-color@7.2.0):
     dependencies:
       '@types/debug': 4.1.13
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -3408,9 +3913,17 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-parse@1.0.7: {}
 
   path-type@4.0.0: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -3447,6 +3960,8 @@ snapshots:
 
   proxy-from-env@2.1.0: {}
 
+  punycode@2.3.1: {}
+
   raf-schd@4.0.3: {}
 
   react-dom@18.3.1(react@18.3.1):
@@ -3481,17 +3996,17 @@ snapshots:
 
   react-is@19.2.7: {}
 
-  react-markdown@10.1.0(@types/react@18.3.27)(react@18.3.1):
+  react-markdown@10.1.0(@types/react@18.3.27)(react@18.3.1)(supports-color@7.2.0):
     dependencies:
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       '@types/react': 18.3.27
       devlop: 1.1.0
-      hast-util-to-jsx-runtime: 2.3.6
+      hast-util-to-jsx-runtime: 2.3.6(supports-color@7.2.0)
       html-url-attributes: 3.0.1
       mdast-util-to-hast: 13.2.1
       react: 18.3.1
-      remark-parse: 11.0.0
+      remark-parse: 11.0.0(supports-color@7.2.0)
       remark-rehype: 11.1.2
       unified: 11.0.5
       unist-util-visit: 5.1.0
@@ -3559,10 +4074,10 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
-  remark-parse@11.0.0:
+  remark-parse@11.0.0(supports-color@7.2.0):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -3575,6 +4090,8 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
+
+  require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
 
@@ -3621,6 +4138,10 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.23.2:
     dependencies:
@@ -3672,6 +4193,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   slash@3.0.0: {}
 
   source-map-js@1.2.1: {}
@@ -3693,6 +4216,10 @@ snapshots:
     dependencies:
       escape-string-regexp: 2.0.0
 
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -3706,6 +4233,10 @@ snapshots:
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
 
   style-to-js@1.1.21:
     dependencies:
@@ -3723,6 +4254,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
   terser@5.46.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
@@ -3733,10 +4266,34 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  tldts-core@7.4.10: {}
+
+  tldts@7.4.10:
+    dependencies:
+      tldts-core: 7.4.10
+
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.10
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -3745,6 +4302,8 @@ snapshots:
   tslib@2.8.1: {}
 
   undici-types@8.3.0: {}
+
+  undici@8.10.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -3803,6 +4362,27 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@3.2.4(@types/node@26.1.1)(jiti@1.21.7)(supports-color@7.2.0)(terser@5.46.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3(supports-color@7.2.0)
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.6(@types/node@26.1.1)(jiti@1.21.7)(terser@5.46.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite@7.3.6(@types/node@26.1.1)(jiti@1.21.7)(terser@5.46.0):
     dependencies:
       esbuild: 0.28.1
@@ -3816,6 +4396,73 @@ snapshots:
       fsevents: 2.3.3
       jiti: 1.21.7
       terser: 5.46.0
+
+  vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.1.1)(jiti@1.21.7)(jsdom@30.0.1)(supports-color@7.2.0)(terser@5.46.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@7.3.6(@types/node@26.1.1)(jiti@1.21.7)(terser@5.46.0))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      debug: 4.4.3(supports-color@7.2.0)
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.6(@types/node@26.1.1)(jiti@1.21.7)(terser@5.46.0)
+      vite-node: 3.2.4(@types/node@26.1.1)(jiti@1.21.7)(supports-color@7.2.0)(terser@5.46.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.13
+      '@types/node': 26.1.1
+      jsdom: 30.0.1
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  whatwg-url@17.1.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -3841,6 +4488,15 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-tostringtag: 1.0.2
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 

--- a/frontend/src/components/admin/workboardEditor/FieldInspector.js
+++ b/frontend/src/components/admin/workboardEditor/FieldInspector.js
@@ -23,11 +23,12 @@ import { Controller, useFieldArray } from 'react-hook-form';
 import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd';
 import CustomFieldControl from '../../common/CustomFieldControl';
 import { ServerMetadataDefaultValueInput, FIELD_TYPES } from './shared';
+import { ATTACHMENT_FIELD_TYPES } from '../../../templates/capabilities';
 import { MONO } from '../../../theme';
 
 // 프리뷰 필드 — 실행 화면과 동일한 공용 렌더러의 preview 모드 (#711)
 export function PreviewField({ field }) {
-  if (field.type === 'image' || field.type === 'video' || field.type === 'audio') {
+  if (ATTACHMENT_FIELD_TYPES.includes(field.type)) {
     const uploadHint = {
       video: `비디오 업로드 (최대 ${field.videoConfig?.maxVideos || 1}개)`,
       audio: `오디오 업로드 (최대 ${field.audioConfig?.maxAudios || 1}개)`,

--- a/frontend/src/components/common/AudioViewerDialog.js
+++ b/frontend/src/components/common/AudioViewerDialog.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  Box,
+  Typography,
+  IconButton,
+} from '@mui/material';
+import { Close, MusicNote } from '@mui/icons-material';
+import { MONO } from '../../theme';
+
+// 생성 오디오 뷰어 (#805) — VideoViewerDialog 와 대칭이되 훨씬 단순하다.
+//
+// 오디오는 썸네일도 전체화면도 의미가 없어 좌우 이동 UI 를 두지 않고
+// 한 작업의 결과물을 **전부 나열해 각각 재생**하게 한다. 대개 1~2개다.
+const formatDuration = (seconds) => {
+  if (seconds == null) return '길이 미상';
+  const total = Math.round(seconds);
+  return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, '0')}`;
+};
+
+function AudioViewerDialog({ audios = [], open, onClose, title = '생성된 오디오' }) {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <MusicNote fontSize="small" color="action" />
+        <Box sx={{ flex: 1 }}>{title}</Box>
+        <IconButton aria-label="닫기" onClick={onClose} size="small">
+          <Close fontSize="small" />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent>
+        {audios.length === 0 ? (
+          <Typography variant="body2" color="text.secondary">오디오가 없습니다.</Typography>
+        ) : (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            {audios.map((audio, index) => (
+              <Box key={audio._id || index}>
+                <Typography variant="body2" noWrap title={audio.generationParams?.prompt || audio.originalName}>
+                  {audio.generationParams?.prompt || audio.originalName || `오디오 ${index + 1}`}
+                </Typography>
+                <Typography variant="caption" color="text.secondary" sx={{ fontFamily: MONO }}>
+                  {formatDuration(audio.metadata?.duration)}
+                  {audio.metadata?.channels ? ` · ${audio.metadata.channels}ch` : ''}
+                  {audio.metadata?.sampleRate ? ` · ${Math.round(audio.metadata.sampleRate / 1000)}kHz` : ''}
+                </Typography>
+                <Box
+                  component="audio"
+                  controls
+                  autoPlay={index === 0}
+                  src={audio.url}
+                  sx={{ display: 'block', width: '100%', mt: 0.5 }}
+                />
+              </Box>
+            ))}
+          </Box>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default AudioViewerDialog;

--- a/frontend/src/components/common/JobHistoryPanel.js
+++ b/frontend/src/components/common/JobHistoryPanel.js
@@ -493,6 +493,32 @@ function JobCard({ job, onView, onRetry, onCancel, onDelete, onImageView, onCont
           </Box>
         )}
 
+        {/* 생성된 오디오 (#805) — 썸네일이 없어 그리드가 아니라 인라인 플레이어로 보여준다 */}
+        {job.resultAudios?.length > 0 && (
+          <Box mb={{ xs: 1.5, md: 1 }}>
+            <Typography variant="caption" display="block" gutterBottom>
+              생성된 오디오 ({job.resultAudios.length}개)
+            </Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+              {job.resultAudios.slice(0, 3).map((audio, index) => (
+                <Box
+                  key={audio._id || index}
+                  component="audio"
+                  controls
+                  preload="none"
+                  src={audio.url}
+                  sx={{ width: '100%', height: 32 }}
+                />
+              ))}
+              {job.resultAudios.length > 3 && (
+                <Typography variant="caption" color="text.secondary">
+                  외 {job.resultAudios.length - 3}개
+                </Typography>
+              )}
+            </Box>
+          </Box>
+        )}
+
         {/* 에러 메시지 */}
         {job.status === 'failed' && job.error && (
           <Alert severity="error" sx={{ mb: { xs: 1.5, md: 1 }, py: 0.5 }}>

--- a/frontend/src/components/common/JobHistoryPanel.js
+++ b/frontend/src/components/common/JobHistoryPanel.js
@@ -60,10 +60,9 @@ import ProjectTagChip from './ProjectTagChip';
 import WorkboardSelectDialog from './WorkboardSelectDialog';
 import { DEFAULT_TAG_COLOR } from '../../theme';
 import { useJobActions } from '../../hooks/useJobActions';
+import { useContinueJob } from '../../hooks/useContinueJob';
 import { relativeTime } from '../../utils/relativeTime';
 import {
-  buildSameWorkboardContinue,
-  buildCrossWorkboardContinue,
   buildWorkboardPickerContinue,
   storeContinueJobData,
 } from '../../utils/continueJob';
@@ -970,6 +969,7 @@ function JobHistoryPanel({
 
   // 재시도/취소/삭제는 전역 피드(pages/JobHistory.js)와 동작을 공유한다 (#728).
   // 사용자 설정(deleteContentWithHistory 등)도 훅이 함께 제공 — 중복 조회 제거.
+  const { continueSameWorkboard, continueCrossWorkboard } = useContinueJob();   // #808
   const jobActions = useJobActions({ invalidateKeys: [queryKey] });
   const userPreferences = jobActions.preferences;
 
@@ -1006,57 +1006,7 @@ function JobHistoryPanel({
     }
   };
 
-  const handleContinueJob = async (job) => {
-    try {
-      let workboardId = null;
-      if (typeof job.workboardId === 'string') workboardId = job.workboardId;
-      else if (job.workboardId?._id) workboardId = job.workboardId._id;
-      else if (job.workboardId?.id) workboardId = job.workboardId.id;
-
-      if (!workboardId || workboardId === 'undefined' || workboardId === 'null') {
-        toast.error('작업판 정보를 찾을 수 없습니다. 작업판 선택 페이지로 이동합니다.');
-        storeContinueJobData(buildWorkboardPickerContinue(job));
-        navigate('/workboards');
-        return;
-      }
-
-      if (!/^[0-9a-fA-F]{24}$/.test(workboardId)) {
-        toast.error('잘못된 작업판 ID입니다. 작업판 선택 페이지로 이동합니다.');
-        storeContinueJobData(buildWorkboardPickerContinue(job));
-        navigate('/workboards');
-        return;
-      }
-
-      const workboardResponse = await workboardAPI.getById(workboardId);
-      const workboard = workboardResponse.data?.workboard;
-
-      if (!workboard) {
-        toast.error('작업판을 찾을 수 없습니다. 작업판 선택 페이지로 이동합니다.');
-        storeContinueJobData(buildWorkboardPickerContinue(job));
-        navigate('/workboards');
-        return;
-      }
-
-      if (!workboard.isActive) {
-        toast.error('작업판이 비활성화되었습니다. 작업판 선택 페이지로 이동합니다.');
-        storeContinueJobData(buildWorkboardPickerContinue(job));
-        navigate('/workboards');
-        return;
-      }
-
-      storeContinueJobData(buildSameWorkboardContinue({ workboardId, workboard, job }));
-      navigate(`/generate/${workboardId}`);
-      toast.success('작업 설정을 불러왔습니다');
-    } catch (error) {
-      console.error('Continue job error:', error);
-      if (error.response?.status === 404) toast.error('작업판이 존재하지 않습니다. 작업판 선택 페이지로 이동합니다.');
-      else if (error.response?.status === 403) toast.error('작업판 접근 권한이 없습니다. 작업판 선택 페이지로 이동합니다.');
-      else toast.error('작업을 계속할 수 없습니다. 작업판 선택 페이지로 이동합니다.');
-
-      storeContinueJobData(buildWorkboardPickerContinue(job));
-      navigate('/workboards');
-    }
-  };
+  const handleContinueJob = (job) => continueSameWorkboard(job);   // #808 — 훅으로 통합
 
   const handleSavePrompt = (job) => { setSavingJob(job); setSavePromptOpen(true); };
   const handleSavePromptSubmit = (data) => { savePromptMutation.mutate(data); };
@@ -1068,26 +1018,10 @@ function JobHistoryPanel({
 
   const handleWorkboardSelected = (workboard) => {
     if (!crossWorkboardJob) return;
-
     const job = crossWorkboardJob;
-
-    // 마지막 생성 미디어 추출
-    const lastGeneratedImage = job.resultImages?.length > 0
-      ? job.resultImages[job.resultImages.length - 1]
-      : null;
-    const lastGeneratedVideo = job.resultVideos?.length > 0
-      ? job.resultVideos[job.resultVideos.length - 1]
-      : null;
-
-    storeContinueJobData(buildCrossWorkboardContinue({
-      workboard, job,
-      lastGeneratedMedia: { image: lastGeneratedImage, video: lastGeneratedVideo },
-    }));
-
     setCrossWorkboardOpen(false);
     setCrossWorkboardJob(null);
-    navigate(`/generate/${workboard._id}`);
-    toast.success('작업판이 선택되었습니다. 설정을 매칭합니다.');
+    continueCrossWorkboard(job, workboard);
   };
 
   return (

--- a/frontend/src/components/common/MediaGrid.js
+++ b/frontend/src/components/common/MediaGrid.js
@@ -30,6 +30,7 @@ import {
   Info,
   Close,
   Videocam,
+  MusicNote,
   CheckCircle
 } from '@mui/icons-material';
 import { useQuery, keepPreviousData } from '@tanstack/react-query';
@@ -40,6 +41,7 @@ import Pagination from './Pagination';
 import VideoViewerDialog from './VideoViewerDialog';
 import ProjectTagChip from './ProjectTagChip';
 import { relativeTime } from '../../utils/relativeTime';
+import { MONO } from '../../theme';
 
 function ImageDetailDialog({ image, open, onClose, type }) {
   if (!image) return null;
@@ -300,6 +302,53 @@ function VideoCard({ video, onEdit, onDelete, onView, readOnly = false, showTags
   );
 }
 
+
+// 빈 상태 문구 (#805)
+const EMPTY_LABELS = {
+  video: '생성된 동영상',
+  audio: '생성된 오디오',
+  uploaded: '업로드된 이미지',
+  uploadedAudio: '업로드된 오디오',
+  generated: '생성된 이미지',
+};
+
+// 오디오 목록 (#805) — 썸네일이 없어 카드 그리드 대신 행 목록 + 인라인 플레이어로 그린다.
+// 생성물은 프롬프트가, 업로드본은 파일명이 식별자가 된다.
+function AudioList({ items, onDelete, readOnly }) {
+  const fmt = (sec) => {
+    if (sec == null) return '길이 미상';
+    const t = Math.round(sec);
+    return `${Math.floor(t / 60)}:${String(t % 60).padStart(2, '0')}`;
+  };
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+      {items.map((item) => (
+        <Card key={item._id} sx={{ p: 1.5, display: 'flex', alignItems: 'flex-start', gap: 1.5 }}>
+          <MusicNote fontSize="small" color="action" sx={{ mt: 0.5 }} />
+          <Box sx={{ minWidth: 0, flex: 1 }}>
+            <Typography variant="body2" noWrap title={item.generationParams?.prompt || item.originalName}>
+              {item.generationParams?.prompt || item.originalName || '오디오'}
+            </Typography>
+            <Typography variant="caption" color="text.secondary" sx={{ fontFamily: MONO }}>
+              {fmt(item.metadata?.duration)}
+              {item.metadata?.channels ? ` · ${item.metadata.channels}ch` : ''}
+              {item.metadata?.sampleRate ? ` · ${Math.round(item.metadata.sampleRate / 1000)}kHz` : ''}
+              {item.createdAt ? ` · ${relativeTime(item.createdAt)}` : ''}
+            </Typography>
+            <Box component="audio" controls preload="none" src={item.url}
+              sx={{ display: 'block', width: '100%', mt: 0.5, height: 32 }} />
+          </Box>
+          {!readOnly && onDelete && (
+            <IconButton aria-label="삭제" size="small" onClick={() => onDelete(item)}>
+              <Delete fontSize="small" />
+            </IconButton>
+          )}
+        </Card>
+      ))}
+    </Box>
+  );
+}
+
 function MediaGrid({
   type,
   fetchFn = null,
@@ -327,9 +376,14 @@ function MediaGrid({
   const [selectedMedia, setSelectedMedia] = useState(null);
   const [detailOpen, setDetailOpen] = useState(false);
 
+  // 오디오는 썸네일이 없어 그리드가 아니라 목록으로 그린다 (#805)
+  const isAudio = type === 'audio' || type === 'uploadedAudio';
+
   // Default fetch functions based on type
   const defaultFetchFn = (params) => {
     if (type === 'video') return imageAPI.getVideos(params);
+    if (type === 'audio') return imageAPI.getAudios(params);              // #805
+    if (type === 'uploadedAudio') return imageAPI.getUploadedAudios(params);
     if (type === 'uploaded') return imageAPI.getUploaded(params);
     return imageAPI.getGenerated(params);
   };
@@ -346,6 +400,7 @@ function MediaGrid({
     const d = data?.data?.data || data?.data || {};
     let items;
     if (type === 'video') items = d.videos || [];
+    else if (type === 'audio' || type === 'uploadedAudio') items = d.audios || [];   // #805
     else items = d.images || [];
     return { items, pagination: d.pagination || {} };
   };
@@ -416,8 +471,16 @@ function MediaGrid({
         </Box>
       ) : items.length === 0 ? (
         <Alert severity="info">
-          {search ? '검색 결과가 없습니다.' : `${type === 'video' ? '생성된 동영상' : type === 'uploaded' ? '업로드된 이미지' : '생성된 이미지'}가 없습니다.`}
+          {search ? '검색 결과가 없습니다.' : `${EMPTY_LABELS[type] || '생성된 이미지'}가 없습니다.`}
         </Alert>
+      ) : isAudio ? (
+        <>
+          <AudioList
+            items={items}
+            onDelete={onDelete}
+            readOnly={readOnly}
+          />
+        </>
       ) : (
         <>
           <Grid container spacing={selectable ? 2 : 3}>

--- a/frontend/src/components/common/WorkboardCatalog.js
+++ b/frontend/src/components/common/WorkboardCatalog.js
@@ -11,6 +11,7 @@ import {
   Image as ImageIcon,
   Hexagon,
   Movie,
+  MusicNote,
   AutoFixHigh,
   Edit,
   MoreVert,
@@ -27,10 +28,11 @@ export const KIND_META = {
   'sdxl':      { icon: Hexagon,     label: 'SDXL',        color: 'primary.main',   tint: 'primary.light' },
   'i2v':       { icon: Movie,       label: '영상 (I2V)',  color: 'warning.main',   tint: 'warning.light' },
   'lora':      { icon: AutoFixHigh, label: 'LoRA 학습',    color: 'success.main',   tint: 'success.light' },
+  'music':     { icon: MusicNote,   label: '오디오 생성',  color: 'error.main',     tint: 'error.light' },   // #805
 };
 
 export function deriveOut(wb) {
-  return wb.outputFormat || 'image'; // image | video | text
+  return wb.outputFormat || 'image'; // image | video | audio | text
 }
 export function deriveSvc(wb) {
   const t = wb.serverId?.serverType || wb.serverType || '';
@@ -43,6 +45,7 @@ export function deriveKind(wb) {
   const out = deriveOut(wb);
   if (out === 'text') return 'gpt-chat';
   if (out === 'video') return 'i2v';
+  if (out === 'audio') return 'music';   // #805
   const svc = deriveSvc(wb);
   return svc === 'comfy' ? 'sdxl' : 'gpt-image';
 }
@@ -50,6 +53,7 @@ export function deriveKind(wb) {
 export const OUTPUT_AXIS = [
   { k: 'image', label: '이미지' },
   { k: 'video', label: '영상' },
+  { k: 'audio', label: '오디오' },
   { k: 'text', label: '텍스트' },
 ];
 export const SERVER_AXIS = [

--- a/frontend/src/hooks/useContinueJob.js
+++ b/frontend/src/hooks/useContinueJob.js
@@ -1,0 +1,103 @@
+import { useNavigate } from 'react-router-dom';
+import toast from 'react-hot-toast';
+import { workboardAPI } from '../services/api';
+import {
+  buildSameWorkboardContinue,
+  buildCrossWorkboardContinue,
+  buildWorkboardPickerContinue,
+  storeContinueJobData,
+} from '../utils/continueJob';
+
+// '계속하기' / '다른 작업판으로 이어가기' 실행 (#808).
+//
+// JobHistoryPanel(프로젝트 상세)과 pages/JobHistory(사이드바)가 같은 로직을 각자 갖고
+// 있었다. 문구와 검증 순서만 달랐을 뿐 하는 일은 같았고, 그 갈라짐 때문에 #762 수정이
+// 한쪽에만 적용되어 #792 로 재발했다. 페이로드 조립은 utils/continueJob 이 맡고,
+// 여기서는 **작업판 검증 → 저장 → 이동** 흐름을 담당한다.
+//
+// 검증 실패는 전부 같은 결말이다 — 작업판 선택 페이지로 보내고 히스토리 값을 들려 보낸다.
+// 사용자가 다른 작업판을 고르면 거기서 이어갈 수 있다.
+
+const OBJECT_ID = /^[0-9a-fA-F]{24}$/;
+
+/** job.workboardId 가 문자열일 수도, populate 된 객체일 수도 있다 */
+export function extractWorkboardId(job) {
+  const raw = job?.workboardId;
+  if (typeof raw === 'string') return raw;
+  return raw?._id || raw?.id || null;
+}
+
+/**
+ * 작업판이 계속하기에 쓸 수 있는 상태인지 판정.
+ * @returns {{ ok: true } | { ok: false, reason: string, message: string }}
+ */
+export function checkWorkboardUsable(workboardId, workboard) {
+  if (!workboardId || workboardId === 'undefined' || workboardId === 'null') {
+    return { ok: false, reason: 'missingId', message: '작업판 정보를 찾을 수 없습니다. 작업판 선택 페이지로 이동합니다.' };
+  }
+  if (!OBJECT_ID.test(workboardId)) {
+    return { ok: false, reason: 'invalidId', message: '잘못된 작업판 ID입니다. 작업판 선택 페이지로 이동합니다.' };
+  }
+  if (!workboard) {
+    return { ok: false, reason: 'notFound', message: '작업판을 찾을 수 없습니다. 작업판 선택 페이지로 이동합니다.' };
+  }
+  if (!workboard.isActive) {
+    return { ok: false, reason: 'inactive', message: '작업판이 비활성화되었습니다. 작업판 선택 페이지로 이동합니다.' };
+  }
+  return { ok: true };
+}
+
+export function useContinueJob() {
+  const navigate = useNavigate();
+
+  const toPicker = (job, message) => {
+    if (message) toast.error(message);
+    storeContinueJobData(buildWorkboardPickerContinue(job));
+    navigate('/workboards');
+  };
+
+  /** 같은 작업판에서 계속하기 */
+  const continueSameWorkboard = async (job) => {
+    const workboardId = extractWorkboardId(job);
+
+    // id 자체가 문제면 API 를 부를 것도 없다
+    const pre = checkWorkboardUsable(workboardId, undefined);
+    if (!pre.ok && pre.reason !== 'notFound') return toPicker(job, pre.message);
+
+    try {
+      const res = await workboardAPI.getById(workboardId);
+      const workboard = res.data?.workboard;
+
+      const verdict = checkWorkboardUsable(workboardId, workboard);
+      if (!verdict.ok) return toPicker(job, verdict.message);
+
+      storeContinueJobData(buildSameWorkboardContinue({ workboardId, workboard, job }));
+      navigate(`/generate/${workboardId}`);
+      toast.success('작업 설정을 불러왔습니다');
+    } catch (error) {
+      // 403/404 는 권한·삭제 — 어느 쪽이든 선택 페이지로 보내는 결말이 같다
+      const status = error.response?.status;
+      const message = status === 404
+        ? '작업판이 존재하지 않습니다. 작업판 선택 페이지로 이동합니다.'
+        : status === 403
+          ? '작업판 접근 권한이 없습니다. 작업판 선택 페이지로 이동합니다.'
+          : '작업을 계속할 수 없습니다. 작업판 선택 페이지로 이동합니다.';
+      toPicker(job, message);
+    }
+  };
+
+  /** 다른 작업판으로 이어가기 — 사용자가 이미 작업판을 고른 뒤 */
+  const continueCrossWorkboard = (job, workboard) => {
+    const lastImage = job.resultImages?.length ? job.resultImages[job.resultImages.length - 1] : null;
+    const lastVideo = job.resultVideos?.length ? job.resultVideos[job.resultVideos.length - 1] : null;
+    storeContinueJobData(buildCrossWorkboardContinue({
+      workboard, job, lastGeneratedMedia: { image: lastImage, video: lastVideo },
+    }));
+    navigate(`/generate/${workboard._id}`);
+    toast.success('작업판이 선택되었습니다. 설정을 매칭합니다.');
+  };
+
+  return { continueSameWorkboard, continueCrossWorkboard };
+}
+
+export default useContinueJob;

--- a/frontend/src/hooks/useContinueJob.test.js
+++ b/frontend/src/hooks/useContinueJob.test.js
@@ -1,0 +1,57 @@
+/**
+ * 계속하기 작업판 검증 (#808)
+ *
+ * JobHistoryPanel 과 pages/JobHistory 가 같은 검증을 각자 하고 있었고, 문구와 순서가
+ * 미묘하게 달랐다. 훅으로 합치면서 판정 규칙을 여기 고정한다.
+ */
+import { extractWorkboardId, checkWorkboardUsable } from './useContinueJob';
+
+const VALID = '6a7c42b40a94566eb3c3e842';
+
+describe('작업판 ID 추출 (#808)', () => {
+  test('문자열 그대로', () => {
+    expect(extractWorkboardId({ workboardId: VALID })).toBe(VALID);
+  });
+
+  test('populate 된 객체는 _id 또는 id', () => {
+    expect(extractWorkboardId({ workboardId: { _id: VALID } })).toBe(VALID);
+    expect(extractWorkboardId({ workboardId: { id: VALID } })).toBe(VALID);
+  });
+
+  test('없으면 null', () => {
+    expect(extractWorkboardId({})).toBeNull();
+    expect(extractWorkboardId(null)).toBeNull();
+  });
+});
+
+describe('작업판 사용 가능 판정 (#808)', () => {
+  const active = { _id: VALID, isActive: true };
+
+  test('활성 작업판이면 통과', () => {
+    expect(checkWorkboardUsable(VALID, active)).toEqual({ ok: true });
+  });
+
+  test.each([
+    ['id 없음', null, active, 'missingId'],
+    ['문자열 "undefined"', 'undefined', active, 'missingId'],
+    ['문자열 "null"', 'null', active, 'missingId'],
+    ['ObjectId 형식 아님', 'not-an-id', active, 'invalidId'],
+    ['작업판 없음', VALID, null, 'notFound'],
+    ['비활성 작업판', VALID, { _id: VALID, isActive: false }, 'inactive'],
+  ])('%s → 거부', (_label, id, wb, reason) => {
+    const v = checkWorkboardUsable(id, wb);
+    expect(v.ok).toBe(false);
+    expect(v.reason).toBe(reason);
+    expect(v.message).toMatch(/작업판 선택 페이지로 이동/);
+  });
+
+  test('거부 사유마다 문구가 다르다 — 사용자가 원인을 구분할 수 있어야 한다', () => {
+    const messages = [
+      checkWorkboardUsable(null, active).message,
+      checkWorkboardUsable('bad', active).message,
+      checkWorkboardUsable(VALID, null).message,
+      checkWorkboardUsable(VALID, { isActive: false }).message,
+    ];
+    expect(new Set(messages).size).toBe(messages.length);
+  });
+});

--- a/frontend/src/pages/ImageGeneration.js
+++ b/frontend/src/pages/ImageGeneration.js
@@ -59,6 +59,7 @@ import PromptGeneratorDialog from '../components/PromptGeneratorDialog';
 import { MONO } from '../theme';
 import { BRAND_GRADIENTS } from '../utils/brandGradients';
 import config from '../config';
+import { ATTACHMENT_FIELD_TYPES } from '../templates/capabilities';
 
 function PromptDataSelectDialog({ open, onClose, onSelect }) {
   const [page, setPage] = useState(1);
@@ -1309,7 +1310,7 @@ function ImageGeneration() {
                 </Box>
                 <Grid container spacing={3.5} sx={{ p: 4 }}>
                   {workboardData.additionalInputFields.map((field) => (
-                    <Grid item xs={12} sm={['image', 'video', 'audio'].includes(field.type) ? 12 : 6} key={field.name}>
+                    <Grid item xs={12} sm={ATTACHMENT_FIELD_TYPES.includes(field.type) ? 12 : 6} key={field.name}>
                       {field.type === 'image' ? (
                         <Controller
                           name={`additionalParams.${field.name}`}

--- a/frontend/src/pages/ImageGeneration.js
+++ b/frontend/src/pages/ImageGeneration.js
@@ -673,6 +673,9 @@ function CustomAudioField({ field, value, onChange, maxAudios = 1 }) {
   );
 }
 
+// 출력 형식별 명사 (#805) — 토스트 문구용
+const OUTPUT_NOUN = { image: '이미지', video: '동영상', audio: '오디오', text: '텍스트' };
+
 // 64비트 부호없는 정수 범위에서 랜덤 시드 생성
 const generateRandomSeed = () => {
   // ComfyUI는 64비트 부호없는 정수를 사용 (음수 불가)
@@ -847,7 +850,8 @@ function ImageGeneration() {
 
   const generateMutation = useMutation({ mutationFn: jobAPI.create,
       onSuccess: (data) => {
-        toast.success('이미지 생성 작업이 시작되었습니다');
+        // 출력 형식에 맞춘 문구 (#805) — 오디오 작업판에서도 "이미지" 라고 뜨던 것
+        toast.success(`${OUTPUT_NOUN[workboardData?.outputFormat] || '이미지'} 생성 작업이 시작되었습니다`);
         queryClient.invalidateQueries({ queryKey: ['historyJobs'] });
         navigate('/jobs');
       },

--- a/frontend/src/pages/JobHistory.js
+++ b/frontend/src/pages/JobHistory.js
@@ -33,6 +33,7 @@ import {
   Delete,
   AccountTree,
   Subject,
+  MusicNote,
   CheckCircle,
   Close,
   ViewList,
@@ -54,6 +55,7 @@ import {
 import config from '../config';
 import ImageViewerDialog from '../components/common/ImageViewerDialog';
 import VideoViewerDialog from '../components/common/VideoViewerDialog';
+import AudioViewerDialog from '../components/common/AudioViewerDialog';
 import WorkboardSelectDialog from '../components/common/WorkboardSelectDialog';
 import { SavePromptDialog, JobDetailDialog } from '../components/common/JobHistoryPanel';
 import { ToneChip, TagChip } from '../components/common/WorkboardCatalog';
@@ -120,25 +122,28 @@ function projectFromTags(tags = []) {
 
 // ---- 정규화 -------------------------------------------------------------
 function jobToItem(job) {
+  // 오디오 (#805) — 썸네일이 없어 type 을 따로 둔다
+  const isAudio = (job.resultAudios?.length || 0) > 0;
   const isVideo = (job.resultVideos?.length || 0) > 0;
-  const type = isVideo ? 'video' : 'image';
-  const results = isVideo ? job.resultVideos : job.resultImages;
+  const type = isAudio ? 'audio' : isVideo ? 'video' : 'image';
+  const results = isAudio ? job.resultAudios : isVideo ? job.resultVideos : job.resultImages;
   return {
     id: job._id,
     kind: 'job',
     type,
     time: new Date(job.createdAt),
-    title: job.workboardId?.name || (isVideo ? '영상 생성' : '이미지 생성'),
+    title: job.workboardId?.name || (isAudio ? '오디오 생성' : isVideo ? '영상 생성' : '이미지 생성'),
     projectName: projectFromTags(job.inputData?.tags),
     model: extractModel(job.inputData?.aiModel),
     res: extractSize(job),
     count: results?.length || 0,
-    duration: isVideo ? results?.[0]?.metadata?.duration : null,
+    duration: (isVideo || isAudio) ? results?.[0]?.metadata?.duration : null,
     status: mapStatus(job.status),
-    thumb: results?.[0]?.url || null,
+    thumb: isAudio ? null : (results?.[0]?.url || null),   // 오디오는 썸네일이 없다
     videoThumb: isVideo ? (results?.[0]?.thumbnailUrl || null) : null, // #672 동영상 첫프레임 썸네일
     results: results || [],
     isVideo,
+    isAudio,
     raw: job,
   };
 }
@@ -188,7 +193,10 @@ function RowVisual({ item }) {
             bgcolor: 'grey.100', display: 'grid', placeItems: 'center',
           }}
         >
-          {item.type === 'video' && item.videoThumb ? (
+          {item.type === 'audio' ? (
+            // 오디오는 썸네일이 없다 (#805) — 음표로 표시하고 클릭 시 재생 다이얼로그
+            <MusicNote fontSize="small" sx={{ color: 'grey.500' }} />
+          ) : item.type === 'video' && item.videoThumb ? (
             // 동영상 썸네일(첫 프레임 jpg) 우선 — 빠름 (#672)
             <Box component="img" src={item.videoThumb} alt="" loading="lazy"
               sx={{ width: '100%', height: '100%', objectFit: 'cover' }} />
@@ -398,7 +406,9 @@ function HistoryCard({ item, onOpenMedia, onMenu, onContinue, onCross, onTextCon
     >
       {/* 미디어 / 프리뷰 영역 */}
       <Box sx={{ position: 'relative', aspectRatio: '4 / 3', bgcolor: 'grey.100', display: 'grid', placeItems: 'center', overflow: 'hidden' }}>
-        {item.type === 'video' && item.videoThumb ? (
+        {item.type === 'audio' ? (
+          <MusicNote sx={{ fontSize: 40, color: 'grey.500' }} />
+        ) : item.type === 'video' && item.videoThumb ? (
           <Box component="img" src={item.videoThumb} alt="" loading="lazy"
             sx={{ width: '100%', height: '100%', objectFit: 'cover' }} />
         ) : (item.type === 'image' || item.type === 'video') && item.thumb ? (
@@ -528,6 +538,7 @@ function JobHistory() {
   const [crossJob, setCrossJob] = useState(null);
   const [imgViewer, setImgViewer] = useState({ open: false, items: [], index: 0 });
   const [vidViewer, setVidViewer] = useState({ open: false, items: [], index: 0 });
+  const [audViewer, setAudViewer] = useState({ open: false, items: [] });   // #805
   const [textDetail, setTextDetail] = useState(null);
   const [viewMode, setViewMode] = useState(() => localStorage.getItem('jobHistoryViewMode') || 'list'); // #675 리스트/그리드 뷰
   const changeViewMode = (mode) => { if (mode) { setViewMode(mode); localStorage.setItem('jobHistoryViewMode', mode); } };
@@ -542,7 +553,8 @@ function JobHistory() {
 
   // ---- handlers ----
   const openMedia = (item) => {
-    if (item.isVideo) setVidViewer({ open: true, items: item.results, index: 0 });
+    if (item.isAudio) setAudViewer({ open: true, items: item.results });      // #805
+    else if (item.isVideo) setVidViewer({ open: true, items: item.results, index: 0 });
     else setImgViewer({ open: true, items: item.results, index: 0 });
   };
 
@@ -725,6 +737,12 @@ function JobHistory() {
         onClose={() => setImgViewer((v) => ({ ...v, open: false }))}
         title="생성된 이미지"
       />
+      <AudioViewerDialog
+        open={audViewer.open}
+        audios={audViewer.items}
+        onClose={() => setAudViewer({ open: false, items: [] })}
+      />
+
       <VideoViewerDialog
         videos={vidViewer.items}
         selectedIndex={vidViewer.index}

--- a/frontend/src/pages/JobHistory.js
+++ b/frontend/src/pages/JobHistory.js
@@ -65,12 +65,11 @@ import EmptyState from '../components/common/EmptyState';
 import { MONO } from '../theme';
 import { relativeTime } from '../utils/relativeTime';
 import {
-  buildSameWorkboardContinue,
-  buildCrossWorkboardContinue,
   buildWorkboardPickerContinue,
   storeContinueJobData,
 } from '../utils/continueJob';
 import { useJobActions } from '../hooks/useJobActions';
+import { useContinueJob } from '../hooks/useContinueJob';
 
 const TYPE_LABEL = { pipeline: '파이프라인', image: '이미지', video: '영상', text: '텍스트' };
 
@@ -547,6 +546,7 @@ function JobHistory() {
   // 재시도/취소/삭제는 프로젝트 상세 패널(JobHistoryPanel)과 동작을 공유한다 (#728).
   // 예전에는 각자 구현이라 이 화면에만 재시도가 빠져 있었다.
   const jobActions = useJobActions({ invalidateKeys: ['historyJobs'] });
+  const { continueSameWorkboard, continueCrossWorkboard } = useContinueJob();   // #808
   const savePromptMutation = useMutation({ mutationFn: promptDataAPI.create,
     onSuccess: () => { toast.success('프롬프트 데이터가 저장되었습니다'); setSaveJob(null); },
     onError: (error) => toast.error('프롬프트 저장 실패: ' + (error.response?.data?.message || error.message)), });
@@ -577,39 +577,13 @@ function JobHistory() {
   const handleRetry = (job) => { closeMenu(); jobActions.retry(job); };
   const handleCancel = (job) => { closeMenu(); jobActions.cancel(job); };
 
-  const handleContinue = async (job) => {
-    try {
-      let workboardId = typeof job.workboardId === 'string' ? job.workboardId : (job.workboardId?._id || job.workboardId?.id);
-      const fallback = () => {
-        storeContinueJobData(buildWorkboardPickerContinue(job));
-        navigate('/workboards');
-      };
-      if (!workboardId || !/^[0-9a-fA-F]{24}$/.test(workboardId)) { toast.error('작업판 정보를 찾을 수 없습니다. 작업판 선택 페이지로 이동합니다.'); return fallback(); }
-      const wbRes = await workboardAPI.getById(workboardId);
-      const workboard = wbRes.data?.workboard;
-      if (!workboard || !workboard.isActive) { toast.error('작업판을 사용할 수 없습니다. 작업판 선택 페이지로 이동합니다.'); return fallback(); }
-      // #792 — sameWorkboard 플래그 포함. 직접 조립하다 #762 수정이 이 경로에 누락됐었다.
-      storeContinueJobData(buildSameWorkboardContinue({ workboardId, workboard, job }));
-      navigate(`/generate/${workboardId}`);
-      toast.success('작업 설정을 불러왔습니다');
-    } catch (error) {
-      toast.error('작업을 계속할 수 없습니다. 작업판 선택 페이지로 이동합니다.');
-      storeContinueJobData(buildWorkboardPickerContinue(job));
-      navigate('/workboards');
-    }
-  };
+  const handleContinue = (job) => continueSameWorkboard(job);
 
   const handleWorkboardSelected = (workboard) => {
     if (!crossJob) return;
     const job = crossJob;
-    const lastImage = job.resultImages?.length ? job.resultImages[job.resultImages.length - 1] : null;
-    const lastVideo = job.resultVideos?.length ? job.resultVideos[job.resultVideos.length - 1] : null;
-    storeContinueJobData(buildCrossWorkboardContinue({
-      workboard, job, lastGeneratedMedia: { image: lastImage, video: lastVideo },
-    }));
     setCrossJob(null);
-    navigate(`/generate/${workboard._id}`);
-    toast.success('작업판이 선택되었습니다. 설정을 매칭합니다.');
+    continueCrossWorkboard(job, workboard);
   };
 
   const handleTextContinue = (item) => {

--- a/frontend/src/pages/JobHistory.js
+++ b/frontend/src/pages/JobHistory.js
@@ -64,6 +64,7 @@ import SegmentTabs from '../components/common/SegmentTabs';
 import EmptyState from '../components/common/EmptyState';
 import { MONO } from '../theme';
 import { relativeTime } from '../utils/relativeTime';
+import { buildHistorySubtitle, MEDIA_ITEM_TYPES } from '../utils/historyItems';
 import {
   buildWorkboardPickerContinue,
   storeContinueJobData,
@@ -183,7 +184,7 @@ function runToItem(run) {
 // ---- 좌측 비주얼 --------------------------------------------------------
 function RowVisual({ item }) {
   const size = 56;
-  if (item.type === 'image' || item.type === 'video' || item.type === 'audio') {
+  if (MEDIA_ITEM_TYPES.includes(item.type)) {
     return (
       <Box sx={{ position: 'relative', width: size, height: size, flex: '0 0 auto' }}>
         <Box
@@ -277,16 +278,8 @@ function StepDots({ statuses }) {
 
 // ---- 한 행 --------------------------------------------------------------
 function HistoryRow({ item, onOpenMedia, onMenu, onContinue, onCross, onTextContinue, onTextDetail, onPipelineDetail }) {
-  const sub =
-    item.type === 'image' ? [item.projectName, item.model, item.res, item.count ? `${item.count}장` : '']
-      : item.type === 'video' ? [item.projectName, item.model, item.res, item.duration != null ? `${Math.round(item.duration)}초` : '']
-      : item.type === 'audio' ? [item.projectName, item.model, item.duration != null ? `${Math.round(item.duration)}초` : '']
-      : item.type === 'text' ? [item.model, item.tokens != null ? `${item.tokens.toLocaleString()} 토큰` : '']
-      // 나머지는 파이프라인 — stepStatuses 는 pipelineToItem 만 만든다.
-      // 새 미디어 타입이 여기로 떨어지면 undefined.length 로 렌더가 죽는다 (#805 오디오 사고)
-      : [item.projectName, item.stepStatuses?.length ? `${item.stepStatuses.length}단계` : '', item.input];
-  const subStr = sub.filter(Boolean).join(' · ');
-  const clickable = item.type === 'image' || item.type === 'video' || item.type === 'audio';
+  const subStr = buildHistorySubtitle(item);
+  const clickable = MEDIA_ITEM_TYPES.includes(item.type);
 
   return (
     <Paper

--- a/frontend/src/pages/JobHistory.js
+++ b/frontend/src/pages/JobHistory.js
@@ -71,7 +71,7 @@ import {
 import { useJobActions } from '../hooks/useJobActions';
 import { useContinueJob } from '../hooks/useContinueJob';
 
-const TYPE_LABEL = { pipeline: '파이프라인', image: '이미지', video: '영상', text: '텍스트' };
+const TYPE_LABEL = { pipeline: '파이프라인', image: '이미지', video: '영상', audio: '오디오', text: '텍스트' };
 
 // ---- 상태 매핑 ----------------------------------------------------------
 function mapStatus(s) {
@@ -183,7 +183,7 @@ function runToItem(run) {
 // ---- 좌측 비주얼 --------------------------------------------------------
 function RowVisual({ item }) {
   const size = 56;
-  if (item.type === 'image' || item.type === 'video') {
+  if (item.type === 'image' || item.type === 'video' || item.type === 'audio') {
     return (
       <Box sx={{ position: 'relative', width: size, height: size, flex: '0 0 auto' }}>
         <Box
@@ -280,10 +280,13 @@ function HistoryRow({ item, onOpenMedia, onMenu, onContinue, onCross, onTextCont
   const sub =
     item.type === 'image' ? [item.projectName, item.model, item.res, item.count ? `${item.count}장` : '']
       : item.type === 'video' ? [item.projectName, item.model, item.res, item.duration != null ? `${Math.round(item.duration)}초` : '']
+      : item.type === 'audio' ? [item.projectName, item.model, item.duration != null ? `${Math.round(item.duration)}초` : '']
       : item.type === 'text' ? [item.model, item.tokens != null ? `${item.tokens.toLocaleString()} 토큰` : '']
-      : [item.projectName, item.stepStatuses.length ? `${item.stepStatuses.length}단계` : '', item.input];
+      // 나머지는 파이프라인 — stepStatuses 는 pipelineToItem 만 만든다.
+      // 새 미디어 타입이 여기로 떨어지면 undefined.length 로 렌더가 죽는다 (#805 오디오 사고)
+      : [item.projectName, item.stepStatuses?.length ? `${item.stepStatuses.length}단계` : '', item.input];
   const subStr = sub.filter(Boolean).join(' · ');
-  const clickable = item.type === 'image' || item.type === 'video';
+  const clickable = item.type === 'image' || item.type === 'video' || item.type === 'audio';
 
   return (
     <Paper
@@ -329,7 +332,7 @@ function HistoryRow({ item, onOpenMedia, onMenu, onContinue, onCross, onTextCont
           )}
 
           {/* 파이프라인 단계 dots + 진행률 */}
-          {item.type === 'pipeline' && item.stepStatuses.length > 0 && (
+          {item.type === 'pipeline' && item.stepStatuses?.length > 0 && (
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1 }}>
               <StepDots statuses={item.stepStatuses} />
               {item.status === 'running' && (

--- a/frontend/src/pages/MyImages.js
+++ b/frontend/src/pages/MyImages.js
@@ -22,6 +22,7 @@ import { useTheme } from '@mui/material/styles';
 import {
   CloudUpload,
   Videocam,
+  MusicNote,
   CheckBox as CheckBoxIcon,
   Close,
   DeleteSweep,
@@ -143,6 +144,34 @@ function FilterRow({ label, color, active, onClick }) {
 }
 
 // 탭 라벨 + 우측 카운트 badge (5c 후속) — count null 이면 라벨만.
+
+// 내 콘텐츠 탭 구성 (#805).
+//
+// 표현은 2단(출처 → 미디어 종류)이지만 **내부 tab 인덱스는 기존 값을 유지**한다.
+// 삭제 분기·쿼리키·isTextTab 이 전부 인덱스로 갈라져 있어, 번호를 재배열하면
+// 그 로직을 전부 따라가야 한다. 오디오만 5·6 으로 덧붙였다.
+const MEDIA_TABS = [
+  // 생성한 콘텐츠
+  [
+    { tab: 0, label: '이미지' },
+    { tab: 2, label: '동영상', icon: <Videocam /> },
+    { tab: 5, label: '오디오', icon: <MusicNote /> },
+    { tab: 4, label: '텍스트' },
+  ],
+  // 업로드한 콘텐츠
+  [
+    { tab: 1, label: '이미지' },
+    { tab: 6, label: '오디오', icon: <MusicNote /> },
+    { tab: 3, label: '텍스트' },
+  ],
+];
+
+// tab 인덱스 → 어느 출처 그룹에 속하는가
+const ORIGIN_OF_TAB = MEDIA_TABS.reduce((acc, group, originIdx) => {
+  group.forEach((m) => { acc[m.tab] = originIdx; });
+  return acc;
+}, {});
+
 function ContentTabLabel({ label, count }) {
   if (count == null) return label;
   return (
@@ -385,6 +414,21 @@ function MyImages() {
       },
       onError: () => toast.error('삭제 실패') });
 
+  // 오디오 삭제 (#805) — 생성물은 히스토리 연동, 업로드본은 단순 삭제
+  const deleteAudioMutation = useMutation({ mutationFn: ({ id, deleteJob }) => imageAPI.deleteAudio(id, deleteJob),
+      onSuccess: () => {
+        toast.success('오디오가 삭제되었습니다');
+        queryClient.invalidateQueries({ queryKey: ['generatedAudios'] });
+      },
+      onError: () => toast.error('삭제 실패') });
+
+  const deleteUploadedAudioMutation = useMutation({ mutationFn: (id) => imageAPI.deleteUploadedAudio(id),
+      onSuccess: () => {
+        toast.success('오디오가 삭제되었습니다');
+        queryClient.invalidateQueries({ queryKey: ['uploadedAudios'] });
+      },
+      onError: () => toast.error('삭제 실패') });
+
   // Bulk delete mutations
   const bulkDeleteMutation = useMutation({ mutationFn: ({ items, deleteJob }) => imageAPI.bulkDelete(items, deleteJob),
       onSuccess: (response) => {
@@ -423,15 +467,24 @@ function MyImages() {
       return;
     }
 
+    // 업로드 오디오는 업로드 이미지와 같은 계열 — 히스토리 개념이 없다 (#805)
+    if (tab === 6) {
+      if (await confirm({ title: '업로드한 오디오를 삭제하시겠습니까?', danger: true, confirmLabel: '삭제' })) {
+        deleteUploadedAudioMutation.mutate(item._id);
+      }
+      return;
+    }
+
     const isVideo = tab === 2;
-    const label = isVideo ? '동영상' : '이미지';
+    const isAudio = tab === 5;
+    const label = isVideo ? '동영상' : isAudio ? '오디오' : '이미지';
     const withHistory = !!deleteHistorySetting && !!item.jobId;
     const ok = await confirm(withHistory
       ? { title: `${label}과 작업 히스토리를 함께 삭제하시겠습니까?`, description: `${label}을 만든 작업 기록도 같이 사라집니다.`, danger: true, confirmLabel: '모두 삭제' }
       : { title: `${label}을 삭제하시겠습니까?`, description: '작업 히스토리는 보존됩니다.', confirmLabel: '삭제' });
     if (!ok) return;
 
-    const mutation = isVideo ? deleteVideoMutation : deleteGeneratedMutation;
+    const mutation = isVideo ? deleteVideoMutation : isAudio ? deleteAudioMutation : deleteGeneratedMutation;
     mutation.mutate({ id: item._id, deleteJob: withHistory });
   };
 
@@ -442,12 +495,16 @@ function MyImages() {
   const getTypeForTab = () => {
     if (tab === 1) return 'uploaded';
     if (tab === 2) return 'video';
+    if (tab === 5) return 'audio';            // #805
+    if (tab === 6) return 'uploadedAudio';    // #805
     return 'generated';
   };
 
   const getQueryKeyForTab = () => {
     if (tab === 1) return 'uploadedImages';
     if (tab === 2) return 'generatedVideos';
+    if (tab === 5) return 'generatedAudios';
+    if (tab === 6) return 'uploadedAudios';
     return 'generatedImages';
   };
 
@@ -529,6 +586,8 @@ function MyImages() {
   const { data: genImagesCountData } = useQuery({ queryKey: ['contentCount', 'generated'], queryFn: () => imageAPI.getGenerated({ limit: 1, page: 1 }), staleTime: 60_000 });
   const { data: upImagesCountData }  = useQuery({ queryKey: ['contentCount', 'uploaded'], queryFn: () => imageAPI.getUploaded({ limit: 1, page: 1 }), staleTime: 60_000 });
   const { data: videosCountData }    = useQuery({ queryKey: ['contentCount', 'video'], queryFn: () => imageAPI.getVideos({ limit: 1, page: 1 }), staleTime: 60_000 });
+  const { data: genAudiosCountData } = useQuery({ queryKey: ['contentCount', 'audioGen'], queryFn: () => imageAPI.getAudios({ limit: 1, page: 1 }), staleTime: 60_000 });
+  const { data: upAudiosCountData }  = useQuery({ queryKey: ['contentCount', 'audioUp'], queryFn: () => imageAPI.getUploadedAudios({ limit: 1, page: 1 }), staleTime: 60_000 });
   const { data: upTextsCountData }   = useQuery({ queryKey: ['contentCount', 'textUp'], queryFn: () => textAPI.getUploaded({ limit: 1, page: 1 }), staleTime: 60_000 });
   const { data: genTextsCountData }  = useQuery({ queryKey: ['contentCount', 'textGen'], queryFn: () => textAPI.getGenerated({ limit: 1, page: 1 }), staleTime: 60_000 });
   // 응답 래핑이 라우트마다 다르다 (#730 D-8):
@@ -543,6 +602,8 @@ function MyImages() {
     videosCountData?.data?.pagination?.total,
     upTextsCountData?.data?.data?.pagination?.total,
     genTextsCountData?.data?.data?.pagination?.total,
+    genAudiosCountData?.data?.pagination?.total,   // [5] 생성 오디오 (#805)
+    upAudiosCountData?.data?.pagination?.total,    // [6] 업로드 오디오 (#805)
   ];
 
   return (
@@ -612,13 +673,28 @@ function MyImages() {
         </Box>
       )}
 
+      {/* 2단 탭 (#805) — 위: 어디서 왔나, 아래: 무엇인가.
+          오디오까지 평면 탭으로 늘리면 7개가 되어 읽기 어려워진다.
+          내부 tab 인덱스는 그대로 두고 표현만 나눈다 (기존 분기 로직 보존). */}
       <Box mb={3}>
+        <Tabs
+          value={ORIGIN_OF_TAB[tab]}
+          onChange={(e, v) => handleTabChange(e, MEDIA_TABS[v][0].tab)}
+          sx={{ mb: 1 }}
+        >
+          <Tab label="생성한 콘텐츠" />
+          <Tab label="업로드한 콘텐츠" />
+        </Tabs>
         <Tabs value={tab} onChange={handleTabChange} variant="scrollable" scrollButtons="auto" allowScrollButtonsMobile>
-          <Tab label={<ContentTabLabel label="생성된 이미지" count={counts[0]} />} />
-          <Tab label={<ContentTabLabel label="업로드된 이미지" count={counts[1]} />} />
-          <Tab icon={<Videocam />} iconPosition="start" label={<ContentTabLabel label="생성된 동영상" count={counts[2]} />} />
-          <Tab label={<ContentTabLabel label="직접 작성 텍스트" count={counts[3]} />} />
-          <Tab label={<ContentTabLabel label="생성된 텍스트" count={counts[4]} />} />
+          {MEDIA_TABS[ORIGIN_OF_TAB[tab]].map((m) => (
+            <Tab
+              key={m.tab}
+              value={m.tab}
+              icon={m.icon}
+              iconPosition={m.icon ? 'start' : undefined}
+              label={<ContentTabLabel label={m.label} count={counts[m.tab]} />}
+            />
+          ))}
         </Tabs>
       </Box>
 

--- a/frontend/src/pages/MyImages.js
+++ b/frontend/src/pages/MyImages.js
@@ -166,6 +166,9 @@ const MEDIA_TABS = [
   ],
 ];
 
+// 업로드 버튼이 뜨는 탭 → 무엇을 올리나 (#805)
+const UPLOAD_TAB_KIND = { 1: 'image', 6: 'audio' };
+
 // tab 인덱스 → 어느 출처 그룹에 속하는가
 const ORIGIN_OF_TAB = MEDIA_TABS.reduce((acc, group, originIdx) => {
   group.forEach((m) => { acc[m.tab] = originIdx; });
@@ -283,13 +286,35 @@ function ImageEditDialog({ image, open, onClose, type, onSuccess, isVideo = fals
   );
 }
 
-function UploadDialog({ open, onClose, onSuccess }) {
+// 업로드 다이얼로그 (#805) — 어느 탭에서 열었는지에 따라 이미지/오디오를 받는다.
+// 예전에는 이미지 전용이라 '업로드한 오디오' 탭에 올릴 방법이 아예 없었다.
+const UPLOAD_KINDS = {
+  image: {
+    title: '이미지 업로드',
+    accept: { 'image/*': ['.jpeg', '.jpg', '.png', '.webp'] },
+    hint: '이미지를 드래그하거나 클릭하여 선택 (JPEG/PNG/WebP)',
+    field: 'image',
+    noun: '이미지',
+    upload: (fd) => imageAPI.upload(fd),
+    queryKey: 'uploadedImages',
+  },
+  audio: {
+    title: '오디오 업로드',
+    accept: { 'audio/*': ['.mp3', '.wav', '.flac', '.ogg', '.m4a', '.aac'] },
+    hint: '오디오를 드래그하거나 클릭하여 선택 (MP3/WAV/FLAC/OGG/M4A/AAC)',
+    field: 'audio',
+    noun: '오디오',
+    upload: (fd) => imageAPI.uploadAudio(fd),
+    queryKey: 'uploadedAudios',
+  },
+};
+
+function UploadDialog({ open, onClose, onSuccess, kind = 'image' }) {
   const [uploading, setUploading] = useState(false);
+  const spec = UPLOAD_KINDS[kind] || UPLOAD_KINDS.image;
 
   const { getRootProps, getInputProps, isDragActive, acceptedFiles } = useDropzone({
-    accept: {
-      'image/*': ['.jpeg', '.jpg', '.png', '.webp']
-    },
+    accept: spec.accept,
     multiple: true
   });
 
@@ -300,12 +325,12 @@ function UploadDialog({ open, onClose, onSuccess }) {
     try {
       const uploadPromises = acceptedFiles.map(async (file) => {
         const formData = new FormData();
-        formData.append('image', file);
-        return await imageAPI.upload(formData);
+        formData.append(spec.field, file);
+        return await spec.upload(formData);
       });
 
       await Promise.all(uploadPromises);
-      toast.success(`${acceptedFiles.length}개 이미지 업로드 완료`);
+      toast.success(`${acceptedFiles.length}개 ${spec.noun} 업로드 완료`);
       onSuccess();
       onClose();
     } catch (error) {
@@ -317,7 +342,7 @@ function UploadDialog({ open, onClose, onSuccess }) {
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
-      <DialogTitle>이미지 업로드</DialogTitle>
+      <DialogTitle>{spec.title}</DialogTitle>
       <DialogContent>
         <Box
           {...getRootProps()}
@@ -335,10 +360,10 @@ function UploadDialog({ open, onClose, onSuccess }) {
           <input {...getInputProps()} />
           <CloudUpload sx={{ fontSize: 48, color: 'grey.400', mb: 2 }} />
           <Typography variant="h6" gutterBottom>
-            {isDragActive ? '이미지를 여기에 놓으세요' : '이미지를 선택하거나 드래그하세요'}
+            {isDragActive ? `${spec.noun}를 여기에 놓으세요` : `${spec.noun}를 선택하거나 드래그하세요`}
           </Typography>
           <Typography variant="body2" color="text.secondary">
-            JPG, PNG, WebP 형식 지원
+            {spec.hint}
           </Typography>
         </Box>
 
@@ -489,7 +514,9 @@ function MyImages() {
   };
 
   const handleUploadSuccess = () => {
-    queryClient.invalidateQueries({ queryKey: ['uploadedImages'] });
+    const spec = UPLOAD_KINDS[UPLOAD_TAB_KIND[tab] || 'image'];
+    queryClient.invalidateQueries({ queryKey: [spec.queryKey] });
+    queryClient.invalidateQueries({ queryKey: ['contentCount'] });
   };
 
   const getTypeForTab = () => {
@@ -613,7 +640,7 @@ function MyImages() {
         description="프로젝트에서 생성·업로드된 모든 자산. 탭으로 종류별 전환."
         actions={!bulkMode && !isTextTab && (
           <Box sx={{ display: 'flex', gap: 1.5, flexShrink: 0 }}>
-            {tab === 1 && (
+            {UPLOAD_TAB_KIND[tab] && (
               <Button
                 variant="contained"
                 startIcon={<CloudUpload />}
@@ -755,6 +782,7 @@ function MyImages() {
         open={uploadOpen}
         onClose={() => setUploadOpen(false)}
         onSuccess={handleUploadSuccess}
+        kind={UPLOAD_TAB_KIND[tab] || 'image'}
       />
 
       <ImageEditDialog

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -182,6 +182,11 @@ export const imageAPI = {
   deleteUploadedAudio: (id) => api.delete(`/images/uploaded-audios/${id}`),
   getVideos: (params) => api.get('/images/videos', { params }),
   getVideoById: (id) => api.get(`/images/videos/${id}`),
+  // 생성 오디오 (#805)
+  getAudios: (params) => api.get('/images/audios', { params }),
+  getAudioById: (id) => api.get(`/images/audios/${id}`),
+  updateAudio: (id, data) => api.put(`/images/audios/${id}`, data),
+  deleteAudio: (id, deleteJob) => api.delete(`/images/audios/${id}`, { params: { deleteJob } }),
   updateVideo: (id, data) => api.put(`/images/videos/${id}`, data),
   deleteVideo: (id, deleteJob) => api.delete(`/images/videos/${id}`, {
     params: { deleteJob },

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -1,0 +1,10 @@
+// vitest 공통 설정 (#808)
+//
+// @testing-library/jest-dom 은 toBeInTheDocument 같은 DOM matcher 를 추가한다.
+// 이미 devDependencies 에 있었으나 러너가 없어 쓰이지 못하고 있었다.
+import '@testing-library/jest-dom';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+// 테스트 간 DOM 잔재 제거 — 안 하면 같은 텍스트가 중복 매치되어 헷갈리는 실패가 난다
+afterEach(() => cleanup());

--- a/frontend/src/templates/ComfyUI-audio.json
+++ b/frontend/src/templates/ComfyUI-audio.json
@@ -1,0 +1,20 @@
+{
+  "additionalInputFields": [
+    {
+      "name": "base_model",
+      "label": "베이스 모델",
+      "type": "baseModel",
+      "required": true,
+      "formatString": "{{##base_model##}}"
+    },
+    {
+      "name": "duration",
+      "label": "길이 (초)",
+      "type": "number",
+      "required": true,
+      "defaultValue": 30,
+      "formatString": "{{##duration##}}"
+    }
+  ],
+  "workflowData": "{\n  \"1\": {\n    \"class_type\": \"CheckpointLoaderSimple\",\n    \"inputs\": {\n      \"ckpt_name\": \"{{##base_model##}}\"\n    },\n    \"_meta\": {\n      \"title\": \"모델 로드\"\n    }\n  },\n  \"2\": {\n    \"class_type\": \"CLIPTextEncode\",\n    \"inputs\": {\n      \"clip\": [\n        \"1\",\n        1\n      ],\n      \"text\": \"{{##prompt##}}\"\n    },\n    \"_meta\": {\n      \"title\": \"프롬프트\"\n    }\n  },\n  \"3\": {\n    \"class_type\": \"CLIPTextEncode\",\n    \"inputs\": {\n      \"clip\": [\n        \"1\",\n        1\n      ],\n      \"text\": \"{{##negative_prompt##}}\"\n    },\n    \"_meta\": {\n      \"title\": \"부정 프롬프트\"\n    }\n  },\n  \"4\": {\n    \"class_type\": \"EmptyLatentAudio\",\n    \"inputs\": {\n      \"seconds\": \"{{##duration##}}\",\n      \"batch_size\": 1\n    },\n    \"_meta\": {\n      \"title\": \"빈 오디오 잠재\"\n    }\n  },\n  \"5\": {\n    \"class_type\": \"KSampler\",\n    \"inputs\": {\n      \"model\": [\n        \"1\",\n        0\n      ],\n      \"positive\": [\n        \"2\",\n        0\n      ],\n      \"negative\": [\n        \"3\",\n        0\n      ],\n      \"latent_image\": [\n        \"4\",\n        0\n      ],\n      \"seed\": \"{{##seed##}}\",\n      \"steps\": 50,\n      \"cfg\": 5,\n      \"sampler_name\": \"euler\",\n      \"scheduler\": \"simple\",\n      \"denoise\": 1\n    },\n    \"_meta\": {\n      \"title\": \"샘플러\"\n    }\n  },\n  \"6\": {\n    \"class_type\": \"VAEDecodeAudio\",\n    \"inputs\": {\n      \"samples\": [\n        \"5\",\n        0\n      ],\n      \"vae\": [\n        \"1\",\n        2\n      ]\n    },\n    \"_meta\": {\n      \"title\": \"오디오 디코드\"\n    }\n  },\n  \"7\": {\n    \"class_type\": \"SaveAudio\",\n    \"inputs\": {\n      \"audio\": [\n        \"6\",\n        0\n      ],\n      \"filename_prefix\": \"{{##user_id##}}/audio/Generated\"\n    },\n    \"_meta\": {\n      \"title\": \"오디오 저장\"\n    }\n  }\n}"
+}

--- a/frontend/src/templates/capabilities.js
+++ b/frontend/src/templates/capabilities.js
@@ -16,7 +16,8 @@ export const SERVER_TYPES = [
 export const CAPABILITIES = {
   "ComfyUI": [
     "image",
-    "video"
+    "video",
+    "audio"
   ],
   "OpenAI": [
     "image",
@@ -38,6 +39,7 @@ const OUTPUT_FORMAT_LABELS = {
   image: '이미지',
   video: '비디오',
   text: '텍스트',
+  audio: '오디오',
 };
 
 const SERVER_TYPE_LABELS = {

--- a/frontend/src/templates/capabilities.js
+++ b/frontend/src/templates/capabilities.js
@@ -35,6 +35,14 @@ export const CAPABILITIES = {
   ]
 };
 
+// 파일을 첨부받는 필드 타입 (#808) — 백엔드 constants/mediaTypes 가 단일 소스.
+// 프론트는 별도 빌드라 직접 import 할 수 없어 여기로 내려보낸다.
+export const ATTACHMENT_FIELD_TYPES = [
+  "image",
+  "video",
+  "audio"
+];
+
 const OUTPUT_FORMAT_LABELS = {
   image: '이미지',
   video: '비디오',

--- a/frontend/src/templates/index.js
+++ b/frontend/src/templates/index.js
@@ -4,6 +4,7 @@
 
 import comfyImage from './ComfyUI-image.json';
 import comfyVideo from './ComfyUI-video.json';
+import comfyAudio from './ComfyUI-audio.json';
 import openAIImage from './OpenAI-image.json';
 import openAIText from './OpenAI-text.json';
 import geminiImage from './Gemini-image.json';
@@ -14,6 +15,7 @@ import dIceAllImage from './d-ice-all-image.json';
 const TEMPLATES = {
   'ComfyUI:image': comfyImage,
   'ComfyUI:video': comfyVideo,
+  'ComfyUI:audio': comfyAudio,
   'OpenAI:image': openAIImage,
   'OpenAI:text': openAIText,
   'Gemini:image': geminiImage,

--- a/frontend/src/utils/continueJob.test.js
+++ b/frontend/src/utils/continueJob.test.js
@@ -1,0 +1,70 @@
+/**
+ * 계속하기 페이로드 계약 (#792 · #808)
+ *
+ * 이 계약이 두 번 깨졌다. #762 가 JobHistoryPanel 만 고쳐 사이드바에서 재발했고(#792),
+ * 그때 페이로드 생성을 utils/continueJob 으로 모았다. 이제 러너가 생겼으니 고정한다.
+ *
+ * 핵심은 sameWorkboard 플래그다 — 이게 없으면 ImageGeneration 이 #673 의
+ * 크로스 안전조건을 같은 작업판에도 적용해, 작업판 기본값이 히스토리의 실사용 모델을 덮는다.
+ */
+import {
+  buildSameWorkboardContinue,
+  buildCrossWorkboardContinue,
+  buildWorkboardPickerContinue,
+} from './continueJob';
+
+const job = {
+  inputData: { additionalParams: { base_model: 'HISTORY_MODEL' } },
+  resultVideos: [{ _id: 'v1' }],
+};
+const workboard = { _id: 'WB1' };
+
+// ImageGeneration.js 의 prefill 판정을 그대로 재현
+const allowPrefill = (payload, bmHasDefault, wbOutputFormat) => {
+  const same = payload.sameWorkboard === true;
+  const prev = payload.prevOutputFormat || null;
+  return same || (!(prev && prev !== wbOutputFormat) && !bmHasDefault);
+};
+
+describe('계속하기 페이로드 (#792)', () => {
+  test('같은 작업판은 sameWorkboard: true', () => {
+    const p = buildSameWorkboardContinue({ workboardId: 'WB1', workboard, job });
+    expect(p.sameWorkboard).toBe(true);
+    expect(p.inputData).toBe(job.inputData);
+    expect(p.prevOutputFormat).toBe('video');
+  });
+
+  test('다른 작업판으로 이어가기는 sameWorkboard: false — 명시적이어야 한다', () => {
+    const p = buildCrossWorkboardContinue({ workboard, job, lastGeneratedMedia: {} });
+    expect(p.sameWorkboard).toBe(false);
+  });
+
+  test('작업판 선택 경유는 복원 판단 정보를 담지 않는다', () => {
+    const p = buildWorkboardPickerContinue(job);
+    expect(p.sameWorkboard).toBeUndefined();
+    expect(p.fromJobHistory).toBe(true);
+  });
+
+  test('결과가 영상이면 prevOutputFormat 이 video, 아니면 image', () => {
+    expect(buildSameWorkboardContinue({ workboardId: 'W', workboard, job }).prevOutputFormat).toBe('video');
+    const imgJob = { inputData: {}, resultVideos: [] };
+    expect(buildSameWorkboardContinue({ workboardId: 'W', workboard, job: imgJob }).prevOutputFormat).toBe('image');
+  });
+});
+
+describe('prefill 판정 — #673 안전조건과 #762 복원의 공존', () => {
+  const same = buildSameWorkboardContinue({ workboardId: 'WB1', workboard, job });
+  const cross = buildCrossWorkboardContinue({ workboard, job, lastGeneratedMedia: {} });
+  const picker = buildWorkboardPickerContinue(job);
+
+  test.each([
+    ['같은 작업판 · 기본값 있음 (#762 회귀 지점)', same, true, 'video', true],
+    ['같은 작업판 · 기본값 없음', same, false, 'video', true],
+    ['크로스 · 기본값 있음 (#673 유지)', cross, true, 'video', false],
+    ['크로스 · 기본값 없음 · 출력 일치', cross, false, 'video', true],
+    ['크로스 · 출력 타입 불일치 (#673 유지)', cross, false, 'image', false],
+    ['작업판 선택 경유', picker, true, 'video', false],
+  ])('%s', (_label, payload, bmHasDefault, out, expected) => {
+    expect(allowPrefill(payload, bmHasDefault, out)).toBe(expected);
+  });
+});

--- a/frontend/src/utils/historyItems.js
+++ b/frontend/src/utils/historyItems.js
@@ -1,0 +1,40 @@
+// 작업 히스토리 항목 표시 로직 (#805 · #808).
+//
+// HistoryRow 안에 인라인으로 있던 부제 계산을 뺐다. 그 코드는 image/video/text 를 거른 뒤
+// **나머지를 파이프라인으로 가정**하고 `item.stepStatuses.length` 를 읽었는데, 오디오 축이
+// 생기며 type 'audio' 가 그리로 떨어져 `undefined.length` 로 목록 전체가 렌더 실패했다.
+//
+// 새 미디어 타입이 늘어도 화면이 죽지 않아야 한다 — 그것을 테스트로 고정하려고 분리했다.
+
+/** 클릭 시 뷰어가 열리는 미디어 항목 타입 */
+export const MEDIA_ITEM_TYPES = ['image', 'video', 'audio'];
+
+const seconds = (v) => (v != null ? `${Math.round(v)}초` : '');
+
+/**
+ * 히스토리 행의 부제 문자열.
+ *
+ * 알 수 없는 타입이 들어와도 **던지지 않는다.** 표시가 빈약해질 뿐이며,
+ * 목록 전체가 사라지는 것보다 낫다.
+ */
+export function buildHistorySubtitle(item) {
+  if (!item) return '';
+  const parts = (() => {
+    switch (item.type) {
+      case 'image':
+        return [item.projectName, item.model, item.res, item.count ? `${item.count}장` : ''];
+      case 'video':
+        return [item.projectName, item.model, item.res, seconds(item.duration)];
+      case 'audio':
+        return [item.projectName, item.model, seconds(item.duration)];
+      case 'text':
+        return [item.model, item.tokens != null ? `${item.tokens.toLocaleString()} 토큰` : ''];
+      case 'pipeline':
+        return [item.projectName, item.stepStatuses?.length ? `${item.stepStatuses.length}단계` : '', item.input];
+      default:
+        // 새 타입이 추가됐는데 여기 반영이 안 된 경우 — 최소한의 정보만 보여주고 넘어간다
+        return [item.projectName, item.model];
+    }
+  })();
+  return parts.filter(Boolean).join(' · ');
+}

--- a/frontend/src/utils/historyItems.test.js
+++ b/frontend/src/utils/historyItems.test.js
@@ -1,0 +1,71 @@
+/**
+ * 작업 히스토리 항목 표시 (#805)
+ *
+ * 오디오 축을 추가했을 때 부제 계산이 "나머지는 파이프라인" 으로 가정하고
+ * stepStatuses.length 를 읽어 **목록 전체가 렌더 실패**했다. 사용자에게는
+ * "선택이 안 된다" 로 보였지만 실제로는 화면이 죽은 것이었다.
+ *
+ * 새 미디어 타입이 늘어도 죽지 않는다는 것을 여기서 고정한다.
+ */
+import { buildHistorySubtitle, MEDIA_ITEM_TYPES } from './historyItems';
+
+describe('부제 계산 — 타입별 (#805)', () => {
+  test('이미지: 장수 표시', () => {
+    expect(buildHistorySubtitle({ type: 'image', projectName: 'P', model: 'M', res: '512x512', count: 3 }))
+      .toBe('P · M · 512x512 · 3장');
+  });
+
+  test('영상: 길이 표시', () => {
+    expect(buildHistorySubtitle({ type: 'video', model: 'M', res: '864x480', duration: 3.04 }))
+      .toBe('M · 864x480 · 3초');
+  });
+
+  test('오디오: 해상도 없이 길이만', () => {
+    expect(buildHistorySubtitle({ type: 'audio', model: 'MM3', duration: 66.2 }))
+      .toBe('MM3 · 66초');
+  });
+
+  test('텍스트: 토큰 수', () => {
+    expect(buildHistorySubtitle({ type: 'text', model: 'gpt', tokens: 11889 }))
+      .toBe('gpt · 11,889 토큰');
+  });
+
+  test('파이프라인: 단계 수', () => {
+    expect(buildHistorySubtitle({ type: 'pipeline', projectName: 'P', stepStatuses: [1, 2], input: 'hi' }))
+      .toBe('P · 2단계 · hi');
+  });
+});
+
+describe('렌더가 죽지 않는다 (#805 회귀 방지)', () => {
+  // 사고의 본질: 새 type 이 파이프라인 분기로 떨어져 undefined.length 로 터졌다
+  test.each([
+    ['오디오 — 사고 당시 타입', { type: 'audio' }],
+    ['아직 없는 타입', { type: 'model3d' }],
+    ['타입 없음', {}],
+    ['stepStatuses 없는 파이프라인', { type: 'pipeline' }],
+    ['빈 객체가 아닌 null', null],
+  ])('%s 이어도 던지지 않는다', (_label, item) => {
+    expect(() => buildHistorySubtitle(item)).not.toThrow();
+    expect(typeof buildHistorySubtitle(item)).toBe('string');
+  });
+
+  test('알 수 없는 타입도 있는 정보는 보여준다', () => {
+    expect(buildHistorySubtitle({ type: 'model3d', projectName: 'P', model: 'M' })).toBe('P · M');
+  });
+
+  test('값이 비면 구분자만 남지 않는다', () => {
+    expect(buildHistorySubtitle({ type: 'image' })).toBe('');
+    expect(buildHistorySubtitle({ type: 'video', model: 'M' })).toBe('M');
+  });
+});
+
+describe('미디어 항목 타입 (#805)', () => {
+  test('세 축이 모두 클릭 가능', () => {
+    expect(MEDIA_ITEM_TYPES).toEqual(['image', 'video', 'audio']);
+  });
+
+  test('텍스트·파이프라인은 미디어가 아니다 — 뷰어를 열면 안 된다', () => {
+    expect(MEDIA_ITEM_TYPES).not.toContain('text');
+    expect(MEDIA_ITEM_TYPES).not.toContain('pipeline');
+  });
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -22,4 +22,16 @@ export default defineConfig({
     global: 'globalThis', // CRA 글로벌 shim 의존 라이브러리 대비
   },
   server: { port: 3000 },
+
+  // 테스트 러너 (#808) — 그동안 프론트엔드에 러너가 없어 UI 로직을 가드할 방법이 없었다.
+  // 작업 히스토리 이원화(#794) 정리처럼 회귀 위험이 큰 리팩터의 전제 조건이다.
+  //
+  // esbuild loader 설정(위)을 그대로 쓰므로 .js 안의 JSX 도 그대로 처리된다.
+  test: {
+    environment: 'jsdom',
+    globals: true,                      // describe/it/expect 를 import 없이
+    setupFiles: './src/setupTests.js',
+    include: ['src/**/*.{test,spec}.{js,jsx}'],
+    css: false,
+  },
 });

--- a/mcp-server/src/constants/serverTypes.js
+++ b/mcp-server/src/constants/serverTypes.js
@@ -12,5 +12,6 @@ export const SERVER_TYPES = [
 export const OUTPUT_FORMATS = [
   "image",
   "video",
+  "audio",
   "text"
 ];

--- a/mcp-server/src/tools/jobs.js
+++ b/mcp-server/src/tools/jobs.js
@@ -381,6 +381,13 @@ export function registerJobTools(server, apiRequest) {
           filename: vid.originalName,
           size: vid.size,
         }));
+        // 오디오 출력 (#805)
+        result.resultAudios = (job.resultAudios || []).map((aud) => ({
+          id: aud._id,
+          filename: aud.originalName,
+          size: aud.size,
+          duration: aud.metadata?.duration,
+        }));
       }
 
       if (job.status === 'failed') {
@@ -420,6 +427,7 @@ export function registerJobTools(server, apiRequest) {
         workboard: job.workboardId?.name || 'Unknown',
         resultImages: (job.resultImages || []).length,
         resultVideos: (job.resultVideos || []).length,
+        resultAudios: (job.resultAudios || []).length,
         createdAt: job.createdAt,
       }));
 

--- a/mcp-server/src/tools/media.js
+++ b/mcp-server/src/tools/media.js
@@ -17,6 +17,20 @@ const MIME_TYPES = {
   '.mp4': 'video/mp4',
   '.webm': 'video/webm',
   '.mov': 'video/quicktime',
+  // 오디오 (#805)
+  '.mp3': 'audio/mpeg',
+  '.flac': 'audio/flac',
+  '.wav': 'audio/wav',
+  '.ogg': 'audio/ogg',
+  '.opus': 'audio/opus',
+  '.m4a': 'audio/mp4',
+};
+
+// mediaType → 조회 경로 · 응답 키 · 기본 확장자/MIME (#805)
+const MEDIA_SPEC = {
+  image: { path: (id) => `/images/generated/${id}`, key: 'image', ext: 'png', mime: 'image/png' },
+  video: { path: (id) => `/images/videos/${id}`, key: 'video', ext: 'mp4', mime: 'video/mp4' },
+  audio: { path: (id) => `/images/audios/${id}`, key: 'audio', ext: 'mp3', mime: 'audio/mpeg' },
 };
 
 /**
@@ -36,31 +50,29 @@ export function registerMediaTools(server, apiRequest, options = {}) {
     'download_result',
     isHttp
       ? vccBaseUrl
-        ? 'Get a generated image or video via signed URL. Returns a direct-access URL for the media file. Get media IDs from get_job_status results. Response includes responseType field to identify the format.'
-        : 'Get a generated image or video. Images are returned as inline base64 data. Videos return metadata with size info. Get media IDs from get_job_status results. Response includes responseType field to identify the format.'
-      : 'Download a generated image or video file to local disk. Get media IDs from get_job_status results. Response includes responseType field to identify the format.',
+        ? 'Get a generated image, video or audio via signed URL. Returns a direct-access URL for the media file. Get media IDs from get_job_status results. Response includes responseType field to identify the format.'
+        : 'Get a generated image, video or audio. Images are returned as inline base64 data. Videos and audio return metadata with size info. Get media IDs from get_job_status results. Response includes responseType field to identify the format.'
+      : 'Download a generated image, video or audio file to local disk. Get media IDs from get_job_status results. Response includes responseType field to identify the format.',
     {
-      mediaId: z.string().describe('Media ID (from get_job_status resultImages/resultVideos)'),
-      mediaType: z.enum(['image', 'video']).describe('Type of media to download'),
+      mediaId: z.string().describe('Media ID (from get_job_status resultImages/resultVideos/resultAudios)'),
+      mediaType: z.enum(['image', 'video', 'audio']).describe('Type of media to download'),
       ...(!isHttp ? {
         downloadDir: z.string().optional().describe('Download directory (default: ~/Downloads/vcc or VCC_DOWNLOAD_DIR)'),
       } : {}),
     },
     async ({ mediaId, mediaType, downloadDir }) => {
       // Get media metadata
-      const metaPath = mediaType === 'image'
-        ? `/images/generated/${mediaId}`
-        : `/images/videos/${mediaId}`;
-      const meta = await apiRequest(metaPath);
-      const mediaItem = mediaType === 'image' ? meta.image : meta.video;
+      const spec = MEDIA_SPEC[mediaType];
+      const meta = await apiRequest(spec.path(mediaId));
+      const mediaItem = meta[spec.key];
 
       if (!mediaItem) {
         throw new Error(`${mediaType} not found`);
       }
 
-      const filename = mediaItem.originalName || `${mediaId}.${mediaType === 'image' ? 'png' : 'mp4'}`;
+      const filename = mediaItem.originalName || `${mediaId}.${spec.ext}`;
       const ext = extname(filename).toLowerCase();
-      const mimeType = MIME_TYPES[ext] || (mediaType === 'image' ? 'image/png' : 'video/mp4');
+      const mimeType = MIME_TYPES[ext] || spec.mime;
 
       // ── HTTP mode ─────────────────────────────────────────────────
       if (isHttp) {
@@ -80,9 +92,7 @@ export function registerMediaTools(server, apiRequest, options = {}) {
         }
 
         // Fallback: VCC_BASE_URL_FOR_MCP 미설정 또는 signed URL 생성 실패
-        const downloadPath = mediaType === 'image'
-          ? `/images/generated/${mediaId}/download`
-          : `/images/videos/${mediaId}/download`;
+        const downloadPath = `${spec.path(mediaId)}/download`;
 
         // 이미지: base64 인라인 반환
         if (mediaType === 'image') {
@@ -107,7 +117,7 @@ export function registerMediaTools(server, apiRequest, options = {}) {
           };
         }
 
-        // 비디오: 메타데이터만 반환
+        // 비디오·오디오: 인라인으로 싣기엔 크므로 메타데이터만 반환 (#805)
         return {
           content: [{
             type: 'text',
@@ -121,9 +131,7 @@ export function registerMediaTools(server, apiRequest, options = {}) {
       }
 
       // ── stdio mode: download to local disk ──────────────────────────
-      const downloadPath = mediaType === 'image'
-        ? `/images/generated/${mediaId}/download`
-        : `/images/videos/${mediaId}/download`;
+      const downloadPath = `${spec.path(mediaId)}/download`;
 
       const targetDir = downloadDir
         ? downloadDir.replace(/^~/, homedir())

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "env:doctor": "node scripts/env-doctor.js",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "test:e2e:headed": "playwright test --headed"
+    "test:e2e:headed": "playwright test --headed",
+    "test:frontend": "pnpm --dir frontend test",
+    "test:all": "npm test && npm run test:frontend"
   },
   "dependencies": {
     "archiver": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "test:frontend": "pnpm --dir frontend test",
-    "test:all": "npm test && npm run test:frontend"
+    "test:all": "pnpm test && pnpm run test:frontend"
   },
   "dependencies": {
     "archiver": "^7.0.1",

--- a/scripts/sync-server-type-mirrors.js
+++ b/scripts/sync-server-type-mirrors.js
@@ -35,6 +35,8 @@ const pickMap = (field) =>
 // 예전에는 ['image','video','text'] 를 여기 하드코딩하고 있어서, ComfyUI 에 audio 를
 // 추가해도 MCP 미러의 OUTPUT_FORMATS 에는 반영되지 않았다. 미러 테스트는 "스크립트 출력과
 // 파일이 일치하는가" 만 보므로 스크립트 자신이 틀리면 잡지 못한다.
+const { ATTACHMENT_FIELD_TYPES } = require('../src/constants/mediaTypes');
+
 const ALL_OUTPUT_FORMATS = [...new Set(
   SERVER_TYPES.flatMap((t) => SERVER_TYPE_SPECS[t].outputFormats)
 )];
@@ -65,6 +67,10 @@ export const SERVER_TYPES = ${json(SERVER_TYPES)};
 // 각 server type 이 지원하는 outputFormat 목록.
 // frontend/src/templates/index.js 의 TEMPLATES 키와 일치해야 함 (테스트로 검증).
 export const CAPABILITIES = ${json(capabilities)};
+
+// 파일을 첨부받는 필드 타입 (#808) — 백엔드 constants/mediaTypes 가 단일 소스.
+// 프론트는 별도 빌드라 직접 import 할 수 없어 여기로 내려보낸다.
+export const ATTACHMENT_FIELD_TYPES = ${json([...ATTACHMENT_FIELD_TYPES])};
 
 const OUTPUT_FORMAT_LABELS = {
   image: '이미지',

--- a/scripts/sync-server-type-mirrors.js
+++ b/scripts/sync-server-type-mirrors.js
@@ -31,6 +31,14 @@ const json = (v) => JSON.stringify(v, null, 2);
 const pickMap = (field) =>
   Object.fromEntries(SERVER_TYPES.map((t) => [t, SERVER_TYPE_SPECS[t][field]]));
 
+// 전체 출력 형식 — 각 serverType 의 outputFormats 합집합에서 유도한다 (#805).
+// 예전에는 ['image','video','text'] 를 여기 하드코딩하고 있어서, ComfyUI 에 audio 를
+// 추가해도 MCP 미러의 OUTPUT_FORMATS 에는 반영되지 않았다. 미러 테스트는 "스크립트 출력과
+// 파일이 일치하는가" 만 보므로 스크립트 자신이 틀리면 잡지 못한다.
+const ALL_OUTPUT_FORMATS = [...new Set(
+  SERVER_TYPES.flatMap((t) => SERVER_TYPE_SPECS[t].outputFormats)
+)];
+
 function renderFrontendCapabilities() {
   const capabilities = Object.fromEntries(
     SERVER_TYPES.map((t) => [t, [...SERVER_TYPE_SPECS[t].outputFormats]])
@@ -115,7 +123,7 @@ function renderMcpConstants() {
   return `${HEADER}
 
 export const SERVER_TYPES = ${json(SERVER_TYPES)};
-export const OUTPUT_FORMATS = ${json(['image', 'video', 'text'])};
+export const OUTPUT_FORMATS = ${json(ALL_OUTPUT_FORMATS)};
 `;
 }
 

--- a/scripts/sync-server-type-mirrors.js
+++ b/scripts/sync-server-type-mirrors.js
@@ -62,6 +62,7 @@ const OUTPUT_FORMAT_LABELS = {
   image: '이미지',
   video: '비디오',
   text: '텍스트',
+  audio: '오디오',
 };
 
 const SERVER_TYPE_LABELS = ${json(pickMap('label'))};

--- a/src/constants/mediaTypes.js
+++ b/src/constants/mediaTypes.js
@@ -1,0 +1,52 @@
+// 미디어 축 단일 소스 (#808).
+//
+// 이미지·비디오·오디오처럼 "축" 이 늘 때마다 같은 목록을 여러 곳에 리터럴로 적어왔고,
+// 그때마다 한두 곳이 빠져 사고가 났다 (#805 백업 디렉토리 누락으로 복원 시 오디오 소실,
+// MCP 미러 OUTPUT_FORMATS 미반영 등). 축을 늘릴 때 **여기만 고치면 되도록** 모은다.
+//
+// serverTypes.js 와 역할이 다르다 — 저기는 "어떤 서버가 무엇을 낼 수 있나"(capability),
+// 여기는 "미디어 축 자체의 성질"(첨부형 필드 타입, 저장 디렉토리, 생성물 모델)이다.
+
+/**
+ * 파일을 첨부받는 필드 타입.
+ *
+ * 공통 성질: 업로드 → ComfyUI 전송 → `{{##필드명##}}` 은 파일명으로 치환되고,
+ * `{{##필드명_attached##}}` 가 1/0 으로 자동 제공된다 (#758, #772).
+ * 일반 필드(string/select/number...)와 달리 required 검증도 별도 경로를 탄다.
+ */
+const ATTACHMENT_FIELD_TYPES = Object.freeze(['image', 'video', 'audio']);
+
+/**
+ * 생성물이 저장되는 미디어 종류 → 저장 서브디렉토리.
+ *
+ * 이 목록이 곧 백업 대상 파일 디렉토리의 근거다 (`reference` 는 업로드본용으로 별도).
+ * queueService 의 saveGeneratedMedia 가 이 매핑으로 경로를 정한다.
+ */
+const GENERATED_MEDIA_DIRS = Object.freeze({
+  image: 'generated',
+  video: 'videos',
+  audio: 'audios',
+});
+
+/** 업로드본이 저장되는 디렉토리 (이미지·비디오·오디오 공용) */
+const UPLOAD_MEDIA_DIR = 'reference';
+
+/**
+ * 생성물 미디어 모델 이름.
+ *
+ * 백업·무결성 검사·계정 삭제가 전부 이 셋을 함께 다뤄야 한다.
+ * 모델 객체가 아니라 **이름**으로 두는 이유는 순환 참조를 피하기 위해서다 —
+ * 각 서비스가 자기 시점에 require 한다.
+ */
+const GENERATED_MEDIA_MODELS = Object.freeze(['GeneratedImage', 'GeneratedVideo', 'GeneratedAudio']);
+
+/** 업로드본 미디어 모델 이름 */
+const UPLOADED_MEDIA_MODELS = Object.freeze(['UploadedImage', 'UploadedVideo', 'UploadedAudio']);
+
+module.exports = {
+  ATTACHMENT_FIELD_TYPES,
+  GENERATED_MEDIA_DIRS,
+  UPLOAD_MEDIA_DIR,
+  GENERATED_MEDIA_MODELS,
+  UPLOADED_MEDIA_MODELS,
+};

--- a/src/constants/serverTypes.js
+++ b/src/constants/serverTypes.js
@@ -23,7 +23,7 @@ const SERVER_TYPE_SPECS = Object.freeze({
   'ComfyUI': Object.freeze({
     label: 'ComfyUI',
     color: '#7e57c2', // 보라 — 서드파티/오픈소스 느낌
-    outputFormats: Object.freeze(['image', 'video']),
+    outputFormats: Object.freeze(['image', 'video', 'audio']),
     modelSource: 'checkpoint',
     healthCheck: Object.freeze({ path: '/system_stats', auth: 'bearer' }),
     defaultUrl: null,

--- a/src/models/GeneratedAudio.js
+++ b/src/models/GeneratedAudio.js
@@ -1,0 +1,86 @@
+const mongoose = require('mongoose');
+
+// 생성된 오디오 (#805) — GeneratedVideo 와 대칭.
+//
+// 비디오와 두 가지가 다르다:
+//  - **썸네일이 없다.** 오디오는 시각 표현이 없어 목록에서 제목·길이로 식별하고
+//    인라인 플레이어로 확인한다 (UploadedAudio #772 와 같은 판단).
+//  - **width/height 가 없다.** metadata 는 duration/sampleRate/channels/codec 이다.
+const generatedAudioSchema = new mongoose.Schema({
+  filename: {
+    type: String,
+    required: true
+  },
+  originalName: {
+    type: String,
+    required: true
+  },
+  mimeType: {
+    type: String,
+    required: true
+  },
+  size: {
+    type: Number,
+    required: true
+  },
+  path: {
+    type: String,
+    required: true
+  },
+  url: {
+    type: String,
+    required: true
+  },
+  userId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true
+  },
+  // 히스토리 삭제 시 콘텐츠를 보존하기 위해 required: false
+  // (GeneratedImage / GeneratedVideo 와 동일한 설계)
+  jobId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'ImageGenerationJob',
+    required: false
+  },
+  metadata: {
+    duration: Number,     // seconds
+    sampleRate: Number,
+    channels: Number,
+    codec: String,
+    format: String
+  },
+  generationParams: {
+    prompt: String,
+    negativePrompt: String,
+    model: String,
+    seed: mongoose.Schema.Types.Mixed,
+    lyrics: String,       // 음악 생성 워크플로의 가사 (#805)
+    duration: mongoose.Schema.Types.Mixed,
+    additionalParams: mongoose.Schema.Types.Mixed
+  },
+  tags: [{
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Tag'
+  }],
+  isPublic: {
+    type: Boolean,
+    default: false
+  },
+  orderIndex: {
+    type: Number,
+    default: 0
+  },
+  downloadCount: {
+    type: Number,
+    default: 0
+  }
+}, {
+  timestamps: true
+});
+
+generatedAudioSchema.index({ userId: 1, createdAt: -1 });
+generatedAudioSchema.index({ jobId: 1 });
+generatedAudioSchema.index({ tags: 1 });
+
+module.exports = mongoose.model('GeneratedAudio', generatedAudioSchema);

--- a/src/models/ImageGenerationJob.js
+++ b/src/models/ImageGenerationJob.js
@@ -69,6 +69,10 @@ const imageGenerationJobSchema = new mongoose.Schema({
     type: mongoose.Schema.Types.ObjectId,
     ref: 'GeneratedVideo'
   }],
+  resultAudios: [{
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'GeneratedAudio'
+  }],
   error: {
     message: String,
     code: String,
@@ -148,6 +152,9 @@ imageGenerationJobSchema.methods.updateStatus = function(status, data = {}) {
 
   if (data.resultVideos) {
     this.resultVideos = data.resultVideos;
+  }
+  if (data.resultAudios) {
+    this.resultAudios = data.resultAudios;
   }
 
   // 비용 추정 (#364) — OpenAI 이미지 생성 worker 가 채움. 다른 provider 는 일단 null.

--- a/src/models/Workboard.js
+++ b/src/models/Workboard.js
@@ -96,7 +96,7 @@ const workboardSchema = new mongoose.Schema({
   },
   outputFormat: {
     type: String,
-    enum: ['image', 'video', 'text'],
+    enum: ['image', 'video', 'text', 'audio'],
     default: 'image'
   },
   serverId: {

--- a/src/routes/files.js
+++ b/src/routes/files.js
@@ -5,7 +5,7 @@ const backupService = require('../services/backupService');
 
 const router = express.Router();
 const UPLOAD_ROOT = process.env.UPLOAD_PATH || './uploads';
-const ALLOWED_SUBDIRS = ['/generated/', '/reference/', '/videos/'];
+const ALLOWED_SUBDIRS = ['/generated/', '/reference/', '/videos/', '/audios/'];   // #805
 
 /**
  * GET /api/files/backup/:id

--- a/src/routes/images.js
+++ b/src/routes/images.js
@@ -1111,7 +1111,7 @@ router.get('/audios/:id', requireAuth, async (req, res) => {
       .populate('jobId')
       .populate('tags');
     
-    if (!video) {
+    if (!audio) {
       return res.status(404).json({ message: 'Audio not found' });
     }
     
@@ -1131,7 +1131,7 @@ router.put('/audios/:id', requireAuth, async (req, res) => {
     
     const audio = await GeneratedAudio.findById(req.params.id);
     
-    if (!video) {
+    if (!audio) {
       return res.status(404).json({ message: 'Audio not found' });
     }
     
@@ -1170,8 +1170,8 @@ router.put('/audios/:id', requireAuth, async (req, res) => {
     await audio.populate('tags');
     
     res.json({
-      message: 'Video updated successfully',
-      video
+      message: 'Audio updated successfully',
+      audio
     });
   } catch (error) {
     res.status(400).json({ message: error.message });
@@ -1184,7 +1184,7 @@ router.delete('/audios/:id', requireAuth, async (req, res) => {
     
     const audio = await GeneratedAudio.findById(req.params.id);
     
-    if (!video) {
+    if (!audio) {
       return res.status(404).json({ message: 'Audio not found' });
     }
     
@@ -1220,7 +1220,7 @@ router.post('/audios/:id/download', async (req, res) => {
   try {
     const audio = await GeneratedAudio.findById(req.params.id);
     
-    if (!video) {
+    if (!audio) {
       return res.status(404).json({ message: 'Audio not found' });
     }
     

--- a/src/routes/images.js
+++ b/src/routes/images.js
@@ -9,6 +9,7 @@ const UploadedVideo = require('../models/UploadedVideo');
 const UploadedAudio = require('../models/UploadedAudio');
 const GeneratedImage = require('../models/GeneratedImage');
 const GeneratedVideo = require('../models/GeneratedVideo');
+const GeneratedAudio = require('../models/GeneratedAudio');
 const ImageGenerationJob = require('../models/ImageGenerationJob');
 const Tag = require('../models/Tag');
 const { escapeRegex } = require('../utils/escapeRegex');
@@ -1062,6 +1063,174 @@ router.post('/videos/:id/download', async (req, res) => {
     await video.incrementDownloadCount();
     
     res.download(video.path, video.originalName);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+// ── 생성 오디오 (#805) — 생성 비디오와 대칭. 썸네일이 없어 thumbnailUrl 관련 처리가 없다 ──
+router.get('/audios', requireAuth, async (req, res) => {
+  try {
+    const { page = 1, limit = 12, search = '' } = req.query;
+    const skip = (page - 1) * limit;
+    
+    const filter = { userId: req.user._id };
+    
+    if (search) {
+      filter.$or = [
+        { originalName: { $regex: escapeRegex(search), $options: 'i' } },
+        { 'generationParams.prompt': { $regex: escapeRegex(search), $options: 'i' } }
+      ];
+    }
+    
+    const audios = await GeneratedAudio.find(filter)
+      .populate('jobId', 'createdAt')
+      .populate('tags')
+      .sort({ createdAt: -1 })
+      .skip(skip)
+      .limit(parseInt(limit));
+    
+    const total = await GeneratedAudio.countDocuments(filter);
+    
+    res.json({
+      audios,
+      pagination: {
+        current: parseInt(page),
+        pages: Math.ceil(total / limit),
+        total
+      }
+    });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+router.get('/audios/:id', requireAuth, async (req, res) => {
+  try {
+    const audio = await GeneratedAudio.findById(req.params.id)
+      .populate('jobId')
+      .populate('tags');
+    
+    if (!video) {
+      return res.status(404).json({ message: 'Audio not found' });
+    }
+    
+    if (audio.userId.toString() !== req.user._id.toString() && !req.user.isAdmin) {
+      return res.status(403).json({ message: 'Access denied' });
+    }
+    
+    res.json({ audio });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+router.put('/audios/:id', requireAuth, async (req, res) => {
+  try {
+    const { tags, isPublic } = req.body;
+    
+    const audio = await GeneratedAudio.findById(req.params.id);
+    
+    if (!video) {
+      return res.status(404).json({ message: 'Audio not found' });
+    }
+    
+    if (audio.userId.toString() !== req.user._id.toString()) {
+      return res.status(403).json({ message: 'Access denied' });
+    }
+    
+    if (tags !== undefined) {
+      const newTags = Array.isArray(tags) ? tags : [];
+      const oldTags = audio.tags.map(t => t.toString());
+      
+      const addedTags = newTags.filter(t => !oldTags.includes(t));
+      const removedTags = oldTags.filter(t => !newTags.includes(t));
+      
+      if (addedTags.length > 0) {
+        await Tag.updateMany(
+          { _id: { $in: addedTags } },
+          { $inc: { usageCount: 1 } }
+        );
+      }
+      if (removedTags.length > 0) {
+        await Tag.updateMany(
+          { _id: { $in: removedTags } },
+          { $inc: { usageCount: -1 } }
+        );
+      }
+      
+      audio.tags = newTags;
+    }
+    
+    if (isPublic !== undefined) {
+      audio.isPublic = isPublic;
+    }
+    
+    await audio.save();
+    await audio.populate('tags');
+    
+    res.json({
+      message: 'Video updated successfully',
+      video
+    });
+  } catch (error) {
+    res.status(400).json({ message: error.message });
+  }
+});
+
+router.delete('/audios/:id', requireAuth, async (req, res) => {
+  try {
+    const { deleteJob = false } = req.query;
+    
+    const audio = await GeneratedAudio.findById(req.params.id);
+    
+    if (!video) {
+      return res.status(404).json({ message: 'Audio not found' });
+    }
+    
+    if (audio.userId.toString() !== req.user._id.toString() && !req.user.isAdmin) {
+      return res.status(403).json({ message: 'Access denied' });
+    }
+
+    // 태그 사용 카운트 감소
+    if (audio.tags && audio.tags.length > 0) {
+      await Tag.updateMany(
+        { _id: { $in: audio.tags } },
+        { $inc: { usageCount: -1 } }
+      );
+    }
+
+    await deleteFile(audio.path);
+    
+    if (deleteJob === 'true' && audio.jobId) {
+      await ImageGenerationJob.findByIdAndDelete(audio.jobId);
+    }
+    
+    await GeneratedAudio.findByIdAndDelete(req.params.id);
+    
+    res.json({
+      message: `Audio${deleteJob === 'true' ? ' and job' : ''} deleted successfully`
+    });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+router.post('/audios/:id/download', async (req, res) => {
+  try {
+    const audio = await GeneratedAudio.findById(req.params.id);
+    
+    if (!video) {
+      return res.status(404).json({ message: 'Audio not found' });
+    }
+    
+    if (!audio.isPublic && (!req.user || audio.userId.toString() !== req.user._id.toString())) {
+      return res.status(403).json({ message: 'Access denied' });
+    }
+    
+    await audio.incrementDownloadCount();
+    
+    res.download(audio.path, audio.originalName);
   } catch (error) {
     res.status(500).json({ message: error.message });
   }

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { requireAuth, userHasWorkboardAccess } = require('../middleware/auth');
+const { ATTACHMENT_FIELD_TYPES } = require('../constants/mediaTypes');
 const { addImageGenerationJob, getQueueStats, cancelQueueJob, abortActiveJob } = require('../services/queueService');
 const openAIChatService = require('../services/openAIChatService');
 const geminiService = require('../services/geminiService');
@@ -82,7 +83,7 @@ router.post('/generate', requireAuth, async (req, res) => {
     // (일반 필드의 required 는 프론트 CustomFieldControl 이 강제 — 여기서는 첨부형만 본다)
     const ap0 = additionalParams || {};
     for (const field of (wb.additionalInputFields || [])) {
-      if (!field.required || !['image', 'video', 'audio'].includes(field.type)) continue;
+      if (!field.required || !ATTACHMENT_FIELD_TYPES.includes(field.type)) continue;
       const v = ap0[field.name] !== undefined ? ap0[field.name] : req.body[field.name];
       const empty = Array.isArray(v) ? v.length === 0 : !v;
       if (empty) {

--- a/src/routes/jobs.js
+++ b/src/routes/jobs.js
@@ -197,6 +197,7 @@ router.get('/my', requireAuth, async (req, res) => {
       .populate('workboardId', 'name')
       .populate('resultImages')
       .populate('resultVideos')
+      .populate('resultAudios')
       .populate('inputData.tags', 'name color isProjectTag')
       .sort({ createdAt: -1 })
       .skip(skip)
@@ -223,6 +224,7 @@ router.get('/:id', requireAuth, async (req, res) => {
       .populate('workboardId', 'name')
       .populate('resultImages')
       .populate('resultVideos')
+      .populate('resultAudios')
       .populate('inputData.referenceImages.imageId');
     
     if (!job) {
@@ -244,7 +246,7 @@ router.delete('/:id', requireAuth, async (req, res) => {
     const { deleteContent } = req.query;
     const shouldDeleteContent = deleteContent === 'true';
 
-    const job = await ImageGenerationJob.findById(req.params.id).populate('resultImages').populate('resultVideos');
+    const job = await ImageGenerationJob.findById(req.params.id).populate('resultImages').populate('resultVideos').populate('resultAudios');
 
     if (!job) {
       return res.status(404).json({ message: 'Job not found' });

--- a/src/routes/projects.js
+++ b/src/routes/projects.js
@@ -522,6 +522,7 @@ router.get('/:id/jobs', requireAuth, async (req, res) => {
         .populate('workboardId', 'name')
         .populate('resultImages')
         .populate('resultVideos')
+        .populate('resultAudios')
         .populate('inputData.tags', 'name color isProjectTag')
         .sort({ createdAt: -1 })
         .skip((parseInt(page) - 1) * parseInt(limit))

--- a/src/services/backupCollections.js
+++ b/src/services/backupCollections.js
@@ -90,4 +90,12 @@ const CACHE_COLLECTIONS = [
   { name: 'ServerModelCache', model: ServerModelCache },
 ];
 
-module.exports = { BACKUP_COLLECTIONS, CACHE_COLLECTIONS };
+// 백업 대상 파일 디렉토리 (#805).
+//
+// backupService 와 restoreService 가 각자 배열을 하드코딩하고 있어서, 오디오 축(#805)을
+// 추가할 때 collections 만 챙기고 파일 디렉토리를 놓쳤다. 문서는 백업되는데 파일은 빠져
+// **복원 시 오디오가 전부 깨지는** 상태였다. 목록을 여기 하나로 모은다.
+const BACKUP_FILE_DIRS = Object.freeze(['generated', 'reference', 'videos', 'audios']);
+
+module.exports = {
+  BACKUP_FILE_DIRS, BACKUP_COLLECTIONS, CACHE_COLLECTIONS };

--- a/src/services/backupCollections.js
+++ b/src/services/backupCollections.js
@@ -25,6 +25,7 @@
  *   감싸지만, 복원 시 정확히 round-trip 되고 구버전(평문) 백업도 호환됨 (#594 PR 설명 참고).
  */
 
+const { GENERATED_MEDIA_DIRS, UPLOAD_MEDIA_DIR } = require('../constants/mediaTypes');
 const User = require('../models/User');
 const Group = require('../models/Group');
 const PromptGuide = require('../models/PromptGuide');
@@ -95,7 +96,9 @@ const CACHE_COLLECTIONS = [
 // backupService 와 restoreService 가 각자 배열을 하드코딩하고 있어서, 오디오 축(#805)을
 // 추가할 때 collections 만 챙기고 파일 디렉토리를 놓쳤다. 문서는 백업되는데 파일은 빠져
 // **복원 시 오디오가 전부 깨지는** 상태였다. 목록을 여기 하나로 모은다.
-const BACKUP_FILE_DIRS = Object.freeze(['generated', 'reference', 'videos', 'audios']);
+const BACKUP_FILE_DIRS = Object.freeze([
+  ...new Set([...Object.values(GENERATED_MEDIA_DIRS), UPLOAD_MEDIA_DIR]),
+]);
 
 module.exports = {
   BACKUP_FILE_DIRS, BACKUP_COLLECTIONS, CACHE_COLLECTIONS };

--- a/src/services/backupCollections.js
+++ b/src/services/backupCollections.js
@@ -36,6 +36,7 @@ const UploadedText = require('../models/UploadedText');
 const UploadedImage = require('../models/UploadedImage');
 const UploadedVideo = require('../models/UploadedVideo');
 const UploadedAudio = require('../models/UploadedAudio');
+const GeneratedAudio = require('../models/GeneratedAudio');
 const PromptData = require('../models/PromptData');
 const Pipeline = require('../models/Pipeline');
 const ImageGenerationJob = require('../models/ImageGenerationJob');
@@ -73,6 +74,7 @@ const BACKUP_COLLECTIONS = [
   { name: 'ConversationJob', model: ConversationJob },
   { name: 'GeneratedImage', model: GeneratedImage },
   { name: 'GeneratedVideo', model: GeneratedVideo },
+  { name: 'GeneratedAudio', model: GeneratedAudio },
   { name: 'GeneratedText', model: GeneratedText },
   { name: 'PipelineRun', model: PipelineRun },
   // 인증 / 시스템 설정

--- a/src/services/backupService.js
+++ b/src/services/backupService.js
@@ -6,7 +6,7 @@ const archiver = require('archiver');
 const BackupJob = require('../models/BackupJob');
 
 // 백업 대상 컬렉션 — backup/restore 공유 단일 소스 (#588)
-const { BACKUP_COLLECTIONS } = require('./backupCollections');
+const { BACKUP_COLLECTIONS, BACKUP_FILE_DIRS } = require('./backupCollections');
 
 // 백업 디렉토리
 const BACKUP_DIR = process.env.BACKUP_PATH || './backups';
@@ -311,11 +311,7 @@ async function executeBackup(jobId) {
     }
 
     // 파일 백업
-    const uploadDirs = [
-      { name: 'generated', path: path.join(UPLOAD_DIR, 'generated') },
-      { name: 'reference', path: path.join(UPLOAD_DIR, 'reference') },
-      { name: 'videos', path: path.join(UPLOAD_DIR, 'videos') }
-    ];
+    const uploadDirs = BACKUP_FILE_DIRS.map((name) => ({ name, path: path.join(UPLOAD_DIR, name) }));
 
     for (const dir of uploadDirs) {
       await job.updateProgress(progress, job.progress.total, `${dir.name} 파일 백업 중...`);

--- a/src/services/comfyUIService.js
+++ b/src/services/comfyUIService.js
@@ -7,7 +7,9 @@ const getMediaTypeFromFilename = (filename) => {
   const imageExts = ['png', 'jpg', 'jpeg', 'webp', 'gif', 'bmp', 'tiff'];
   const videoExts = ['mp4', 'webm', 'mov', 'avi', 'mkv'];
   const animatedExts = ['gif', 'webp', 'apng'];
-  
+  const audioExts = ['flac', 'wav', 'mp3', 'ogg', 'opus', 'm4a', 'aac'];   // #805
+
+  if (audioExts.includes(ext)) return 'audio';
   if (videoExts.includes(ext)) return 'video';
   if (animatedExts.includes(ext)) return 'animated';
   if (imageExts.includes(ext)) return 'image';
@@ -29,7 +31,15 @@ const getMimeType = (filename) => {
     'webm': 'video/webm',
     'mov': 'video/quicktime',
     'avi': 'video/x-msvideo',
-    'mkv': 'video/x-matroska'
+    'mkv': 'video/x-matroska',
+    // 오디오 (#805) — ComfyUI SaveAudio 는 기본 flac, SaveAudioMP3/Opus 도 있다
+    'flac': 'audio/flac',
+    'wav': 'audio/wav',
+    'mp3': 'audio/mpeg',
+    'ogg': 'audio/ogg',
+    'opus': 'audio/opus',
+    'm4a': 'audio/mp4',
+    'aac': 'audio/aac'
   };
   return mimeTypes[ext] || 'application/octet-stream';
 };
@@ -66,6 +76,7 @@ const getNodeExecutionOrder = (history) => {
 const processHistoryResult = async (serverUrl, history) => {
   const images = [];
   const videos = [];
+  const audios = [];   // #805
   console.log(`🔍 Processing history outputs...`);
 
   if (history.outputs) {
@@ -157,16 +168,37 @@ const processHistoryResult = async (serverUrl, history) => {
         }
       }
       
-      if (!nodeOutput.images && !nodeOutput.gifs) {
-        console.log(`ℹ️ Node ${nodeId} has no images or gifs`);
+      // 오디오 출력 (#805) — SaveAudio / SaveAudioMP3 / SaveAudioOpus 는
+      // `audio` 키로 [{filename, subfolder, type}] 을 돌려준다 (width/height 없음).
+      if (nodeOutput.audio) {
+        console.log(`🔊 Node ${nodeId} has ${nodeOutput.audio.length} audio outputs`);
+
+        for (const audioInfo of nodeOutput.audio) {
+          const mediaUrl = `${serverUrl}/view?filename=${encodeURIComponent(audioInfo.filename)}&subfolder=${encodeURIComponent(audioInfo.subfolder || '')}&type=${audioInfo.type || 'output'}`;
+          const mediaResponse = await axios.get(mediaUrl, { responseType: 'arraybuffer' });
+          const mimeType = getMimeType(audioInfo.filename);
+
+          console.log(`✅ Downloaded audio: ${audioInfo.filename}, size: ${mediaResponse.data.byteLength} bytes, mime: ${mimeType}`);
+
+          audios.push({
+            buffer: Buffer.from(mediaResponse.data),
+            filename: audioInfo.filename,
+            mediaType: 'audio',
+            mimeType,
+          });
+        }
+      }
+
+      if (!nodeOutput.images && !nodeOutput.gifs && !nodeOutput.audio) {
+        console.log(`ℹ️ Node ${nodeId} has no images, gifs or audio`);
       }
     }
   } else {
     console.warn('⚠️ No outputs in history');
   }
   
-  console.log(`🎉 Successfully processed ${images.length} images and ${videos.length} videos`);
-  return { images, videos };
+  console.log(`🎉 Successfully processed ${images.length} images, ${videos.length} videos, ${audios.length} audios`);
+  return { images, videos, audios };
 };
 
 const submitWorkflow = async (serverUrl, workflowJson, progressCallback, executionTimeout = 300000) => {

--- a/src/services/integrityService.js
+++ b/src/services/integrityService.js
@@ -24,6 +24,7 @@ const GeneratedVideo = require('../models/GeneratedVideo');
 const UploadedImage = require('../models/UploadedImage');
 const UploadedVideo = require('../models/UploadedVideo');
 const UploadedAudio = require('../models/UploadedAudio');
+const GeneratedAudio = require('../models/GeneratedAudio');
 const Project = require('../models/Project');
 const Tag = require('../models/Tag');
 const Workboard = require('../models/Workboard');
@@ -221,10 +222,11 @@ const FILE_CHECKS = [
   { Model: UploadedImage, urlFields: ['url'] },
   { Model: UploadedVideo, urlFields: ['url', 'thumbnailUrl'] },
   { Model: UploadedAudio, urlFields: ['url'] },
+  { Model: GeneratedAudio, urlFields: ['url'] },
 ];
 
 // uploads 하위 중 파일 정합성 검사 대상 서브디렉토리 (임시/백업 디렉토리는 제외)
-const CHECKED_SUBDIRS = ['generated', 'reference', 'videos'];
+const CHECKED_SUBDIRS = ['generated', 'reference', 'videos', 'audios'];   // #805
 
 /**
  * 파일↔DB 정합성 진단 (P1).

--- a/src/services/integrityService.js
+++ b/src/services/integrityService.js
@@ -23,6 +23,8 @@ const GeneratedImage = require('../models/GeneratedImage');
 const GeneratedVideo = require('../models/GeneratedVideo');
 const UploadedImage = require('../models/UploadedImage');
 const UploadedVideo = require('../models/UploadedVideo');
+const { GENERATED_MEDIA_MODELS, UPLOADED_MEDIA_MODELS } = require('../constants/mediaTypes');
+const { BACKUP_FILE_DIRS } = require('./backupCollections');
 const UploadedAudio = require('../models/UploadedAudio');
 const GeneratedAudio = require('../models/GeneratedAudio');
 const Project = require('../models/Project');
@@ -216,17 +218,17 @@ function walkFiles(dir, out = []) {
 }
 
 // 파일 정합성 대상 — 미디어 콘텐츠 (url + 파생 파일)
-const FILE_CHECKS = [
-  { Model: GeneratedImage, urlFields: ['url'] },
-  { Model: GeneratedVideo, urlFields: ['url', 'thumbnailUrl'] },
-  { Model: UploadedImage, urlFields: ['url'] },
-  { Model: UploadedVideo, urlFields: ['url', 'thumbnailUrl'] },
-  { Model: UploadedAudio, urlFields: ['url'] },
-  { Model: GeneratedAudio, urlFields: ['url'] },
-];
+// 미디어 모델 목록은 constants/mediaTypes 가 단일 소스 (#808).
+// urlFields 는 모델마다 다르므로(비디오만 thumbnailUrl 이 있다) 여기서 보완한다.
+const THUMBNAIL_MODELS = new Set(['GeneratedVideo', 'UploadedVideo']);
+const MEDIA_MODELS = { GeneratedImage, GeneratedVideo, GeneratedAudio, UploadedImage, UploadedVideo, UploadedAudio };
+const FILE_CHECKS = [...GENERATED_MEDIA_MODELS, ...UPLOADED_MEDIA_MODELS].map((name) => ({
+  Model: MEDIA_MODELS[name],
+  urlFields: THUMBNAIL_MODELS.has(name) ? ['url', 'thumbnailUrl'] : ['url'],
+}));
 
 // uploads 하위 중 파일 정합성 검사 대상 서브디렉토리 (임시/백업 디렉토리는 제외)
-const CHECKED_SUBDIRS = ['generated', 'reference', 'videos', 'audios'];   // #805
+const CHECKED_SUBDIRS = BACKUP_FILE_DIRS;   // #808 — 백업 대상과 같은 목록이어야 한다
 
 /**
  * 파일↔DB 정합성 진단 (P1).

--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -1054,9 +1054,19 @@ const getExtensionFromMimeType = (mimeType) => {
     'video/webm': 'webm',
     'video/quicktime': 'mov',
     'video/x-msvideo': 'avi',
-    'video/x-matroska': 'mkv'
+    'video/x-matroska': 'mkv',
+    // 오디오 (#805) — SaveAudioAdvanced 는 flac / mp3 / opus 를 낸다
+    'audio/flac': 'flac',
+    'audio/wav': 'wav',
+    'audio/mpeg': 'mp3',
+    'audio/ogg': 'ogg',
+    'audio/opus': 'opus',
+    'audio/mp4': 'm4a',
+    'audio/aac': 'aac'
   };
-  return mimeToExt[mimeType] || 'bin';
+  // 모르는 MIME 은 null 을 돌려준다 — 호출부가 원본 파일명 확장자로 넘어갈 수 있도록.
+  // 예전에는 'bin' 을 돌려줬는데, truthy 라서 호출부의 `||` 폴백이 죽어 있었다 (#805 에서 발견).
+  return mimeToExt[mimeType] || null;
 };
 
 const saveGeneratedMedia = async (jobId, mediaItems, inputData, mediaType, workboard = null) => {

--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -10,6 +10,7 @@ const gptImageService = require('./gptImageService');
 const dIceAllService = require('./dIceAllService');
 const { computeOpenAIImageCost, computeGeminiImageCost } = require('../utils/pricing');
 const { applyOmitDirectives } = require('../utils/workflowDirectives');
+const { ATTACHMENT_FIELD_TYPES, GENERATED_MEDIA_DIRS } = require('../constants/mediaTypes');
 const ImageGenerationJob = require('../models/ImageGenerationJob');
 const GeneratedImage = require('../models/GeneratedImage');
 const GeneratedVideo = require('../models/GeneratedVideo');
@@ -922,7 +923,7 @@ const injectInputsIntoWorkflow = async (workflowTemplate, inputData, workboard =
       // `{{##필드명_attached##}}` 가 1/0 (number) 으로 치환된다. 흰 PNG 자동 주입(#230)과
       // 무관하게 "사용자가 실제로 첨부했는가" 를 나타내므로, VCC Optional Image 노드나
       // 스위치 노드의 분기 입력, `_vcc.omitInputsUnless` (#771) 의 조건으로 사용할 수 있다.
-      if (field.type === 'image' || field.type === 'video' || field.type === 'audio') {
+      if (ATTACHMENT_FIELD_TYPES.includes(field.type)) {
         const hasAttachment = Array.isArray(rawValue)
           ? rawValue.length > 0
           : Boolean(extractValue(rawValue));
@@ -1081,8 +1082,7 @@ const saveGeneratedMedia = async (jobId, mediaItems, inputData, mediaType, workb
   }
   
   const savedItems = [];
-  // 오디오는 별도 디렉토리 (#805) — files.js ALLOWED_SUBDIRS 와 무결성 검사 대상에 함께 등록해야 한다
-  const subDir = { video: 'videos', audio: 'audios' }[mediaType] || 'generated';
+  const subDir = GENERATED_MEDIA_DIRS[mediaType] || GENERATED_MEDIA_DIRS.image;
   
   for (let i = 0; i < mediaItems.length; i++) {
     try {

--- a/src/services/queueService.js
+++ b/src/services/queueService.js
@@ -13,6 +13,7 @@ const { applyOmitDirectives } = require('../utils/workflowDirectives');
 const ImageGenerationJob = require('../models/ImageGenerationJob');
 const GeneratedImage = require('../models/GeneratedImage');
 const GeneratedVideo = require('../models/GeneratedVideo');
+const GeneratedAudio = require('../models/GeneratedAudio');
 const UploadedImage = require('../models/UploadedImage');
 const UploadedVideo = require('../models/UploadedVideo');
 const UploadedAudio = require('../models/UploadedAudio');
@@ -102,9 +103,11 @@ const initializeQueues = async () => {
       console.log(`ComfyUI result:`, JSON.stringify(result, null, 2));
       console.log(`Result images count: ${result?.images?.length || 0}`);
       console.log(`Result videos count: ${result?.videos?.length || 0}`);
+      console.log(`Result audios count: ${result?.audios?.length || 0}`);
       await updateJobStatus(job.data.jobId, 'completed', {
         resultImages: result.images,
         resultVideos: result.videos,
+        resultAudios: result.audios,
         usage: result.usage,
         costEstimate: result.costEstimate
       });
@@ -140,6 +143,7 @@ const SERVICE_MAP = {
   'OpenAI Compatible:image': handleOpenAIImage,
   'ComfyUI:image': handleComfyUIWorkflow,
   'ComfyUI:video': handleComfyUIWorkflow,
+  'ComfyUI:audio': handleComfyUIWorkflow,   // #805
   'd-ice-all:image': handleDIceAllImage,
 };
 
@@ -403,15 +407,17 @@ const processImageGeneration = async (job) => {
     
     const hasImages = generationResult.images && generationResult.images.length > 0;
     const hasVideos = generationResult.videos && generationResult.videos.length > 0;
-    
-    if (!hasImages && !hasVideos) {
-      console.error('❌ No images or videos returned from generation backend!');
+    const hasAudios = generationResult.audios && generationResult.audios.length > 0;   // #805
+
+    if (!hasImages && !hasVideos && !hasAudios) {
+      console.error('❌ No media returned from generation backend!');
       console.error('🔍 Full generation result for debugging:', JSON.stringify(generationResult, null, 2));
       throw new Error('No media returned from generation backend');
     }
     
     let savedImages = [];
     let savedVideos = [];
+    let savedAudios = [];
     
     if (hasImages) {
       console.log(`💾 Starting to save ${generationResult.images.length} images...`);
@@ -424,6 +430,12 @@ const processImageGeneration = async (job) => {
       savedVideos = await saveGeneratedMedia(jobId, generationResult.videos, enhancedInputData, 'video', workboardData);
       console.log(`✅ Saved ${savedVideos.length} videos successfully`);
     }
+
+    if (hasAudios) {
+      console.log(`🔊 Starting to save ${generationResult.audios.length} audios...`);
+      savedAudios = await saveGeneratedMedia(jobId, generationResult.audios, enhancedInputData, 'audio', workboardData);
+      console.log(`✅ Saved ${savedAudios.length} audios successfully`);
+    }
     
     job.progress(100);
 
@@ -431,6 +443,7 @@ const processImageGeneration = async (job) => {
     return {
       images: savedImages,
       videos: savedVideos,
+      audios: savedAudios,   // #805
       usage: generationResult.usage,
       costEstimate: generationResult.costEstimate,
     };
@@ -1047,7 +1060,7 @@ const getExtensionFromMimeType = (mimeType) => {
 };
 
 const saveGeneratedMedia = async (jobId, mediaItems, inputData, mediaType, workboard = null) => {
-  const typeLabel = mediaType === 'video' ? 'videos' : 'images';
+  const typeLabel = { video: 'videos', audio: 'audios' }[mediaType] || 'images';
   console.log(`🖼️ Starting to save ${mediaItems?.length || 0} generated ${typeLabel} for job ${jobId}`);
   console.log('📊 Media data:', mediaItems);
   console.log('📋 Input data for saving:', inputData);
@@ -1058,7 +1071,8 @@ const saveGeneratedMedia = async (jobId, mediaItems, inputData, mediaType, workb
   }
   
   const savedItems = [];
-  const subDir = mediaType === 'video' ? 'videos' : 'generated';
+  // 오디오는 별도 디렉토리 (#805) — files.js ALLOWED_SUBDIRS 와 무결성 검사 대상에 함께 등록해야 한다
+  const subDir = { video: 'videos', audio: 'audios' }[mediaType] || 'generated';
   
   for (let i = 0; i < mediaItems.length; i++) {
     try {
@@ -1077,7 +1091,8 @@ const saveGeneratedMedia = async (jobId, mediaItems, inputData, mediaType, workb
         continue;
       }
       
-      const ext = getExtensionFromMimeType(itemData.mimeType) || itemData.filename?.split('.').pop() || (mediaType === 'video' ? 'mp4' : 'png');
+      const ext = getExtensionFromMimeType(itemData.mimeType) || itemData.filename?.split('.').pop()
+        || ({ video: 'mp4', audio: 'flac' }[mediaType] || 'png');
       const filename = `generated_${Date.now()}_${i}.${ext}`;
       const targetDir = path.join(process.env.UPLOAD_PATH || './uploads', subDir);
       
@@ -1119,6 +1134,17 @@ const saveGeneratedMedia = async (jobId, mediaItems, inputData, mediaType, workb
       }
       
       // 동영상 첫 프레임 썸네일 생성 (#672, best-effort — 실패해도 동영상 저장은 계속)
+      // 오디오 메타데이터 (#805) — 업로드 경로(#772)와 같은 ffprobe 헬퍼를 쓴다
+      if (mediaType === 'audio') {
+        try {
+          const { probeAudioMetadata } = require('../utils/audioUpload');
+          metadata = await probeAudioMetadata(filePath);
+          console.log(`audio ${i + 1} metadata:`, JSON.stringify(metadata));
+        } catch (audioMetaError) {
+          console.warn(`Failed to extract audio metadata for ${i + 1}:`, audioMetaError.message);
+        }
+      }
+
       let thumbnailUrl = null;
       if (mediaType === 'video') {
         try {
@@ -1137,7 +1163,7 @@ const saveGeneratedMedia = async (jobId, mediaItems, inputData, mediaType, workb
       const generatedData = {
         filename,
         originalName: itemData.filename || filename,
-        mimeType: itemData.mimeType || (mediaType === 'video' ? 'video/mp4' : 'image/png'),
+        mimeType: itemData.mimeType || ({ video: 'video/mp4', audio: 'audio/flac' }[mediaType] || 'image/png'),
         size: itemData.buffer.length,
         path: filePath,
         url: `/uploads/${subDir}/${filename}`,
@@ -1165,6 +1191,8 @@ const saveGeneratedMedia = async (jobId, mediaItems, inputData, mediaType, workb
       let savedItem;
       if (mediaType === 'video') {
         savedItem = new GeneratedVideo(generatedData);
+      } else if (mediaType === 'audio') {
+        savedItem = new GeneratedAudio(generatedData);
       } else {
         savedItem = new GeneratedImage(generatedData);
       }

--- a/src/services/restoreService.js
+++ b/src/services/restoreService.js
@@ -9,7 +9,7 @@ const { ENCRYPTION_KEY } = backupService;
 
 // 복원 대상 컬렉션 — backup/restore 공유 단일 소스 (#588).
 // 복호화 대상은 백업 시 암호화한 필드(encryptFields)와 동일하게 적용.
-const { BACKUP_COLLECTIONS, CACHE_COLLECTIONS } = require('./backupCollections');
+const { BACKUP_COLLECTIONS, CACHE_COLLECTIONS, BACKUP_FILE_DIRS } = require('./backupCollections');
 
 const UPLOAD_DIR = process.env.UPLOAD_PATH || './uploads';
 const TEMP_DIR = process.env.TEMP_PATH || path.join(UPLOAD_DIR, 'restore-temp');
@@ -339,9 +339,7 @@ async function executeRestore(jobId, zipPath, options = {}) {
   const statistics = {
     collectionsRestored: {},
     filesRestored: {
-      generated: 0,
-      reference: 0,
-      videos: 0
+      ...Object.fromEntries(BACKUP_FILE_DIRS.map((d) => [d, 0]))
     },
     skipped: 0,
     errors: 0,
@@ -387,7 +385,7 @@ async function executeRestore(jobId, zipPath, options = {}) {
 
     // 파일 복구
     if (!options.skipFiles) {
-      const fileDirs = ['generated', 'reference', 'videos'];
+      const fileDirs = BACKUP_FILE_DIRS;
 
       for (const dir of fileDirs) {
         currentStep++;

--- a/src/services/userDeletionService.js
+++ b/src/services/userDeletionService.js
@@ -21,6 +21,7 @@ const GeneratedText = require('../models/GeneratedText');
 const UploadedImage = require('../models/UploadedImage');
 const UploadedVideo = require('../models/UploadedVideo');
 const UploadedAudio = require('../models/UploadedAudio');
+const GeneratedAudio = require('../models/GeneratedAudio');
 const UploadedText = require('../models/UploadedText');
 const PipelineRun = require('../models/PipelineRun');
 const ApiKey = require('../models/ApiKey');
@@ -31,6 +32,7 @@ const USER_CONTENT_MODELS = [
   ConversationJob,
   GeneratedImage,
   GeneratedVideo,
+  GeneratedAudio,
   GeneratedText,
   UploadedImage,
   UploadedVideo,

--- a/src/tests/backupFileDirs.test.js
+++ b/src/tests/backupFileDirs.test.js
@@ -26,12 +26,19 @@ describe('백업 파일 디렉토리 (#805)', () => {
     }
   });
 
-  test('queueService 의 저장 서브디렉토리가 백업 대상에 포함된다', () => {
-    const src = fs.readFileSync(path.join(__dirname, '..', 'services', 'queueService.js'), 'utf8');
-    const m = src.match(/const subDir = \{([^}]*)\}/);
-    expect(m).toBeTruthy();
-    // { video: 'videos', audio: 'audios' } + 기본값 'generated'
-    const dirs = [...m[1].matchAll(/'([a-z]+)'/g)].map((x) => x[1]);
-    for (const d of dirs) expect(BACKUP_FILE_DIRS).toContain(d);
+  test('생성물 저장 디렉토리와 업로드 디렉토리가 모두 백업 대상이다', () => {
+    // 예전에는 queueService 소스에서 리터럴을 정규식으로 긁어 대조했는데, #808 에서
+    // 양쪽 모두 constants/mediaTypes 파생으로 바뀌어 상수끼리 직접 비교한다.
+    const { GENERATED_MEDIA_DIRS, UPLOAD_MEDIA_DIR } = require('../constants/mediaTypes');
+    for (const dir of Object.values(GENERATED_MEDIA_DIRS)) {
+      expect(BACKUP_FILE_DIRS).toContain(dir);
+    }
+    expect(BACKUP_FILE_DIRS).toContain(UPLOAD_MEDIA_DIR);
+  });
+
+  test('무결성 검사 대상 서브디렉토리가 백업 대상과 일치', () => {
+    // 백업에는 들어가는데 무결성 검사에서 빠지면 고아 파일을 영영 못 찾는다
+    const src = fs.readFileSync(path.join(__dirname, '..', 'services', 'integrityService.js'), 'utf8');
+    expect(src).toMatch(/CHECKED_SUBDIRS = BACKUP_FILE_DIRS/);
   });
 });

--- a/src/tests/backupFileDirs.test.js
+++ b/src/tests/backupFileDirs.test.js
@@ -1,0 +1,37 @@
+/**
+ * 백업 파일 디렉토리 단일 소스 (#805)
+ *
+ * backupService 와 restoreService 가 각자 배열을 하드코딩하고 있어서, 오디오 축을
+ * 추가할 때 collections 만 챙기고 파일 디렉토리를 놓쳤다. 문서는 백업되는데 파일이
+ * 빠져 **복원 시 오디오가 전부 깨지는** 상태였다.
+ *
+ * 미디어를 저장하는 모델이 늘면 그 저장 디렉토리도 여기 들어와야 한다.
+ */
+const fs = require('fs');
+const path = require('path');
+const { BACKUP_FILE_DIRS } = require('../services/backupCollections');
+
+describe('백업 파일 디렉토리 (#805)', () => {
+  test('생성물·업로드본 저장 디렉토리를 모두 포함', () => {
+    // queueService 의 subDir 매핑(generated/videos/audios)과 업로드 경로(reference)
+    expect([...BACKUP_FILE_DIRS].sort()).toEqual(['audios', 'generated', 'reference', 'videos']);
+  });
+
+  test('backupService 와 restoreService 가 배열을 다시 하드코딩하지 않는다', () => {
+    for (const file of ['backupService.js', 'restoreService.js']) {
+      const src = fs.readFileSync(path.join(__dirname, '..', 'services', file), 'utf8');
+      expect(src).toContain('BACKUP_FILE_DIRS');
+      // 예전처럼 리터럴 배열을 다시 만들면 같은 사고가 재발한다
+      expect(src).not.toMatch(/\[\s*'generated'\s*,\s*'reference'\s*,\s*'videos'\s*\]/);
+    }
+  });
+
+  test('queueService 의 저장 서브디렉토리가 백업 대상에 포함된다', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'services', 'queueService.js'), 'utf8');
+    const m = src.match(/const subDir = \{([^}]*)\}/);
+    expect(m).toBeTruthy();
+    // { video: 'videos', audio: 'audios' } + 기본값 'generated'
+    const dirs = [...m[1].matchAll(/'([a-z]+)'/g)].map((x) => x[1]);
+    for (const d of dirs) expect(BACKUP_FILE_DIRS).toContain(d);
+  });
+});

--- a/src/tests/integrityService.test.js
+++ b/src/tests/integrityService.test.js
@@ -33,6 +33,7 @@ jest.mock('../models/GeneratedVideo', () => MockGenVideo);
 jest.mock('../models/UploadedImage', () => MockUploadedImage);
 jest.mock('../models/UploadedVideo', () => mockModel('UploadedVideo'));
 jest.mock('../models/UploadedAudio', () => mockModel('UploadedAudio'));
+jest.mock('../models/GeneratedAudio', () => mockModel('GeneratedAudio'));
 jest.mock('../models/Project', () => mockModel('Project'));
 jest.mock('../models/Tag', () => mockModel('Tag'));
 jest.mock('../models/Workboard', () => mockModel('Workboard'));

--- a/src/tests/mediaTypesSingleSource.test.js
+++ b/src/tests/mediaTypesSingleSource.test.js
@@ -1,0 +1,64 @@
+/**
+ * 미디어 축 단일 소스 (#808)
+ *
+ * 이미지·비디오·오디오처럼 축이 늘 때마다 같은 목록을 여러 곳에 리터럴로 적어왔고,
+ * 그때마다 한두 곳이 빠져 사고가 났다. 리터럴이 다시 등장하면 여기서 잡는다.
+ */
+const fs = require('fs');
+const path = require('path');
+const {
+  ATTACHMENT_FIELD_TYPES,
+  GENERATED_MEDIA_DIRS,
+  GENERATED_MEDIA_MODELS,
+  UPLOADED_MEDIA_MODELS,
+} = require('../constants/mediaTypes');
+
+const read = (...p) => fs.readFileSync(path.join(__dirname, '..', ...p), 'utf8');
+const readRepo = (...p) => fs.readFileSync(path.join(__dirname, '..', '..', ...p), 'utf8');
+
+describe('미디어 축 상수 (#808)', () => {
+  test('세 축이 모두 정의돼 있다', () => {
+    expect(ATTACHMENT_FIELD_TYPES).toEqual(['image', 'video', 'audio']);
+    expect(Object.keys(GENERATED_MEDIA_DIRS).sort()).toEqual(['audio', 'image', 'video']);
+    expect(GENERATED_MEDIA_MODELS).toHaveLength(3);
+    expect(UPLOADED_MEDIA_MODELS).toHaveLength(3);
+  });
+
+  test('생성물 모델과 저장 디렉토리의 축이 일치', () => {
+    // GeneratedImage/Video/Audio ↔ generated/videos/audios — 하나가 늘면 다른 쪽도 늘어야 한다
+    expect(GENERATED_MEDIA_MODELS.length).toBe(Object.keys(GENERATED_MEDIA_DIRS).length);
+  });
+});
+
+describe('첨부형 필드 타입 리터럴 재도입 방지 (#808)', () => {
+  // 실제로 이 목록이 4곳에 흩어져 있었다
+  const targets = [
+    ['routes', 'jobs.js'],
+    ['services', 'queueService.js'],
+  ];
+
+  test.each(targets)('%s/%s 가 상수를 쓴다', (dir, file) => {
+    const src = read(dir, file);
+    expect(src).toContain('ATTACHMENT_FIELD_TYPES');
+    expect(src).not.toMatch(/\['image',\s*'video',\s*'audio'\]/);
+    expect(src).not.toMatch(/type === 'image' \|\| .*type === 'video' \|\| .*type === 'audio'/);
+  });
+
+  test('프론트엔드도 mirror 상수를 쓴다', () => {
+    for (const p of [
+      ['frontend', 'src', 'components', 'admin', 'workboardEditor', 'FieldInspector.js'],
+      ['frontend', 'src', 'pages', 'ImageGeneration.js'],
+    ]) {
+      const src = readRepo(...p);
+      expect(src).toContain('ATTACHMENT_FIELD_TYPES');
+      expect(src).not.toMatch(/\['image',\s*'video',\s*'audio'\]/);
+    }
+  });
+
+  test('mirror 가 백엔드 상수와 일치', () => {
+    const src = readRepo('frontend', 'src', 'templates', 'capabilities.js');
+    const m = src.match(/export const ATTACHMENT_FIELD_TYPES = (\[[\s\S]*?\]);/);
+    expect(m).toBeTruthy();
+    expect(JSON.parse(m[1])).toEqual([...ATTACHMENT_FIELD_TYPES]);
+  });
+});

--- a/src/tests/serverTypesMirror.test.js
+++ b/src/tests/serverTypesMirror.test.js
@@ -27,6 +27,22 @@ describe('serverTypes mirror 동기화 (#745)', () => {
     expect(onDisk).toBe(renderMcpConstants());
   });
 
+  // "스크립트 출력 == 파일" 만 보면 **스크립트 자신이 틀린 경우**를 못 잡는다.
+  // 실제로 OUTPUT_FORMATS 가 ['image','video','text'] 로 하드코딩돼 있어, ComfyUI 에
+  // audio 를 추가해도 MCP 미러에 반영되지 않았는데 위 두 테스트는 통과했다 (#805).
+  // 그래서 원본(SERVER_TYPE_SPECS)과 직접 대조한다.
+  test('mcp OUTPUT_FORMATS 가 원본 outputFormats 의 합집합과 일치', () => {
+    const { SERVER_TYPES, SERVER_TYPE_SPECS } = require('../constants/serverTypes');
+    const expected = [...new Set(SERVER_TYPES.flatMap((t) => SERVER_TYPE_SPECS[t].outputFormats))];
+
+    const onDisk = fs.readFileSync(MCP_TARGET, 'utf8');
+    const m = onDisk.match(/export const OUTPUT_FORMATS = (\[[\s\S]*?\]);/);
+    expect(m).toBeTruthy();
+    const actual = JSON.parse(m[1]);
+
+    expect([...actual].sort()).toEqual([...expected].sort());
+  });
+
   test('capability 조합마다 frontend 템플릿이 등록되어 있음', () => {
     // TEMPLATES 는 JSON import 라 codegen 대상이 아님 — 키 존재만 텍스트로 검증.
     const indexSrc = fs.readFileSync(

--- a/src/tests/serverTypesSingleSource.test.js
+++ b/src/tests/serverTypesSingleSource.test.js
@@ -36,7 +36,7 @@ describe('serverTypes 단일 source 정합성 (#745)', () => {
     for (const key of Object.keys(SERVICE_MAP)) {
       const [serverType, format] = key.split(':');
       expect(SERVER_TYPES).toContain(serverType);
-      expect(['image', 'video']).toContain(format);
+      expect(['image', 'video', 'audio']).toContain(format);   // #805
     }
   });
 

--- a/src/tests/userDeletionService.test.js
+++ b/src/tests/userDeletionService.test.js
@@ -10,6 +10,7 @@ describe('#660 userDeletionService', () => {
     expect(names).toEqual([
       'ApiKey',
       'ConversationJob',
+      'GeneratedAudio',
       'GeneratedImage',
       'GeneratedText',
       'GeneratedVideo',

--- a/workboards/README.md
+++ b/workboards/README.md
@@ -28,6 +28,7 @@
 | `comfyui/minimax-h3-fl2v.json` | MiniMax H3 - FL2V | 영상 + 스테레오 오디오 | H3 모델 4종 |
 | `comfyui/minimax-h3-r2v.json` | MiniMax H3 - R2V | 〃 | H3 모델 4종 + VHS_LoadVideo |
 | `comfyui/ltx-2.5-fl2v.json` | LTX-2.5 - FL2V | 영상 + 동기화 오디오 | LTX-2.5 모델 6종 · ComfyUI 0.32+ |
+| `comfyui/minimax-music-3-t2m.json` | MiniMax Music 3 - T2M | **음악 (mp3)** | MiniMax Music 3 모델 3종 · ComfyUI 0.33+ |
 
 ---
 
@@ -208,6 +209,35 @@ LTX 형식 프롬프트로 늘려준다.
 이미 워크플로 안에 있다.
 
 ---
+
+## MiniMax Music 3
+
+설명과 가사로 **완성곡**을 만든다. VCC 의 오디오 출력 작업판이며 결과는 mp3 로 저장된다.
+ComfyUI 0.33 이상이 필요하다 (공식 템플릿이 그때 들어왔다).
+
+### 필요한 모델
+
+```
+models/
+├── diffusion_models/minimax/minimax_music3_dit_fp16.safetensors
+│   (저VRAM 이면 minimax_music3_dit_int8_convrot.safetensors)
+├── text_encoders/minimax_music3_text_encoder_pruned_int8_convrot.safetensors
+└── vae/minimax/minimax_music3_dav.safetensors
+```
+
+받는 곳: [🤗 Comfy-Org/MiniMax-Music-3](https://huggingface.co/Comfy-Org/MiniMax-Music-3)
+텍스트 인코더는 루트에, 나머지는 `minimax/` 아래에 둔 기준이다.
+
+### 입력
+
+| 필드 | 설명 |
+|---|---|
+| 프롬프트 | 장르·BPM·조성·악기·분위기. `Global Metadata: ...` 형식이 잘 먹는다 |
+| 가사 (선택) | **비우면 연주곡**이 된다. `[verse]` `[chorus]` 구조 표기 사용 가능 |
+| 최대 길이 (초) | **상한값**이다. 실제 길이는 모델이 곡에 맞춰 정하며 더 짧게 나온다 |
+| 타일 디코드 | 메모리가 부족할 때 켠다. 조금 느려진다 |
+
+실측: 최대 120초 설정 · RTX PRO 6000 기준 **72초 소요 → 21초 곡** (mp3 44.1kHz 스테레오).
 
 ## 갱신 규칙
 

--- a/workboards/comfyui/minimax-music-3-t2m.json
+++ b/workboards/comfyui/minimax-music-3-t2m.json
@@ -1,0 +1,102 @@
+{
+  "_exportVersion": 1,
+  "appVersion": {
+    "major": 4,
+    "minor": 0
+  },
+  "exportedAt": "2026-08-14T14:31:29.172Z",
+  "workboard": {
+    "name": "MiniMax Music 3 - T2M",
+    "description": "MiniMax Music 3 — 설명과 가사로 완성곡을 만듭니다. 가사를 비우면 연주곡이 됩니다.",
+    "workboardType": "image",
+    "outputFormat": "audio",
+    "additionalInputFields": [
+      {
+        "name": "base_model",
+        "label": "베이스 모델",
+        "type": "baseModel",
+        "required": true,
+        "defaultValue": "minimax\\minimax_music3_dit_fp16.safetensors",
+        "formatString": "{{##base_model##}}",
+        "imageConfig": {
+          "maxImages": 1
+        },
+        "videoConfig": {
+          "maxVideos": 1
+        },
+        "audioConfig": {
+          "maxAudios": 1
+        },
+        "options": []
+      },
+      {
+        "name": "lyrics",
+        "label": "가사 (선택)",
+        "type": "string",
+        "required": false,
+        "defaultValue": "",
+        "description": "비워두면 연주곡이 됩니다. [verse] [chorus] 같은 구조 표기를 쓸 수 있습니다.",
+        "formatString": "{{##lyrics##}}",
+        "imageConfig": {
+          "maxImages": 1
+        },
+        "videoConfig": {
+          "maxVideos": 1
+        },
+        "audioConfig": {
+          "maxAudios": 1
+        },
+        "options": []
+      },
+      {
+        "name": "max_duration",
+        "label": "최대 길이 (초)",
+        "type": "number",
+        "required": true,
+        "defaultValue": 120,
+        "description": "상한값입니다. 실제 길이는 모델이 곡에 맞춰 정하며 이보다 짧게 나올 수 있습니다.",
+        "formatString": "{{##max_duration##}}",
+        "imageConfig": {
+          "maxImages": 1
+        },
+        "videoConfig": {
+          "maxVideos": 1
+        },
+        "audioConfig": {
+          "maxAudios": 1
+        },
+        "options": []
+      },
+      {
+        "name": "tiled_decode",
+        "label": "타일 디코드 (저VRAM)",
+        "type": "boolean",
+        "required": false,
+        "defaultValue": false,
+        "description": "메모리가 부족할 때 켭니다. 켜면 조금 느려집니다.",
+        "formatString": "{{##tiled_decode##}}",
+        "imageConfig": {
+          "maxImages": 1
+        },
+        "videoConfig": {
+          "maxVideos": 1
+        },
+        "audioConfig": {
+          "maxAudios": 1
+        },
+        "options": []
+      }
+    ],
+    "workflowData": "{\n  \"3\": {\n    \"inputs\": {\n      \"clip_name\": \"minimax_music3_text_encoder_pruned_int8_convrot.safetensors\",\n      \"type\": \"minimax\",\n      \"device\": \"default\"\n    },\n    \"class_type\": \"CLIPLoader\",\n    \"_meta\": {\n      \"title\": \"CLIPLoader\"\n    }\n  },\n  \"6\": {\n    \"inputs\": {\n      \"unet_name\": \"{{##base_model##}}\",\n      \"weight_dtype\": \"default\"\n    },\n    \"class_type\": \"UNETLoader\",\n    \"_meta\": {\n      \"title\": \"UNETLoader\"\n    }\n  },\n  \"7\": {\n    \"inputs\": {\n      \"vae_name\": \"minimax\\\\minimax_music3_dav.safetensors\"\n    },\n    \"class_type\": \"VAELoader\",\n    \"_meta\": {\n      \"title\": \"VAELoader\"\n    }\n  },\n  \"9\": {\n    \"inputs\": {\n      \"model\": [\n        \"6\",\n        0\n      ],\n      \"positive\": [\n        \"13\",\n        0\n      ],\n      \"negative\": [\n        \"10\",\n        0\n      ],\n      \"latent_image\": [\n        \"15\",\n        0\n      ],\n      \"seed\": [\n        \"38\",\n        0\n      ],\n      \"steps\": 30,\n      \"cfg\": 1.7,\n      \"sampler_name\": \"euler\",\n      \"scheduler\": \"simple\",\n      \"denoise\": 1\n    },\n    \"class_type\": \"KSampler\",\n    \"_meta\": {\n      \"title\": \"KSampler\"\n    }\n  },\n  \"10\": {\n    \"inputs\": {\n      \"conditioning\": [\n        \"13\",\n        0\n      ]\n    },\n    \"class_type\": \"ConditioningZeroOut\",\n    \"_meta\": {\n      \"title\": \"ConditioningZeroOut\"\n    }\n  },\n  \"12\": {\n    \"inputs\": {\n      \"samples\": [\n        \"9\",\n        0\n      ],\n      \"vae\": [\n        \"7\",\n        0\n      ]\n    },\n    \"class_type\": \"VAEDecodeAudio\",\n    \"_meta\": {\n      \"title\": \"VAEDecodeAudio\"\n    }\n  },\n  \"13\": {\n    \"inputs\": {\n      \"clip\": [\n        \"3\",\n        0\n      ],\n      \"caption\": \"{{##prompt##}}\",\n      \"lyrics\": \"{{##lyrics##}}\",\n      \"seed\": [\n        \"38\",\n        0\n      ],\n      \"max_duration\": \"{{##max_duration##}}\",\n      \"cfg_scale\": 1.7,\n      \"top_k\": 50\n    },\n    \"class_type\": \"MiniMaxMusic3TextEncode\",\n    \"_meta\": {\n      \"title\": \"MiniMaxMusic3TextEncode\"\n    }\n  },\n  \"15\": {\n    \"inputs\": {\n      \"seconds\": [\n        \"13\",\n        1\n      ],\n      \"batch_size\": 1\n    },\n    \"class_type\": \"EmptyMiniMaxMusic3LatentAudio\",\n    \"_meta\": {\n      \"title\": \"EmptyMiniMaxMusic3LatentAudio\"\n    }\n  },\n  \"35\": {\n    \"inputs\": {\n      \"audio\": [\n        \"43\",\n        0\n      ],\n      \"filename_prefix\": \"{{##user_id##}}/audio/MiniMax_Music_3\",\n      \"format\": \"mp3\",\n      \"format.quality\": \"V0\"\n    },\n    \"class_type\": \"SaveAudioAdvanced\",\n    \"_meta\": {\n      \"title\": \"오디오 저장\"\n    }\n  },\n  \"38\": {\n    \"inputs\": {\n      \"seed\": \"{{##seed##}}\"\n    },\n    \"class_type\": \"SeedNode\",\n    \"_meta\": {\n      \"title\": \"SeedNode\"\n    }\n  },\n  \"42\": {\n    \"inputs\": {\n      \"samples\": [\n        \"9\",\n        0\n      ],\n      \"vae\": [\n        \"7\",\n        0\n      ],\n      \"tile_size\": 1536,\n      \"overlap\": 64\n    },\n    \"class_type\": \"VAEDecodeAudioTiled\",\n    \"_meta\": {\n      \"title\": \"VAEDecodeAudioTiled\"\n    }\n  },\n  \"43\": {\n    \"inputs\": {\n      \"on_false\": [\n        \"12\",\n        0\n      ],\n      \"on_true\": [\n        \"42\",\n        0\n      ],\n      \"switch\": \"{{##tiled_decode##}}\"\n    },\n    \"class_type\": \"ComfySwitchNode\",\n    \"_meta\": {\n      \"title\": \"ComfySwitchNode\"\n    }\n  }\n}",
+    "allowedModelTypes": [],
+    "modelExposurePolicy": "full",
+    "modelWhitelist": [],
+    "loraExposurePolicy": "full",
+    "loraWhitelist": [],
+    "version": 1
+  },
+  "server": {
+    "name": "ComfyUI-Video",
+    "serverType": "ComfyUI"
+  }
+}


### PR DESCRIPTION
v4.0.0 의 본체. 오디오를 네 번째 출력 축으로 추가하고, 그 과정에서 다섯 번 드러난 "이원화된 소스" 문제를 정리했다.

## 오디오 출력 축 (#805)

서버는 ComfyUI 를 그대로 쓰므로 신규 serverType 은 없다. 입력 쪽 오디오(#772)는 이미 있었고 이번은 **출력**이다.

**수집 규약** — ComfyUI 는 `SaveAudio` 계열 출력을 `nodeOutput.audio` 로 돌려준다 (`images`/`gifs` 와 다른 세 번째 키, width/height 없음, 기본 flac).

- `GeneratedAudio` 모델 · `uploads/audios/` 저장 · ffprobe 메타데이터
- `/audios` 라우트 5종 · 백업 · 무결성 · 계정삭제 배선
- `serverTypes` 단일 소스 + mirror, `ComfyUI:audio` 핸들러
- 내 콘텐츠 **2단 탭 재편** (생성한/업로드한 → 이미지·동영상·오디오·텍스트)
- 작업 히스토리 오디오 재생, 카탈로그 오디오 종류, MCP 오디오 지원

**MiniMax Music 3 작업판** — ComfyUI 0.33 공식 템플릿을 변환기로 API 포맷 전환. 실측 72초 → mp3 44.1kHz 스테레오.

## 이원화 소스 정리 (#808)

오디오 축을 추가하며 **같은 원인의 사고가 다섯 번** 났다. 전부 "같은 계약을 두 곳이 각자 들고 있어 한쪽만 고쳐진" 경우다.

| 사고 | 결과 |
|---|---|
| 백업 디렉토리 하드코딩 | **복원 시 오디오 소실** |
| sync 스크립트가 OUTPUT_FORMATS 하드코딩 | MCP 미러에 audio 미반영 |
| 히스토리 오디오를 패널에만 추가 | 음악 재생 불가 |
| 부제 계산이 "나머지는 파이프라인" 가정 | **작업 히스토리 화면 전체 렌더 실패** |
| 라우트 복제 시 치환 누락 | MCP 다운로드 500 |

**대응**

- `constants/mediaTypes` 신설 — 첨부형 필드 타입 · 저장 디렉토리 · 미디어 모델 목록
- `BACKUP_FILE_DIRS` · `FILE_CHECKS` · `CHECKED_SUBDIRS` 를 파생으로
- sync 스크립트가 `ATTACHMENT_FIELD_TYPES` 를 프론트 mirror 로 내려보냄
- `useContinueJob` 훅 — 두 히스토리 구현의 계속하기 로직 통합 (#794)
- `utils/historyItems` — 부제 계산 추출 + 모르는 타입에 대한 default 분기

## 프론트엔드 테스트 러너 연결

그동안 러너가 없어 UI 로직을 가드할 방법이 없었다 (`sanitizeHtml.test.js` 는 실행되지 않는 고아 파일이었다).

- vitest + jsdom (pnpm). `vite.config.js` 의 test 블록이 빌드와 같은 esbuild loader 를 쓴다
- `pnpm run test:all` 로 백엔드+프론트 동시 실행
- 사고 지점 위주로 가드 작성 — 되돌려서 실제로 잡히는지 확인함

## pnpm 전용 명시

루트·frontend·mcp-server 모두 이미 pnpm 이었으나 문서와 스크립트에 npm 이 섞여 있었다. 공급망 공격 대비가 이유이며 CLAUDE.md 에 정책과 주의사항을 기록했다.

## 검증

- **jest 443 · vitest 68**
- MiniMax Music 3 실제 생성 (UI · MCP 양쪽)
- 백업/복원 왕복에서 오디오 보존 (사용자 확인)
- MCP 왕복: `list_workboards` → `generate` → `get_job_status` → `download_result`

closes #805, closes #808