### PR TITLE
fix: 워크플로가 쓰지 않는 입력칸을 감춘다 (#820)

### DIFF
--- a/frontend/src/pages/ImageGeneration.js
+++ b/frontend/src/pages/ImageGeneration.js
@@ -866,6 +866,10 @@ function ImageGeneration() {
 
   const workboardData = workboard?.data?.workboard;
   const isComfyUIWorkboard = workboardData?.serverId?.serverType === 'ComfyUI';
+  // 워크플로가 실제로 쓰는 내장 입력 (#820). 백엔드가 계산해 내려준다.
+  // 예전 작업판(필드 미제공)은 전부 표시 — 감추는 쪽이 안전한 기본값이 아니다.
+  const supportedInputs = workboardData?.supportedInputs
+    || { prompt: true, negativePrompt: true, seed: true, lora: isComfyUIWorkboard };
 
   // 작업판 데이터가 로드되면 선택 필드들의 기본값 설정
   useEffect(() => {
@@ -1214,7 +1218,7 @@ function ImageGeneration() {
               />
 
               {/* LoRA — 프롬프트의 <lora:이름:가중치> 태그를 칩으로 표시 (목업 06, #552). 추가는 기존 prompt-insert 모달 */}
-              {workboardData?.supportsLora && (
+              {supportedInputs.lora && (
                 <Box>
                   <Typography variant="caption" sx={{ color: 'text.secondary', fontWeight: 500, display: 'block', mb: 1 }}>
                     LoRA
@@ -1245,7 +1249,8 @@ function ImageGeneration() {
                 </Box>
               )}
 
-              {/* 부정 프롬프트 */}
+              {/* 부정 프롬프트 — 워크플로가 실제로 쓸 때만 (#820) */}
+              {supportedInputs.negativePrompt && (
               <Controller
                 name="negativePrompt"
                 control={control}
@@ -1260,8 +1265,10 @@ function ImageGeneration() {
                   />
                 )}
               />
+              )}
 
-              {/* 시드 값 설정 */}
+              {/* 시드 값 설정 — 워크플로가 실제로 쓸 때만 (#820) */}
+              {supportedInputs.seed && (
               <Paper variant="outlined" sx={{ p: 3 }}>
                 <Box display="flex" alignItems="center" justifyContent="space-between" mb={2}>
                   <Typography variant="subtitle1">시드 (Seed)</Typography>
@@ -1303,6 +1310,7 @@ function ImageGeneration() {
                   }}
                 />
               </Paper>
+              )}
               </Box>
             </Paper>
 
@@ -1458,7 +1466,7 @@ function ImageGeneration() {
       </form>
 
       {/* LoRA 목록 모달 */}
-      {workboardData?.supportsLora && (
+      {supportedInputs.lora && (
         <MetadataPickerModal
           kind="lora"
           open={loraModalOpen}

--- a/src/routes/workboards.js
+++ b/src/routes/workboards.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const mongoose = require('mongoose');
 const { requireAuth, requireAdmin, buildWorkboardAccessFilter, userHasWorkboardAccess } = require('../middleware/auth');
-const { getOmitConditionedFieldNames, workflowSupportsLora } = require('../utils/workflowDirectives');
+const { getOmitConditionedFieldNames, getSupportedBuiltinInputs } = require('../utils/workflowDirectives');
 const Workboard = require('../models/Workboard');
 const Server = require('../models/Server');
 const Group = require('../models/Group');
@@ -518,8 +518,8 @@ router.get('/:id', requireAuth, async (req, res) => {
     // 프론트가 workflowData 를 파싱하지 않도록 백엔드가 계산해 내려준다.
     const payload = workboard.toObject();
     payload.omitConditionedFields = getOmitConditionedFieldNames(workboard.workflowData);
-    // LoRA 영역 표시 여부 (#816) — 워크플로에 LoRA 로더나 lora 필드가 있을 때만
-    payload.supportsLora = workflowSupportsLora(workboard.workflowData, workboard.additionalInputFields);
+    // 워크플로가 실제로 쓰는 내장 입력 (#820) — 쓰지 않는 칸은 화면에서 감춘다
+    payload.supportedInputs = getSupportedBuiltinInputs(workboard.workflowData, workboard.additionalInputFields);
 
     res.json({ workboard: payload });
   } catch (error) {

--- a/src/utils/workflowDirectives.js
+++ b/src/utils/workflowDirectives.js
@@ -210,26 +210,40 @@ function getOmitConditionedFieldNames(workflowData) {
 }
 
 /**
- * 이 워크플로가 LoRA 를 실제로 쓰는가 (#816).
+ * 워크플로가 실제로 쓰는 내장 입력 (#820).
  *
- * 생성 화면의 LoRA 영역은 그동안 "ComfyUI 작업판이면 무조건" 표시됐다. 그래서 LoRA 슬롯이
- * 없는 워크플로(MiniMax H3 · Music 3 등)에서도 뜨고, 추가해도 아무 효과가 없었다.
+ * 생성 화면은 프롬프트·부정 프롬프트·시드·LoRA 를 **작업판과 무관하게 항상** 보여줬다.
+ * 그래서 워크플로가 쓰지 않는 칸에 사용자가 입력하면 아무 데도 안 가고 조용히 버려졌다.
+ * MiniMax Music 3 는 negative 를 caption 조건의 ZeroOut 으로 만들어 부정 프롬프트를
+ * 받지 않는데, 화면에는 칸이 떠 있어 "입력해도 무시된다" 는 혼란을 낳았다.
  *
- * 판정 근거는 둘 중 하나다 — LoRA 로더 노드가 있거나, lora 타입 필드가 정의돼 있거나.
+ * 프론트가 workflowData 를 파싱하지 않도록 백엔드가 계산해 내려준다 (#774 와 같은 방식).
  *
- * @param {string} workflowData — 작업판 워크플로 JSON 문자열
+ * @param {string} workflowData
  * @param {Array} additionalInputFields
+ * @returns {{ prompt: boolean, negativePrompt: boolean, seed: boolean, lora: boolean }}
  */
-function workflowSupportsLora(workflowData, additionalInputFields = []) {
-  if ((additionalInputFields || []).some((f) => f && f.type === 'lora')) return true;
-  if (!workflowData || typeof workflowData !== 'string') return false;
-  try {
-    const parsed = JSON.parse(workflowData);
-    return Object.values(parsed).some((n) => /lora/i.test(n?.class_type || ''));
-  } catch {
-    // 따옴표 없는 플레이스홀더로 파싱이 안 되는 경우 — 문자열 검사로 대체
-    return /"class_type"\s*:\s*"[^"]*[Ll]ora/.test(workflowData);
+function getSupportedBuiltinInputs(workflowData, additionalInputFields = []) {
+  const wf = typeof workflowData === 'string' ? workflowData : '';
+  const uses = (name) => wf.includes(`{{##${name}##}}`);
+
+  // LoRA 는 플레이스홀더가 아니라 노드/필드로 판정한다 —
+  // LoRA 태그는 프롬프트 문자열에 섞여 들어가므로 전용 플레이스홀더가 없다.
+  let lora = (additionalInputFields || []).some((f) => f && f.type === 'lora');
+  if (!lora && wf) {
+    try {
+      lora = Object.values(JSON.parse(wf)).some((n) => /lora/i.test(n?.class_type || ''));
+    } catch {
+      lora = /"class_type"\s*:\s*"[^"]*[Ll]ora/.test(wf);
+    }
   }
+
+  return {
+    prompt: uses('prompt'),
+    negativePrompt: uses('negative_prompt'),
+    seed: uses('seed'),
+    lora,
+  };
 }
 
-module.exports = { applyOmitDirectives, isFalsy, getOmitConditionedFieldNames, workflowSupportsLora };
+module.exports = { applyOmitDirectives, isFalsy, getOmitConditionedFieldNames, getSupportedBuiltinInputs };


### PR DESCRIPTION
생성 화면이 프롬프트·부정 프롬프트·시드·LoRA 를 작업판과 무관하게 항상 보여줬고, 워크플로가 안 쓰면 입력이 조용히 버려졌다.

**사용자 보고 추적 결과** — `prompt` 는 정상이었다 (`caption` 에 연결돼 있고, 같은 시드로 caption 만 바꾸면 결과가 완전히 달라지는 것을 실측). 실제로 버려지던 것은 **부정 프롬프트**다. Music 3 는 negative 를 caption 조건의 `ConditioningZeroOut` 으로 만들어 부정 프롬프트를 받지 않는다.

등록된 작업판 **9개 중 6개**가 쓰지 않는 칸을 띄우고 있었다. `LTX-2.3` 은 시드조차 쓰지 않는데 시드 UI 가 떠 있었다.

`getSupportedBuiltinInputs()` 가 워크플로를 검사해 `supportedInputs` 로 내려준다. #816 의 `workflowSupportsLora` 를 흡수했다. 예전 응답에는 전부 표시로 폴백한다.

브라우저 확인 완료. jest 443.

closes #820