### PR TITLE
fix: 작업 히스토리에서 오디오만 액션·필터가 빠져 있음 (#818)

### DIFF
--- a/frontend/src/pages/JobHistory.js
+++ b/frontend/src/pages/JobHistory.js
@@ -338,7 +338,7 @@ function HistoryRow({ item, onOpenMedia, onMenu, onContinue, onCross, onTextCont
 
           {/* 액션 */}
           <Box sx={{ display: 'flex', gap: 0.75, mt: 1.25, flexWrap: 'wrap' }} onClick={(e) => e.stopPropagation()}>
-            {(item.type === 'image' || item.type === 'video') && item.status !== 'error' && (
+            {MEDIA_ITEM_TYPES.includes(item.type) && item.status !== 'error' && (
               <>
                 <Button variant="outlined" startIcon={<Refresh />} onClick={() => onContinue(item.raw)}>
                   계속하기
@@ -374,7 +374,7 @@ function HistoryRow({ item, onOpenMedia, onMenu, onContinue, onCross, onTextCont
               전문 보기 →
             </Typography>
           )}
-          {(item.type === 'image' || item.type === 'video') && (
+          {MEDIA_ITEM_TYPES.includes(item.type) && (
             <IconButton aria-label="더보기" size="small" onClick={(e) => onMenu(e, item)}>
               <MoreVert fontSize="small" />
             </IconButton>
@@ -388,7 +388,7 @@ function HistoryRow({ item, onOpenMedia, onMenu, onContinue, onCross, onTextCont
 // ---- 페이지 -------------------------------------------------------------
 // 큰 썸네일(그리드) 카드 — 리스트(HistoryRow)와 동일 핸들러 재사용 (#675)
 function HistoryCard({ item, onOpenMedia, onMenu, onContinue, onCross, onTextContinue, onTextDetail, onPipelineDetail }) {
-  const clickable = item.type === 'image' || item.type === 'video';
+  const clickable = MEDIA_ITEM_TYPES.includes(item.type);
   return (
     <Paper
       variant="outlined"
@@ -406,7 +406,7 @@ function HistoryCard({ item, onOpenMedia, onMenu, onContinue, onCross, onTextCon
         ) : item.type === 'video' && item.videoThumb ? (
           <Box component="img" src={item.videoThumb} alt="" loading="lazy"
             sx={{ width: '100%', height: '100%', objectFit: 'cover' }} />
-        ) : (item.type === 'image' || item.type === 'video') && item.thumb ? (
+        ) : MEDIA_ITEM_TYPES.includes(item.type) && item.thumb ? (
           item.type === 'video' ? (
             <Box component="video" src={`${item.thumb}#t=0.1`} muted playsInline preload="metadata"
               sx={{ width: '100%', height: '100%', objectFit: 'cover' }} />
@@ -447,7 +447,7 @@ function HistoryCard({ item, onOpenMedia, onMenu, onContinue, onCross, onTextCon
         </Box>
         <Typography sx={{ fontSize: 11, color: 'text.secondary', fontFamily: MONO }}>{relativeTime(item.time)}</Typography>
         <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', mt: 'auto', pt: 0.5 }} onClick={(e) => e.stopPropagation()}>
-          {(item.type === 'image' || item.type === 'video') && item.status !== 'error' && (
+          {MEDIA_ITEM_TYPES.includes(item.type) && item.status !== 'error' && (
             <>
               <Button variant="outlined" startIcon={<Refresh />} onClick={() => onContinue(item.raw)}>계속</Button>
               <Button variant="outlined" startIcon={<ArrowForward />} onClick={() => onCross(item.raw)}>다른작업</Button>
@@ -510,6 +510,7 @@ function JobHistory() {
     pipeline: items.filter((i) => i.type === 'pipeline').length,
     image: items.filter((i) => i.type === 'image').length,
     video: items.filter((i) => i.type === 'video').length,
+    audio: items.filter((i) => i.type === 'audio').length,   // #818
     text: items.filter((i) => i.type === 'text').length,
   }), [items]);
 
@@ -617,6 +618,7 @@ function JobHistory() {
           { value: 'pipeline', label: '파이프라인', count: counts.pipeline },
           { value: 'image', label: '이미지', count: counts.image },
           { value: 'video', label: '영상', count: counts.video },
+          { value: 'audio', label: '오디오', count: counts.audio },
           { value: 'text', label: '텍스트', count: counts.text },
         ]}
       />
@@ -667,7 +669,7 @@ function JobHistory() {
         </Box>
       )}
 
-      {/* 이미지/영상 행 오버플로우 메뉴 */}
+      {/* 미디어 행 오버플로우 메뉴 — 항목은 모두 출력 형식과 무관하다 (#818) */}
       <Menu anchorEl={menuAnchor} open={!!menuAnchor} onClose={closeMenu}>
         <MenuItem onClick={() => menuJob && handleViewDetail(menuJob)}>
           <Info fontSize="small" sx={{ mr: 1 }} /> 상세


### PR DESCRIPTION
오디오 항목에 더보기(⋮)·계속하기·다른 작업 버튼이 없었고 세그먼트 필터에도 오디오가 없었다.

액션 조건이 `image || video` 로 하드코딩돼 있었고(행형·카드형 5곳), 오디오 축에서 만든 `MEDIA_ITEM_TYPES` 를 이 자리들에는 적용하지 않았다. 메뉴 항목은 확인 결과 모두 출력 형식과 무관해 막을 이유가 없었다.

히스토리 화면에서만 **세 번째로 빠뜨린 자리**다 (앞선 둘: 사이드바 미표시, 부제 렌더 크래시). 이 파일은 타입별 분기가 흩어져 있어 새 축 추가 시 놓치기 쉽다 — #794 통합 때 함께 볼 것.

브라우저 확인 완료: 오디오 행 액션 3종, 세그먼트 '오디오 1'.

closes #818