### PR TITLE
fix: 생성 화면의 이미지 전용 전제 정리 (#816)

### DIFF
--- a/frontend/src/components/common/CustomFieldControl.js
+++ b/frontend/src/components/common/CustomFieldControl.js
@@ -26,6 +26,9 @@ import MetadataFieldInput from './MetadataFieldInput';
  * - preview 모드: 폼 없이 disabled 로 동일 UI 렌더 — 프리뷰가 정의상 실행과 같은 모습
  */
 
+// 텍스트 필드는 기본적으로 여러 줄을 받는다 (#816).
+// 예전에는 이름에 'prompt' 가 들어갈 때만 멀티라인이라, lyrics 처럼 긴 글이 들어오는
+// 필드가 한 줄짜리로 나왔다. 짧게 쓰고 싶으면 그냥 짧게 쓰면 되지만, 그 반대는 불가능하다.
 const isPromptLike = (field) => (field.name || '').includes('prompt');
 
 function requiredMessage(field) {
@@ -118,8 +121,9 @@ function FieldBody({ field, value, onChange, error, size, disabled, serverId, wo
           label={field.label}
           required={field.required}
           placeholder={field.placeholder}
-          multiline={isPromptLike(field)}
-          rows={isPromptLike(field) ? 2 : 1}
+          multiline
+          minRows={isPromptLike(field) ? 3 : 2}
+          maxRows={12}
           value={value ?? ''}
           onChange={(e) => onChange(e.target.value)}
           error={!!error}

--- a/frontend/src/pages/ImageGeneration.js
+++ b/frontend/src/pages/ImageGeneration.js
@@ -677,6 +677,10 @@ function CustomAudioField({ field, value, onChange, maxAudios = 1 }) {
 // 출력 형식별 명사 (#805) — 토스트 문구용
 const OUTPUT_NOUN = { image: '이미지', video: '동영상', audio: '오디오', text: '텍스트' };
 
+// 반칸(sm=6) 이 아니라 한 줄을 다 쓰는 필드 (#816).
+// 첨부형은 미리보기 때문에, 텍스트는 여러 줄 입력이라 좁으면 쓰기 어렵다.
+const FULL_WIDTH_FIELD_TYPES = [...ATTACHMENT_FIELD_TYPES, 'string'];
+
 // 64비트 부호없는 정수 범위에서 랜덤 시드 생성
 const generateRandomSeed = () => {
   // ComfyUI는 64비트 부호없는 정수를 사용 (음수 불가)
@@ -1178,7 +1182,7 @@ function ImageGeneration() {
             <Paper variant="outlined" sx={{ mb: 4 }}>
               {/* 카드 헤더 — 목업 06: 제목 + 우측 텍스트 액션 */}
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, px: 4, py: 2.5, borderBottom: 1, borderColor: 'divider' }}>
-                <Typography variant="h6">기본 설정</Typography>
+                <Typography variant="h6">프롬프트</Typography>
                 <Box sx={{ flex: 1 }} />
                 <Button startIcon={<FolderOpen />} onClick={() => setPromptDataDialogOpen(true)}>
                   프롬프트 불러오기
@@ -1210,7 +1214,7 @@ function ImageGeneration() {
               />
 
               {/* LoRA — 프롬프트의 <lora:이름:가중치> 태그를 칩으로 표시 (목업 06, #552). 추가는 기존 prompt-insert 모달 */}
-              {isComfyUIWorkboard && (
+              {workboardData?.supportsLora && (
                 <Box>
                   <Typography variant="caption" sx={{ color: 'text.secondary', fontWeight: 500, display: 'block', mb: 1 }}>
                     LoRA
@@ -1306,11 +1310,11 @@ function ImageGeneration() {
             {workboardData?.additionalInputFields?.length > 0 && (
               <Paper variant="outlined" sx={{ mb: 4 }}>
                 <Box sx={{ px: 4, py: 2.5, borderBottom: 1, borderColor: 'divider' }}>
-                  <Typography variant="h6">고급 설정</Typography>
+                  <Typography variant="h6">입력 항목</Typography>
                 </Box>
                 <Grid container spacing={3.5} sx={{ p: 4 }}>
                   {workboardData.additionalInputFields.map((field) => (
-                    <Grid item xs={12} sm={ATTACHMENT_FIELD_TYPES.includes(field.type) ? 12 : 6} key={field.name}>
+                    <Grid item xs={12} sm={FULL_WIDTH_FIELD_TYPES.includes(field.type) ? 12 : 6} key={field.name}>
                       {field.type === 'image' ? (
                         <Controller
                           name={`additionalParams.${field.name}`}
@@ -1441,11 +1445,11 @@ function ImageGeneration() {
                 disabled={generating || generateMutation.isPending}
                 startIcon={generating ? <CircularProgress size={20} /> : <Send />}
               >
-                {generating ? '생성 중...' : '이미지 생성 시작'}
+                {generating ? '생성 중...' : '생성 시작'}
               </Button>
 
               <Alert severity="info" sx={{ mt: 2.5 }}>
-                이미지 생성은 백그라운드에서 처리됩니다.
+                생성은 백그라운드에서 처리됩니다.
                 작업 히스토리에서 진행 상황을 확인할 수 있습니다.
               </Alert>
             </Paper>
@@ -1454,7 +1458,7 @@ function ImageGeneration() {
       </form>
 
       {/* LoRA 목록 모달 */}
-      {isComfyUIWorkboard && (
+      {workboardData?.supportsLora && (
         <MetadataPickerModal
           kind="lora"
           open={loraModalOpen}

--- a/src/routes/workboards.js
+++ b/src/routes/workboards.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const mongoose = require('mongoose');
 const { requireAuth, requireAdmin, buildWorkboardAccessFilter, userHasWorkboardAccess } = require('../middleware/auth');
-const { getOmitConditionedFieldNames } = require('../utils/workflowDirectives');
+const { getOmitConditionedFieldNames, workflowSupportsLora } = require('../utils/workflowDirectives');
 const Workboard = require('../models/Workboard');
 const Server = require('../models/Server');
 const Group = require('../models/Group');
@@ -518,6 +518,8 @@ router.get('/:id', requireAuth, async (req, res) => {
     // 프론트가 workflowData 를 파싱하지 않도록 백엔드가 계산해 내려준다.
     const payload = workboard.toObject();
     payload.omitConditionedFields = getOmitConditionedFieldNames(workboard.workflowData);
+    // LoRA 영역 표시 여부 (#816) — 워크플로에 LoRA 로더나 lora 필드가 있을 때만
+    payload.supportsLora = workflowSupportsLora(workboard.workflowData, workboard.additionalInputFields);
 
     res.json({ workboard: payload });
   } catch (error) {

--- a/src/utils/workflowDirectives.js
+++ b/src/utils/workflowDirectives.js
@@ -209,4 +209,27 @@ function getOmitConditionedFieldNames(workflowData) {
   return [...names];
 }
 
-module.exports = { applyOmitDirectives, isFalsy, getOmitConditionedFieldNames };
+/**
+ * 이 워크플로가 LoRA 를 실제로 쓰는가 (#816).
+ *
+ * 생성 화면의 LoRA 영역은 그동안 "ComfyUI 작업판이면 무조건" 표시됐다. 그래서 LoRA 슬롯이
+ * 없는 워크플로(MiniMax H3 · Music 3 등)에서도 뜨고, 추가해도 아무 효과가 없었다.
+ *
+ * 판정 근거는 둘 중 하나다 — LoRA 로더 노드가 있거나, lora 타입 필드가 정의돼 있거나.
+ *
+ * @param {string} workflowData — 작업판 워크플로 JSON 문자열
+ * @param {Array} additionalInputFields
+ */
+function workflowSupportsLora(workflowData, additionalInputFields = []) {
+  if ((additionalInputFields || []).some((f) => f && f.type === 'lora')) return true;
+  if (!workflowData || typeof workflowData !== 'string') return false;
+  try {
+    const parsed = JSON.parse(workflowData);
+    return Object.values(parsed).some((n) => /lora/i.test(n?.class_type || ''));
+  } catch {
+    // 따옴표 없는 플레이스홀더로 파싱이 안 되는 경우 — 문자열 검사로 대체
+    return /"class_type"\s*:\s*"[^"]*[Ll]ora/.test(workflowData);
+  }
+}
+
+module.exports = { applyOmitDirectives, isFalsy, getOmitConditionedFieldNames, workflowSupportsLora };


### PR DESCRIPTION
오디오 작업판 실사용에서 드러난 네 가지.

1. 버튼 `이미지 생성 시작` → **`생성 시작`** (음악 작업판에서도 '이미지' 라고 떴다)
2. 섹션명 `기본/고급 설정` → **`프롬프트/입력 항목`** (뒤쪽은 고급이 아니라 그냥 입력이고 필수 항목도 거기 있다)
3. 텍스트 필드 **전체 폭 + 항상 멀티라인** — 멀티라인이 이름에 `prompt` 가 들어갈 때만 켜져 `lyrics` 가 좁은 한 줄로 나왔다
4. LoRA 영역을 **워크플로가 실제로 쓸 때만** 표시 — 배포 중인 ComfyUI 작업판(H3 FL2V · Music 3 · LTX-2.5) 전부가 LoRA 를 안 쓰는데 모두 표시되고 있었다

`workflowSupportsLora()` 를 백엔드가 계산해 `supportsLora` 로 내려준다. 프론트가 workflowData 를 파싱하지 않게 하는 기존 방식(#774)을 따랐다.

브라우저에서 확인 완료. jest 443.

closes #816