### PR TITLE
fix: 선택 다이얼로그가 방금 만든 미디어를 못 보여주던 것 (#827)

### DIFF
--- a/frontend/src/components/common/ImageSelectDialog.js
+++ b/frontend/src/components/common/ImageSelectDialog.js
@@ -97,6 +97,9 @@ function ImageSelectDialog({
           type={getType()}
           fetchFn={fetchFn}
           queryKey={`imageSelect-${tab}-${tagsParam}`}
+          // 열 때마다 새로 받는다 (#827). 전역 5분 캐시를 상속하면 방금 생성한 이미지가
+          // 목록에 없고, 새로고침해야 나타났다. 12개짜리 모달이라 재조회 비용이 작다.
+          staleTime={0}
           selectable
           multiSelect={multiple}
           selectedItems={selectedImages}

--- a/frontend/src/components/common/MediaGrid.js
+++ b/frontend/src/components/common/MediaGrid.js
@@ -370,6 +370,9 @@ function MediaGrid({
   onBulkToggle,
   onStateChange,
   extraQuery = null,  // 추가 query params (e.g. tags 필터) — Phase 5c 후속
+  // 전역 기본값(5분, App.js)을 덮어쓴다. 선택 다이얼로그처럼 "열 때마다 현재 상태여야 하는"
+  // 곳은 0 을 준다 (#827) — 방금 생성한 이미지가 안 보이던 원인.
+  staleTime,
 }) {
   const [search, setSearch] = useState('');
   const [page, setPage] = useState(1);
@@ -394,7 +397,7 @@ function MediaGrid({
   // extraQuery 변화 시 자동으로 새 쿼리 — queryKey 에 직렬화 포함
   const extraQueryKey = extraQuery ? JSON.stringify(extraQuery) : '';
   useEffect(() => { setPage(1); }, [extraQueryKey]);
-  const { data, isLoading } = useQuery({ queryKey: [actualQueryKey, search, page, pageSize, extraQueryKey], queryFn: () => actualFetchFn({ search: search || undefined, page, limit: pageSize, ...(extraQuery || {}) }), placeholderData: keepPreviousData });
+  const { data, isLoading } = useQuery({ queryKey: [actualQueryKey, search, page, pageSize, extraQueryKey], queryFn: () => actualFetchFn({ search: search || undefined, page, limit: pageSize, ...(extraQuery || {}) }), placeholderData: keepPreviousData, ...(staleTime !== undefined && { staleTime }) });
 
   const defaultExtractor = (data) => {
     const d = data?.data?.data || data?.data || {};

--- a/frontend/src/components/common/VideoSelectDialog.js
+++ b/frontend/src/components/common/VideoSelectDialog.js
@@ -91,6 +91,8 @@ function VideoSelectDialog({
           type="video"
           fetchFn={fetchFn}
           queryKey={`videoSelect-${tab}`}
+          // 열 때마다 새로 받는다 (#827) — ImageSelectDialog 와 같은 이유
+          staleTime={0}
           selectable
           multiSelect={multiple}
           selectedItems={selectedVideos}

--- a/frontend/src/components/common/selectDialogFreshness.test.js
+++ b/frontend/src/components/common/selectDialogFreshness.test.js
@@ -1,0 +1,59 @@
+/**
+ * 미디어 선택 다이얼로그의 신선도 계약 (#827)
+ *
+ * 전역 React Query 기본값은 staleTime 5분이다 (App.js). 선택 다이얼로그가 이걸 상속하면
+ * 방금 생성한 이미지가 목록에 없고, 새로고침해야 나타난다 — 실제로 그렇게 새어나갔다.
+ *
+ * 이 계약은 눈에 잘 띄지 않는다. prop 하나가 빠져도 화면은 멀쩡히 그려지고, 캐시가 비어 있는
+ * 첫 조회에서는 증상도 안 나온다. 그래서 값으로 고정해 둔다.
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { vi } from 'vitest';
+
+// MediaGrid 를 가로채 넘어온 props 만 기록한다 — 렌더 결과가 아니라 계약을 본다.
+const gridProps = [];
+vi.mock('./MediaGrid', () => ({
+  default: (props) => {
+    gridProps.push(props);
+    return null;
+  },
+}));
+
+vi.mock('../../services/api', () => ({
+  imageAPI: {
+    getUploaded: vi.fn(),
+    getGenerated: vi.fn(),
+    getVideos: vi.fn(),
+  },
+}));
+
+import ImageSelectDialog from './ImageSelectDialog';
+import VideoSelectDialog from './VideoSelectDialog';
+
+beforeEach(() => {
+  gridProps.length = 0;
+});
+
+describe('선택 다이얼로그는 전역 5분 캐시를 상속하지 않는다 (#827)', () => {
+  // 렌더 횟수는 StrictMode 등으로 늘 수 있어 세지 않는다. 마운트가 있었다는 것과
+  // 모든 렌더가 staleTime 0 을 넘겼다는 것만 본다.
+  test('ImageSelectDialog 가 staleTime 0 을 넘긴다', () => {
+    render(<ImageSelectDialog open onClose={() => {}} onSelect={() => {}} />);
+    expect(gridProps.length).toBeGreaterThan(0);
+    expect(gridProps.map((p) => p.staleTime)).toEqual(gridProps.map(() => 0));
+  });
+
+  test('VideoSelectDialog 가 staleTime 0 을 넘긴다', () => {
+    render(<VideoSelectDialog open onClose={() => {}} onSelect={() => {}} />);
+    expect(gridProps.length).toBeGreaterThan(0);
+    expect(gridProps.map((p) => p.staleTime)).toEqual(gridProps.map(() => 0));
+  });
+
+  test('닫힌 상태에서는 그리드가 아예 마운트되지 않는다', () => {
+    // MUI Dialog 는 닫히면 자식을 언마운트한다. 이 전제가 깨지면 (keepMounted 등)
+    // 다시 열어도 마운트가 없어 재조회가 일어나지 않는다 — staleTime 0 이 무의미해진다.
+    render(<ImageSelectDialog open={false} onClose={() => {}} onSelect={() => {}} />);
+    expect(gridProps).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## 원인

전역 React Query 기본값이 `staleTime: 5분` 이다 (`frontend/src/App.js`). `MediaGrid` 의
`useQuery` 가 이걸 상속한다. 다이얼로그를 닫으면 언마운트되지만 캐시는 남아 있어,
**5분 안에 다시 열면 네트워크 요청 없이 이전 목록**이 그려졌다. 새로고침이 듣는 이유는
인메모리 캐시를 통째로 버리기 때문이다.

## 왜 "생성 완료 시 무효화" 가 아닌가

`ImageGeneration` 의 `generateMutation.onSuccess` 는 **작업 제출** 시점이라 그때는 결과물이
아직 없다. 실제 완성은 나중에 비동기로 일어난다. 완료 시점에 사용자가 어느 화면에 있는지에
기대야 하고, 다른 탭·다른 경로로 만들어진 것은 여전히 못 잡는다.

선택 다이얼로그는 사용자가 의도적으로 여는 모달이고 한 번에 12개만 가져온다.
**열 때마다 새로 받는 편이 무엇으로 만들어졌든 상관없이 항상 맞다.**

## 변경

- `MediaGrid` 에 `staleTime` prop 추가 — 미지정 시 전역 기본값 그대로 (기존 사용처 무영향)
- `ImageSelectDialog` · `VideoSelectDialog` 에서 `staleTime={0}`
- `AudioSelectDialog` 는 해당 없음 — MediaGrid 를 쓰지 않고 자체 상태로 직접 조회 (#805)

## 테스트

`selectDialogFreshness.test.js`. 이 계약은 눈에 띄지 않는다 — prop 이 빠져도 화면은 멀쩡히
그려지고, 캐시가 빈 첫 조회에서는 증상도 안 난다. `MediaGrid` 를 가로채 넘어온 props 만 본다.

`staleTime={0}` 을 지웠을 때 실제로 실패하는 것을 확인했다 (`1 failed | 70 passed`).

MUI Dialog 가 닫힐 때 자식을 언마운트한다는 전제도 함께 고정했다 — `keepMounted` 등으로
이 전제가 깨지면 다시 열어도 마운트가 없어 재조회가 일어나지 않는다.

## 확인

- `pnpm run test:frontend` 71 passed
- 컨테이너 재빌드 후 실제 동작 확인: 다이얼로그를 닫고 **51초 뒤** 다시 열었을 때
  `GET /api/images/generated` 가 새로 나갔다 (백엔드 access log 1건 → 2건).
  기존 5분 캐시였다면 요청이 나가지 않았을 간격이다.

## 남은 것

`MyImages`(내 콘텐츠)도 같은 `MediaGrid` 를 5분 캐시로 쓴다. 페이지 안에서의 업로드·삭제는
자체 무효화가 걸려 있으나, 다른 화면에서 생성한 뒤 5분 안에 들어오면 같은 방식으로 누락될
수 있다. 범위를 넘어서 별건으로 남긴다.

closes #827